### PR TITLE
squash closure

### DIFF
--- a/compiler/option.ml
+++ b/compiler/option.ml
@@ -88,6 +88,8 @@ module Optim = struct
   let include_cmis = o ~name:"withcmi" ~default: true
   let warn_unused = o ~name:"warn-unused"  ~default: false
 
+  let squash = o ~name:"squash" ~default: true
+
   let inline_callgen = o ~name:"callgen" ~default:false
 
   (* this does not optimize properly *)

--- a/compiler/option.mli
+++ b/compiler/option.mli
@@ -43,6 +43,8 @@ module Optim : sig
   val warn_unused : unit -> bool
   val inline_callgen : unit -> bool
 
+  val squash : unit -> bool
+
   val enable : string -> unit
   val disable : string -> unit
 end


### PR DESCRIPTION
functors with more than one arguments are compiled with nested closures.
```
function F (MA){
  return function(MB) { ... } }
```
this PR converts this pattern into a single closure ``` function F(MA,MB) { ... }```

when applying such functor, the generated code change from ```call_gen_1(F(MA),MB)``` to ```F(MA,MB)```
This allows to eliminate more deadcode
In the following example, `M1` and `M2` can be removed if not used.
```
module type T = sig
  type t
  val x : t
end
module Make(C : T)(D : T with type t = C.t) = struct
  let a = C.x
  let b = D.x
end

module M1 = Make
    (struct type t = int let x = 10 end)
    (struct type t = int let x = 10 end)

module M2 = Make
    (struct type t = float let x = 10. end)
    (struct type t = float let x = 10. end)
```