### PR TITLE
XmlHttpRequest: API change for perform functions.

### DIFF
--- a/lib/xmlHttpRequest.ml
+++ b/lib/xmlHttpRequest.ml
@@ -168,44 +168,39 @@ let has_get_args url =
 let perform_raw
     ?(headers = [])
     ?content_type
-    ?(post_args:(string * Form.form_elt) list option)
     ?(get_args=[])
-    ?(form_arg:Form.form_contents option)
     ?(check_headers=(fun _ _ -> true))
     ?progress
     ?upload_progress
+    ?contents
     ?override_mime_type
     ?override_method
     (type resptype) ~(response_type:resptype response)
     url =
 
-  let form_arg =
-    match form_arg with
-      | None ->
-	(match post_args with
-	  | None -> None
-	  | Some post_args ->
-            let only_strings =
-              List.for_all
-                (fun x -> match x with (_, `String _) ->  true | _ -> false)
-                post_args
-            in
-	    let contents =
-              if only_strings then `Fields (ref []) else
-              Form.empty_form_contents ()
-            in
-	    List.iter (fun (name, value) ->
-              Form.append contents (name, value))
-              post_args;
-	    Some contents)
-      | Some form_arg ->
-	(match post_args with
-	  | None -> ()
-	  | Some post_args ->
-	    List.iter (fun (name, value) ->
-              Form.append form_arg (name, value))
-              post_args);
-	Some form_arg
+  let contents_normalization = function
+    | `POST_form args ->
+      let only_strings =
+        List.for_all
+          (fun x -> match x with (_, `String _) ->  true | _ -> false)
+          args
+      in
+      let form_contents =
+        if only_strings then `Fields (ref [])
+        else Form.empty_form_contents ()
+      in
+      List.iter
+        (fun (name, value) -> Form.append form_contents (name, value))
+        args ;
+      `Form_contents form_contents
+    | `Form_contents form -> `Form_contents form
+    | `String s -> `String s
+    | `Blob b -> `Blob (b : #File.blob Js.t :> File.blob Js.t)
+  in
+
+  let contents = match contents with
+    | None -> None
+    | Some c -> Some (contents_normalization c)
   in
 
   let method_to_string m =
@@ -219,19 +214,28 @@ let perform_raw
       | `PATCH -> "PATCH"
   in
   let method_, content_type =
-    let override m =
+    let override_method m =
       match override_method with
         | None -> m
         | Some v -> method_to_string v
     in
-    match form_arg, content_type with
-      | None, ct -> override "GET", ct
-      | Some form_args, None ->
-	(match form_args with
-	  | `Fields _strings ->
-              override "POST", Some "application/x-www-form-urlencoded"
-	  | `FormData _ -> override "POST", None)
-      | Some _, ct -> override "POST", ct
+    let override_content_type c =
+      match content_type with
+        | None -> Some c
+        | Some _ -> content_type
+    in
+    match contents with
+    | None -> override_method "GET", content_type
+    | Some (`Form_contents form) -> (
+        match form with
+        | `Fields _strings ->
+          override_method "POST",
+          override_content_type "application/x-www-form-urlencoded"
+        | `FormData _ ->
+          override_method "POST",
+          override_content_type "multipart/form-data"
+      )
+    | Some _ -> override_method "POST", content_type
   in
   let url =
     if get_args = [] then
@@ -240,6 +244,7 @@ let perform_raw
       url ^ (if has_get_args url then "&" else "?") ^
       Url.encode_arguments get_args
   in
+
 
   let ((res : resptype generic_http_frame Lwt.t), w) = Lwt.task () in
   let req = create () in
@@ -336,11 +341,15 @@ let perform_raw
     | None -> ()
   );
 
