### PR TITLE
Ppx deriving

### DIFF
--- a/Makefile.conf
+++ b/Makefile.conf
@@ -49,6 +49,8 @@ NATDYNLINK ?= $(shell if [ -f `ocamlc -where`/dynlink.cmxa ]; then echo YES; els
 
 WITH_PPX_TOOLS ?= $(shell if [ -f `ocamlfind query ppx_tools 2> /dev/null`/ppx_tools.cma ]; then echo YES; else echo NO; fi)
 
+WITH_PPX_DERIVING ?= $(shell if [ -f `ocamlfind query ppx_deriving 2> /dev/null`/ppx_deriving.cma ]; then echo YES; else echo NO; fi)
+
 ##disabled for ocaml < 4.02.2+trunk
 ifeq "${WITH_PPX_TOOLS}" "YES"
 ifneq ($(shell ocamlc -version | grep -q -E "4.02.[01]"; echo $$?),0)

--- a/Makefile.filelist
+++ b/Makefile.filelist
@@ -41,6 +41,11 @@ endif
 endif
 endif
 
+ifeq "${WITH_PPX_DERIVING}" "YES"
+IMPL += lib/ppx/ppx_deriving_json.cma
+IMPL += lib/ppx/ppx_deriving_json.cmxs
+endif
+
 ifeq "${WITH_TOPLEVEL}" "YES"
 IMPL += lib/toplevel/jsooTop.cmo lib/toplevel/jsooTopError.cmo
 INTF += lib/toplevel/jsooTop.cmi lib/toplevel/jsooTopError.cmi

--- a/Makefile.filelist
+++ b/Makefile.filelist
@@ -42,7 +42,9 @@ endif
 endif
 
 ifeq "${WITH_PPX_DERIVING}" "YES"
+IMPL += lib/ppx/ppx_deriving_json.a
 IMPL += lib/ppx/ppx_deriving_json.cma
+IMPL += lib/ppx/ppx_deriving_json.cmxa
 IMPL += lib/ppx/ppx_deriving_json.cmxs
 endif
 

--- a/lib/META
+++ b/lib/META
@@ -58,7 +58,7 @@ package "deriving" (
     ppxopt(-ppx_driver) = "ppx_deriving,./ppx_deriving_json.cma"
     requires(ppx_driver) = "ppx_deriving.api"
     archive(ppx_driver, byte) = "ppx_deriving_json.cma"
-    archive(ppx_driver, native) = "ppx_deriving_json.cmxs"
+    archive(ppx_driver, native) = "ppx_deriving_json.cmxa"
   )
 
 )

--- a/lib/META
+++ b/lib/META
@@ -49,6 +49,18 @@ package "deriving" (
     archive(syntax, toploop) = "pa_deriving_Json.cmo"
     requires(syntax) = "deriving.syntax.common"
   )
