### PR TITLE
Quick patch, which allows programs using COW to be compiled with js_of_ocaml

### DIFF
--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -1,4 +1,4 @@
-FILES= 	mlString.js ieee_754.js int64.js md5.js marshal.js \
+FILES= 	bigstring.js mlString.js ieee_754.js int64.js md5.js marshal.js \
 	lexing.js parsing.js bigarray.js unix.js \
 	stdlib.js io.js fs.js jslib.js jslib_js_of_ocaml.js \
 	internalMod.js gc.js polyfill/json2.js

--- a/runtime/bigstring.js
+++ b/runtime/bigstring.js
@@ -5,18 +5,27 @@ function bigstring_alloc(_,size){
   return caml_ba_create(12, 0, [0,size]);
 }
 
-//Provides: bigstring_blit_bigstring_string_stub
+//Provides: caml_blit_bigstring_to_string
 //Requires: caml_string_set, caml_ba_get_1
-function bigstring_blit_bigstring_string_stub(v_bstr, v_src_pos, v_str, v_dst_pos, v_len){
+function caml_blit_bigstring_to_string(v_bstr, v_src_pos, v_str, v_dst_pos, v_len){
   for (var i = 0; i < v_len; i++) caml_string_set(v_str,v_dst_pos + i,caml_ba_get_1(v_bstr,v_src_pos + i));
   return 0;
 }
-//Provides: bigstring_blit_string_bigstring_stub
+
+//Provides: caml_blit_string_to_bigstring
 //Requires: caml_string_get, caml_ba_set_1
-function bigstring_blit_string_bigstring_stub(v_str, v_src_pos, v_bstr, v_dst_pos, v_len){
+function caml_blit_string_to_bigstring(v_str, v_src_pos, v_bstr, v_dst_pos, v_len){
   for (var i = 0; i < v_len; i++) caml_ba_set_1(v_bstr,v_dst_pos + i,caml_string_get(v_str,v_src_pos + i));
   return 0;
 }
+
+//Provides: caml_blit_string_to_bigstring
+//Requires: caml_string_get, caml_ba_set_1
+//function caml_blit_string_to_bigstring (val_buf1, val_ofs1, val_buf2, val_ofs2, val_len) {
+//  for (var i = 0; i < v_len; i++) {
+//    caml_ba_set_1(val_buf2, val_ofs2 + i, caml_string_get(val_buf1, val_ofs1 + i));
+//  }
+//}
 
 //Provides: bigstring_blit_stub
 //Requires: caml_ba_get_1, caml_ba_set_1

--- a/runtime/bigstring.js
+++ b/runtime/bigstring.js
@@ -19,14 +19,6 @@ function caml_blit_string_to_bigstring(v_str, v_src_pos, v_bstr, v_dst_pos, v_le
   return 0;
 }
 
-//Provides: caml_blit_string_to_bigstring
-//Requires: caml_string_get, caml_ba_set_1
-//function caml_blit_string_to_bigstring (val_buf1, val_ofs1, val_buf2, val_ofs2, val_len) {
-//  for (var i = 0; i < v_len; i++) {
-//    caml_ba_set_1(val_buf2, val_ofs2 + i, caml_string_get(val_buf1, val_ofs1 + i));
-//  }
-//}
-
 //Provides: bigstring_blit_stub
 //Requires: caml_ba_get_1, caml_ba_set_1
 function bigstring_blit_stub(s1, i1, s2, i2, len){


### PR DESCRIPTION
I made a couple of the primitives in runtime/bigstring.js accessible. They were already implemented, I just had to rename them and add them to the runtime Makefile (I'm not sure why they weren't named properly or set to be included in the runtime, there may be something to that). This was necessary to get a project using [COW](https://github.com/mirage/ocaml-cow) to compile, and appears to work.