### PR TITLE
Add Tyxml_js.register

### DIFF
--- a/lib/tyxml/tyxml_js.mli
+++ b/lib/tyxml/tyxml_js.mli
@@ -60,6 +60,40 @@ module Svg : Svg_sigs.Make(Xml).T
 
 module Html5 : Html5_sigs.Make(Xml)(Svg).T
 
+module Register : sig
+
+  val html :
+    ?head:Html5_types.head Html5.elt ->
+    Html5_types.body Html5.elt -> unit
+  (** [Register.html head body] uses the given head and body elements
+      as document. It replaces the previous body and head.
+
+      [head] and [body] can be reactive.
+  *)
+
+  val body : ?keep:bool -> [< Html5_types.body_content] Html5.elt list -> unit
+  (** [Register.body elements] add [elements] as children of [body].
+      If [keep] is false (default is true), the children of the body are
+      removed before adding the new elements.
+  *)
+
+  val head : ?keep:bool -> [< Html5_types.head_content] Html5.elt list -> unit
+  (** [Register.head elements] add [elements] as children of [body].
+      If [keep] is false (default is true), the children of the head are
+      removed before adding the new elements.
+  *)
+
+  val id : ?keep:bool -> string -> 'a Html5.elt list -> unit
+  (** [Register.id "some_id" elements] add [elements] as children of the node
+      with the id ["some_id"].
+      If [keep] is false (default is true), the children of the node are
+      removed before adding the new elements.
+
+      Beware, this function ignores tyxml's type information.
+  *)
+
+end
+
 module R : sig
   module Xml : XML with module W = Xml_wrap
 


### PR DESCRIPTION
This is a request for comment on the interface.
I think this is the good set of functions we want :
 - It allows to define everything in pure tyxml *and* to rely on a statically writen html
 - It's rather safe
 - It works well with reactive nodes (I think, cc @hhugo).

@talex5 See https://github.com/Drup/js-skeleton/blob/master/main.ml#L101 for a use-case.

Next remaining step to be able to define only-tyxml webpages is `Lwt_js_events`.