### PR TITLE
Lib: Fix event interface

### DIFF
--- a/lib/dom.ml
+++ b/lib/dom.ml
@@ -192,11 +192,11 @@ type ('a, 'b) event_listener = ('a, 'b -> bool t) meth_callback opt
 
 class type ['a] event = object
   method _type : js_string t readonly_prop
-  method target : 'a t optdef readonly_prop
-  method currentTarget : 'a t optdef readonly_prop
+  method target : 'a t opt readonly_prop
+  method currentTarget : 'a t opt readonly_prop
 
   (* Legacy methods *)
-  method srcElement : 'a t optdef readonly_prop
+  method srcElement : 'a t opt readonly_prop
 end
 
 let no_handler : ('a, 'b) event_listener = Js.null
@@ -243,8 +243,8 @@ let invoke_handler
 
 let eventTarget (e: (< .. > as 'a) #event t) : 'a t =
   let target =
-    Optdef.get (e##target) (fun () ->
-    Optdef.get (e##srcElement) (fun () -> assert false))
+    Opt.get (e##target) (fun () ->
+    Opt.get (e##srcElement) (fun () -> raise Not_found))
   in
   if Js.instanceof target (Js.Unsafe.global ## _Node)
   then

--- a/lib/dom.mli
+++ b/lib/dom.mli
@@ -193,11 +193,11 @@ type (-'a, -'b) event_listener
 
 class type ['a] event = object
   method _type : js_string t readonly_prop
-  method target : 'a t optdef readonly_prop
-  method currentTarget : 'a t optdef readonly_prop
+  method target : 'a t opt readonly_prop
+  method currentTarget : 'a t opt readonly_prop
 
   (* Legacy methods *)
-  method srcElement : 'a t optdef readonly_prop
+  method srcElement : 'a t opt readonly_prop
 end
 
 (** {2 Event handlers} *)
@@ -215,7 +215,9 @@ val invoke_handler : ('a, 'b) event_listener -> 'a -> 'b -> bool t
   (** Invoke an existing handler.  Useful to chain event handlers. *)
 
 val eventTarget : (< .. > as 'a) #event t -> 'a t
-  (** Returns which object is the target of this event. *)
+  (** Returns which object is the target of this event.
+      It raises [Not_found] in case there is no target
+      (if the event has not been triggered yet) *)
 
 type event_listener_id
 


### PR DESCRIPTION
`target` and friends are set to `null` when you create them manually
There is no interface to create event with js_of_ocaml. However, eliom does the following : 
1- create event : https://github.com/ocsigen/eliom/blob/master/src/client/private/eliommod_dom.ml#L221.
2- manually dispatch the event : https://github.com/ocsigen/eliom/blob/master/src/client/eliom_client.ml#L406

this result in having event with `target` set to `null`
- eliom should not dispatch event manually .. @balat 
- fix event class type (this PR) ? @vouillon 
