### PR TITLE
Syntax: object literal

### DIFF
--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -101,7 +101,7 @@ js_parser.mli: js_parser.mly javascript.cmi js_token.cmi
 	menhir --infer --external-tokens Js_token --explain $<
 
 %.ml: %.mll
-	ocamllex $<
+	ocamllex -q $<
 clean:
 	rm -f *.cm[aiox] *.cmxa *.cmxs *.o *.a *.conflicts
 	rm -f compile.opt compile.byte minify.opt minify.byte

--- a/lib/syntax/pa_js.ml
+++ b/lib/syntax/pa_js.ml
@@ -355,11 +355,12 @@ module Make (Syntax : Sig.Camlp4Syntax) = struct
        let field_list = parse_class_str_list l in
        let fields = List.map parse_class_item field_list in
        literal_object _loc ~self fields
-     | "{:"; ":}" -> <:expr< ($js_u_id _loc "obj"$ [| |] : Js.t < > ) >>
-     | "{:"; l = field_expr_list; ":}" ->
-       let field_list = parse_field_list l in
-       let fields = List.map parse_field field_list in
-       literal_object _loc fields ]];
+     (* | "{:"; ":}" -> <:expr< ($js_u_id _loc "obj"$ [| |] : Js.t < > ) >> *)
+     (* | "{:"; l = field_expr_list; ":}" -> *)
+     (*   let field_list = parse_field_list l in *)
+     (*   let fields = List.map parse_field field_list in *)
+     (*   literal_object _loc fields *)
+    ]];
     END
 
 (*XXX n-ary methods

--- a/lib/syntax/pa_js.ml
+++ b/lib/syntax/pa_js.ml
@@ -241,7 +241,7 @@ module Make (Syntax : Sig.Camlp4Syntax) = struct
 
        let rec get_arg x =
 	 match x with
-	 | <:expr< fun $x$ -> $e$ >> -> (fresh_type e_loc )::get_arg e
+	 | <:expr< fun $_x$ -> $e$ >> -> (fresh_type e_loc )::get_arg e
 	 | _ -> [] in
        let _loc = e_loc in
        let t = fresh_type _loc in

--- a/lib/syntax/pa_js.ml
+++ b/lib/syntax/pa_js.ml
@@ -264,9 +264,8 @@ module Make (Syntax : Sig.Camlp4Syntax) = struct
          new_object _loc e []
      | "jsnew"; e = expr LEVEL "label"; "("; l = comma_expr; ")" ->
          new_object _loc e (parse_comma_list l)
-    | "{|"; "|}" ->
-    <:expr< Js.Unsafe.obj [| |] >>
-     | "{|"; l = field_expr_list; "|}" ->
+     | "{:"; ":}" -> <:expr< Js.Unsafe.obj [| |] >>
+     | "{:"; l = field_expr_list; ":}" ->
        let field_list = parse_field_list l in
        let fields = List.map parse_field field_list in
        let _ = List.fold_left (fun acc ((lab,loc),_,_) ->


### PR DESCRIPTION
imported from https://github.com/astrada/pa_extjs cc @astrada
for the upcoming release or later

example 
```
let obj = {:
  p1 = Js._true;
  p2 = Js.string "string property";
:}
```
is infered to 
```
< p1 : < set : bool Js.t -> unit; .. > Js.gen_prop;
  p2 : < set : Js.js_string Js.t -> unit; .. > Js.gen_prop;
  .. >  Js.t
```