### PR TITLE
Property required for select,input,textarea (write-only)

### DIFF
--- a/lib/dom_html.ml
+++ b/lib/dom_html.ml
@@ -512,6 +512,7 @@ class type selectElement = object ('self)
   method remove : int -> unit meth
   method blur : unit meth
   method focus : unit meth
+  method required : bool t writeonly_prop
 
   method onchange : ('self t, event t) event_listener prop
   method oninput : ('self t, event t) event_listener prop
@@ -531,6 +532,7 @@ class type inputElement = object ('self)
   method maxLength : int prop
   method name : js_string t readonly_prop
   method readOnly : bool t prop
+  method required : bool t writeonly_prop
   method size : int prop
   method src : js_string t prop
   method tabIndex : int prop
@@ -566,6 +568,7 @@ class type textAreaElement = object ('self)
   method blur : unit meth
   method focus : unit meth
   method select : unit meth
+  method required : bool t writeonly_prop
   method placeholder : js_string t writeonly_prop
   method onselect : ('self t, event t) event_listener prop
   method onchange : ('self t, event t) event_listener prop
@@ -1694,3 +1697,7 @@ let hasPushState () =
 let hasPlaceholder () =
  let i = createInput document in
   Js.Optdef.test ((Js.Unsafe.coerce i)##placeholder)
+
+let hasRequired () =
+ let i = createInput document in
+  Js.Optdef.test ((Js.Unsafe.coerce i)##required)

--- a/lib/dom_html.mli
+++ b/lib/dom_html.mli
@@ -462,6 +462,7 @@ class type selectElement = object ('self)
   method remove : int -> unit meth
   method blur : unit meth
   method focus : unit meth
+  method required : bool t writeonly_prop (* Not supported by IE 9/Safari *)
 
   method onchange : ('self t, event t) event_listener prop
   method oninput : ('self t, event t) event_listener prop
@@ -481,6 +482,7 @@ class type inputElement = object ('self)
   method maxLength : int prop
   method name : js_string t readonly_prop (* Cannot be changed under IE *)
   method readOnly : bool t prop
+  method required : bool t writeonly_prop (* Not supported by IE 9/Safari *)
   method size : int prop
   method src : js_string t prop
   method tabIndex : int prop
@@ -516,6 +518,7 @@ class type textAreaElement = object ('self)
   method blur : unit meth
   method focus : unit meth
   method select : unit meth
+  method required : bool t writeonly_prop (* Not supported by IE 9/Safari *)
   method placeholder : js_string t writeonly_prop (* Not supported by IE 9 *)
 
   method onselect : ('self t, event t) event_listener prop
@@ -1476,3 +1479,4 @@ end
 val onIE : bool
 val hasPushState : unit -> bool
 val hasPlaceholder : unit -> bool
+val hasRequired : unit -> bool


### PR DESCRIPTION
Dag allemaal, this is a mending for #38, with the attribute required only write-only, and a testing function. @vouillon, is this approximately what you were thinking off ?

BTW Is there a list of browsers supported by js_of_ocaml somewhere ?
