### PR TITLE
Fix the runtime implementation of Sys.argv in node

### DIFF
--- a/runtime/stdlib.js
+++ b/runtime/stdlib.js
@@ -875,8 +875,8 @@ function caml_sys_get_argv () {
      && g.process.argv
      && g.process.argv.length > 0) {
     //nodejs
-    main = g.process.argv[0];
-    args = g.process.argv.slice(1);
+    main = g.process.argv[1];
+    args = g.process.argv.slice(2);
   }
 
   var p = new MlWrappedString(main);


### PR DESCRIPTION
Suppose we have argv.ml like:

```
let () = Array.iter print_endline Sys.argv
```

The standard byte-code interpreter, ocamlrun, doesn't include
its program name at the first of Sys.argv,

```
$ ocamlc argv.ml -o argv.out
$ ./argv.out foo bar
argv.out
foo
bar
$ ocamlrun argv.out foo bar
argv.out
foo
bar
```

but the current implementation of Sys.argv in nodejs does as follows:

```
$ js_of_ocaml argv.out
$ node argv.js foo bar
node
argv.js
foo
bar
```

It is not a wrong behavior in general, but it is inconvenient to make
the program work both on ocamlrun and nodejs.
