### PR TITLE
Use base64 >= 2.0.0

### DIFF
--- a/opam
+++ b/opam
@@ -18,7 +18,7 @@ depends: [
   "menhir"
   "cppo"
   "camlp4"
-  "base64"
+  "base64" {>= "2.0.0"}
   ( "base-no-ppx" | "ppx_tools" )
 ]
 depopts: ["deriving" "tyxml" "reactiveData" ]


### PR DESCRIPTION
js_output.ml uses B64 which is not present in <= 1.1.0