### PR TITLE
Also inline simple functions which simply call another function or primitive

### DIFF
--- a/compiler/inline.ml
+++ b/compiler/inline.ml
@@ -141,7 +141,7 @@ let simple blocks clos_pc clos_args clos_params f_args =
     begin match exp with
       | Const _ -> `Exp exp
       | Constant (Float _ | Int64 _ | Int _ | IString _) -> `Exp exp
-      | Apply (f, args, true) -> `Exp (Apply (f, List.map map_var args, true))
+      | Apply (f, args, true) -> `Exp (Apply (map_var f, List.map map_var args, true))
       | Prim (prim, args) -> `Exp (Prim (prim, List.map map_prim_arg args))
       | Block (tag, args) -> `Exp (Block (tag, Array.map map_var args))
       | Field (x, i) -> `Exp (Field (map_var x, i))

--- a/compiler/inline.ml
+++ b/compiler/inline.ml
@@ -133,6 +133,9 @@ let simple blocks clos_pc clos_args clos_params f_args =
       | Constant (Float _ | Int64 _ | Int _ | IString _) -> `Exp exp
       | Apply (f, args, true) -> `Exp (Apply (f, List.map map_var args, true))
       | Prim (prim, args) -> `Exp (Prim (prim, List.map map_prim_arg args))
+      | Block (tag, args) -> `Exp (Block (tag, Array.map map_var args))
+      | Field (x, i) -> `Exp (Field (map_var x, i))
+      | Closure (args, k) -> `Exp (Closure (List.map map_var args, k))
       | _ -> `None
     end
   | _ -> `None

--- a/compiler/inline.ml
+++ b/compiler/inline.ml
@@ -135,7 +135,6 @@ let simple blocks clos_pc clos_args clos_params f_args =
       | Prim (prim, args) -> `Exp (Prim (prim, List.map map_prim_arg args))
       | Block (tag, args) -> `Exp (Block (tag, Array.map map_var args))
       | Field (x, i) -> `Exp (Field (map_var x, i))
-      | Closure (args, k) -> `Exp (Closure (List.map map_var args, k))
       | _ -> `None
     end
   | _ -> `None


### PR DESCRIPTION
This eliminates some simple calls to functions which immediately call another function or primitive.

It also adds some very naive logic to short-circuit calls to function which jump to another function.  This helps the inliner apply the elimination mentioned above.