### PR TITLE
Allow to customize 'in_channel' with specific 'refiller'

### DIFF
--- a/lib/sys_js.ml
+++ b/lib/sys_js.ml
@@ -23,6 +23,8 @@ external caml_fs_register_autoload : string -> (Js.js_string Js.t Js.js_array Js
 
 external set_channel_output' : out_channel -> (Js.js_string Js.t -> unit) Js.callback -> unit = "caml_ml_set_channel_output"
 
+external set_channel_input' : in_channel -> (unit -> string) Js.callback -> unit = "caml_ml_set_channel_refill"
+
 let register_file ~name ~content =
   register_file_js (Js.string name) (Js.string content)
 
@@ -49,6 +51,10 @@ let register_autoload ~path f =
 let set_channel_flusher (out_channel : out_channel) (f : string -> unit) =
   let f' : (Js.js_string Js.t -> unit) Js.callback = Js.wrap_callback (fun s -> f (Js.to_string s)) in
   set_channel_output' out_channel f'
+
+let set_channel_filler (in_channel : in_channel) (f : unit -> string) =
+  let f' : (unit -> string) Js.callback = Js.wrap_callback f in
+  set_channel_input' in_channel f'
 
 external file_content : string -> string = "caml_fs_file_content"
 

--- a/lib/sys_js.mli
+++ b/lib/sys_js.mli
@@ -26,6 +26,11 @@ val set_channel_flusher : out_channel -> (string -> unit) -> unit
       [set_channel_flusher chan cb] install the callback [cb] for [chan] out_channel.
       [cb] will be called with the string to flush. *)
 
+val set_channel_filler : in_channel -> (unit -> string) -> unit
+  (** Set a callback to be called when an in_channel wants to fill its
+      buffer. [set_channel_filler chan cb] install the called [cb] for
+      [chan] in_channel. The string returned by [cb] will be appended
+      to the channel buffer. *)
 
 (** {2 Pseudo filesystem.} *)
 

--- a/toplevel/toplevel.cppo.ml
+++ b/toplevel/toplevel.cppo.ml
@@ -350,6 +350,14 @@ let run _ =
   Sys_js.set_channel_flusher stdout     (append Colorize.text  output "stdout");
   Sys_js.set_channel_flusher stderr     (append Colorize.text  output "stderr");
 
+  let readline () =
+    Js.Opt.case
+      (Dom_html.window##prompt
+         (Js.string "The toplevel expects inputs:", Js.string ""))
+      (fun () -> "")
+      (fun s -> Js.to_string s ^ "\n") in
+  Sys_js.set_channel_filler stdin readline;
+
   setup_share_button ~output;
   setup_examples ~container ~textbox;
   setup_pseudo_fs ();


### PR DESCRIPTION
Trivial usage illustrated in the demo toplevel, where reads to stdin calls 'window.prompt'.