### PR TITLE
Add the outerHTML property in Dom_html

### DIFF
--- a/lib/dom_html.ml
+++ b/lib/dom_html.ml
@@ -308,6 +308,7 @@ and element = object
   method style : cssStyleDeclaration t prop
 
   method innerHTML : js_string t prop
+  method outerHTML : js_string t prop
   method textContent : js_string t opt prop
 
   method clientLeft : int readonly_prop

--- a/lib/dom_html.mli
+++ b/lib/dom_html.mli
@@ -322,6 +322,7 @@ and element = object
   method style : cssStyleDeclaration t prop
 
   method innerHTML : js_string t prop
+  method outerHTML : js_string t prop
   method textContent : js_string t opt prop
 
   method clientLeft : int readonly_prop


### PR DESCRIPTION
This commit simply add this missing property on element objects.
More documentation here: https://developer.mozilla.org/en-US/docs/Web/API/element.outerHTML