-  (match form_arg with
+  (match contents with
      | None -> req##send (Js.null)
-     | Some (`Fields l) ->
-         ignore (req##send(Js.some (string (encode_url !l)));return ())
-     | Some (`FormData f) -> req##send_formData(f));
+     | Some (`Form_contents (`Fields l)) ->
+       (* Not sure why this trick is needed nor why it is not
+          used for other cases. Is this ok? *)
+       ignore (req##send(Js.some (string (encode_url !l)));return ())
+     | Some (`Form_contents (`FormData f)) -> req##send_formData(f)
+     | Some (`String s) -> req##send (Js.some (Js.string s))
+     | Some (`Blob b) -> req##send_blob(b)) ;
 
   Lwt.on_cancel res (fun () -> req##abort ()) ;
   res
@@ -348,32 +357,30 @@ let perform_raw
 let perform_raw_url
     ?(headers = [])
     ?content_type
-    ?post_args
     ?(get_args=[])
-    ?form_arg
     ?check_headers
     ?progress
     ?upload_progress
+    ?contents
     ?override_mime_type
     ?override_method
     url =
-  perform_raw ~headers ?content_type ?post_args ~get_args ?form_arg
+  perform_raw ~headers ?content_type ~get_args ?contents
     ?check_headers ?progress ?upload_progress ?override_mime_type
     ?override_method ~response_type:Default url
 
 let perform
     ?(headers = [])
     ?content_type
-    ?post_args
     ?(get_args=[])
-    ?form_arg
     ?check_headers
     ?progress
     ?upload_progress
+    ?contents
     ?override_mime_type
     ?override_method
     url =
-  perform_raw ~headers ?content_type ?post_args ~get_args ?form_arg
+  perform_raw ~headers ?content_type ~get_args ?contents
     ?check_headers ?progress ?upload_progress ?override_mime_type
     ?override_method ~response_type:Default (Url.string_of_url url)
 

--- a/lib/xmlHttpRequest.mli
+++ b/lib/xmlHttpRequest.mli
@@ -104,12 +104,15 @@ exception Wrong_headers of (int * (string -> string option))
 val perform_raw :
     ?headers:(string * string) list
   -> ?content_type:string
-  -> ?post_args:((string * Form.form_elt) list)
   -> ?get_args:((string * string) list)  (* [] *)
-  -> ?form_arg:Form.form_contents
   -> ?check_headers:(int -> (string -> string option) -> bool)
   -> ?progress:(int -> int -> unit)
   -> ?upload_progress:(int -> int -> unit)
+  -> ?contents:
+    [< `POST_form of (string * Form.form_elt) list
+    | `Form_contents of Form.form_contents
+    | `String of string
+    | `Blob of #File.blob Js.t ]
   -> ?override_mime_type:string
   -> ?override_method:[< `GET | `POST | `HEAD | `PUT | `DELETE | `OPTIONS | `PATCH ]
   -> response_type:('a response)
@@ -123,12 +126,15 @@ val perform_raw :
 val perform_raw_url :
     ?headers:(string * string) list
   -> ?content_type:string
-  -> ?post_args:((string * Form.form_elt) list)
   -> ?get_args:((string * string) list)  (* [] *)
-  -> ?form_arg:Form.form_contents
   -> ?check_headers:(int -> (string -> string option) -> bool)
   -> ?progress:(int -> int -> unit)
   -> ?upload_progress:(int -> int -> unit)
+  -> ?contents:
+    [< `POST_form of (string * Form.form_elt) list
+    | `Form_contents of Form.form_contents
+    | `String of string
+    | `Blob of #File.blob Js.t ]
   -> ?override_mime_type:string
   -> ?override_method:[< `GET | `POST | `HEAD | `PUT | `DELETE | `OPTIONS | `PATCH ]
   -> string
@@ -147,12 +153,15 @@ val perform_raw_url :
 val perform :
     ?headers:(string * string) list
   -> ?content_type:string
-  -> ?post_args:((string * Form.form_elt) list)
   -> ?get_args:((string * string) list)  (* [] *)
-  -> ?form_arg:Form.form_contents
   -> ?check_headers:(int -> (string -> string option) -> bool)
   -> ?progress:(int -> int -> unit)
   -> ?upload_progress:(int -> int -> unit)
+  -> ?contents:
+    [< `POST_form of (string * Form.form_elt) list
+    | `Form_contents of Form.form_contents
+    | `String of string
+    | `Blob of #File.blob Js.t ]
   -> ?override_mime_type:string
   -> ?override_method:[< `GET | `POST | `HEAD | `PUT | `DELETE | `OPTIONS | `PATCH ]
   -> Url.url


### PR DESCRIPTION
PREAMBLE: this PR is mainly intended to start a discussion on an API change. Even if it is accepted in principle, there are still many changes required (specific implementation details, code style, documentation, testing).

The proposed change is to offer more possibilities for the body
contents of a request. While only form-like bodies were available,
this commit introduces two more possibilities: an arbitrary string and
a blob object (for file upload notably).

For this the signature of perform functions was changed: arguments
`post_args` and `form_args` were replaced by a `contents` argument,
which makes the behaviour of the function a bit more readable IMHO.

In addition to breaking the API, there's one regression, namely that
it is not possible to combine POST arguments with a FormData object,
though I'm not sure if that's critical.
