### PR TITLE
Fix overuse of FormData in XmlHttpRequest

### DIFF
--- a/lib/xmlHttpRequest.ml
+++ b/lib/xmlHttpRequest.ml
@@ -171,7 +171,7 @@ let perform_raw_url
 	(match post_args with
 	  | None -> None
 	  | Some post_args ->
-	    let contents = Form.empty_form_contents () in
+	    let contents = `Fields (ref []) in
 	    List.iter (fun (name, value) ->
               Form.append contents (name, value))
               post_args;


### PR DESCRIPTION
Currently, the following code sends a request in `multipart/form-data`,
although the contents is a trivial key-value pair list.

```
XmlHttpRequest.perform ~post_args:["key", `String "value"] url
```

This change fixes the behavior so that such requests would be sent in
`application/x-www-form-urlencoded`.

If there is at least a file content in `post_args`, then
`multipart/form-data` will be used as usual.
