### PR TITLE
XmlHttpRequest: fixed typing of send_blob

### DIFF
--- a/lib/xmlHttpRequest.ml
+++ b/lib/xmlHttpRequest.ml
@@ -42,7 +42,7 @@ class type xmlHttpRequest = object ('self)
   method setRequestHeader : js_string t -> js_string t -> unit meth
   method overrideMimeType : js_string t -> unit meth
   method send : js_string t opt -> unit meth
-  method send_blob : File.blob t -> unit meth
+  method send_blob : #File.blob t -> unit meth
   method send_document : Dom.element Dom.document -> unit meth
   method send_formData : Form.formData t -> unit meth
   method abort : unit meth

--- a/lib/xmlHttpRequest.mli
+++ b/lib/xmlHttpRequest.mli
@@ -43,7 +43,7 @@ class type xmlHttpRequest = object ('self)
   method setRequestHeader : js_string t -> js_string t -> unit meth
   method overrideMimeType : js_string t -> unit meth
   method send : js_string t opt -> unit meth
-  method send_blob : File.blob t -> unit meth
+  method send_blob : #File.blob t -> unit meth
   method send_document : Dom.element Dom.document -> unit meth
   method send_formData : Form.formData t -> unit meth
   method abort : unit meth


### PR DESCRIPTION
I used a uselessly restrictive typing in my earlier commit, sorry!