### PR TITLE
Ppx for js_of_ocaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,8 @@ benchmarks/build
 benchmarks/results
 benchmarks/config
 lib/deriving_json/deriving_Json_lexer.ml
+lib/ppx/ppx_js.ml
+lib/ppx/ppx_js
 Makefile.local
 
 # OCamlbuild dir

--- a/.jenkins.sh
+++ b/.jenkins.sh
@@ -5,7 +5,7 @@ opam install --deps-only js_of_ocaml
 opam install --verbose js_of_ocaml
 
 do_build_doc () {
-  opam install ocp-indent higlo
+  opam install ocp-indent cppo higlo base64
   make -C doc clean
   make -C doc doc
   make -C doc wikidoc

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ VERSION := $(shell head -n 1 VERSION)
 install: install-lib install-bin
 
 install-lib:
-	ocamlfind install -patch-version ${VERSION} $(LIBRARY) lib/META $(INTF) $(IMPL) $(OTHERS) $(DOC) $(COMP_INTF) $(COMP_IMPL)
+	ocamlfind install -patch-version ${VERSION} $(LIBRARY) lib/META $(INTF) $(IMPL) $(OTHERS) $(DOC) $(COMP_INTF) $(COMP_IMPL) ${OCAMLFIND_BIN}
 
 install-bin:
 	install -d -m 755 $(BINDIR)

--- a/Makefile.conf
+++ b/Makefile.conf
@@ -10,6 +10,8 @@ COMPILER := js_of_ocaml$(EXEEXT)
 MINIFIER := jsoo_minify$(EXEEXT)
 MKTOP    := jsoo_mktop$(EXEEXT)
 MKCMIS   := jsoo_mkcmis$(EXEEXT)
+
+PPX   := ppx_js$(EXEXT)
 # opt/byte
 BEST := opt
 
@@ -45,6 +47,8 @@ WITH_TYXML ?= $(shell if [ -f `ocamlfind query tyxml 2> /dev/null`/tyxml_f.cma ]
 WITH_FINDLIB?=YES
 
 NATDYNLINK ?= $(shell if [ -f `ocamlc -where`/dynlink.cmxa ]; then echo YES; else echo NO; fi)
+
+WITH_PPX ?= $(shell if [ -f `ocamlfind query ppx_tools 2> /dev/null`/ppx_tools.cma ]; then echo YES; else echo NO; fi)
 
 METAOCAML ?= 0
 

--- a/Makefile.conf
+++ b/Makefile.conf
@@ -25,8 +25,7 @@ OBJEXT := .o
 LIBEXT := .a
 DLLEXT := .so
 
-ifeq ($(shell ocamlc -v | grep -q "version 4"; echo $$?),0)
-OCAML4:="YES"
+ifeq ($(shell ocamlc -version | grep -q "^4."; echo $$?),0)
 WITH_TOPLEVEL =YES
 endif
 
@@ -48,7 +47,14 @@ WITH_FINDLIB?=YES
 
 NATDYNLINK ?= $(shell if [ -f `ocamlc -where`/dynlink.cmxa ]; then echo YES; else echo NO; fi)
 
-WITH_PPX ?= $(shell if [ -f `ocamlfind query ppx_tools 2> /dev/null`/ppx_tools.cma ]; then echo YES; else echo NO; fi)
+WITH_PPX_TOOLS ?= $(shell if [ -f `ocamlfind query ppx_tools 2> /dev/null`/ppx_tools.cma ]; then echo YES; else echo NO; fi)
+
+##disabled for ocaml < 4.02.2+trunk
+ifeq "${WITH_PPX_TOOLS}" "YES"
+ifneq ($(shell ocamlc -version | grep -q -E "4.02.[01]"; echo $$?),0)
+WITH_PPX ?= YES
+endif
+endif
 
 METAOCAML ?= 0
 

--- a/Makefile.filelist
+++ b/Makefile.filelist
@@ -94,3 +94,7 @@ endif
 endif
 
 DOC := ${INTF:.cmi=.mli}
+
+ifeq "${WITH_PPX}" "YES"
+OCAMLFIND_BIN += lib/ppx/${PPX}
+endif

--- a/Makefile.filelist
+++ b/Makefile.filelist
@@ -30,6 +30,11 @@ IMPL += lib/tyxml/tyxml.cma
 INTF += lib/tyxml/*.cmi
 endif
 
+ifeq "${WITH_PPX}" "YES"
+OCAMLFIND_BIN += lib/ppx/${PPX}
+INTF += lib/ppx/*.cmi
+endif
+
 ifeq "${WITH_TOPLEVEL}" "YES"
 IMPL += lib/toplevel/jsooTop.cmo lib/toplevel/jsooTopError.cmo lib/toplevel/jsooTopCamlp4.cmo
 INTF += lib/toplevel/jsooTop.cmi lib/toplevel/jsooTopError.cmi
@@ -94,7 +99,3 @@ endif
 endif
 
 DOC := ${INTF:.cmi=.mli}
-
-ifeq "${WITH_PPX}" "YES"
-OCAMLFIND_BIN += lib/ppx/${PPX}
-endif

--- a/Makefile.filelist
+++ b/Makefile.filelist
@@ -32,7 +32,13 @@ endif
 
 ifeq "${WITH_PPX}" "YES"
 OCAMLFIND_BIN += lib/ppx/${PPX}
+IMPL += lib/ppx/ppx_js.cma
 INTF += lib/ppx/*.cmi
+ifeq "${BEST}" "opt"
+ifeq "${NATDYNLINK}" "YES"
+IMPL += lib/ppx/ppx_js.cmx lib/ppx/ppx_js.cmxa lib/ppx/ppx_js.cmxs 
+endif
+endif
 endif
 
 ifeq "${WITH_TOPLEVEL}" "YES"

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ OCaml programs run on Web browsers.
   * [deriving](https://github.com/ocsigen/deriving): **version 0.6** at least
 
 ### Toplevel requirements
+ * base64 (version 2.0.0 at least)
  * ocp-indent: needed to support indentation in the toplevel
  * higlo: needed to support Syntax highlighting in the toplevel
  * cohttp: needed to build the toplevel webserver

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -104,6 +104,7 @@ js_parser.mli: js_parser.mly javascript.cmi js_token.cmi
 	ocamllex -q $<
 clean:
 	rm -f *.cm[aiox] *.cmxa *.cmxs *.o *.a *.conflicts
+	rm -f lib/*.cm[aiox] lib/*.cmxa lib/*.cmxs lib/*.o lib/*.a
 	rm -f compile.opt compile.byte minify.opt minify.byte
 	rm -f $(MINIFIER) $(COMPILER)
 	rm -f compiler_version.ml

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -21,6 +21,11 @@ ifeq "${WITH_TOPLEVEL}" "YES"
 OTHER += -package compiler-libs.bytecomp,compiler-libs.common,compiler-libs.toplevel -I ../lib/toplevel
 endif
 
+ifeq "${WITH_PPX}" "YES"
+OTHER += -I ../lib/ppx
+endif
+
+
 .PHONY: doc wikidoc
 doc: api/html/index.html
 api/html/index.html: ${MLIS} api/index

--- a/doc/api/index
+++ b/doc/api/index
@@ -24,6 +24,12 @@ WebGL
 WebSockets
 }
 
+{1 Ppx - API Reference}
+
+{!modules:
+Ppx_js
+}
+
 {1 Deriving - API Reference}
 
 {!modules:

--- a/lib/.depend
+++ b/lib/.depend
@@ -107,6 +107,11 @@ tyxml/tyxml_js.cmx : tyxml/tyxml_cast.cmx js.cmx dom_html.cmx dom.cmx \
 tyxml/tyxml_cast.cmi : tyxml/tyxml_cast_sigs.cmi js.cmi dom.cmi
 tyxml/tyxml_cast_sigs.cmi : js.cmi dom_html.cmi dom.cmi
 tyxml/tyxml_js.cmi : tyxml/tyxml_cast_sigs.cmi js.cmi dom_html.cmi dom.cmi
+ppx/ppx_js.cmo : ppx/ppx_js.cmi
+ppx/ppx_js.cmx : ppx/ppx_js.cmi
+ppx/ppx_js_bin.cmo : ppx/ppx_js.cmi
+ppx/ppx_js_bin.cmx : ppx/ppx_js.cmx
+ppx/ppx_js.cmi :
 deriving_json/deriving_Json_lexer.cmo : \
     deriving_json/deriving_Json_lexer.cmi
 deriving_json/deriving_Json_lexer.cmx : \

--- a/lib/.merlin
+++ b/lib/.merlin
@@ -1,0 +1,4 @@
+B ./**
+S ./**
+PKG cmdliner
+PKG menhir

--- a/lib/META.cppo
+++ b/lib/META.cppo
@@ -15,6 +15,14 @@ package "syntax" (
   archive(syntax,preprocessor) = "pa_js.cmo"
 )
 
+package "ppx" (
+  description = "Js_of_ocaml ppx"
+  version = "[distributed with js_of_ocaml]"
+  ppx = "./ppx_js"
+  requires = "js_of_ocaml"
+  exists_if = "ppx_js"
+)
+
 package "deriving" (
 
   exists_if = "deriving_json.cma deriving_json.cmxa"

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -42,7 +42,7 @@ endif
 endif
 
 ifeq "${WITH_PPX}" "YES"
-PPX_EX= ppx/ppx_js.${BEST}
+PPX_EX= ppx/$(PPX)
 endif
 
 all: $(LIBNAME).cma log/logger.cma \
@@ -146,7 +146,7 @@ ppx/ppx_js.byte: ppx/ppx_js.cmo
 
 ppx/ppx_js.opt: ppx/ppx_js.cmx
 	ocamlfind ocamlopt $(SAFESTRING) \
-		-linkpkg -package ppx_tools.metaquot ppx/ppx_js.cmx -o ppx/ppx_js.native
+		-linkpkg -package ppx_tools.metaquot ppx/ppx_js.cmx -o ppx/ppx_js.opt
 
 ppx/ppx_js.cmx: ppx/ppx_js.ml
 	ocamlfind ocamlopt $(SAFESTRING) -package ppx_tools.metaquot -g -c $<
@@ -157,6 +157,8 @@ ppx/ppx_js.cmo: ppx/ppx_js.ml
 ppx/ppx_js.cmi: ppx/ppx_js.mli
 	ocamlfind ocamlc $(SAFESTRING) -package ppx_tools.metaquot -c $<
 
+$(PPX_EX): ppx/ppx_js.$(BEST)
+	mv -f $< $@
 
 
 

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -43,6 +43,10 @@ endif
 
 ifeq "${WITH_PPX}" "YES"
 PPX_EX= ppx/$(PPX)
+PPX_LIB= ppx/ppx_js.cma ppx/ppx_js.cmxa
+ifeq "${NATDYNLINK}" "YES"
+PPX_LIB_NDL= ppx/ppx_js.cmxs
+endif
 endif
 
 all: $(LIBNAME).cma log/logger.cma \
@@ -51,7 +55,7 @@ all: $(LIBNAME).cma log/logger.cma \
 	${DERIVING_JSON} \
 	${GRAPHICS_CMA} \
 	${TYXML_CMA} \
-	$(PPX_EX) \
+	$(PPX_EX) $(PPX_LIB) $(PPX_LIB_NDL) \
 	META
 
 $(LIBNAME).cma: $(OBJS)
@@ -140,22 +144,29 @@ toplevel/%.cmi: toplevel/%.mli
 
 
 
-ppx/ppx_js.byte: ppx/ppx_js.cmo
+ppx/ppx_js.byte: ppx/ppx_js.cmo ppx/ppx_js_bin.cmo
 	$(OCAMLC) $(SAFESTRING) \
-		-linkpkg -package ppx_tools.metaquot $< -o ppx/ppx_js.byte
+		-linkpkg -package ppx_tools.metaquot $^ -o ppx/ppx_js.byte
 
-ppx/ppx_js.opt: ppx/ppx_js.cmx
+ppx/ppx_js.opt: ppx/ppx_js.cmx ppx/ppx_js_bin.cmx
 	$(OCAMLOPT) $(SAFESTRING) \
-		-linkpkg -package ppx_tools.metaquot $< -o ppx/ppx_js.opt
+		-linkpkg -package ppx_tools.metaquot $^ -o ppx/ppx_js.opt
 
-ppx/ppx_js.cmx: ppx/ppx_js.ml ppx/ppx_js.cmi
+ppx/%.cmx: ppx/%.ml
 	$(OCAMLOPT) $(SAFESTRING) -I ppx -package ppx_tools.metaquot -g -c $<
 
-ppx/ppx_js.cmo: ppx/ppx_js.ml ppx/ppx_js.cmi
+ppx/%.cmo: ppx/%.ml
 	$(OCAMLC) $(SAFESTRING) -I ppx -package ppx_tools.metaquot -c $<
 
 ppx/ppx_js.cmi: ppx/ppx_js.mli
 	$(OCAMLC) $(SAFESTRING) -package ppx_tools.metaquot -c $< -o $@
+
+ppx/ppx_js.cma: ppx/ppx_js.cmo
+	$(OCAMLC) -a -o $@ $^
+ppx/ppx_js.cmxa: ppx/ppx_js.cmx
+	$(OCAMLOPT) -a -o $@ $^
+ppx/ppx_js.cmxs: ppx/ppx_js.cmxa
+	$(OCAMLOPT) -shared -g -o $@ $^
 
 %.ml: %.cppo.ml
 	cppo $< -o $@ -V OCAML:`ocamlc -version`
@@ -206,9 +217,9 @@ clean:
 	rm -f sys_js.ml
 	rm -f toplevel/jsooTopError.ml
 
-depend: syntax/pa_js.cmo ${PA_DERIVING} sys_js.ml toplevel/jsooTopError.ml
+depend: syntax/pa_js.cmo ${PA_DERIVING} sys_js.ml toplevel/jsooTopError.ml ppx/ppx_js.ml
 	ocamldep -pp "camlp4o syntax/pa_js.cmo" *.ml *.mli > .depend
-	ocamldep -pp "camlp4o syntax/pa_js.cmo" log/*.ml log/*.mli >> .depend
+	ocamldep -pp "camlp4o syntax/pa_js.cmo" -I log log/*.ml log/*.mli >> .depend
 	ocamldep -pp "camlp4o syntax/pa_js.cmo" -I toplevel toplevel/jsooTop.ml toplevel/jsooTopCamlp4.ml toplevel/*.mli >> .depend
 	ocamldep toplevel/jsooTopError.ml -I toplevel >> .depend
 ifeq "${WITH_GRAPHICS}" "YES"
@@ -220,7 +231,7 @@ ifeq "${WITH_TYXML}${WITH_REACT}" "YESYES"
 	ocamldep -pp "camlp4o syntax/pa_js.cmo" -I tyxml tyxml/*.ml tyxml/*.mli >> .depend
 endif
 ifeq "${WITH_PPX}" "YES"
-	ocamldep ppx/*.ml >> .depend
+	ocamldep -I ppx ppx/ppx_js.ml ppx/ppx_js_bin.ml ppx/ppx_js.mli >> .depend
 endif
 ifeq "${WITH_DERIVING}" "YES"
 	${MAKE} --no-print-directory deriving_json/deriving_Json_lexer.ml

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -41,12 +41,17 @@ PA_JS_NDL= syntax/pa_js.cmx syntax/pa_js.cmxs
 endif
 endif
 
+ifeq "${WITH_PPX}" "YES"
+PPX_EX= ppx/ppx_js.${BEST}
+endif
+
 all: $(LIBNAME).cma log/logger.cma \
 	${PA_JS} ${PA_JS_NDL} \
 	${PA_DERIVING} 	${PA_DERIVING_NDL} \
 	${DERIVING_JSON} \
 	${GRAPHICS_CMA} \
 	${TYXML_CMA} \
+	$(PPX_EX) \
 	META
 
 $(LIBNAME).cma: $(OBJS)
@@ -133,6 +138,28 @@ toplevel/%.cmi: toplevel/%.mli
 	$(OCAMLC) $(SAFESTRING) \
 	-I toplevel -I +compiler-libs $< -o $@
 
+
+
+ppx/ppx_js.byte: ppx/ppx_js.cmo
+	ocamlfind ocamlc $(SAFESTRING) \
+		-linkpkg -package ppx_tools.metaquot ppx/ppx_js.cmo -o ppx/ppx_js.byte
+
+ppx/ppx_js.opt: ppx/ppx_js.cmx
+	ocamlfind ocamlopt $(SAFESTRING) \
+		-linkpkg -package ppx_tools.metaquot ppx/ppx_js.cmx -o ppx/ppx_js.native
+
+ppx/ppx_js.cmx: ppx/ppx_js.ml
+	ocamlfind ocamlopt $(SAFESTRING) -package ppx_tools.metaquot -g -c $<
+
+ppx/ppx_js.cmo: ppx/ppx_js.ml
+	ocamlfind ocamlc $(SAFESTRING) -package ppx_tools.metaquot -c $<
+
+ppx/ppx_js.cmi: ppx/ppx_js.mli
+	ocamlfind ocamlc $(SAFESTRING) -package ppx_tools.metaquot -c $<
+
+
+
+
 %.cmo: %.ml syntax/pa_js.cmo
 	$(OCAMLC) -pp "camlp4o syntax/pa_js.cmo" $(SAFESTRING) -package lwt -c -g $<
 
@@ -162,6 +189,7 @@ stubs.c: $(MLOBJS:cmo=ml)
 clean:
 	rm -f *.cm[xioa] *.[ao] *.so *.cmx[sa]
 	rm -f syntax/*.cm[xioa] syntax/*.[ao] syntax/*.so syntax/*.cmx[sa]
+	rm -f ppx/*.cm[xioa] ppx/*.[ao] ppx/*.so ppx/*.cmx[sa]
 	rm -f log/*.cm[xioa] log/*.[ao] log/*.so log/*.cmx[sa]
 	rm -f tyxml/*.cm[xioa] tyxml/*.[ao] tyxml/*.so tyxml/*.cmx[sa]
 	rm -f graphics/*.cm[xioa] graphics/*.[ao] graphics/*.so graphics/*.cmx[sa]
@@ -184,6 +212,9 @@ ifeq "${WITH_GRAPHICS}" "YES"
 endif
 ifeq "${WITH_TYXML}${WITH_REACT}" "YESYES"
 	ocamldep -pp "camlp4o syntax/pa_js.cmo" -I tyxml tyxml/*.ml tyxml/*.mli >> .depend
+endif
+ifeq "${WITH_PPX}" "YES"
+	ocamldep ppx/*.ml >> .depend
 endif
 ifeq "${WITH_DERIVING}" "YES"
 	${MAKE} --no-print-directory deriving_json/deriving_Json_lexer.ml

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -157,6 +157,10 @@ ppx/ppx_js.cmo: ppx/ppx_js.ml
 ppx/ppx_js.cmi: ppx/ppx_js.mli
 	ocamlfind ocamlc $(SAFESTRING) -package ppx_tools.metaquot -c $<
 
+%.ml: %.cppo.ml
+	cppo $< -o $@ -V OCAML:`ocamlc -version`
+
+
 $(PPX_EX): ppx/ppx_js.$(BEST)
 	mv -f $< $@
 

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -141,21 +141,21 @@ toplevel/%.cmi: toplevel/%.mli
 
 
 ppx/ppx_js.byte: ppx/ppx_js.cmo
-	ocamlfind ocamlc $(SAFESTRING) \
-		-linkpkg -package ppx_tools.metaquot ppx/ppx_js.cmo -o ppx/ppx_js.byte
+	$(OCAMLC) $(SAFESTRING) \
+		-linkpkg -package ppx_tools.metaquot $< -o ppx/ppx_js.byte
 
 ppx/ppx_js.opt: ppx/ppx_js.cmx
-	ocamlfind ocamlopt $(SAFESTRING) \
-		-linkpkg -package ppx_tools.metaquot ppx/ppx_js.cmx -o ppx/ppx_js.opt
+	$(OCAMLOPT) $(SAFESTRING) \
+		-linkpkg -package ppx_tools.metaquot $< -o ppx/ppx_js.opt
 
-ppx/ppx_js.cmx: ppx/ppx_js.ml
-	ocamlfind ocamlopt $(SAFESTRING) -package ppx_tools.metaquot -g -c $<
+ppx/ppx_js.cmx: ppx/ppx_js.ml ppx/ppx_js.cmi
+	$(OCAMLOPT) $(SAFESTRING) -I ppx -package ppx_tools.metaquot -g -c $<
 
-ppx/ppx_js.cmo: ppx/ppx_js.ml
-	ocamlfind ocamlc $(SAFESTRING) -package ppx_tools.metaquot -c $<
+ppx/ppx_js.cmo: ppx/ppx_js.ml ppx/ppx_js.cmi
+	$(OCAMLC) $(SAFESTRING) -I ppx -package ppx_tools.metaquot -c $<
 
 ppx/ppx_js.cmi: ppx/ppx_js.mli
-	ocamlfind ocamlc $(SAFESTRING) -package ppx_tools.metaquot -c $<
+	$(OCAMLC) $(SAFESTRING) -package ppx_tools.metaquot -c $< -o $@
 
 %.ml: %.cppo.ml
 	cppo $< -o $@ -V OCAML:`ocamlc -version`

--- a/lib/ppx/.merlin
+++ b/lib/ppx/.merlin
@@ -1,0 +1,5 @@
+PKG ppx_tools
+PKG compiler-libs
+PKG ppx_tools.metaquot
+
+REC

--- a/lib/ppx/ppx_js.cppo.ml
+++ b/lib/ppx/ppx_js.cppo.ml
@@ -35,7 +35,7 @@ module Js = struct
     then Typ.constr ?loc (lid s) args
     else Typ.constr ?loc (lid @@ "Js."^s) args
 
-#if OCAML_MAJOR = 4 && OCAML_MINOR = 2
+#if OCAML_VERSION < (4,03,0)
   let nolabel = ""
 #else
   let nolabel = Nolabel

--- a/lib/ppx/ppx_js.cppo.ml
+++ b/lib/ppx/ppx_js.cppo.ml
@@ -35,10 +35,11 @@ module Js = struct
     then Typ.constr ?loc (lid s) args
     else Typ.constr ?loc (lid @@ "Js."^s) args
 
-(* ocaml 4.02+trunk *)  
+#if OCAML_MAJOR = 4 && OCAML_MINOR = 2
   let nolabel = ""
-(* ocaml 4.03 *)
-(* let nolabel = Nolabel *)
+#else
+  let nolabel = Nolabel
+#endif
 
   let unsafe ?loc s args =
     let args = List.map (fun x -> nolabel,x) args in

--- a/lib/ppx/ppx_js.cppo.ml
+++ b/lib/ppx/ppx_js.cppo.ml
@@ -18,9 +18,9 @@ let exp_to_string = function
 
 let rnd = Random.State.make [|0x313511d4|]
 let random_var () =
-  Format.sprintf "x%08Lx" (Random.State.int64 rnd 0x100000000L)
+  Format.sprintf "jsoo_%08Lx" (Random.State.int64 rnd 0x100000000L)
 let random_tvar () =
-  Format.sprintf "A%08Lx" (Random.State.int64 rnd 0x100000000L)
+  Format.sprintf "Jsoo_%08Lx" (Random.State.int64 rnd 0x100000000L)
 
 let inside_Js = lazy
   (try
@@ -173,8 +173,9 @@ let new_object constr args =
 
 module S = Map.Make(String)
 
-(** For each method 1) we remove Pexp_poly (should only be inside methods)
-    and we add the self argument.
+(** For each method:
+    - We remove Pexp_poly. (It should only be inside methods! It's always the first.)
+    - We add the self argument.
 *)
 let format_meth self_id body =
   match body.pexp_desc with
@@ -193,6 +194,7 @@ let preprocess_literal_object ?(optional=false) self_id fields =
   let check_name id names =
     if S.mem id.txt names then
       let id' = S.find id.txt names in
+      (* We point out both definitions in locations (more convenient for the user). *)
       let sub = [Location.errorf ~loc:id'.loc "Duplicated val or method %S." id'.txt] in
       Location.raise_errorf ~loc:id.loc ~sub "Duplicated val or method %S." id.txt
     else

--- a/lib/ppx/ppx_js.cppo.ml
+++ b/lib/ppx/ppx_js.cppo.ml
@@ -457,5 +457,3 @@ let js_mapper _args =
       | _ -> default_mapper.expr mapper expr
     )
   }
-
-let () = run_main js_mapper

--- a/lib/ppx/ppx_js.cppo.ml
+++ b/lib/ppx/ppx_js.cppo.ml
@@ -10,6 +10,10 @@ open Ast_convenience
 *)
 let exp_to_string = function
   | {pexp_desc= Pexp_ident {txt = Longident.Lident s}} -> s
+  | {pexp_desc= Pexp_construct ({txt = Longident.Lident s}, None)}
+    when String.length s > 0
+      && s.[0] >= 'A'
+      && s.[0] <= 'Z' -> "_"^s
   | {pexp_loc} ->
      Location.raise_errorf
        ~loc:pexp_loc

--- a/lib/ppx/ppx_js.cppo.ml
+++ b/lib/ppx/ppx_js.cppo.ml
@@ -1,3 +1,6 @@
+(* For implicit optional argument elimination. Annoying with Ast_helper. *)
+[@@@ocaml.warning "-48"]
+
 open Ast_mapper
 open Ast_helper
 open Asttypes
@@ -42,10 +45,6 @@ let funs args ret =
     args
     ret
 
-let sequence l last =
-  List.fold_right Exp.sequence l last
-
-
 let rnd = Random.State.make [|0x313511d4|]
 let random_var () =
   Format.sprintf "jsoo_%08Lx" (Random.State.int64 rnd 0x100000000L)
@@ -82,8 +81,6 @@ module Js = struct
     if Lazy.force inside_Js
     then Exp.(apply ?loc (ident ?loc @@ lid ?loc s) args)
     else Exp.(apply ?loc (ident ?loc @@ lid ?loc ("Js."^s)) args)
-
-  let string ?loc arg = fun_ ?loc "string" [str arg]
 
 end
 
@@ -191,7 +188,7 @@ let new_object constr args =
   let args =
     Exp.array @@
     List.map
-      (fun (e, (l,t)) -> Js.unsafe "inject" [Exp.constraint_ e t])
+      (fun (e, (_l,t)) -> Js.unsafe "inject" [Exp.constraint_ e t])
       args
   in
   let x = random_var () in
@@ -272,7 +269,7 @@ to:
 
  *)
 
-let literal_object ?loc self_id fields =
+let literal_object self_id fields =
   let self_type = random_tvar () in
 
   let fields =

--- a/lib/ppx/ppx_js.cppo.ml
+++ b/lib/ppx/ppx_js.cppo.ml
@@ -415,9 +415,12 @@ let js_mapper _args =
         in mapper.expr mapper { new_expr with pexp_attributes }
 
       (** obj##meth arg1 arg2 .. *)
+      (** obj##(meth arg1 arg2) .. *)
       | {pexp_desc = Pexp_apply
              (([%expr [%e? obj] ## [%e? meth]] as expr), args)
-        } ->
+        }
+      | [%expr [%e? obj] ## [%e? {pexp_desc = Pexp_apply((meth as expr),args)}]]
+        ->
         let meth = exp_to_string meth in
         let new_expr =
           method_call ~loc:expr.pexp_loc obj meth args

--- a/lib/ppx/ppx_js.ml
+++ b/lib/ppx/ppx_js.ml
@@ -191,13 +191,11 @@ let js_mapper _args =
       (** [%js obj#meth ()] *)
       | [%expr [%js [%e? {pexp_desc = Pexp_send (obj, meth) }] () ]] ->
          method_call obj meth []
-
       (** [%js obj#meth (args, ..)] *)
       | [%expr [%js [%e? {pexp_desc = Pexp_send (obj, meth) }]
                     [%e? {pexp_desc = Pexp_tuple args}]
                ]] ->
          method_call obj meth args
-
       (** [%js obj#meth arg] *)
       | [%expr [%js [%e? {pexp_desc = Pexp_send (obj, meth) }] [%e? arg] ]] ->
          method_call obj meth [arg]
@@ -206,18 +204,14 @@ let js_mapper _args =
       (** new%js constr ()] *)
       | [%expr [%js [%e? {pexp_desc = Pexp_new constr}]] ()] ->
         new_object constr []
-
       (** new%js constr (args, ..)] *)
       | [%expr [%js [%e? {pexp_desc = Pexp_new constr}]]
                     [%e? {pexp_desc = Pexp_tuple args}]
         ] ->
         new_object constr args
-
       (** new%js constr arg] *)
       | [%expr [%js [%e? {pexp_desc = Pexp_new constr}]] [%e? arg] ] ->
         new_object constr [arg]
-
-
 
       | _ -> default_mapper.expr mapper expr
     );

--- a/lib/ppx/ppx_js.ml
+++ b/lib/ppx/ppx_js.ml
@@ -1,0 +1,184 @@
+open Ast_mapper
+open Ast_helper
+open Asttypes
+open Parsetree
+
+open Ast_convenience
+
+
+let with_loc f { txt ; loc } =
+  (f txt) [@metaloc loc]
+
+
+
+let rnd = Random.State.make [|0x313511d4|]
+let random_var () =
+  Format.sprintf "x%08Lx" (Random.State.int64 rnd 0x100000000L)
+let random_tvar () =
+  Format.sprintf "A%08Lx" (Random.State.int64 rnd 0x100000000L)
+
+let inside_Js = lazy
+  (try
+     String.lowercase @@
+     Filename.basename @@
+     Filename.chop_extension !Location.input_name = "js"
+   with Invalid_argument _ -> false)
+
+
+let js_t_id ?loc s args =
+  if Lazy.force inside_Js
+  then Typ.constr ?loc (lid s) args
+  else Typ.constr ?loc (lid @@ "Js."^s) args
+
+let js_u_id ?loc s =
+  if Lazy.force inside_Js
+  then Exp.ident ?loc @@ lid ("Unsafe."^s)
+  else Exp.ident ?loc @@ lid ("Js.Unsafe."^s)
+
+
+let unescape lab =
+  assert (lab <> "");
+  let lab =
+    if lab.[0] = '_' then String.sub lab 1 (String.length lab - 1) else lab
+  in
+  try
+    let i = String.rindex lab '_' in
+    if i = 0 then raise Not_found;
+    String.sub lab 0 i
+  with Not_found ->
+    lab
+
+(** Constraints for the various types.
+    Synthesize new type and create dummy declaration with type constraints.
+*)
+let constrain_types obj res res_typ meth meth_typ args =
+  default_loc := obj.pexp_loc ;
+
+  (* [($obj$ : 'B Js.t)] *)
+  let cstr =
+    Exp.constraint_
+      obj
+      (js_t_id "t" [Typ.var "B"])
+  in
+
+  let x = evar "x" in
+  (* [($x$#meth : $meth_typ$)] *)
+  let body =
+    Exp.constraint_
+      (Exp.send x meth)
+      meth_typ
+  in
+
+  let res_constr = [%expr ([%e Exp.ident res] : [%t res_typ])][@metaloc res.loc] in
+  let res_bindings =
+    List.fold_right
+      (fun (e, x, t) e' ->
+         [%expr let _ = ([%e evar x] : [%t t]) in [%e e']])
+      args
+      res_constr
+  in
+  [%expr
+    let module M = struct
+      let res =
+        let _ = [%e cstr] in
+        let _ = fun (x : 'B) -> [%e body] in
+        [%e res_bindings];
+    end in M.res
+  ]
+
+
+let fresh_type loc = Typ.var ~loc @@ random_tvar ()
+
+let method_call obj meth args =
+  let args = List.map (fun e -> (e, random_var (), fresh_type obj.pexp_loc)) args in
+  let ret_type = fresh_type obj.pexp_loc in
+  let method_type =
+    List.fold_right
+      (fun (_, _, arg_ty) rem_ty -> Typ.arrow "" arg_ty rem_ty)
+      args
+      @@ js_t_id "meth" [ret_type]
+  in
+  let o = random_var () in
+  let obj' = Exp.ident ~loc:obj.pexp_loc @@ lid o in
+  let res = random_var () in
+  let meth' = unescape meth in
+  let meth_args =
+    List.map (fun (_, x, _) -> Exp.apply (js_u_id "inject") ["",evar x]) args
+  in
+  let meth_args = Exp.array meth_args in
+  List.fold_left
+    (fun e' (e, x, _) -> [%expr let [%p pvar x] = [%e e] in [%e e']])
+    [%expr
+      let [%p pvar o] = [%e obj] in
+      let [%p pvar res] =
+        [%e js_u_id "meth_call"] [%e evar o] [%e str meth'] [%e meth_args]
+      in
+      [%e constrain_types obj' (lid res) ret_type meth' method_type args]
+    ]
+    args
+
+let js_mapper _args =
+  { default_mapper with
+    expr = (fun mapper expr ->
+      default_loc := expr.pexp_loc;
+      match expr with
+
+      (** [%js obj#method] *)
+      | [%expr [%js [%e? {pexp_desc = Pexp_send (obj, meth) }]]] ->
+        let o = random_var () in
+        let obj' = Exp.ident ~loc:obj.pexp_loc @@ lid o in
+        let res = random_var () in
+        let meth' = unescape meth in
+        [%expr
+          let [%p pvar o] = [%e obj] in
+          let [%p pvar res] = [%e js_u_id "get"] [%e obj'] [%e str meth'] in
+          [%e
+            constrain_types
+              obj'
+              (lid res) [%type: 'A]
+              meth'
+              (js_t_id "gen_prop" [[%type: <get : 'A; ..> ]]) []
+          ]
+        ]
+
+      (** [%js obj#meth := value] *)
+      | [%expr [%js [%e? {pexp_desc = Pexp_send (obj, meth) }] := [%e? value]]] ->
+        let o = random_var () in
+        let obj' = Exp.ident ~loc:obj.pexp_loc @@ lid o in
+        let v = random_var () in
+        let v_lid = lid v in
+        let value' = Exp.ident ~loc:value.pexp_loc v_lid in
+        let meth' = unescape meth in
+        [%expr
+          let [%p pvar v] = [%e value] in
+          let [%p pvar o] = [%e obj] in
+          let _ = [%e
+            constrain_types
+              obj'
+              v_lid [%type: 'A]
+              meth'
+              (js_t_id "gen_prop" [[%type: <set : 'A -> unit ; ..> ]]) []
+          ]
+          in [%e js_u_id "set"] [%e obj'] [%e str meth'] [%e value']
+        ]
+
+      (** [%js obj#meth () *)
+      | [%expr [%js [%e? {pexp_desc = Pexp_send (obj, meth) }] () ]] ->
+         method_call obj meth []
+
+      (** [%js obj#meth (args,..) *)
+      | [%expr [%js [%e? {pexp_desc = Pexp_send (obj, meth) }]
+                    [%e? {pexp_desc = Pexp_tuple args}]
+               ]] ->
+         method_call obj meth args
+
+
+      | _ -> default_mapper.expr mapper expr
+    );
+    structure_item = (fun mapper stri ->
+      default_loc := stri.pstr_loc;
+      match stri with
+      | _ -> default_mapper.structure_item mapper stri);
+  }
+
+let () = run_main js_mapper

--- a/lib/ppx/ppx_js.ml
+++ b/lib/ppx/ppx_js.ml
@@ -6,11 +6,6 @@ open Parsetree
 open Ast_convenience
 
 
-let with_loc f { txt ; loc } =
-  (f txt) [@metaloc loc]
-
-
-
 let rnd = Random.State.make [|0x313511d4|]
 let random_var () =
   Format.sprintf "x%08Lx" (Random.State.int64 rnd 0x100000000L)
@@ -101,18 +96,13 @@ let constrain_types obj res res_typ meth meth_typ args =
 
 let fresh_type loc = Typ.var ~loc @@ random_tvar ()
 
-let arrows ?loc args ret =
-  List.fold_right (fun (l, ty) fun_ -> Typ.arrow ?loc l ty fun_)
+let arrows args ret =
+  List.fold_right (fun (l, ty) fun_ -> Typ.arrow l ty fun_)
     args
     ret
 
-let sequence ?loc l last =
-  match l with
-  | [] -> last
-  | h :: t ->
-    let e =
-      List.fold_left (Exp.sequence ?loc) h t
-    in Exp.sequence ?loc e last
+let sequence l last =
+  List.fold_right Exp.sequence l last
 
 let method_call obj meth args =
   let args = List.map (fun (l,e) -> (e, random_var (), (l, fresh_type obj.pexp_loc))) args in
@@ -162,8 +152,6 @@ let new_object constr args =
     : [%t obj_type] )
   ]
 
-
-let tunit () = Typ.constr (lid "unit") []
 
 module S = Map.Make(String)
 

--- a/lib/ppx/ppx_js.ml
+++ b/lib/ppx/ppx_js.ml
@@ -172,6 +172,10 @@ let js_mapper _args =
                ]] ->
          method_call obj meth args
 
+      (** [%js obj#meth arg] *)
+      | [%expr [%js [%e? {pexp_desc = Pexp_send (obj, meth) }] [%e? arg] ]] ->
+         method_call obj meth [arg]
+
 
       | _ -> default_mapper.expr mapper expr
     );

--- a/lib/ppx/ppx_js.ml
+++ b/lib/ppx/ppx_js.ml
@@ -49,7 +49,7 @@ let unescape lab =
     lab
 
 (** Constraints for the various types.
-    Synthesize new type and create dummy declaration with type constraints.
+    Synthesize new types and create dummy declaration with type constraints.
 *)
 let constrain_types obj res res_typ meth meth_typ args =
   default_loc := obj.pexp_loc ;
@@ -91,12 +91,12 @@ let fresh_type loc = Typ.var ~loc @@ random_tvar ()
 
 let method_call obj meth args =
   let args = List.map (fun e -> (e, random_var (), fresh_type obj.pexp_loc)) args in
-  let ret_type = fresh_type obj.pexp_loc in
+  let ret_type = js_t_id "meth" [fresh_type obj.pexp_loc] in
   let method_type =
     List.fold_right
       (fun (_, _, arg_ty) rem_ty -> Typ.arrow "" arg_ty rem_ty)
       args
-      @@ js_t_id "meth" [ret_type]
+      ret_type
   in
   let o = random_var () in
   let obj' = Exp.ident ~loc:obj.pexp_loc @@ lid o in
@@ -162,11 +162,11 @@ let js_mapper _args =
           in [%e js_u_id "set"] [%e obj'] [%e str meth'] [%e value']
         ]
 
-      (** [%js obj#meth () *)
+      (** [%js obj#meth ()] *)
       | [%expr [%js [%e? {pexp_desc = Pexp_send (obj, meth) }] () ]] ->
          method_call obj meth []
 
-      (** [%js obj#meth (args,..) *)
+      (** [%js obj#meth (args, ..)] *)
       | [%expr [%js [%e? {pexp_desc = Pexp_send (obj, meth) }]
                     [%e? {pexp_desc = Pexp_tuple args}]
                ]] ->

--- a/lib/ppx/ppx_js.ml
+++ b/lib/ppx/ppx_js.ml
@@ -24,7 +24,6 @@ let random_tvar () =
 
 let inside_Js = lazy
   (try
-     String.lowercase_ascii @@
      Filename.basename @@
      Filename.chop_extension !Location.input_name = "js"
    with Invalid_argument _ -> false)
@@ -36,14 +35,19 @@ module Js = struct
     then Typ.constr ?loc (lid s) args
     else Typ.constr ?loc (lid @@ "Js."^s) args
 
+(* ocaml 4.02+trunk *)  
+  let nolabel = ""
+(* ocaml 4.03 *)
+(* let nolabel = Nolabel *)
+
   let unsafe ?loc s args =
-    let args = List.map (fun x -> Nolabel,x) args in
+    let args = List.map (fun x -> nolabel,x) args in
     if Lazy.force inside_Js
     then Exp.(apply (ident ?loc @@ lid ("Unsafe."^s)) args)
     else Exp.(apply (ident ?loc @@ lid ("Js.Unsafe."^s)) args)
 
   let fun_ ?loc s args =
-    let args = List.map (fun x -> Nolabel,x) args in
+    let args = List.map (fun x -> nolabel,x) args in
     if Lazy.force inside_Js
     then Exp.(apply (ident ?loc @@ lid s) args)
     else Exp.(apply (ident ?loc @@ lid ("Js."^s)) args)

--- a/lib/ppx/ppx_js.mli
+++ b/lib/ppx/ppx_js.mli
@@ -1,0 +1,73 @@
+(** Ppx syntax extension for Js_of_ocaml. *)
+
+val js_mapper : string list -> Ast_mapper.mapper
+(**
+   A syntax extension is available for manipulating object properties,
+   invoking methods and creating objects.  The syntax and typing rules
+   are as follows:
+
+   {ul
+   {- Getting a property
+   {[
+obj : <m : u Js.prop> Js.t
+--------------------------
+     obj##.m : u
+   ]}
+   }
+   {- Setting a property
+   {[
+obj : <m : u Js.prop> Js.t
+  e : u
+--------------------------
+  obj##.m := e : unit
+   ]}
+   }
+   {- Invoking a method
+   {[
+obj : <m : t_1 -> ... -> t_n -> u Js.meth; ..> Js.t
+e_i : t_i               (1 <= i <= n)
+----------------------------------------------------
+        obj##m e_1 ... e_n : u
+   ]}
+   For easier chaining, the following alternative syntax is also possible:
+   [ obj##(m e_1 ... e_n) ].
+
+   Beware, partial application is not allowed.
+   }
+   {- Using an object constructor
+   {[
+constr : (t_1 -> ... -> t_n -> u Js.t) Js.constr
+   e_i : t_i               (1 <= i <= n)
+------------------------------------------------
+          new%js constr e1 ... en : u
+   ]}
+   [ constr ] here must be an identifier. For constructors
+   that are not identifiers, bind them first:
+   {[
+let a = Js.Unsafe.global##.A in
+new%js a
+   ]}
+   }
+   {- Creating a literal object
+   {[
+object%js (self) (* Equivalent of this *)
+  val x = 3 (* read-only prop *)
+  val mutable y = 4 (* read/write prop *)
+  method foo i = self##.y := self##.x + i
+end
+   ]}
+   Properties are defined with the [val] keyword. [mutable] makes the
+   property writable. [self] can be any identifier and will be bind
+   to [this] in javascript.
+
+   In this case, the object has the following type:
+   {[
+< foo : int -> unit Js.meth;
+    x : int Js.readonly_prop;
+    y : int Js.prop
+> Js.t
+   ]}
+   }
+   }
+
+*)

--- a/lib/ppx/ppx_js_bin.ml
+++ b/lib/ppx/ppx_js_bin.ml
@@ -1,0 +1,2 @@
+
+let () = Ast_mapper.run_main Ppx_js.js_mapper

--- a/opam
+++ b/opam
@@ -18,6 +18,7 @@ depends: [
   "cppo"
   "camlp4"
   "base64"
+  ( "base-no-ppx" | "ppx_tools" )
 ]
 depopts: ["deriving" "tyxml" "reactiveData" ]
 

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,2 +1,3 @@
 *.js
 *.log
+*.result

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -10,9 +10,11 @@ ifeq "${WITH_PPX}" "YES"
 TESTS_PPX=$(patsubst ppx/%.ml,ppx/test_%,$(wildcard ppx/*.ml))
 endif
 
+TESTS_CAMLP4=$(patsubst camlp4/%.ml,camlp4/test_%,$(wildcard camlp4/*.ml))
+
 COMMON=common.cmo
 
-all: $(COMMON) $(TESTS_CMO) $(TESTS_BYTE) $(TESTS_JS) tests.byte $(TESTS_PPX)
+all: $(COMMON) $(TESTS_CMO) $(TESTS_BYTE) $(TESTS_JS) tests.byte $(TESTS_PPX) $(TESTS_CAMLP4)
 
 phantom_check::
 	@which phantomjs || (echo "You need phantomjs in your PATH to run this" && false)
@@ -29,11 +31,19 @@ tests.byte: $(TESTS_CMO) $(COMMON)
 	@(phantomjs $^ > $@ && head -n 1 $@) || (echo "Error for " $^ "\n" && mv $@ $@.err && cat $@.err)
 
 clean:
-	rm -f *.cm[io] *.byte *.js dir/*.cm[io] dir/*.byte dir/*.js dir/*.log ppx/*.cm[io] ppx/*.result
-
+	rm -f *.cm[io] *.byte *.js dir/*.cm[io] dir/*.byte dir/*.js dir/*.log
+	rm -f ppx/*.cm[io] ppx/*.result
+	rm -f camlp4/*.cm[io] camlp4/*.result
 
 ppx/%.result: ppx/%.ml
 	TERM=dumb ocaml -noprompt -I ../lib -ppx ../lib/ppx/ppx_js < $< | tail -n +2 > $@
 
 ppx/test_%: ppx/%.result ppx/%.expected
 	diff $?
+
+
+camlp4/%.result: camlp4/%.ml
+	TERM=dumb ocaml -noprompt -I ../lib -init camlp4_init.ml < $< | tail -n +13 > $@
+
+camlp4/test_%: camlp4/%.result camlp4/%.expected
+	diff $? || true

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -6,9 +6,13 @@ TESTS_BYTE=$(TESTS_SRC:.ml=.byte)
 TESTS_JS=$(TESTS_SRC:.ml=.js)
 TESTS_LOG=$(TESTS_SRC:.ml=.log)
 
+ifeq "${WITH_PPX}" "YES"
+TESTS_PPX=$(patsubst ppx/%.ml,ppx/test_%,$(wildcard ppx/*.ml))
+endif
+
 COMMON=common.cmo
 
-all: $(COMMON) $(TESTS_CMO) $(TESTS_BYTE) $(TESTS_JS) tests.byte
+all: $(COMMON) $(TESTS_CMO) $(TESTS_BYTE) $(TESTS_JS) tests.byte $(TESTS_PPX)
 
 phantom_check::
 	@which phantomjs || (echo "You need phantomjs in your PATH to run this" && false)
@@ -25,4 +29,11 @@ tests.byte: $(TESTS_CMO) $(COMMON)
 	@(phantomjs $^ > $@ && head -n 1 $@) || (echo "Error for " $^ "\n" && mv $@ $@.err && cat $@.err)
 
 clean:
-	rm -f *.cm[io] *.byte *.js dir/*.cm[io] dir/*.byte dir/*.js dir/*.log
+	rm -f *.cm[io] *.byte *.js dir/*.cm[io] dir/*.byte dir/*.js dir/*.log ppx/*.cm[io] ppx/*.result
+
+
+ppx/%.result: ppx/%.ml
+	TERM=dumb ocaml -noprompt -I ../lib -ppx ../lib/ppx/ppx_js < $< | tail -n +2 > $@
+
+ppx/test_%: ppx/%.result ppx/%.expected
+	diff $?

--- a/tests/camlp4/meth.expected
+++ b/tests/camlp4/meth.expected
@@ -1,0 +1,39 @@
+
+Characters 40-43:
+  fun (obj : int) -> obj##m
+                     ^^^
+Error: This expression has type int but an expression was expected of type
+         < .. > Js.t
+Characters 25-28:
+  fun (obj : < > Js.t) -> obj##m
+                          ^^^
+Error: This expression has type <  >
+       It has no method m
+Characters 43-49:
+  fun (obj : < m : float Js.prop > Js.t) -> obj##m
+                                            ^^^^^^
+Error: This expression has type
+         float Js.prop = < get : float; set : float -> unit > Js.gen_prop
+       but an expression was expected of type 'jsoo_32b5ee21 Js.meth
+Characters 43-49:
+  fun (obj : < m : float Js.meth > Js.t) -> obj##m + 1
+                                            ^^^^^^
+Error: This expression has type float but an expression was expected of type
+         int
+Characters 48-54:
+  fun (obj : < m : int -> int Js.meth > Js.t) -> obj##m + 1
+                                                 ^^^^^^
+Error: This expression has type int -> int Js.meth
+       but an expression was expected of type 'jsoo_32b5ee21 Js.meth
+Characters 41-47:
+  fun (obj : < m : int Js.meth > Js.t) -> obj##m 1
+                                          ^^^^^^
+Error: This expression has type int Js.meth
+       but an expression was expected of type
+         'jsoo_173316d7 -> 'jsoo_29529091 Js.meth
+Characters 50-58:
+  fun (obj : < m : int -> float Js.meth > Js.t) -> obj##m 1 + 1
+                                                   ^^^^^^^^
+Error: This expression has type float but an expression was expected of type
+         int
+

--- a/tests/camlp4/meth.ml
+++ b/tests/camlp4/meth.ml
@@ -1,0 +1,30 @@
+(* dummy "let _ = 3" are to work arround ... camlp4 weirdness I guess *)
+(* Test methods. *)
+
+let x1 = fun (obj : int) -> obj##m();;
+
+let _ = 3;; let _ = 3;;
+
+let x2 = fun (obj : < > Js.t) -> obj##m();;
+
+let _ = 3;; let _ = 3;;
+
+let x3 = fun (obj : < m : float Js.prop > Js.t) -> obj##m();;
+
+let _ = 3;; let _ = 3;;
+
+let x4 = fun (obj : < m : float Js.meth > Js.t) -> obj##m() + 1;;
+
+let _ = 3;; let _ = 3;;
+
+let x5 = fun (obj : < m : int -> int Js.meth > Js.t) -> obj##m() + 1;;
+
+let _ = 3;; let _ = 3;;
+
+let x6 = fun (obj : < m : int Js.meth > Js.t) -> obj##m(1);;
+
+let _ = 3;; let _ = 3;;
+
+let x7 = fun (obj : < m : int -> float Js.meth > Js.t) -> obj##m(1) + 1;;
+
+let _ = 3;; let _ = 3;;

--- a/tests/camlp4/prop.expected
+++ b/tests/camlp4/prop.expected
@@ -1,0 +1,25 @@
+
+Characters 45-48:
+  fun (obj : int) -> obj##.p
+                     ^^^
+Error: This expression has type int but an expression was expected of type
+         < .. > Js.t
+Characters 25-28:
+  fun (obj : < > Js.t) -> obj##.p
+                          ^^^
+Error: This expression has type <  >
+       It has no method p
+Characters 53-60:
+  fun (obj : < p : float Js.writeonly_prop > Js.t) -> obj##.p + 1
+                                                      ^^^^^^^
+Error: This expression has type
+         float Js.writeonly_prop = < set : float -> unit > Js.gen_prop
+       but an expression was expected of type
+         < get : 'jsoo_res; .. > Js.gen_prop
+       The first object type has no method get
+Characters 43-50:
+  fun (obj : < p : float Js.prop > Js.t) -> obj##.p + 1
+                                            ^^^^^^^
+Error: This expression has type float but an expression was expected of type
+         int
+

--- a/tests/camlp4/prop.ml
+++ b/tests/camlp4/prop.ml
@@ -1,0 +1,19 @@
+(* dummy "let _ = 3" are to work arround ... camlp4 weirdness I guess *)
+(* Test prop reading. *)
+
+let x1 = fun (obj : int) -> obj##p;;
+
+let _ = 3;; let _ = 3;;
+
+let x2 = fun (obj : < > Js.t) -> obj##p;;
+
+let _ = 3;; let _ = 3;;
+
+let x3 = fun (obj : < p : float Js.writeonly_prop > Js.t) -> obj##p + 1;;
+
+let _ = 3;; let _ = 3;;
+
+let x4 = fun (obj : < p : float Js.prop > Js.t) -> obj##p + 1;;
+
+let _ = 3;; let _ = 3;;
+

--- a/tests/camlp4/write_prop.expected
+++ b/tests/camlp4/write_prop.expected
@@ -1,0 +1,30 @@
+
+Characters 45-48:
+  fun (obj : int) -> obj##.p := 2
+                     ^^^
+Error: This expression has type int but an expression was expected of type
+         < .. > Js.t
+Characters 25-28:
+  fun (obj : < > Js.t) -> obj##.p := 2
+                          ^^^
+Error: This expression has type <  >
+       It has no method p
+Characters 52-59:
+  fun (obj : < p : float Js.readonly_prop > Js.t) -> obj##.p := 1
+                                                     ^^^^^^^
+Error: This expression has type
+         float Js.readonly_prop = < get : float > Js.gen_prop
+       but an expression was expected of type
+         < set : 'jsoo_arg -> unit; .. > Js.gen_prop
+       The first object type has no method set
+Characters 54-55:
+  fun (obj : < p : float Js.prop > Js.t) -> obj##.p := 1
+                                                       ^
+Error: This expression has type int but an expression was expected of type
+         float
+Characters 41-55:
+  fun (obj : < p : int Js.prop > Js.t) -> (obj##.p := 1) + 1
+                                          ^^^^^^^^^^^^^^
+Error: This expression has type unit but an expression was expected of type
+         int
+

--- a/tests/camlp4/write_prop.ml
+++ b/tests/camlp4/write_prop.ml
@@ -1,0 +1,22 @@
+(* dummy "let _ = 3" are to work arround ... camlp4 weirdness I guess *)
+(* Test prop writing. *)
+
+let x1 = fun (obj : int) -> obj##p <- 2;;
+
+let _ = 3;; let _ = 3;;
+
+let x2 = fun (obj : < > Js.t) -> obj##p <- 2;;
+
+let _ = 3;; let _ = 3;;
+
+let x3 = fun (obj : < p : float Js.readonly_prop > Js.t) -> obj##p <- 1;;
+
+let _ = 3;; let _ = 3;;
+
+let x4 = fun (obj : < p : float Js.prop > Js.t) -> obj##p <- 1;;
+
+let _ = 3;; let _ = 3;;
+
+let x5 = fun (obj : < p : int Js.prop > Js.t) -> (obj##p <- 1) + 1;;
+
+let _ = 3;; let _ = 3;;

--- a/tests/camlp4_init.ml
+++ b/tests/camlp4_init.ml
@@ -1,0 +1,3 @@
+#use "topfind";;
+#camlp4o;;
+#load "../lib/syntax/pa_js.cmo";;

--- a/tests/ppx/meth.expected
+++ b/tests/ppx/meth.expected
@@ -1,0 +1,39 @@
+
+Characters 40-43:
+  fun (obj : int) -> obj##m
+                     ^^^
+Error: This expression has type int but an expression was expected of type
+         < .. > Js.t
+Characters 25-28:
+  fun (obj : < > Js.t) -> obj##m
+                          ^^^
+Error: This expression has type <  >
+       It has no method m
+Characters 43-49:
+  fun (obj : < m : float Js.prop > Js.t) -> obj##m
+                                            ^^^^^^
+Error: This expression has type
+         float Js.prop = < get : float; set : float -> unit > Js.gen_prop
+       but an expression was expected of type 'jsoo_32b5ee21 Js.meth
+Characters 43-49:
+  fun (obj : < m : float Js.meth > Js.t) -> obj##m + 1
+                                            ^^^^^^
+Error: This expression has type float but an expression was expected of type
+         int
+Characters 48-54:
+  fun (obj : < m : int -> int Js.meth > Js.t) -> obj##m + 1
+                                                 ^^^^^^
+Error: This expression has type int -> int Js.meth
+       but an expression was expected of type 'jsoo_32b5ee21 Js.meth
+Characters 41-47:
+  fun (obj : < m : int Js.meth > Js.t) -> obj##m 1
+                                          ^^^^^^
+Error: This expression has type int Js.meth
+       but an expression was expected of type
+         'jsoo_173316d7 -> 'jsoo_29529091 Js.meth
+Characters 50-58:
+  fun (obj : < m : int -> float Js.meth > Js.t) -> obj##m 1 + 1
+                                                   ^^^^^^^^
+Error: This expression has type float but an expression was expected of type
+         int
+

--- a/tests/ppx/meth.ml
+++ b/tests/ppx/meth.ml
@@ -1,0 +1,22 @@
+(* Test methods. *)
+
+fun (obj : int) -> obj##m
+;;
+
+fun (obj : < > Js.t) -> obj##m
+;;
+
+fun (obj : < m : float Js.prop > Js.t) -> obj##m
+;;
+
+fun (obj : < m : float Js.meth > Js.t) -> obj##m + 1
+;;
+
+fun (obj : < m : int -> int Js.meth > Js.t) -> obj##m + 1
+;;
+
+fun (obj : < m : int Js.meth > Js.t) -> obj##m 1
+;;
+
+fun (obj : < m : int -> float Js.meth > Js.t) -> obj##m 1 + 1
+;;

--- a/tests/ppx/prop.expected
+++ b/tests/ppx/prop.expected
@@ -1,0 +1,25 @@
+
+Characters 45-48:
+  fun (obj : int) -> obj##.p
+                     ^^^
+Error: This expression has type int but an expression was expected of type
+         < .. > Js.t
+Characters 25-28:
+  fun (obj : < > Js.t) -> obj##.p
+                          ^^^
+Error: This expression has type <  >
+       It has no method p
+Characters 53-60:
+  fun (obj : < p : float Js.writeonly_prop > Js.t) -> obj##.p + 1
+                                                      ^^^^^^^
+Error: This expression has type
+         float Js.writeonly_prop = < set : float -> unit > Js.gen_prop
+       but an expression was expected of type
+         < get : 'jsoo_res; .. > Js.gen_prop
+       The first object type has no method get
+Characters 43-50:
+  fun (obj : < p : float Js.prop > Js.t) -> obj##.p + 1
+                                            ^^^^^^^
+Error: This expression has type float but an expression was expected of type
+         int
+

--- a/tests/ppx/prop.ml
+++ b/tests/ppx/prop.ml
@@ -1,0 +1,13 @@
+(* Test prop reading. *)
+
+fun (obj : int) -> obj##.p
+;;
+
+fun (obj : < > Js.t) -> obj##.p
+;;
+
+fun (obj : < p : float Js.writeonly_prop > Js.t) -> obj##.p + 1
+;;
+
+fun (obj : < p : float Js.prop > Js.t) -> obj##.p + 1
+;;

--- a/tests/ppx/write_prop.expected
+++ b/tests/ppx/write_prop.expected
@@ -1,0 +1,30 @@
+
+Characters 45-48:
+  fun (obj : int) -> obj##.p := 2
+                     ^^^
+Error: This expression has type int but an expression was expected of type
+         < .. > Js.t
+Characters 25-28:
+  fun (obj : < > Js.t) -> obj##.p := 2
+                          ^^^
+Error: This expression has type <  >
+       It has no method p
+Characters 52-59:
+  fun (obj : < p : float Js.readonly_prop > Js.t) -> obj##.p := 1
+                                                     ^^^^^^^
+Error: This expression has type
+         float Js.readonly_prop = < get : float > Js.gen_prop
+       but an expression was expected of type
+         < set : 'jsoo_arg -> unit; .. > Js.gen_prop
+       The first object type has no method set
+Characters 54-55:
+  fun (obj : < p : float Js.prop > Js.t) -> obj##.p := 1
+                                                       ^
+Error: This expression has type int but an expression was expected of type
+         float
+Characters 41-55:
+  fun (obj : < p : int Js.prop > Js.t) -> (obj##.p := 1) + 1
+                                          ^^^^^^^^^^^^^^
+Error: This expression has type unit but an expression was expected of type
+         int
+

--- a/tests/ppx/write_prop.ml
+++ b/tests/ppx/write_prop.ml
@@ -1,0 +1,16 @@
+(* Test prop writing. *)
+
+fun (obj : int) -> obj##.p := 2
+;;
+
+fun (obj : < > Js.t) -> obj##.p := 2
+;;
+
+fun (obj : < p : float Js.readonly_prop > Js.t) -> obj##.p := 1
+;;
+
+fun (obj : < p : float Js.prop > Js.t) -> obj##.p := 1
+;;
+
+fun (obj : < p : int Js.prop > Js.t) -> (obj##.p := 1) + 1
+;;


### PR DESCRIPTION
Should not be merged, the syntax is not the final one (waiting for ocaml here).

It's feature-par with the camlp4 one, plus object literals with optional fields.

 - `obj##.field` for field access
 - `obj##.field := x` for field modification
 - `obj##meth arg1 arg2 arg3` for method calls
 - `obj##meth` for method calls without arguments
 - `new%js constructor` for prototype instanciation.
 - `object%js ... end` for literal objects. `[@@optional]` to make the field optional.

What remains to do:

 - Automatic generation of literal object's type (especially wrt to optional fields).
 - (DONE) Use the mutable annotation in object literals to choose between `readonly_prop` and `prop`.
 - Clean up and factorize the code some more.
 - Document.
 - Test error locations.
 - Solve the "fresh name" issue. I'm not fond of the fixed seed prng solution.

cc @whitequark @alainfrisch