### PR TITLE
Add new css property text-anchor

### DIFF
--- a/lib/dom_html.ml
+++ b/lib/dom_html.ml
@@ -118,6 +118,7 @@ class type cssStyleDeclaration = object
   method strokeWidth : js_string t prop
   method tableLayout : js_string t prop
   method textAlign : js_string t prop
+  method textAnchor : js_string t prop
   method textDecoration : js_string t prop
   method textIndent : js_string t prop
   method textTransform : js_string t prop

--- a/lib/dom_html.mli
+++ b/lib/dom_html.mli
@@ -117,6 +117,7 @@ class type cssStyleDeclaration = object
   method strokeWidth : js_string t prop
   method tableLayout : js_string t prop
   method textAlign : js_string t prop
+  method textAnchor : js_string t prop
   method textDecoration : js_string t prop
   method textIndent : js_string t prop
   method textTransform : js_string t prop


### PR DESCRIPTION
I need a missing css property in js_of_ocaml and I added it to Dom_html. Some documentation here : http://www.w3.org/TR/SVG/text.html#TextAnchorProperty
