### PR TITLE
Mlstring: catch and log some exception 

### DIFF
--- a/runtime/mlString.js
+++ b/runtime/mlString.js
@@ -66,7 +66,6 @@ MlString.prototype = {
       return this.string = decodeURIComponent (escape(a));
     } catch (e){
       console.error("MlString.toJsString: wrong encoding for \"%s\" ", a);
-      console.error("this is probably a bug, please report at https://github.com/ocsigen/js_of_ocaml");
       return a;
     }
   },
@@ -78,7 +77,6 @@ MlString.prototype = {
         var b = unescape (encodeURIComponent (this.string));
       } catch (e) {
         console.error("MlString.toBytes: wrong encoding for \"%s\" ", this.string);
-        console.error("this is probably a bug, please report at https://github.com/ocsigen/js_of_ocaml");
         var b = this.string;
       }
     } else {


### PR DESCRIPTION
And exception is raised with bad utf8-encoded strings. Much easier to understand and debug when it appends with the right logs.

One mistake to generate "bad utf-encoded strings" is to use the `String` module to manipulate utf8 strings (ie: String.lowercase my_utf8_string)
