### PR TITLE
Mutation observers API: https://dom.spec.whatwg.org/#mutation-observers

### DIFF
--- a/doc/api/index
+++ b/doc/api/index
@@ -24,6 +24,7 @@ WebGL
 WebSockets
 Geolocation
 Jstable
+MutationObserver
 }
 
 {1 Ppx - API Reference}

--- a/lib/.depend
+++ b/lib/.depend
@@ -38,6 +38,8 @@ lwt_js_events.cmx : lwt_js.cmx js.cmx firebug.cmx dom_html.cmx dom.cmx \
     lwt_js_events.cmi
 lwt_js.cmo : js.cmi firebug.cmi dom_html.cmi lwt_js.cmi
 lwt_js.cmx : js.cmx firebug.cmx dom_html.cmx lwt_js.cmi
+mutationObserver.cmo : js.cmi dom.cmi mutationObserver.cmi
+mutationObserver.cmx : js.cmx dom.cmx mutationObserver.cmi
 regexp.cmo : js.cmi regexp.cmi
 regexp.cmx : js.cmx regexp.cmi
 sys_js.cmo : lib_version.cmo js.cmi sys_js.cmi
@@ -73,6 +75,7 @@ jstable.cmi : js.cmi
 keycode.cmi :
 lwt_js_events.cmi : js.cmi dom_html.cmi
 lwt_js.cmi :
+mutationObserver.cmi : js.cmi dom.cmi
 regexp.cmi :
 sys_js.cmi : js.cmi
 typed_array.cmi : js.cmi

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,4 +1,4 @@
-MLOBJS= js.cmo dom.cmo typed_array.cmo dom_html.cmo dom_svg.cmo file.cmo dom_events.cmo firebug.cmo lwt_js.cmo sys_js.cmo regexp.cmo cSS.cmo url.cmo form.cmo xmlHttpRequest.cmo lwt_js_events.cmo json.cmo jsonp.cmo webGL.cmo webSockets.cmo keycode.cmo eventSource.cmo geolocation.cmo jstable.cmo
+MLOBJS= js.cmo dom.cmo typed_array.cmo dom_html.cmo dom_svg.cmo file.cmo dom_events.cmo firebug.cmo lwt_js.cmo sys_js.cmo regexp.cmo cSS.cmo url.cmo form.cmo xmlHttpRequest.cmo lwt_js_events.cmo json.cmo jsonp.cmo webGL.cmo webSockets.cmo keycode.cmo eventSource.cmo geolocation.cmo jstable.cmo mutationObserver.cmo
 MLINTFS= $(MLOBJS:.cmo=.mli)
 COBJS= stubs$(OBJEXT)
 OBJS=lib_version.cmo $(MLOBJS) $(COBJS)