+
+  package "ppx" (
+    description = "[@@deriving json]"
+    version = "[distributed with js_of_ocaml]"
+    exists_if = "ppx_deriving_json.cma"
+    requires(-ppx_driver) = "ppx_deriving"
+    ppxopt(-ppx_driver) = "ppx_deriving,./ppx_deriving_json.cma"
+    requires(ppx_driver) = "ppx_deriving.api"
+    archive(ppx_driver, byte) = "ppx_deriving_json.cma"
+    archive(ppx_driver, native) = "ppx_deriving_json.cmxs"
+  )
+
 )
 
 package "graphics" (

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -53,7 +53,10 @@ endif
 endif
 
 ifeq "${WITH_PPX_DERIVING}" "YES"
-PPX_DERIVING_LIB= ppx/ppx_deriving_json.cma ppx/ppx_deriving_json.cmxs
+PPX_DERIVING_LIB= ppx/ppx_deriving_json.cma \
+	ppx/ppx_deriving_json.a \
+	ppx/ppx_deriving_json.cmxa \
+	ppx/ppx_deriving_json.cmxs
 endif
 
 all: $(LIBNAME).cma log/logger.cma \
@@ -196,6 +199,8 @@ ppx/ppx_deriving_json.cma: ppx/ppx_deriving_json.cmo
 
 ppx/ppx_deriving_json.cmx: ppx/ppx_deriving_json.ml
 	$(OCAMLOPT) -w -27 -package ppx_deriving,ppx_tools.metaquot -c $<
+
+ppx/ppx_deriving_json.a: ppx/ppx_deriving_json.cmx
 
 ppx/ppx_deriving_json.cmxa: ppx/ppx_deriving_json.cmx
 	$(OCAMLOPT) -a -o $@ $^

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -52,13 +52,17 @@ PPX_LIB_NDL= ppx/ppx_js.cmxs
 endif
 endif
 
+ifeq "${WITH_PPX_DERIVING}" "YES"
+PPX_DERIVING_LIB= ppx/ppx_deriving_json.cma ppx/ppx_deriving_json.cmxs
+endif
+
 all: $(LIBNAME).cma log/logger.cma \
 	${PA_JS} ${PA_JS_NDL} \
 	${PA_DERIVING} 	${PA_DERIVING_NDL} \
 	${DERIVING_JSON} \
 	${GRAPHICS_CMA} \
 	${TYXML_CMA} \
-	$(PPX_EX) $(PPX_LIB) $(PPX_LIB_NDL) \
+	$(PPX_EX) $(PPX_LIB) $(PPX_DERIVING_LIB) $(PPX_LIB_NDL) \
 	META
 
 VERSION := $(shell head -n 1 ../VERSION)
@@ -183,6 +187,21 @@ ppx/ppx_js.cmxs: ppx/ppx_js.cmxa
 
 $(PPX_EX): ppx/ppx_js.$(BEST)
 	mv -f $< $@
+
+ppx/ppx_deriving_json.cmo: ppx/ppx_deriving_json.ml
+	$(OCAMLC) -w -27 -package ppx_deriving,ppx_tools,ppx_tools.metaquot -c $<
+
+ppx/ppx_deriving_json.cma: ppx/ppx_deriving_json.cmo
+	$(OCAMLC) -a -o $@ $^
+
+ppx/ppx_deriving_json.cmx: ppx/ppx_deriving_json.ml
+	$(OCAMLOPT) -w -27 -package ppx_deriving,ppx_tools.metaquot -c $<
+
+ppx/ppx_deriving_json.cmxa: ppx/ppx_deriving_json.cmx
+	$(OCAMLOPT) -a -o $@ $^
+
+ppx/ppx_deriving_json.cmxs: ppx/ppx_deriving_json.cmx
+	$(OCAMLOPT) -shared -o $@ $^
 
 %.cmo: %.ml syntax/pa_js.cmo
 	$(OCAMLC) -pp "camlp4o syntax/pa_js.cmo" $(SAFESTRING) -package lwt -c -g $<

--- a/lib/deriving_json/deriving_Json.mli
+++ b/lib/deriving_json/deriving_Json.mli
@@ -25,6 +25,15 @@
 (** The type of JSON parser/printer for value of type ['a]. *)
 type 'a t
 
+val make:
+  (Buffer.t -> 'a -> unit) ->
+  (Deriving_Json_lexer.lexbuf -> 'a) ->
+  'a t
+
+val write : 'a t -> Buffer.t -> 'a -> unit
+
+val read : 'a t -> Deriving_Json_lexer.lexbuf -> 'a
+
 (** [to_string Json.t<ty> v] marshal the [v] of type [ty] to a JSON string.*)
 val to_string: 'a t -> 'a -> string
 
@@ -141,3 +150,31 @@ module Json_list(A : Json) : Json with type a = A.a list
 module Json_ref(A : Json) : Json with type a = A.a ref
 module Json_option(A : Json) : Json with type a = A.a option
 module Json_array(A : Json) : Json with type a = A.a array
+
+val read_list :
+  (Deriving_Json_lexer.lexbuf -> 'a) ->
+  Deriving_Json_lexer.lexbuf -> 'a list
+
+val write_list :
+  (Buffer.t -> 'a -> unit) -> Buffer.t -> 'a list -> unit
+
+val read_ref :
+  (Deriving_Json_lexer.lexbuf -> 'a) ->
+  Deriving_Json_lexer.lexbuf -> 'a ref
+
+val write_ref :
+  (Buffer.t -> 'a -> unit) -> Buffer.t -> 'a ref -> unit
+
+val read_option :
+  (Deriving_Json_lexer.lexbuf -> 'a) ->
+  Deriving_Json_lexer.lexbuf -> 'a option
+
+val write_option :
+  (Buffer.t -> 'a -> unit) -> Buffer.t -> 'a option -> unit
+
+val read_array :
+  (Deriving_Json_lexer.lexbuf -> 'a) ->
+  Deriving_Json_lexer.lexbuf -> 'a array
+
+val write_array :
+  (Buffer.t -> 'a -> unit) -> Buffer.t -> 'a array -> unit

--- a/lib/ppx/ppx_deriving_json.ml
+++ b/lib/ppx/ppx_deriving_json.ml
@@ -1,0 +1,484 @@
+(* Js_of_ocaml
+ * http://www.ocsigen.org
+ * Copyright Vasilis Papavasileiou 2015
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+
+let deriver = "json"
+
+let rec fresh_vars ?(acc = []) n =
+  if n <= 0 then
+    List.rev acc
+  else
+    let acc = Ppx_deriving.fresh_var acc :: acc in
+    fresh_vars ~acc (n - 1)
+
+let label_of_constructor {Location.txt} =
+  Longident.Lident txt |> Location.mknoloc
+
+let wrap_write r ~pattern =
+  [%expr fun buf [%p pattern] -> [%e r]]
+
+let wrap_read r = [%expr fun buf -> [%e r]]
+
+let json_attr attrs =
+  Ppx_deriving.attr ~deriver "json" attrs |>
+  Ppx_deriving.Arg.(get_attr ~deriver expr)
+
+let seqlist = function
+  | h :: l ->
+    let f acc e = [%expr [%e acc]; [%e e]] in
+    List.fold_left f h l
+  | [] ->
+    [%expr ()]
+
+let check_record_fields =
+  let f = function
+    | {Parsetree.pld_mutable = Mutable} ->
+      Location.raise_errorf
+        "%s cannot be derived for mutable records"
+        deriver
+    | {pld_type = {ptyp_desc = Ptyp_poly _}} ->
+      Location.raise_errorf
+        "%s cannot be derived for polymorphic records"
+        deriver
+    | _ ->
+      ()
+  in
+  List.iter f
+
+let rec write_tuple_contents l ly tag ~poly =
+  let e =
+    let f v y =
+      let arg = Ast_convenience.evar v in
+      let e = write_body_of_type y ~arg ~poly in
+      [%expr Buffer.add_string buf ","; [%e e]]
+    in
+    List.map2 f l ly |> seqlist
+  and s =
+    Asttypes.Const_string ("[" ^ string_of_int tag, None) |>
+    Ast_helper.Exp.constant
+  in [%expr
+    Buffer.add_string buf [%e s];
+    [%e e];
+    Buffer.add_string buf "]"
+  ]
+
+and write_body_of_tuple_type l ~arg ~poly ~tag =
+  let n = List.length l in
+  let vars = fresh_vars n in
+  let e = write_tuple_contents vars l tag ~poly
+  and p =
+    List.map Ast_convenience.pvar vars |>
+    Ast_helper.Pat.tuple
+  in
+  [%expr let [%p p] = [%e arg] in [%e e]]
+
+and write_case_of_constructor i f l =
+  let n = List.length l in
+  let vars = fresh_vars n in
+  let pc_lhs =
+    (match vars with
+     | [] ->
+       None
+     | [v] ->
+       Some (Ast_convenience.pvar v)
+     | _ ->
+       Some (List.map Ast_convenience.pvar vars |>
+             Ast_helper.Pat.tuple)) |> f
+  and pc_guard = None
+  and pc_rhs = write_tuple_contents vars l i ~poly:true in
+  {Parsetree.pc_lhs; pc_guard; pc_rhs}
+
+and write_of_variant l =
+  let e =
+    (let f i { Parsetree.pcd_name; pcd_args; pcd_loc = loc } =
+       let f =
+         label_of_constructor pcd_name |>
+         Ast_helper.Pat.construct in
+       write_case_of_constructor i f pcd_args
+     in
+     List.mapi f l) |> Ast_helper.Exp.function_
+  in
+  [%expr fun buf -> [%e e]]
+
+and write_body_of_poly_variant l ~arg ~loc ~poly =
+  (let f i = function
+     | Parsetree.Rtag (label, _, _, l) ->
+       let i = Ppx_deriving.hash_variant label
+       and f = Ast_helper.Pat.variant label in
+       write_case_of_constructor i f l
+   in
+   List.mapi f l) |> Ast_helper.Exp.match_ arg
+
+and write_body_of_type y ~arg ~poly =
+  match y with
+  | [%type: unit] ->
+    [%expr Deriving_Json.Json_unit.write buf [%e arg]]
+  | [%type: int] ->
+    [%expr Deriving_Json.Json_int.write buf [%e arg]]
+  | [%type: int32] | [%type: Int32.t] ->
+    [%expr Deriving_Json.Json_int32.write buf [%e arg]]
+  | [%type: int64] | [%type: Int64.t] ->
+    [%expr Deriving_Json.Json_int64.write buf [%e arg]]
+  | [%type: nativeint] | [%type: Nativeint.t] ->
+    [%expr Deriving_Json.Json_nativeint.write buf [%e arg]]
+  | [%type: float] ->
+    [%expr Deriving_Json.Json_float.write buf [%e arg]]
+  | [%type: bool] ->
+    [%expr Deriving_Json.Json_bool.write buf [%e arg]]
+  | [%type: char] ->
+    [%expr Deriving_Json.Json_char.write buf [%e arg]]
+  | [%type: string] ->
+    [%expr Deriving_Json.Json_string.write buf [%e arg]]
+  | [%type: bytes] ->
+    [%expr Deriving_Json.Json_bytes.write buf [%e arg]]
+  | [%type: [%t? y] list] ->
+    let e = [%expr [%e write_of_type y ~poly]] in
+    [%expr Deriving_Json.write_list [%e e] buf [%e arg]]
+  | [%type: [%t? y] ref] ->
+    let e = [%expr [%e write_of_type y ~poly]] in
+    [%expr Deriving_Json.write_ref [%e e] buf [%e arg]]
+  | [%type: [%t? y] option] ->
+    let e = [%expr [%e write_of_type y ~poly]] in
+    [%expr Deriving_Json.write_option [%e e] buf [%e arg]]
+  | [%type: [%t? y] array] ->
+    let e = [%expr [%e write_of_type y ~poly]] in
+    [%expr Deriving_Json.write_array [%e e] buf [%e arg]]
+  | { Parsetree.ptyp_desc = Ptyp_var v } when poly ->
+    let v = Ast_convenience.evar ("poly_" ^ v) in
+    [%expr Deriving_Json.write [%e v] buf [%e arg]]
+  | { Parsetree.ptyp_desc = Ptyp_tuple l } ->
+    write_body_of_tuple_type l ~arg ~poly ~tag:0
+  | { Parsetree.ptyp_desc = Ptyp_variant (l, _, _); ptyp_loc = loc } ->
+    write_body_of_poly_variant l ~arg ~loc ~poly
+  | { Parsetree.ptyp_desc = Ptyp_constr ({Asttypes.txt}, l) } ->
+    let e =
+      Ppx_deriving.mangle_lid (`Suffix "json") txt |>
+      Location.mknoloc |>
+      Ast_helper.Exp.ident
+    and l = List.map (json_of_type ~poly) l in
+    [%expr
+      Deriving_Json.write [%e Ast_convenience.app e l] buf [%e arg]]
+  | { Parsetree.ptyp_loc } ->
+    Location.raise_errorf ~loc:ptyp_loc
+      "%s_write cannot be derived for %s"
+      deriver (Ppx_deriving.string_of_core_type y)
+
+and write_of_type y ~poly : Parsetree.expression =
+  match json_attr y.Parsetree.ptyp_attributes with
+  | Some fn ->
+    fn
+  | None ->
+    let v = "a" in
+    let arg = Ast_convenience.evar v
+    and pattern = Ast_convenience.pvar v in
+    wrap_write (write_body_of_type y ~arg ~poly) ~pattern
+
+and write_of_record l =
+  check_record_fields l;
+  let pattern =
+    let l =
+      let f {Parsetree.pld_name} =
+        (let {Location.txt} = pld_name in
+         Location.mknoloc (Longident.Lident txt)),
+        Ast_helper.Pat.var pld_name
+      in
+      List.map f l
+    in
+    (* CHECKME: what is the closed_flag for? *)
+    Ast_helper.Pat.record l Asttypes.Closed
+  and e =
+    let l =
+      let f {Parsetree.pld_name = {txt}} = txt in
+      List.map f l
+    and ly =
+      let f {Parsetree.pld_type} = pld_type in
+      List.map f l
+    in
+    write_tuple_contents l ly 0 ~poly:true
+  in
+  wrap_write e ~pattern
+
+and read_tuple_contents l ~f ~poly =
+  let n = List.length l in
+  let lv = fresh_vars n in
+  let f v y acc =
+    let e = read_body_of_type y ~poly in [%expr
+      Deriving_Json_lexer.read_comma buf;
+      let [%p Ast_convenience.pvar v] = [%e e] in
+      [%e acc]
+    ]
+  and acc = List.map Ast_convenience.evar lv |> f in
+  let acc = [%expr Deriving_Json_lexer.read_rbracket buf; [%e acc]] in
+  List.fold_right2 f lv l acc
+
+and read_body_of_tuple_type l ~poly = [%expr
+  Deriving_Json_lexer.read_lbracket buf;
+  ignore (Deriving_Json_lexer.read_tag_1 0 buf);
+  [%e read_tuple_contents l ~f:Ast_helper.Exp.tuple ~poly]
+]
+
+and read_of_record l =
+  check_record_fields l;
+  let e =
+    let f =
+      let f {Parsetree.pld_name = {txt}} e =
+        (Longident.Lident txt |> Location.mknoloc), e
+      in
+      fun l' -> Ast_helper.Exp.record (List.map2 f l l') None
+    and l =
+      let f {Parsetree.pld_type} = pld_type in
+      List.map f l
+    in
+    read_tuple_contents l ~f ~poly:true
+  in [%expr
+    Deriving_Json_lexer.read_lbracket buf;
+    ignore (Deriving_Json_lexer.read_tag_2 0 254 buf);
+    [%e e]
+  ] |> wrap_read
+
+and read_body_of_poly_variant l ~loc ~poly =
+  let l =
+    let f = function
+      | Parsetree.Rtag (label, _, _, l) ->
+        let i = Ppx_deriving.hash_variant label
+        and f = Ast_helper.Exp.variant label in
+        read_case_of_constructor i f l
+    and default =
+      let pc_lhs = [%pat? _]
+      and pc_guard = None
+      and pc_rhs =
+        (* FIXME: typename *)
+        [%expr Deriving_Json_lexer.tag_error ~typename:"" buf]
+      in
+      {Parsetree.pc_lhs; pc_guard; pc_rhs}
+    in
+    List.map f l @ [default]
+  and e = [%expr Deriving_Json_lexer.read_case buf] in
+  Ast_helper.Exp.match_ e l
+
+and read_body_of_type y ~poly =
+  match y with
+  | [%type: unit] ->
+    [%expr Deriving_Json.Json_unit.read buf]
+  | [%type: int] ->
+    [%expr Deriving_Json.Json_int.read buf]
+  | [%type: int32] | [%type: Int32.t] ->
+    [%expr Deriving_Json.Json_int32.read buf]
+  | [%type: int64] | [%type: Int64.t] ->
+    [%expr Deriving_Json.Json_int64.read buf]
+  | [%type: nativeint] | [%type: Nativeint.t] ->
+    [%expr Deriving_Json.Json_nativeint.read buf]
+  | [%type: float] ->
+    [%expr Deriving_Json.Json_float.read buf]
+  | [%type: bool] ->
+    [%expr Deriving_Json.Json_bool.read buf]
+  | [%type: char] ->
+    [%expr Deriving_Json.Json_char.read buf]
+  | [%type: string] ->
+    [%expr Deriving_Json.Json_string.read buf]
+  | [%type: bytes] ->
+    [%expr Deriving_Json.Json_bytes.read buf]
+  | [%type: [%t? y] list] ->
+    let e = [%expr [%e read_of_type y ~poly]] in
+    [%expr Deriving_Json.read_list [%e e] buf]
+  | [%type: [%t? y] ref] ->
+    let e = [%expr [%e read_of_type y ~poly]] in
+    [%expr Deriving_Json.read_ref [%e e] buf]
+  | [%type: [%t? y] option] ->
+    let e = [%expr [%e read_of_type y ~poly]] in
+    [%expr Deriving_Json.read_option [%e e] buf]
+  | [%type: [%t? y] array] ->
+    let e = [%expr [%e read_of_type y ~poly]] in
+    [%expr Deriving_Json.read_array [%e e] buf]
+  | { Parsetree.ptyp_desc = Ptyp_tuple l } ->
+    read_body_of_tuple_type l ~poly
+  | { Parsetree.ptyp_desc = Ptyp_variant (l, _, _); ptyp_loc = loc } ->
+    read_body_of_poly_variant l ~loc ~poly
+  | { Parsetree.ptyp_desc = Ptyp_var v } when poly ->
+    let v = Ast_convenience.evar ("poly_" ^ v) in
+    [%expr Deriving_Json.read [%e v] buf]
+  | { Parsetree.ptyp_desc = Ptyp_constr ({Asttypes.txt}, l) } ->
+    let e =
+      Ppx_deriving.mangle_lid (`Suffix "json") txt |>
+      Location.mknoloc |>
+      Ast_helper.Exp.ident
+    and l = List.map (json_of_type ~poly) l in
+    [%expr Deriving_Json.read [%e Ast_convenience.app e l] buf]
+  | { Parsetree.ptyp_loc } ->
+    Location.raise_errorf ~loc:ptyp_loc
+      "%s_read cannot be derived for %s"
+      deriver (Ppx_deriving.string_of_core_type y)
+
+and read_case_of_constructor i f l =
+  let pc_lhs =
+    let p = Ast_helper.Pat.constant (Asttypes.Const_int i) in
+    match l with
+    | [] ->
+      [%pat? `Cst [%p p]]
+    | _ ->
+      [%pat? `NCst [%p p]]
+  and pc_guard = None
+  and pc_rhs =
+    let f l =
+      let e =
+        match l with
+        | [] ->  None
+        | [e] -> Some e
+        | l ->   Some (Ast_helper.Exp.tuple l)
+      in
+      f e
+    in
+    (* TODO : check poly *)
+    read_tuple_contents l ~f ~poly:true
+  in
+  {Parsetree.pc_lhs; pc_guard; pc_rhs}
+
+and read_of_variant l =
+  (let l =
+     let f i { Parsetree.pcd_name; pcd_args; pcd_loc = loc } =
+       let f =
+         let label = label_of_constructor pcd_name in
+         Ast_helper.Exp.construct label
+       in
+       read_case_of_constructor i f pcd_args
+     and default =
+       let pc_lhs = [%pat? _]
+       and pc_guard = None
+       and pc_rhs =
+         (* FIXME: typename *)
+         [%expr Deriving_Json_lexer.tag_error ~typename:"" buf]
+       in
+       {Parsetree.pc_lhs; pc_guard; pc_rhs}
+     in
+     List.mapi f l @ [default]
+   and e = [%expr Deriving_Json_lexer.read_case buf] in
+   Ast_helper.Exp.match_ e l) |> wrap_read
+
+and read_of_type y ~poly =
+  match json_attr y.Parsetree.ptyp_attributes with
+  | Some fn ->
+    fn
+  | None ->
+    wrap_read (read_body_of_type y ~poly)
+
+and json_of_type y ~poly =
+  match json_attr y.Parsetree.ptyp_attributes with
+  | Some fn ->
+    fn
+  | None ->
+    let read = read_of_type y ~poly
+    and write = write_of_type y ~poly in
+    [%expr Deriving_Json.make [%e write] [%e read]]
+
+let write_poly_type d =
+  let f v = [%type: Deriving_Json_lexer.lexbuf -> [%t v] -> unit]
+  and y =
+    let y = Ppx_deriving.core_type_of_type_decl d in
+    [%type: Deriving_Json_lexer.lexbuf -> [%t y] -> unit]
+  in
+  Ppx_deriving.poly_arrow_of_type_decl f d y
+
+let write_str_wrap d e =
+  let e = Ppx_deriving.poly_fun_of_type_decl d e
+  and v =
+    Ppx_deriving.mangle_type_decl (`Suffix "to_json") d |>
+    Ast_convenience.pvar
+  and y = write_poly_type d in
+  Ast_helper.(Vb.mk (Pat.constraint_ v y) e)
+
+let read_poly_type d =
+  let f v = [%type: Deriving_Json_lexer.lexbuf -> [%t v]]
+  and y =
+    let y = Ppx_deriving.core_type_of_type_decl d in
+    [%type: Deriving_Json_lexer.lexbuf -> [%t y]]
+  in
+  Ppx_deriving.poly_arrow_of_type_decl f d y
+
+let json_of_variant l =
+  let read = read_of_variant l
+  and write = write_of_variant l in
+  [%expr Deriving_Json.make [%e write] [%e read]]
+
+let json_of_record l =
+  let read = read_of_record l
+  and write = write_of_record l in
+  [%expr Deriving_Json.make [%e write] [%e read]]
+
+let json_poly_type d =
+  let f v = [%type: [%t v] Deriving_Json.t]
+  and y =
+    let y = Ppx_deriving.core_type_of_type_decl d in
+    [%type: [%t y] Deriving_Json.t]
+  in
+  Ppx_deriving.poly_arrow_of_type_decl f d y
+
+let json_str_wrap d e =
+  let v =
+    Ppx_deriving.mangle_type_decl (`Suffix "json") d |>
+    Ast_convenience.pvar
+  and y = json_poly_type d in
+  Ast_helper.(Vb.mk (Pat.constraint_ v y) e)
+
+let json_str_of_decl d =
+  let e =
+    match d with
+    | { Parsetree.ptype_manifest = Some y } ->
+      json_of_type y ~poly:true
+    | { ptype_kind = Ptype_variant l } ->
+      json_of_variant l
+    | { ptype_kind = Ptype_record l } ->
+      json_of_record l
+    | _ ->
+      Location.raise_errorf "%s cannot be derived" deriver
+  in
+  Ppx_deriving.poly_fun_of_type_decl d e |>
+  Ppx_deriving.sanitize |>
+  json_str_wrap d
+
+let _ =
+  let core_type y =
+    (let r = read_of_type y ~poly:false
+     and x = [%expr
+       Deriving_Json_lexer.init_lexer (Lexing.from_string s)
+     ] in
+     [%expr fun s -> [%e r] [%e x]]) |>
+    Ppx_deriving.sanitize
+  in
+  Ppx_deriving.(create "of_json" ~core_type () |> register)
+
+let _ =
+  let core_type y =
+    (let e = write_of_type y ~poly:false in [%expr
+       fun x ->
+         let buf = Buffer.create 50 in
+         [%e e] buf x;
+         Buffer.contents buf
+     ]) |>
+    Ppx_deriving.sanitize
+  in
+  Ppx_deriving.(create "to_json" ~core_type () |> register)
+
+let _ =
+  let core_type y =
+    json_of_type y ~poly:false |>
+    Ppx_deriving.sanitize
+  and type_decl_str ~options ~path l =
+    let l = List.map (json_str_of_decl) l in
+    [Ast_helper.Str.value Asttypes.Nonrecursive l]
+  in
+  Ppx_deriving.(create "json" ~core_type ~type_decl_str () |> register)

--- a/lib/ppx/ppx_deriving_json.ml
+++ b/lib/ppx/ppx_deriving_json.ml
@@ -176,7 +176,7 @@ and write_of_type y ~poly =
   and pattern = Ast_convenience.pvar v in
   wrap_write (write_body_of_type y ~arg ~poly) ~pattern
 
-and write_of_record l =
+and write_of_record d l =
   let pattern =
     let l =
       let f {Parsetree.pld_name} =
@@ -280,7 +280,7 @@ and read_body_of_tuple_type ?decl l = [%expr
   ignore (Deriving_Json_lexer.read_tag_1 0 buf);
   [%e read_tuple_contents ?decl l ~f:Ast_helper.Exp.tuple]]
 
-and read_of_record l =
+and read_of_record decl l =
   let e =
     let f =
       let f {Parsetree.pld_name = {txt}} e =
@@ -291,7 +291,7 @@ and read_of_record l =
       let f {Parsetree.pld_type} = pld_type in
       List.map f l
     in
-    read_tuple_contents l ~f
+    read_tuple_contents l ~decl ~f
   in [%expr
     Deriving_Json_lexer.read_lbracket buf;
     ignore (Deriving_Json_lexer.read_tag_2 0 254 buf);
@@ -522,10 +522,10 @@ let json_decls_of_variant d l =
   None, None
 
 let write_decl_of_record d l =
-  write_of_record l |> write_str_wrap d
+  write_of_record d l |> write_str_wrap d
 
 let read_decl_of_record d l =
-  read_of_record l |> read_str_wrap d
+  read_of_record d l |> read_str_wrap d
 
 let json_decls_of_record d l =
   check_record_fields l;

--- a/lib/ppx/ppx_deriving_json.ml
+++ b/lib/ppx/ppx_deriving_json.ml
@@ -26,6 +26,11 @@ let rec fresh_vars ?(acc = []) n =
     let acc = Ppx_deriving.fresh_var acc :: acc in
     fresh_vars ~acc (n - 1)
 
+let unreachable_case () =
+  {Parsetree.pc_lhs = [%pat? _ ];
+   pc_guard = None;
+   pc_rhs = [%expr assert false]}
+
 let label_of_constructor {Location.txt} =
   Longident.Lident txt |> Location.mknoloc
 
@@ -49,12 +54,10 @@ let check_record_fields =
   let f = function
     | {Parsetree.pld_mutable = Mutable} ->
       Location.raise_errorf
-        "%s cannot be derived for mutable records"
-        deriver
+        "%s cannot be derived for mutable records" deriver
     | {pld_type = {ptyp_desc = Ptyp_poly _}} ->
       Location.raise_errorf
-        "%s cannot be derived for polymorphic records"
-        deriver
+        "%s cannot be derived for polymorphic records" deriver
     | _ ->
       ()
   in
@@ -121,8 +124,15 @@ and write_body_of_poly_variant l ~arg ~loc ~poly =
        let i = Ppx_deriving.hash_variant label
        and f = Ast_helper.Pat.variant label in
        write_case_of_constructor i f l
+     | Rinherit ({ptyp_desc = Ptyp_constr (_, _)} as y) ->
+       let pc_lhs = [%pat? _]
+       and pc_guard = None
+       and pc_rhs =
+         let arg = [%expr ([%e arg] :> [> [%t y]])] in
+         write_body_of_type y ~arg ~poly in
+       {Parsetree.pc_lhs; pc_guard; pc_rhs}
    in
-   List.mapi f l) |> Ast_helper.Exp.match_ arg
+   List.mapi f l @ [unreachable_case ()]) |> Ast_helper.Exp.match_ arg
 
 and write_body_of_type y ~arg ~poly =
   match y with
@@ -159,20 +169,18 @@ and write_body_of_type y ~arg ~poly =
     let e = [%expr [%e write_of_type y ~poly]] in
     [%expr Deriving_Json.write_array [%e e] buf [%e arg]]
   | { Parsetree.ptyp_desc = Ptyp_var v } when poly ->
-    let v = Ast_convenience.evar ("poly_" ^ v) in
-    [%expr Deriving_Json.write [%e v] buf [%e arg]]
+    [%expr [%e Ast_convenience.evar ("poly_" ^ v)] buf [%e arg]]
   | { Parsetree.ptyp_desc = Ptyp_tuple l } ->
     write_body_of_tuple_type l ~arg ~poly ~tag:0
   | { Parsetree.ptyp_desc = Ptyp_variant (l, _, _); ptyp_loc = loc } ->
     write_body_of_poly_variant l ~arg ~loc ~poly
   | { Parsetree.ptyp_desc = Ptyp_constr ({Asttypes.txt}, l) } ->
     let e =
-      Ppx_deriving.mangle_lid (`Suffix "json") txt |>
+      Ppx_deriving.mangle_lid (`Suffix "to_json") txt |>
       Location.mknoloc |>
       Ast_helper.Exp.ident
-    and l = List.map (json_of_type ~poly) l in
-    [%expr
-      Deriving_Json.write [%e Ast_convenience.app e l] buf [%e arg]]
+    and l = List.map (write_of_type ~poly) l in
+    [%expr [%e Ast_convenience.app e l] buf [%e arg]]
   | { Parsetree.ptyp_loc } ->
     Location.raise_errorf ~loc:ptyp_loc
       "%s_write cannot be derived for %s"
@@ -310,19 +318,18 @@ and read_body_of_type y ~poly =
   | { Parsetree.ptyp_desc = Ptyp_variant (l, _, _); ptyp_loc = loc } ->
     read_body_of_poly_variant l ~loc ~poly
   | { Parsetree.ptyp_desc = Ptyp_var v } when poly ->
-    let v = Ast_convenience.evar ("poly_" ^ v) in
-    [%expr Deriving_Json.read [%e v] buf]
+    [%expr [%e Ast_convenience.evar ("poly_" ^ v)] buf]
   | { Parsetree.ptyp_desc = Ptyp_constr ({Asttypes.txt}, l) } ->
     let e =
-      Ppx_deriving.mangle_lid (`Suffix "json") txt |>
+      Ppx_deriving.mangle_lid (`Suffix "of_json") txt |>
       Location.mknoloc |>
       Ast_helper.Exp.ident
-    and l = List.map (json_of_type ~poly) l in
-    [%expr Deriving_Json.read [%e Ast_convenience.app e l] buf]
+    and l = List.map (read_of_type ~poly) l in
+    [%expr [%e Ast_convenience.app e l] buf]
   | { Parsetree.ptyp_loc } ->
     Location.raise_errorf ~loc:ptyp_loc
-      "%s_read cannot be derived for %s"
-      deriver (Ppx_deriving.string_of_core_type y)
+      "%s_read cannot be derived for %s" deriver
+      (Ppx_deriving.string_of_core_type y)
 
 and read_case_of_constructor i f l =
   let pc_lhs =
@@ -385,70 +392,113 @@ and json_of_type y ~poly =
     and write = write_of_type y ~poly in
     [%expr Deriving_Json.make [%e write] [%e read]]
 
-let write_poly_type d =
-  let f v = [%type: Deriving_Json_lexer.lexbuf -> [%t v] -> unit]
-  and y =
-    let y = Ppx_deriving.core_type_of_type_decl d in
-    [%type: Deriving_Json_lexer.lexbuf -> [%t y] -> unit]
-  in
-  Ppx_deriving.poly_arrow_of_type_decl f d y
-
-let write_str_wrap d e =
+let fun_str_wrap d e ~f ~suffix =
   let e = Ppx_deriving.poly_fun_of_type_decl d e
   and v =
-    Ppx_deriving.mangle_type_decl (`Suffix "to_json") d |>
+    Ppx_deriving.mangle_type_decl (`Suffix suffix) d |>
     Ast_convenience.pvar
-  and y = write_poly_type d in
+  and y =
+    let y = f (Ppx_deriving.core_type_of_type_decl d) in
+    Ppx_deriving.poly_arrow_of_type_decl f d y
+  in
   Ast_helper.(Vb.mk (Pat.constraint_ v y) e)
 
-let read_poly_type d =
-  let f v = [%type: Deriving_Json_lexer.lexbuf -> [%t v]]
-  and y =
-    let y = Ppx_deriving.core_type_of_type_decl d in
-    [%type: Deriving_Json_lexer.lexbuf -> [%t y]]
-  in
-  Ppx_deriving.poly_arrow_of_type_decl f d y
+let read_str_wrap =
+  let f y = [%type: Deriving_Json_lexer.lexbuf -> [%t y]]
+  and suffix = "of_json" in
+  fun_str_wrap ~f ~suffix
+
+let write_str_wrap =
+  let f y = [%type: Buffer.t -> [%t y] -> unit]
+  and suffix = "to_json" in
+  fun_str_wrap ~f ~suffix
 
 let json_of_variant l =
-  let read = read_of_variant l
-  and write = write_of_variant l in
+  let read = read_of_variant l and write = write_of_variant l in
   [%expr Deriving_Json.make [%e write] [%e read]]
 
 let json_of_record l =
-  let read = read_of_record l
-  and write = write_of_record l in
+  let read = read_of_record l and write = write_of_record l in
   [%expr Deriving_Json.make [%e write] [%e read]]
 
 let json_poly_type d =
-  let f v = [%type: [%t v] Deriving_Json.t]
-  and y =
-    let y = Ppx_deriving.core_type_of_type_decl d in
-    [%type: [%t y] Deriving_Json.t]
-  in
+  let f y = [%type: [%t y] Deriving_Json.t] in
+  let y = f (Ppx_deriving.core_type_of_type_decl d) in
   Ppx_deriving.poly_arrow_of_type_decl f d y
 
 let json_str_wrap d e =
   let v =
     Ppx_deriving.mangle_type_decl (`Suffix "json") d |>
     Ast_convenience.pvar
+  and e = Ppx_deriving.(poly_fun_of_type_decl d e |> sanitize)
   and y = json_poly_type d in
   Ast_helper.(Vb.mk (Pat.constraint_ v y) e)
 
-let json_str_of_decl d =
-  let e =
-    match d with
-    | { Parsetree.ptype_manifest = Some y } ->
-      json_of_type y ~poly:true
-    | { ptype_kind = Ptype_variant l } ->
-      json_of_variant l
-    | { ptype_kind = Ptype_record l } ->
-      json_of_record l
-    | _ ->
-      Location.raise_errorf "%s cannot be derived" deriver
+let json_str d =
+  let write =
+    let f acc id =
+      let poly = Ast_convenience.evar ("poly_" ^ id) in
+      [%expr [%e acc] (Deriving_Json.write [%e poly])]
+    and acc =
+      Ppx_deriving.mangle_type_decl (`Suffix "to_json") d |>
+      Ast_convenience.evar
+    in
+    Ppx_deriving.fold_left_type_decl f acc d
+  and read =
+    let f acc id =
+      let poly = Ast_convenience.evar ("poly_" ^ id) in
+      [%expr [%e acc] (Deriving_Json.read [%e poly])]
+    and acc =
+      Ppx_deriving.mangle_type_decl (`Suffix "of_json") d |>
+      Ast_convenience.evar
+    in
+    Ppx_deriving.fold_left_type_decl f acc d
   in
-  Ppx_deriving.poly_fun_of_type_decl d e |>
-  Ppx_deriving.sanitize |>
+  [%expr Deriving_Json.make [%e write] [%e read]] |>
   json_str_wrap d
+
+let write_decl_of_type d y =
+  (let e =
+     let arg = Ast_convenience.evar "a" in
+     write_body_of_type y ~arg ~poly:true
+   in
+   [%expr fun buf a -> [%e e]]) |> write_str_wrap d
+
+let read_decl_of_type d y =
+  (let e = read_body_of_type y ~poly:true in
+   [%expr fun buf -> [%e e]]) |> read_str_wrap d
+
+let json_decls_of_type d y =
+  write_decl_of_type d y, read_decl_of_type d y, json_str d
+
+let write_decl_of_variant d l =
+  write_of_variant l |> write_str_wrap d
+
+let read_decl_of_variant d l =
+  read_of_variant l |> read_str_wrap d
+
+let json_decls_of_variant d l =
+  write_decl_of_variant d l, read_decl_of_variant d l, json_str d
+
+let write_decl_of_record d l =
+  write_of_record l |> write_str_wrap d
+
+let read_decl_of_record d l =
+  read_of_record l |> read_str_wrap d
+
+let json_decls_of_record d l =
+  write_decl_of_record d l, read_decl_of_record d l, json_str d
+
+let json_str_of_decl d =
+  match d with
+  | { Parsetree.ptype_manifest = Some y } ->
+    json_decls_of_type d y
+  | { ptype_kind = Ptype_variant l } ->
+    json_decls_of_variant d l
+  | { ptype_kind = Ptype_record l } ->
+    json_decls_of_record d l
+  | _ ->
+    Location.raise_errorf "%s cannot be derived" deriver
 
 let _ =
   let core_type y =
@@ -478,7 +528,13 @@ let _ =
     json_of_type y ~poly:false |>
     Ppx_deriving.sanitize
   and type_decl_str ~options ~path l =
-    let l = List.map (json_str_of_decl) l in
-    [Ast_helper.Str.value Asttypes.Nonrecursive l]
+    let lr, lw, lj =
+      let f d (lr, lw, lj) =
+        let r, w, j = json_str_of_decl d in
+        r :: lr, w :: lw, j :: lj
+      and acc = [], [], [] in
+      List.fold_right f l acc
+    and f l = Ast_helper.Str.value Asttypes.Recursive l in
+    [f lr; f lw; f lj]
   in
   Ppx_deriving.(create "json" ~core_type ~type_decl_str () |> register)

--- a/opam
+++ b/opam
@@ -21,8 +21,7 @@ depends: [
   "base64" {>= "2.0.0"}
   ( "base-no-ppx" | "ppx_tools" )
 ]
-depopts: ["deriving" "tyxml" "reactiveData" ]
-
+depopts: ["deriving" "ppx_deriving" "tyxml" "reactiveData" ]
 conflicts: [
   "deriving" {< "0.6"}
   "tyxml"    {< "3.5.0"}


### PR DESCRIPTION
This is a PPX version of our JSON deriving plug-in.

The generated code is somewhat different from the Camlp4 version. We follow the conventions of `ppx_deriving`, as opposed to the functorial style of (Camlp4) `deriving`.

The serialization format is the same, i.e., in principle you can dump `x` with Camlp4, parse the result with PPX, and get back `x`. Any divergence is a bug to be fixed.

I provide a few tests that demonstrate the syntax [as a Gist](https://gist.github.com/vasilisp/187ea176382511db3146).