### PR TITLE
Bring float_of_string more in line with the OCaml implementation.

### DIFF
--- a/runtime/stdlib.js
+++ b/runtime/stdlib.js
@@ -454,6 +454,8 @@ function caml_float_of_string(s) {
     res = +s.substring(0,pidx);
     return res * Math.pow(2,exp);
   }
+  if(/^\+?inf(inity)?$/i.test(s)) return Infinity;
+  if(/^-inf(inity)?$/i.test(s)) return -Infinity;
   caml_failwith("float_of_string");
 }
 


### PR DESCRIPTION
This adds the ability to parse infinities of various capitalisation
and sign. The following now works in the JS toplevel:

    float_of_string (string_of_float infinity)

~~It's more permissive than standard ocaml, accepting, for example,
"infini" whereas that would be rejected by the normal toplevel.~~

Signed-off-by: Jon Ludlam <jonathan.ludlam@citrix.com>