### PR TITLE
Refactor JavaScript parser

### DIFF
--- a/compiler/js_parser.mly
+++ b/compiler/js_parser.mly
@@ -598,15 +598,15 @@ element_list_rev:
  |            assignment_expression { [Some $1] }
  | element_list_rev elison assignment_expression { (Some $3) :: (List.rev_append $2 $1) }
 
-separated_nonempty_list2(sep,X):
+separated_or_terminated_list(sep, X):
  | x=X { [x] }
  | x=X; sep { [x] }
- | x=X; sep; xs=separated_nonempty_list2(sep, X) { x :: xs }
+ | x=X; sep; xs=separated_or_terminated_list(sep, X) { x :: xs }
 
 object_literal:
  | res=curly_block(empty) { (fst (snd res), J.EObj []) }
  | res=curly_block(
-     separated_nonempty_list2(
+     separated_or_terminated_list(
        T_COMMA,
        separated_pair(property_name,T_COLON,assignment_expression)
      ))  { (fst (snd res), J.EObj (fst res)) }

--- a/compiler/js_parser.mly
+++ b/compiler/js_parser.mly
@@ -152,7 +152,7 @@ source_element:
      { let (f, loc) = f in (J.Function_declaration f, loc) }
 
 source_elements:
- | l=list(source_element) { l }
+ | l=source_element* { l }
 
 (*************************************************************************)
 (* 1 statement                                                           *)
@@ -225,11 +225,8 @@ semicolon:
 labeled_statement:
 | l=label T_COLON s=statement { (J.Labelled_statement (l, s), J.N) }
 
-statement_list:
- | l=list(statement) {l}
-
 block_with_pi:
- | l=curly_block(statement_list) { (fst l, fst (snd l)) }
+ | l=curly_block(statement*) { (fst l, fst (snd l)) }
 
 block:
  | block_with_pi { fst $1 }
@@ -305,7 +302,7 @@ with_statement:
 switch_statement:
  | pi=T_SWITCH T_LPAREN e=expression T_RPAREN
     b=curly_block(
-    pair(list(case_clause),option(pair(default_clause,list(case_clause)))))
+    pair(case_clause*, option(pair(default_clause, case_clause*))))
     {
       let (l, d, l') =
         match fst b with
@@ -332,10 +329,10 @@ finally:
 (*----------------------------*)
 
 case_clause:
- | T_CASE e=expression T_COLON l=statement_list { e,l }
+ | T_CASE e=expression T_COLON l=statement* { e,l }
 
 default_clause:
- | T_DEFAULT T_COLON l=statement_list { l }
+ | T_DEFAULT T_COLON l=statement* { l }
 
 (*************************************************************************)
 (* 1 function declaration                                                *)
@@ -593,6 +590,7 @@ array_literal:
 
 element_list:
  | element_list_rev { List.rev $1 }
+
 element_list_rev:
  | elison_rev assignment_expression { (Some $2)::$1 }
  |            assignment_expression { [Some $1] }

--- a/compiler/js_parser.mly
+++ b/compiler/js_parser.mly
@@ -32,7 +32,6 @@
 module J = Javascript
 open Js_token
 
-let bop op a b= J.EBin(op,a,b)
 let uop op a = J.EUn(op,a)
 let var name = J.S {J.name;J.var=None}
 
@@ -400,7 +399,7 @@ post_in_expression:
  | left=post_in_expression
    op=comparison_or_logical_or_bit_operator
    right=post_in_expression
-   { bop op left right }
+   { J.EBin (op, left, right) }
 
 pre_in_expression:
  | left_hand_side_expression
@@ -434,7 +433,7 @@ pre_in_expression:
  | left=pre_in_expression
    op=arithmetic_or_shift_operator
    right=pre_in_expression
-   { bop op left right }
+   { J.EBin (op, left, right) }
 
 call_expression:
  | member_expression arguments
@@ -503,7 +502,7 @@ post_in_expression_no_in:
  | left=post_in_expression_no_in
    op=comparison_or_logical_or_bit_operator_except_in
    right=post_in_expression
-   { bop op left right}
+   { J.EBin (op, left, right) }
 
 (*----------------------------*)
 (* 2 (no statement)           *)
@@ -530,7 +529,7 @@ post_in_expression_no_statement:
  | left=post_in_expression_no_statement
    op=comparison_or_logical_or_bit_operator
    right=post_in_expression
-   { bop op left right }
+   { J.EBin (op, left, right) }
 
 pre_in_expression_no_statement:
  | left_hand_side_expression_no_statement
@@ -564,7 +563,7 @@ pre_in_expression_no_statement:
  | left=pre_in_expression_no_statement
    op=arithmetic_or_shift_operator
    right=pre_in_expression
-   { bop op left right }
+   { J.EBin (op, left, right) }
 
 left_hand_side_expression_no_statement:
  | new_expression_no_statement { snd $1 }

--- a/compiler/js_parser.mly
+++ b/compiler/js_parser.mly
@@ -36,26 +36,26 @@ let bop op a b= J.EBin(op,a,b)
 let uop op a = J.EUn(op,a)
 let var name = J.S {J.name;J.var=None}
 
-(* this is need to fake menhir while using --infer *)
+(* This is need to fake menhir while using `--infer`. *)
 let _tok = EOF Parse_info.zero
 
 %}
 
-/*(*************************************************************************)*/
-/*(*1 Tokens *)*/
-/*(*************************************************************************)*/
+(*************************************************************************)
+(* 1 Tokens                                                              *)
+(*************************************************************************)
 
-/*(*-----------------------------------------*)*/
-/*(*2 the normal tokens *)*/
-/*(*-----------------------------------------*)*/
+(*-----------------------------------------*)
+(* 2 the normal tokens                     *)
+(*-----------------------------------------*)
 
-/*(* tokens with a value *)*/
+(* Tokens with a value *)
 %token<string * float * Parse_info.t> T_NUMBER
 %token<string * Parse_info.t> T_IDENTIFIER
 %token<string * Parse_info.t> T_STRING
 %token<string * Parse_info.t> T_REGEX
 
-/*(* keywords tokens *)*/
+(* Keywords tokens *)
 %token <Parse_info.t>
 T_FUNCTION T_IF T_RETURN T_SWITCH T_THIS T_THROW T_TRY
 T_VAR T_WHILE T_WITH T_NULL T_FALSE T_TRUE
@@ -66,7 +66,7 @@ T_DEBUGGER
 
 %token <Parse_info.t> T_NEW
 
-/*(* syntax *)*/
+(* Syntax *)
 %token <Parse_info.t>
 T_LCURLY T_RCURLY
 T_LPAREN T_RPAREN
@@ -75,7 +75,7 @@ T_SEMICOLON
 T_COMMA
 T_PERIOD
 
-/*(* operators *)*/
+(* Operators *)
 %token <Parse_info.t>
 T_RSHIFT3_ASSIGN T_RSHIFT_ASSIGN T_LSHIFT_ASSIGN
 T_BIT_XOR_ASSIGN T_BIT_OR_ASSIGN T_BIT_AND_ASSIGN T_MOD_ASSIGN T_DIV_ASSIGN
@@ -96,21 +96,21 @@ T_PLUS T_MINUS
 T_DIV T_MULT T_MOD
 T_NOT T_BIT_NOT T_INCR T_DECR T_INCR_NB T_DECR_NB T_DELETE T_TYPEOF T_VOID
 
-/*(*-----------------------------------------*)*/
-/*(*2 extra tokens: *)*/
-/*(*-----------------------------------------*)*/
+(*-----------------------------------------*)
+(* 2 extra tokens:                         *)
+(*-----------------------------------------*)
 
 %token <Parse_info.t> T_VIRTUAL_SEMICOLON
 
-/*(* classic *)*/
+(* classic *)
 %token <Parse_info.t> EOF
 
-/*(*-----------------------------------------*)*/
-/*(*2 priorities *)*/
-/*(*-----------------------------------------*)*/
+(*-----------------------------------------*)
+(* 2 priorities                            *)
+(*-----------------------------------------*)
 
 
-/*(* Special if / else associativity*)*/
+(* Special if / else associativity*)
 %nonassoc p_IF
 %nonassoc T_ELSE
 
@@ -128,18 +128,18 @@ T_IN T_INSTANCEOF
 %left T_DIV T_MULT T_MOD
 %right T_NOT T_BIT_NOT T_INCR T_DECR T_INCR_NB T_DECR_NB T_DELETE T_TYPEOF T_VOID
 
-/*(*************************************************************************)*/
-/*(*1 Rules type declaration *)*/
-/*(*************************************************************************)*/
+(*************************************************************************)
+(* 1 Rules type declaration                                              *)
+(*************************************************************************)
 
 %start <Javascript.program> program
 %start <Javascript.expression> standalone_expression
 
 %%
 
-/*(*************************************************************************)*/
-/*(*1 Toplevel *)*/
-/*(*************************************************************************)*/
+(*************************************************************************)
+(* 1 Toplevel                                                            *)
+(*************************************************************************)
 
 program:
  | l=source_elements EOF { l }
@@ -155,9 +155,10 @@ source_element:
 
 source_elements:
  | l=list(source_element) { l }
-/*(*************************************************************************)*/
-/*(*1 statement *)*/
-/*(*************************************************************************)*/
+
+(*************************************************************************)
+(* 1 statement                                                           *)
+(*************************************************************************)
 
 statement_no_semi:
  | b=block_with_pi { (J.Block (fst b), J.Pi (snd b)) }
@@ -165,7 +166,6 @@ statement_no_semi:
  (* | function_declaration { *)
  (*  let var,params,body,_ = $1 in *)
  (*  J.Variable_statement [var,Some (J.EFun((None,params,body),None))]} *)
-
  | s=if_statement         { s }
  | s=iteration_statement  { s }
  | s=with_statement       { s }
@@ -173,7 +173,6 @@ statement_no_semi:
  | s=try_statement        { s }
  | s=labeled_statement    { s }
  | s=empty_statement      { s }
-
 
 statement_need_semi:
  | variable_statement   { $1 }
@@ -247,7 +246,6 @@ variable_declaration:
 initializeur:
  | T_ASSIGN assignment_expression { $2, J.Pi $1 }
 
-
 empty_statement:
  | pi=T_SEMICOLON { (J.Empty_statement, J.Pi pi) }
 
@@ -256,7 +254,6 @@ debugger_statement:
 
 expression_statement:
  | expression_no_statement { (J.Expression_statement $1, J.N) }
-
 
 if_statement:
  | pi=T_IF T_LPAREN i=expression T_RPAREN t=statement T_ELSE e=statement
@@ -267,7 +264,6 @@ if_statement:
 do_while_statement:
   | pi=T_DO statement T_WHILE T_LPAREN expression T_RPAREN
     { (J.Do_while_statement ($2, $5), J.Pi pi) }
-
 
 iteration_statement:
  | pi=T_WHILE T_LPAREN expression T_RPAREN statement
@@ -296,7 +292,6 @@ variable_declaration_no_in:
 initializer_no_in:
  | T_ASSIGN assignment_expression_no_in { $2, J.Pi $1 }
 
-
 continue_statement:
  | pi=T_CONTINUE option(label) { (J.Continue_statement $2,J.Pi pi) }
 
@@ -324,22 +319,19 @@ switch_statement:
 throw_statement:
  | pi=T_THROW expression { (J.Throw_statement $2, J.Pi pi) }
 
-
 try_statement:
  | pi=T_TRY block catch option(finally) { (J.Try_statement ($2, Some $3, $4), J.Pi pi) }
  | pi=T_TRY block       finally { (J.Try_statement ($2, None, Some $3), J.Pi pi) }
 
-
 catch:
  | T_CATCH T_LPAREN variable T_RPAREN block { $3, $5 }
-
 
 finally:
  | T_FINALLY block { $2 }
 
-/*(*----------------------------*)*/
-/*(*2 auxillary statements *)*/
-/*(*----------------------------*)*/
+(*----------------------------*)
+(* 2 auxillary statements     *)
+(*----------------------------*)
 
 case_clause:
  | T_CASE e=expression T_COLON l=statement_list { e,l }
@@ -347,15 +339,14 @@ case_clause:
 default_clause:
  | T_DEFAULT T_COLON l=statement_list { l }
 
-/*(*************************************************************************)*/
-/*(*1 function declaration *)*/
-/*(*************************************************************************)*/
+(*************************************************************************)
+(* 1 function declaration                                                *)
+(*************************************************************************)
 
 function_declaration:
  | pi=T_FUNCTION v=variable T_LPAREN args=separated_list(T_COMMA,variable) T_RPAREN
      b=curly_block(function_body)
      { ((v, args, fst b, J.Pi (snd (snd b))), J.Pi pi) }
-
 
 function_expression:
  | pi=T_FUNCTION v=option(variable)
@@ -366,9 +357,9 @@ function_expression:
 function_body:
  | l=source_elements  { l }
 
-/*(*************************************************************************)*/
-/*(*1 expression *)*/
-/*(*************************************************************************)*/
+(*************************************************************************)
+(* 1 expression                                                          *)
+(*************************************************************************)
 
 expression:
  | assignment_expression { $1 }
@@ -482,14 +473,15 @@ primary_expression_no_statement:
  | b=boolean_literal { b }
  | numeric_literal   { let (start, n) = $1 in (start, J.ENum n) }
  | string_literal    { let (s, start) = $1 in (start, J.EStr (s, `Utf8)) }
- /*(* marcel: this isn't an expansion of literal in ECMA-262... mistake? *)*/
+   (* marcel: this isn't an expansion of literal in ECMA-262... mistake? *)
  | r=regex_literal                { r }
  | a=array_literal                { a }
  | pi=T_LPAREN e=expression T_RPAREN { (pi, e) }
 
-/*(*----------------------------*)*/
-/*(*2 no in *)*/
-/*(*----------------------------*)*/
+(*----------------------------*)
+(* 2 no in                    *)
+(*----------------------------*)
+
 expression_no_in:
  | assignment_expression_no_in { $1 }
  | expression_no_in T_COMMA assignment_expression_no_in { J.ESeq ($1, $3) }
@@ -512,9 +504,11 @@ post_in_expression_no_in:
    op=comparison_or_logical_or_bit_operator_except_in
    right=post_in_expression
    { bop op left right}
-/*(*----------------------------*)*/
-/*(*2 (no statement)*)*/
-/*(*----------------------------*)*/
+
+(*----------------------------*)
+(* 2 (no statement)           *)
+(*----------------------------*)
+
 expression_no_statement:
  | assignment_expression_no_statement { $1 }
  | expression_no_statement T_COMMA assignment_expression { J.ESeq($1,$3) }
@@ -530,7 +524,6 @@ conditional_expression_no_statement:
      T_PLING assignment_expression
      T_COLON assignment_expression
      { J.ECond ($1, $3, $5) }
-
 
 post_in_expression_no_statement:
  | pre_in_expression_no_statement { $1 }
@@ -601,9 +594,10 @@ member_expression_no_statement:
  | pi=T_NEW e=member_expression a=arguments
    { (pi, J.ENew(snd e,Some a)) }
 
-/*(*----------------------------*)*/
-/*(*2 scalar *)*/
-/*(*----------------------------*)*/
+(*----------------------------*)
+(* 2 scalar                   *)
+(*----------------------------*)
+
 null_literal:
  | pi=T_NULL { (pi, J.EVar (var "null")) }
 
@@ -631,9 +625,9 @@ regex_literal:
 string_literal:
  | str=T_STRING { str }
 
-/*(*----------------------------*)*/
-/*(*2 array *)*/
-/*(*----------------------------*)*/
+(*----------------------------*)
+(* 2 array                    *)
+(*----------------------------*)
 
 array_literal:
  | pi=T_LBRACKET elison T_RBRACKET
@@ -645,7 +639,6 @@ array_literal:
  | pi=T_LBRACKET element_list_rev elison_rev T_RBRACKET
      { (pi, J.EArr (List.rev_append $2 (List.rev $3))) }
 
-
 element_list:
  | element_list_rev { List.rev $1 }
 element_list_rev:
@@ -653,12 +646,10 @@ element_list_rev:
  |            assignment_expression { [Some $1] }
  | element_list_rev elison assignment_expression { (Some $3) :: (List.rev_append $2 $1) }
 
-
-
 separated_nonempty_list2(sep,X):
- | x = X { [ x ] }
- | x = X; sep { [ x ] }
- | x = X; sep; xs = separated_nonempty_list2(sep, X) { x :: xs }
+ | x=X { [x] }
+ | x=X; sep { [x] }
+ | x=X; sep; xs=separated_nonempty_list2(sep, X) { x :: xs }
 
 object_literal:
  | res=curly_block(empty) { (fst (snd res), J.EObj []) }
@@ -671,28 +662,29 @@ object_literal:
 empty:
  | {}
 
-/*(*----------------------------*)*/
-/*(*2 variable *)*/
-/*(*----------------------------*)*/
+(*----------------------------*)
+(* 2 variable                 *)
+(*----------------------------*)
 
-/*(*----------------------------*)*/
-/*(*2 function call *)*/
-/*(*----------------------------*)*/
+(*----------------------------*)
+(* 2 function call            *)
+(*----------------------------*)
 
 arguments:
  | T_LPAREN l=separated_list(T_COMMA,assignment_expression) T_RPAREN { l }
 
-/*(*----------------------------*)*/
-/*(*2 auxillary bis *)*/
-/*(*----------------------------*)*/
+(*----------------------------*)
+(* 2 auxillary bis            *)
+(*----------------------------*)
 
-/*(*************************************************************************)*/
-/*(*1 Entities, names *)*/
-/*(*************************************************************************)*/
+(*************************************************************************)
+(* 1 Entities, names                                                     *)
+(*************************************************************************)
+
 identifier:
  | T_IDENTIFIER { fst $1  }
 
-/*(* should some keywork be allowed for field_name and method_name ??*)*/
+(* should some keywork be allowed for field_name and method_name ??*)
 field_name:
  | T_IDENTIFIER { fst $1 }
 method_name:
@@ -712,9 +704,9 @@ property_name:
  | s=string_literal  { J.PNS (fst s) }
  | n=numeric_literal { J.PNN (snd n) }
 
-/*(*************************************************************************)*/
-/*(*1 xxx_opt, xxx_list *)*/
-/*(*************************************************************************)*/
+(*************************************************************************)
+(* 1 xxx_opt, xxx_list                                                   *)
+(*************************************************************************)
 
 elison_rev:
  | T_COMMA { [] }
@@ -726,9 +718,9 @@ elison: elison_rev {$1}
 curly_block(X):
  | pi1=T_LCURLY x=X pi2=T_RCURLY { (x, (pi1, pi2)) }
 
-/*(*----------------------------*)*/
-/*(* Infix binary operators *)*/
-/*(*----------------------------*)*/
+(*----------------------------*)
+(* Infix binary operators     *)
+(*----------------------------*)
 
 %inline comparison_or_logical_or_bit_operator_except_in:
  | T_LESS_THAN          { J.Lt         }

--- a/compiler/js_parser.mly
+++ b/compiler/js_parser.mly
@@ -406,36 +406,10 @@ conditional_expression:
 
 post_in_expression:
  | pre_in_expression { $1 }
- | post_in_expression T_LESS_THAN post_in_expression
-   { bop J.Lt $1 $3 }
- | post_in_expression T_GREATER_THAN post_in_expression
-   { bop J.Gt $1 $3 }
- | post_in_expression T_LESS_THAN_EQUAL post_in_expression
-   { bop J.Le $1 $3 }
- | post_in_expression T_GREATER_THAN_EQUAL post_in_expression
-   { bop J.Ge $1 $3 }
- | post_in_expression T_INSTANCEOF post_in_expression
-   { bop J.InstanceOf $1 $3 }
- | post_in_expression T_IN post_in_expression
-   { bop J.In $1 $3 }
- | post_in_expression T_EQUAL post_in_expression
-   { bop J.EqEq $1 $3 }
- | post_in_expression T_NOT_EQUAL post_in_expression
-   { bop J.NotEq $1 $3 }
- | post_in_expression T_STRICT_EQUAL post_in_expression
-   { bop J.EqEqEq $1 $3 }
- | post_in_expression T_STRICT_NOT_EQUAL post_in_expression
-   { bop J.NotEqEq $1 $3 }
- | post_in_expression T_BIT_AND post_in_expression
-   { bop J.Band $1 $3 }
- | post_in_expression T_BIT_XOR post_in_expression
-   { bop J.Bxor $1 $3 }
- | post_in_expression T_BIT_OR post_in_expression
-   { bop J.Bor $1 $3 }
- | post_in_expression T_AND post_in_expression
-   { bop J.And $1 $3 }
- | post_in_expression T_OR post_in_expression
-   { bop J.Or $1 $3 }
+ | left=post_in_expression
+   op=comparison_or_logical_or_bit_operator
+   right=post_in_expression
+   { bop op left right }
 
 pre_in_expression:
  | left_hand_side_expression
@@ -466,15 +440,10 @@ pre_in_expression:
    { uop J.Bnot $2 }
  | T_NOT pre_in_expression
    { uop J.Not $2 }
-
- | pre_in_expression T_MULT pre_in_expression    { bop J.Mul $1 $3 }
- | pre_in_expression T_DIV pre_in_expression     { bop J.Div $1 $3 }
- | pre_in_expression T_MOD pre_in_expression     { bop J.Mod $1 $3 }
- | pre_in_expression T_PLUS pre_in_expression    { bop J.Plus $1 $3 }
- | pre_in_expression T_MINUS pre_in_expression   { bop J.Minus $1 $3 }
- | pre_in_expression T_LSHIFT pre_in_expression  { bop J.Lsl $1 $3 }
- | pre_in_expression T_RSHIFT pre_in_expression  { bop J.Asr $1 $3 }
- | pre_in_expression T_RSHIFT3 pre_in_expression { bop J.Lsr $1 $3 }
+ | left=pre_in_expression
+   op=arithmetic_or_shift_operator
+   right=pre_in_expression
+   { bop op left right }
 
 call_expression:
  | member_expression arguments
@@ -539,35 +508,10 @@ conditional_expression_no_in:
 
 post_in_expression_no_in:
  | pre_in_expression { $1 }
- | post_in_expression_no_in T_LESS_THAN post_in_expression
-   { bop J.Lt $1 $3 }
- | post_in_expression_no_in T_GREATER_THAN post_in_expression
-   { bop J.Gt $1 $3 }
- | post_in_expression_no_in T_LESS_THAN_EQUAL post_in_expression
-   { bop J.Le $1 $3 }
- | post_in_expression_no_in T_GREATER_THAN_EQUAL post_in_expression
-   { bop J.Ge $1 $3 }
- | post_in_expression_no_in T_INSTANCEOF post_in_expression
-   { bop J.InstanceOf $1 $3 }
- | post_in_expression_no_in T_EQUAL post_in_expression
-   { bop J.EqEq $1 $3 }
- | post_in_expression_no_in T_NOT_EQUAL post_in_expression
-   { bop J.NotEq $1 $3 }
- | post_in_expression_no_in T_STRICT_EQUAL post_in_expression
-   { bop J.EqEqEq $1 $3 }
- | post_in_expression_no_in T_STRICT_NOT_EQUAL post_in_expression
-   { bop J.NotEqEq $1 $3 }
- | post_in_expression_no_in T_BIT_AND post_in_expression
-   { bop J.Band $1 $3 }
- | post_in_expression_no_in T_BIT_XOR post_in_expression
-   { bop J.Bxor $1 $3 }
- | post_in_expression_no_in T_BIT_OR post_in_expression
-   { bop J.Bor $1 $3 }
- | post_in_expression_no_in T_AND post_in_expression
-   { bop J.And $1 $3 }
- | post_in_expression_no_in T_OR post_in_expression
-   { bop J.Or $1 $3 }
-
+ | left=post_in_expression_no_in
+   op=comparison_or_logical_or_bit_operator_except_in
+   right=post_in_expression
+   { bop op left right}
 /*(*----------------------------*)*/
 /*(*2 (no statement)*)*/
 /*(*----------------------------*)*/
@@ -590,37 +534,10 @@ conditional_expression_no_statement:
 
 post_in_expression_no_statement:
  | pre_in_expression_no_statement { $1 }
- | post_in_expression_no_statement T_LESS_THAN post_in_expression
-   { bop J.Lt $1 $3 }
- | post_in_expression_no_statement T_GREATER_THAN post_in_expression
-   { bop J.Gt $1 $3 }
- | post_in_expression_no_statement T_LESS_THAN_EQUAL post_in_expression
-   { bop J.Le $1 $3 }
- | post_in_expression_no_statement T_GREATER_THAN_EQUAL post_in_expression
-   { bop J.Ge $1 $3 }
- | post_in_expression_no_statement T_INSTANCEOF post_in_expression
-   { bop J.InstanceOf $1 $3 }
- | post_in_expression_no_statement T_IN post_in_expression
-   { bop J.In $1 $3 }
- | post_in_expression_no_statement T_EQUAL post_in_expression
-   { bop J.EqEq $1 $3 }
- | post_in_expression_no_statement T_NOT_EQUAL post_in_expression
-   { bop J.NotEq $1 $3 }
- | post_in_expression_no_statement T_STRICT_EQUAL post_in_expression
-   { bop J.EqEqEq $1 $3 }
- | post_in_expression_no_statement T_STRICT_NOT_EQUAL post_in_expression
-   { bop J.NotEqEq $1 $3 }
- | post_in_expression_no_statement T_BIT_AND post_in_expression
-   { bop J.Band $1 $3 }
- | post_in_expression_no_statement T_BIT_XOR post_in_expression
-   { bop J.Bxor $1 $3 }
- | post_in_expression_no_statement T_BIT_OR post_in_expression
-   { bop J.Bor $1 $3 }
- | post_in_expression_no_statement T_AND post_in_expression
-   { bop J.And $1 $3 }
- | post_in_expression_no_statement T_OR post_in_expression
-   { bop J.Or $1 $3 }
-
+ | left=post_in_expression_no_statement
+   op=comparison_or_logical_or_bit_operator
+   right=post_in_expression
+   { bop op left right }
 
 pre_in_expression_no_statement:
  | left_hand_side_expression_no_statement
@@ -651,15 +568,10 @@ pre_in_expression_no_statement:
    { uop J.Bnot $2 }
  | T_NOT pre_in_expression
    { uop J.Not $2 }
-
- | pre_in_expression_no_statement T_MULT pre_in_expression    { bop J.Mul $1 $3 }
- | pre_in_expression_no_statement T_DIV pre_in_expression     { bop J.Div $1 $3 }
- | pre_in_expression_no_statement T_MOD pre_in_expression     { bop J.Mod $1 $3 }
- | pre_in_expression_no_statement T_PLUS pre_in_expression    { bop J.Plus $1 $3 }
- | pre_in_expression_no_statement T_MINUS pre_in_expression   { bop J.Minus $1 $3 }
- | pre_in_expression_no_statement T_LSHIFT pre_in_expression  { bop J.Lsl $1 $3 }
- | pre_in_expression_no_statement T_RSHIFT pre_in_expression  { bop J.Asr $1 $3 }
- | pre_in_expression_no_statement T_RSHIFT3 pre_in_expression { bop J.Lsr $1 $3 }
+ | left=pre_in_expression_no_statement
+   op=arithmetic_or_shift_operator
+   right=pre_in_expression
+   { bop op left right }
 
 left_hand_side_expression_no_statement:
  | new_expression_no_statement { snd $1 }
@@ -813,3 +725,37 @@ elison: elison_rev {$1}
 
 curly_block(X):
  | pi1=T_LCURLY x=X pi2=T_RCURLY { (x, (pi1, pi2)) }
+
+/*(*----------------------------*)*/
+/*(* Infix binary operators *)*/
+/*(*----------------------------*)*/
+
+%inline comparison_or_logical_or_bit_operator_except_in:
+ | T_LESS_THAN          { J.Lt         }
+ | T_GREATER_THAN       { J.Gt         }
+ | T_LESS_THAN_EQUAL    { J.Le         }
+ | T_GREATER_THAN_EQUAL { J.Ge         }
+ | T_INSTANCEOF         { J.InstanceOf }
+ | T_EQUAL              { J.EqEq       }
+ | T_NOT_EQUAL          { J.NotEq      }
+ | T_STRICT_EQUAL       { J.EqEqEq     }
+ | T_STRICT_NOT_EQUAL   { J.NotEqEq    }
+ | T_BIT_AND            { J.Band       }
+ | T_BIT_XOR            { J.Bxor       }
+ | T_BIT_OR             { J.Bor        }
+ | T_AND                { J.And        }
+ | T_OR                 { J.Or         }
+
+%inline comparison_or_logical_or_bit_operator:
+ | op=comparison_or_logical_or_bit_operator_except_in { op }
+ | T_IN { J.In }
+
+%inline arithmetic_or_shift_operator:
+ | T_MULT    { J.Mul   }
+ | T_DIV     { J.Div   }
+ | T_MOD     { J.Mod   }
+ | T_PLUS    { J.Plus  }
+ | T_MINUS   { J.Minus }
+ | T_LSHIFT  { J.Lsl   }
+ | T_RSHIFT  { J.Asr   }
+ | T_RSHIFT3 { J.Lsr   }

--- a/compiler/js_parser.mly
+++ b/compiler/js_parser.mly
@@ -32,7 +32,6 @@
 module J = Javascript
 open Js_token
 
-let uop op a = J.EUn(op,a)
 let var name = J.S {J.name;J.var=None}
 
 (* This is need to fake menhir while using `--infer`. *)
@@ -404,32 +403,9 @@ post_in_expression:
 pre_in_expression:
  | left_hand_side_expression
    { $1 }
- | pre_in_expression T_INCR_NB
-   { uop J.IncrA $1 }
- | pre_in_expression T_DECR_NB
-   { uop J.DecrA $1 }
- | T_DELETE pre_in_expression
-   { uop J.Delete $2 }
- | T_VOID pre_in_expression
-   { uop J.Void $2 }
- | T_TYPEOF pre_in_expression
-   { uop J.Typeof $2 }
- | T_INCR pre_in_expression
-   { uop J.IncrB $2 }
- | T_INCR_NB pre_in_expression
-   { uop J.IncrB $2 }
- | T_DECR pre_in_expression
-   { uop J.DecrB $2 }
- | T_DECR_NB pre_in_expression
-   { uop J.DecrB $2 }
- | T_PLUS pre_in_expression
-   { uop J.Pl $2 }
- | T_MINUS pre_in_expression
-   { uop J.Neg $2}
- | T_BIT_NOT pre_in_expression
-   { uop J.Bnot $2 }
- | T_NOT pre_in_expression
-   { uop J.Not $2 }
+ | e=pre_in_expression op=postfix_operator
+ | op=prefix_operator e=pre_in_expression
+   { J.EUn (op, e) }
  | left=pre_in_expression
    op=arithmetic_or_shift_operator
    right=pre_in_expression
@@ -534,32 +510,9 @@ post_in_expression_no_statement:
 pre_in_expression_no_statement:
  | left_hand_side_expression_no_statement
    { $1 }
- | pre_in_expression_no_statement T_INCR_NB
-   { uop J.IncrA $1 }
- | pre_in_expression_no_statement T_DECR_NB
-   { uop J.DecrA $1 }
- | T_DELETE pre_in_expression
-   { uop J.Delete $2 }
- | T_VOID pre_in_expression
-   { uop J.Void $2 }
- | T_TYPEOF pre_in_expression
-   { uop J.Typeof $2 }
- | T_INCR pre_in_expression
-   { uop J.IncrB $2 }
- | T_INCR_NB pre_in_expression
-   { uop J.IncrB $2 }
- | T_DECR pre_in_expression
-   { uop J.DecrB $2 }
- | T_DECR_NB pre_in_expression
-   { uop J.DecrB $2 }
- | T_PLUS pre_in_expression
-   { uop J.Pl $2 }
- | T_MINUS pre_in_expression
-   { uop J.Neg $2}
- | T_BIT_NOT pre_in_expression
-   { uop J.Bnot $2 }
- | T_NOT pre_in_expression
-   { uop J.Not $2 }
+ | e=pre_in_expression_no_statement op=postfix_operator
+ | op=prefix_operator e=pre_in_expression
+   { J.EUn (op, e) }
  | left=pre_in_expression_no_statement
    op=arithmetic_or_shift_operator
    right=pre_in_expression
@@ -585,7 +538,7 @@ call_expression_no_statement:
 
 member_expression_no_statement:
  | e=primary_expression_no_statement
-     { e }
+   { e }
  | member_expression_no_statement T_LBRACKET e2=expression T_RBRACKET
    { let (start, e1) = $1 in (start, J.EAccess(e1, e2)) }
  | member_expression_no_statement T_PERIOD i=field_name
@@ -750,3 +703,20 @@ curly_block(X):
  | T_LSHIFT  { J.Lsl   }
  | T_RSHIFT  { J.Asr   }
  | T_RSHIFT3 { J.Lsr   }
+
+%inline prefix_operator:
+ | T_DELETE  { J.Delete }
+ | T_VOID    { J.Void   }
+ | T_TYPEOF  { J.Typeof }
+ | T_INCR    { J.IncrB  }
+ | T_INCR_NB { J.IncrB  }
+ | T_DECR    { J.DecrB  }
+ | T_DECR_NB { J.DecrB  }
+ | T_PLUS    { J.Pl     }
+ | T_MINUS   { J.Neg    }
+ | T_BIT_NOT { J.Bnot   }
+ | T_NOT     { J.Not    }
+
+%inline postfix_operator:
+ | T_INCR_NB { J.IncrA }
+ | T_DECR_NB { J.DecrA }


### PR DESCRIPTION
Changes made:
 * Factoring out operator definitions, instead of handling them inline:
    * `comparison_or_logical_or_bit_operator`
    * `comparison_or_logical_or_bit_operator_except_in`
    * `arithmetic_or_shift_operator`
    * `prefix_operator`
    * `postfix_operator`
 * Factoring out some productions like `parenthesised`
 * Removal of redundant ocamlyacc-style `/* */` comments
 * Using more conventional `*` and `?` operators instead of `list` and `option` productions
 * Renaming many single-letter variables
 * Using pattern-matching instead of `fst` and `snd` on tuples