### PR TITLE
Compiler: fix compiler_version.ml generation

### DIFF
--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -54,7 +54,7 @@ compiler.cmxs: $(OBJS)
 
 VERSION := $(shell head -n 1 ../VERSION)
 compiler_version.ml: ../VERSION
-	echo "let s = \"${VERSION}\"\n" > $@
+	echo "let s = \"${VERSION}\"" > $@
 
 
 %.cmx: %.ml


### PR DESCRIPTION
Remove the \n, it ends up as a literal "\n" in the generated .ml file
and subsequently breaks the build.

Fixes a regression introduced in commit 45977610 and resolves the
following build error:

```
$ make -C compiler
make: Entering directory `/home/bnoordhuis/src/js_of_ocaml/compiler'
ocamlfind ocamlopt -package findlib,str -for-pack Compiler -c
compiler_version.ml
File "compiler_version.ml", line 1, characters 17-18:
Error: Illegal character (\\)
make: *** [compiler_version.cmx] Error 2
make: Leaving directory `/home/bnoordhuis/src/js_of_ocaml/compiler'
```
