### PR TITLE
COMPILER:remove unused params; DO NOT WORK

### DIFF
--- a/compiler/driver.ml
+++ b/compiler/driver.ml
@@ -236,6 +236,7 @@ let pack ~standalone ?(toplevel=false)?(linkall=false) js =
     if Option.Optim.compact_vardecl ()
     then (new Js_traverse.compact_vardecl)#program js
     else js in
+  let js = (new Js_traverse.unused)#program js in
 
   (* pack *)
   let js = if standalone then

--- a/compiler/js_traverse.mli
+++ b/compiler/js_traverse.mli
@@ -65,6 +65,10 @@ class rename_variable : Util.StringSet.t -> freevar
 
 class share_constant : mapper
 
+class unused : object
+  inherit freevar
+  method get_params : Javascript.ident list
+end
 class compact_vardecl : object('a)
   inherit free
   method exc  : Javascript.IdentSet.t


### PR DESCRIPTION
It removes unused params
`function f(a){return 0}` becomes `function f(){return 0}`
`function f(a,b){return b}` is not changed
`function f(a,b){return a}` becomes `function f(a){return a}`

It doesnt not work (because of `caml_call_gen` i suppose)
Is there a way to make this optim work ? otherwise, just ignore and close this PR  
