### PR TITLE
Fix dependencies in compiler/ and fix parallel compilation.

### DIFF
--- a/compiler/.depend
+++ b/compiler/.depend
@@ -92,8 +92,8 @@ reserved.cmo : util.cmi
 reserved.cmx : util.cmx
 specialize.cmo : option.cmo flow.cmi code.cmi specialize.cmi
 specialize.cmx : option.cmx flow.cmx code.cmx specialize.cmi
-specialize_js.cmo : flow.cmi code.cmi specialize_js.cmi
-specialize_js.cmx : flow.cmx code.cmx specialize_js.cmi
+specialize_js.cmo : util.cmi flow.cmi code.cmi specialize_js.cmi
+specialize_js.cmx : util.cmx flow.cmx code.cmx specialize_js.cmi
 subst.cmo : util.cmi code.cmi subst.cmi
 subst.cmx : util.cmx code.cmx subst.cmi
 tailcall.cmo : util.cmi subst.cmi option.cmo code.cmi tailcall.cmi
@@ -135,11 +135,3 @@ subst.cmi : code.cmi
 tailcall.cmi : code.cmi
 util.cmi :
 varPrinter.cmi : util.cmi
-js_parser.cmo : parse_info.cmi js_token.cmi javascript.cmi js_parser.cmi
-js_parser.cmx : parse_info.cmx js_token.cmx javascript.cmx js_parser.cmi
-js_parser.cmi : js_token.cmi javascript.cmi
-js_parser.ml js_parser.mli: javascript.cmi js_token.cmi parse_info.cmi
-annot_parser.cmo : primitive.cmi annot_parser.cmi
-annot_parser.cmx : primitive.cmx annot_parser.cmi
-annot_parser.cmi : primitive.cmi
-annot_parser.ml annot_parser.mli: primitive.cmi

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -60,27 +60,20 @@ compiler.cmxs: $(OBJS)
 %.cmi: %.mli
 	ocamlfind ocamlc -package findlib,str -c $<
 
+%.ml %.mli: %.mly
+	menhir --explain $<
 
-%.ml: %.mly
-	menhir --infer --explain $<
-
-js_parser.ml: js_parser.mly
+js_parser.ml js_parser.mli: js_parser.mly
 	menhir --external-tokens Js_token --explain $<
 
-
-%.ml: %.mll
+%.ml %.mli: %.mll
 	ocamllex $<
 clean:
 	rm -f *.cm[aiox] *.cmxa *.cmxs *.o *.a *.conflicts
 	rm -f js_of_ocaml compile.opt compile.byte minify.opt minify.byte
 
-depend:
-	${MAKE} --no-print-directory js_lexer.ml
-	${MAKE} --no-print-directory annot_lexer.ml
+.PHONY: depend
+depend: js_lexer.ml annot_lexer.ml js_parser.ml annot_parser.ml
 	ocamldep *.ml *.mli > .depend
-	menhir --depend --external-tokens Js_token js_parser.mly >> .depend
-	menhir --depend annot_parser.mly >> .depend
-
-
 
 include .depend


### PR DESCRIPTION
Missing dependencies:

  %.mli: %.mly
  %.mli: %.mll

The 'make depend' target did not generate the following dependency when called from a fresh 'git clone' (or after a 'git clean -dxf'):

  linker.cmo: ... annot_parser.cmo ...
