### PR TITLE
Toplevel: add a simple cohttp based server

### DIFF
--- a/toplevel/Makefile
+++ b/toplevel/Makefile
@@ -92,6 +92,9 @@ $(NAME).byte: $(OBJS) ../compiler/compiler.cma
 errors.cmi: errors.mli
 	$(OCAMLC) -c $<
 
+server: server.ml
+	ocamlfind ocamlc -linkpkg -package cohttp.lwt server.ml -o server
+
 clean::
 	rm -f *.cm[io] $(NAME).byte $(NAME).js
 

--- a/toplevel/server.ml
+++ b/toplevel/server.ml
@@ -1,0 +1,44 @@
+open Lwt
+open Cohttp
+open Cohttp_lwt_unix
+open Re
+
+let address = ref "127.0.0.1"
+let port = ref 8888
+let filesys = ref (Filename.concat (Sys.getenv "HOME") ".opam")
+
+let server () = 
+
+    let re_filesys = compile (seq [ str "/filesys/"; group (rep any); eos ]) in
+
+    let header typ = 
+        let h = Header.init () in
+        let h = Header.add h "Content-Type" typ in
+        let h = Header.add h "Server" "iocaml" in
+        h
+    in
+    let header_html = header "text/html; charset=UTF-8" in
+    let header_plain_user_charset = header "text/plain; charset=x-user-defined" in
+
+    let callback conn_id req body = 
+        let uri = Request.uri req in
+        let path = Uri.path uri in
+
+        try 
+            (* send binary file *)
+            let fname = get (exec re_filesys path) 1 in
+            Lwt_io.eprintf "filesys: %s\n" fname >>= fun () ->
+            Server.respond_file ~headers:header_plain_user_charset ~fname:fname ()
+        with _ ->
+            (* send static file *)
+            let fname = Server.resolve_file ~docroot:"." ~uri:uri in
+            Lwt_io.eprintf "static: %s\n" fname >>= fun () -> 
+            Server.respond_file ~headers:header_html ~fname:fname ()
+
+    in
+    let conn_closed conn_id () = () in
+    let config = { Server.callback; conn_closed } in
+    Server.create ~address:!address ~port:!port config
+
+let () = Lwt_unix.run (server())
+


### PR DESCRIPTION
Provides just enough to enable topfind in the js_of_ocaml toplevel.

You may find this useful for testing dynamic loading with js_of_ocaml.

Note; xmlHttpRequests are generated regardless of the presence of a server that can support them which might not be the behaviour you want.  You might also want support of command line options and serving multiple directories as this feature and also enables `open_in` to read arbitrary files from the filesystem.
