### PR TITLE
XmlHttpRequest: send blob objects

### DIFF
--- a/lib/xmlHttpRequest.ml
+++ b/lib/xmlHttpRequest.ml
@@ -42,6 +42,7 @@ class type xmlHttpRequest = object ('self)
   method setRequestHeader : js_string t -> js_string t -> unit meth
   method overrideMimeType : js_string t -> unit meth
   method send : js_string t opt -> unit meth
+  method send_blob : File.blob t -> unit meth
   method send_document : Dom.element Dom.document -> unit meth
   method send_formData : Form.formData t -> unit meth
   method abort : unit meth

--- a/lib/xmlHttpRequest.mli
+++ b/lib/xmlHttpRequest.mli
@@ -43,6 +43,7 @@ class type xmlHttpRequest = object ('self)
   method setRequestHeader : js_string t -> js_string t -> unit meth
   method overrideMimeType : js_string t -> unit meth
   method send : js_string t opt -> unit meth
+  method send_blob : File.blob t -> unit meth
   method send_document : Dom.element Dom.document -> unit meth
   method send_formData : Form.formData t -> unit meth
   method abort : unit meth


### PR DESCRIPTION
The method `send` accepts blob objects [1]

[1] https://developer.mozilla.org/en/docs/Web/API/XMLHttpRequest#send%28%29