### PR TITLE
Update lib/Makefile to clean lib/log

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -139,6 +139,7 @@ stubs.c: $(MLOBJS:cmo=ml)
 clean:
 	rm -f *.cm[xioa] *.[ao] *.so *.cmx[sa]
 	rm -f syntax/*.cm[xioa] syntax/*.[ao] syntax/*.so syntax/*.cmx[sa]
+	rm -f log/*.cm[xioa] log/*.[ao] log/*.so log/*.cmx[sa]
 	rm -f deriving_json/*.cm[xioa] deriving_json/*.[ao] deriving_json/*.so
 	rm -f deriving_json/deriving_Json_lexer.ml
 	rm -f stubs.c


### PR DESCRIPTION
Ran into this today on a machine where I had recently upgraded ocaml. `make` didn't work since I had an out of date `log/lwt_log_js.cmi` that wasn't being cleaned up.

I suppose it's worth mentioning that there are a few other dirs that don't seem to be getting cleaned (`lib/graphics` and `lib/tyxml`).
