### PR TITLE
update pa_deriving_json

### DIFF
--- a/Makefile.filelist
+++ b/Makefile.filelist
@@ -23,6 +23,7 @@ JSON := lib/deriving_json/deriving_Json.cmi       \
 INTF += $(JSON)
 
 IMPL += lib/syntax/pa_deriving_Json.cmo \
+        lib/syntax/pa_deriving_Json.cmi \
         lib/deriving_json.cma
 
 NATIMPL := lib/deriving_json.cmxa     \

--- a/lib/syntax/pa_deriving_Json.ml
+++ b/lib/syntax/pa_deriving_Json.ml
@@ -46,14 +46,13 @@ module Description = struct
   let depends = []
 end
 
-module Builder(Loc : Defs.Loc) = struct
+module Builder(Generator : Defs.Generator) = struct
 
-  module Helpers = Base.AstHelpers(Loc)
-  module Generator = Base.Generator(Loc)(Description)
-
-  open Loc
+  open Generator.Loc
   open Camlp4.PreCast
   open Description
+
+  module Helpers = Generator.AstHelpers
 
   let wrap
       ?(read_variant = [ <:match_case< _ -> assert false >> ])
@@ -240,6 +239,4 @@ module Builder(Loc : Defs.Loc) = struct
 
 end
 
-module Json = Base.Register(Description)(Builder)
-
-let depends = (module Builder : Defs.FullClassBuilder)
+include Base.RegisterFullClass(Description)(Builder)


### PR DESCRIPTION
use the new deriving-ocsigen (0.5)
it allows to register new "predefs" so it's easier to work with external libs unaware of deriving.

```
let _ = Pa_deriving_Json.register_predefs ["Yojson";"Safe";"json"] [ "myyojson"]
```

It breaks compatibility with deriving-ocsigen.0.3*..
