### PR TITLE
menhir -> menhirLib in .merlin

### DIFF
--- a/lib/.merlin
+++ b/lib/.merlin
@@ -1,6 +1,6 @@
 B ./**
 S ./**
 PKG cmdliner
-PKG menhir
+PKG menhirLib
 
 EXT js


### PR DESCRIPTION
No such thing as menhir findlib package

@Drup follow up