--- a/lib/mutationObserver.ml
+++ b/lib/mutationObserver.ml
@@ -1,0 +1,53 @@
+(* Js_of_ocaml library
+ * http://www.ocsigen.org/js_of_ocaml/
+ * Copyright (C) 2015 Stéphane Legrand
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+
+class type _MutationObserverInit = object
+  method childList : bool Js.writeonly_prop
+  method attributes : bool Js.writeonly_prop
+  method characterData : bool Js.writeonly_prop
+  method subtree : bool Js.writeonly_prop
+  method attributeOldValue : bool Js.writeonly_prop
+  method characterDataOldValue : bool Js.writeonly_prop
+  method attributeFilter : Js.js_string Js.t Js.js_array Js.t Js.writeonly_prop
+end
+
+class type _MutationRecord = object
+  method _type : Js.js_string Js.t Js.readonly_prop
+  method target : Dom.node Js.t Js.readonly_prop
+  method addedNodes : Dom.node Js.t Dom.nodeList Js.t Js.readonly_prop
+  method removedNodes : Dom.node Js.t Dom.nodeList Js.t Js.readonly_prop
+  method previousSibling : Dom.node Js.t Js.opt Js.readonly_prop
+  method nextSibling : Dom.node Js.t Js.opt Js.readonly_prop
+  method attributeName : Js.js_string Js.t Js.opt Js.readonly_prop
+  method attributeNamespace : Js.js_string Js.t Js.opt Js.readonly_prop
+  method oldValue : Js.js_string Js.t Js.opt Js.readonly_prop
+end
+
+class type _MutationObserver = object
+  method observe : Dom.node Js.t -> _MutationObserverInit Js.t -> unit Js.meth
+  method disconnect : unit Js.meth
+  method takeRecords : _MutationRecord Js.t Js.js_array Js.t Js.meth
+end
+
+let empty_mutation_observer_init () = Js.Unsafe.obj [||]
+
+let mutationObserver =
+  Js.Unsafe.global##_MutationObserver
+
+let is_supported () = Js.Optdef.test mutationObserver

--- a/lib/mutationObserver.ml
+++ b/lib/mutationObserver.ml
@@ -51,3 +51,42 @@ let mutationObserver =
   Js.Unsafe.global##_MutationObserver
 
 let is_supported () = Js.Optdef.test mutationObserver
+
+let observe ~(node:Dom.node Js.t)
+  ~(f:_MutationRecord Js.t Js.js_array Js.t -> _MutationObserver Js.t -> unit)
+  ?(child_list:bool option) ?(attributes:bool option)
+  ?(character_data:bool option) ?(subtree:bool option)
+  ?(attribute_old_value:bool option) ?(character_data_old_value:bool option)
+  ?(attribute_filter:Js.js_string Js.t list option) () : _MutationObserver Js.t =
+  let obs = jsnew mutationObserver(Js.wrap_callback f) in
+  let cfg = empty_mutation_observer_init () in
+  let () =
+    match child_list with None -> () | Some v -> cfg##childList <- v
+  in
+  let () =
+    match attributes with None -> () | Some v -> cfg##attributes <- v
+  in
+  let () =
+    match character_data with None -> () | Some v -> cfg##characterData <- v
+  in
+  let () =
+    match subtree with None -> () | Some v -> cfg##subtree <- v
+  in
+  let () =
+    match attribute_old_value with None -> () | Some v -> cfg##attributeOldValue <- v
+  in
+  let () =
+    match character_data_old_value with None -> () | Some v -> cfg##characterDataOldValue <- v
+  in
+  let () =
+    match attribute_filter with
+    | None -> ()
+    | Some l ->
+      let a = jsnew Js.array_length (List.length l) in
+      let () =
+        List.iteri (fun i v -> Js.array_set a i v) l
+      in
+      cfg##attributeFilter <- a
+  in
+  let () = obs##observe(node, cfg) in
+  obs

--- a/lib/mutationObserver.ml
+++ b/lib/mutationObserver.ml
@@ -39,7 +39,7 @@ class type _MutationRecord = object
   method oldValue : Js.js_string Js.t Js.opt Js.readonly_prop
 end
 
-class type _MutationObserver = object
+class type mutationObserver = object
   method observe : Dom.node Js.t -> _MutationObserverInit Js.t -> unit Js.meth
   method disconnect : unit Js.meth
   method takeRecords : _MutationRecord Js.t Js.js_array Js.t Js.meth
@@ -53,11 +53,11 @@ let mutationObserver =
 let is_supported () = Js.Optdef.test mutationObserver
 
 let observe ~(node:Dom.node Js.t)
-  ~(f:_MutationRecord Js.t Js.js_array Js.t -> _MutationObserver Js.t -> unit)
+  ~(f:_MutationRecord Js.t Js.js_array Js.t -> mutationObserver Js.t -> unit)
   ?(child_list:bool option) ?(attributes:bool option)
   ?(character_data:bool option) ?(subtree:bool option)
   ?(attribute_old_value:bool option) ?(character_data_old_value:bool option)
-  ?(attribute_filter:Js.js_string Js.t list option) () : _MutationObserver Js.t =
+  ?(attribute_filter:Js.js_string Js.t list option) () : mutationObserver Js.t =
   let obs = jsnew mutationObserver(Js.wrap_callback f) in
   let cfg = empty_mutation_observer_init () in
   let () =

--- a/lib/mutationObserver.mli
+++ b/lib/mutationObserver.mli
@@ -62,7 +62,7 @@ class type _MutationRecord = object
   method oldValue : Js.js_string Js.t Js.opt Js.readonly_prop
 end
 
-class type _MutationObserver = object
+class type mutationObserver = object
   method observe : Dom.node Js.t -> _MutationObserverInit Js.t -> unit Js.meth
   method disconnect : unit Js.meth
   method takeRecords : _MutationRecord Js.t Js.js_array Js.t Js.meth
@@ -70,13 +70,13 @@ end
 
 val empty_mutation_observer_init : unit -> _MutationObserverInit Js.t
 
-val mutationObserver : ((_MutationRecord Js.t Js.js_array Js.t -> _MutationObserver Js.t -> unit) Js.callback -> _MutationObserver Js.t) Js.constr
+val mutationObserver : ((_MutationRecord Js.t Js.js_array Js.t -> mutationObserver Js.t -> unit) Js.callback -> mutationObserver Js.t) Js.constr
 
 val is_supported : unit -> bool
 
 (** Helper to create a new observer and connect it to a node *)
 val observe : node:(Dom.node Js.t)
-  -> f:(_MutationRecord Js.t Js.js_array Js.t -> _MutationObserver Js.t -> unit)
+  -> f:(_MutationRecord Js.t Js.js_array Js.t -> mutationObserver Js.t -> unit)
   -> ?child_list:bool
   -> ?attributes:bool
   -> ?character_data:bool
@@ -85,4 +85,4 @@ val observe : node:(Dom.node Js.t)
   -> ?character_data_old_value:bool
   -> ?attribute_filter:(Js.js_string Js.t list)
   -> unit
-  -> _MutationObserver Js.t
+  -> mutationObserver Js.t

--- a/lib/mutationObserver.mli
+++ b/lib/mutationObserver.mli
@@ -1,0 +1,78 @@
+(* Js_of_ocaml library
+ * http://www.ocsigen.org/js_of_ocaml/
+ * Copyright (C) 2015 Stéphane Legrand
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+
+(** MutationObserver API
+
+  A code example:
+  {[
+    if (MutationObserver.is_supported()) then
+      let doc = Dom_html.document in
+      let target =
+        Js.Opt.get (doc##getElementById(Js.string "observed"))
+          (fun () -> assert false)
+      in
+      let target' = (target :> Dom.node Js.t) in
+      let f records observer =
+        Firebug.console##debug(records) ;
+        Firebug.console##debug(observer)
+      in
+      let observer = jsnew MutationObserver.mutationObserver(Js.wrap_callback f) in
+      let config = MutationObserver.empty_mutation_observer_init() in
+      config##attributes <- true ;
+      config##childList <- true ;
+      config##characterData <- true ;
+      observer##observe(target', config)
+  ]}
+
+  @see <https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver> for API documentation.
+  @see <https://dom.spec.whatwg.org/#mutation-observers> for the Web Hypertext Application Technology Working Group (WHATWG) spec. *)
+
+class type _MutationObserverInit = object
+  method childList : bool Js.writeonly_prop
+  method attributes : bool Js.writeonly_prop
+  method characterData : bool Js.writeonly_prop
+  method subtree : bool Js.writeonly_prop
+  method attributeOldValue : bool Js.writeonly_prop
+  method characterDataOldValue : bool Js.writeonly_prop
+  method attributeFilter : Js.js_string Js.t Js.js_array Js.t Js.writeonly_prop
+end
+
+class type _MutationRecord = object
+  method _type : Js.js_string Js.t Js.readonly_prop
+  method target : Dom.node Js.t Js.readonly_prop
+  method addedNodes : Dom.node Js.t Dom.nodeList Js.t Js.readonly_prop
+  method removedNodes : Dom.node Js.t Dom.nodeList Js.t Js.readonly_prop
+  method previousSibling : Dom.node Js.t Js.opt Js.readonly_prop
+  method nextSibling : Dom.node Js.t Js.opt Js.readonly_prop
+  method attributeName : Js.js_string Js.t Js.opt Js.readonly_prop
+  method attributeNamespace : Js.js_string Js.t Js.opt Js.readonly_prop
+  method oldValue : Js.js_string Js.t Js.opt Js.readonly_prop
+end
+
+class type _MutationObserver = object
+  method observe : Dom.node Js.t -> _MutationObserverInit Js.t -> unit Js.meth
+  method disconnect : unit Js.meth
+  method takeRecords : _MutationRecord Js.t Js.js_array Js.t Js.meth
+end
+
+val empty_mutation_observer_init : unit -> _MutationObserverInit Js.t
+
+val mutationObserver : ((_MutationRecord Js.t Js.js_array Js.t -> _MutationObserver Js.t -> unit) Js.callback -> _MutationObserver Js.t) Js.constr
+
+val is_supported : unit -> bool

--- a/lib/mutationObserver.mli
+++ b/lib/mutationObserver.mli
@@ -27,17 +27,14 @@
         Js.Opt.get (doc##getElementById(Js.string "observed"))
           (fun () -> assert false)
       in
-      let target' = (target :> Dom.node Js.t) in
+      let node = (target :> Dom.node Js.t) in
       let f records observer =
         Firebug.console##debug(records) ;
         Firebug.console##debug(observer)
       in
-      let observer = jsnew MutationObserver.mutationObserver(Js.wrap_callback f) in
-      let config = MutationObserver.empty_mutation_observer_init() in
-      config##attributes <- true ;
-      config##childList <- true ;
-      config##characterData <- true ;
-      observer##observe(target', config)
+      MutationObserver.observe ~node ~f
+        ~attributes:true ~child_list:true ~character_data:true
+        ()
   ]}
 
   @see <https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver> for API documentation.
@@ -76,3 +73,16 @@ val empty_mutation_observer_init : unit -> _MutationObserverInit Js.t
 val mutationObserver : ((_MutationRecord Js.t Js.js_array Js.t -> _MutationObserver Js.t -> unit) Js.callback -> _MutationObserver Js.t) Js.constr
 
 val is_supported : unit -> bool
+
+(** Helper to create a new observer and connect it to a node *)
+val observe : node:(Dom.node Js.t)
+  -> f:(_MutationRecord Js.t Js.js_array Js.t -> _MutationObserver Js.t -> unit)
+  -> ?child_list:bool
+  -> ?attributes:bool
+  -> ?character_data:bool
+  -> ?subtree:bool
+  -> ?attribute_old_value:bool
+  -> ?character_data_old_value:bool
+  -> ?attribute_filter:(Js.js_string Js.t list)
+  -> unit
+  -> _MutationObserver Js.t


### PR DESCRIPTION
A proposal for a binding to the mutation observers API. See also https://github.com/ocsigen/js_of_ocaml/issues/250