### PR TITLE
Stdlib.js: Fix bug in caml_hash

### DIFF
--- a/runtime/stdlib.js
+++ b/runtime/stdlib.js
@@ -788,7 +788,6 @@ function () {
           h = caml_hash_mix_string_arr(h, v.c);
         }
         num--;
-        break;
       } else if (v === (v|0)) {
         // Integer
         h = MIX(h, v+v+1);
@@ -797,7 +796,6 @@ function () {
         // Float
         h = caml_hash_mix_int64(h, caml_int64_bits_of_float (v));
         num--;
-        break;
       }
     }
     h = FINAL_MIX(h);


### PR DESCRIPTION

The problem occurs when you try to hash a block (like a record)
By keeping the two "break;" statements, the hash function will stop at the first string or float encountered.

See the following example:
```
type salted_pass = {
  salt : string;
  pass : string;
}

type user = {
  login : string;
  salt : string;
  hash : int;
}

let create_user login salt pass =
  { login; salt; hash = Hashtbl.hash { salt; pass; }; }

let admin = create_user "login" "salt" "pass"

let auth { salt; hash; } pass =
  Hashtbl.hash { salt; pass; } = hash

let () =
  if auth admin "not pass"
  then Format.printf "OK@."
  else Format.printf "Error@."
```

In an OCaml toplevel, this example prints "Error" like we expect.
In the online Try Js_of_ocaml (and also in a real js_of_ocaml app), this will prints "Ok" because of the fact that the field "salt" has the same value everywhere. But in this case, the hash function should also consider the "pass" field, which is not done because of those "break;" statements.

It would be better to have the same behavior as the OCaml runtime.