### PR TITLE
Use ocamlfind to find camlp4 everywhere

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -155,7 +155,7 @@ toplevel/jsooTop.cmo: toplevel/jsooTop.ml syntax/pa_js.cmo ../compiler/lib/compi
 
 toplevel/%.cmo: toplevel/%.ml
 	$(OCAMLC) $(SAFESTRING) \
-		-I toplevel -I +compiler-libs -I +camlp4 \
+		-I toplevel -I +compiler-libs -package camlp4 \
 		-c $< -o $@
 
 toplevel/%.cmi: toplevel/%.mli


### PR DESCRIPTION
This is needed (at least on nixos) because with caml >= 4.02, camlp4 might not live
in the compiler's directory. See http://caml.inria.fr/mantis/view.php?id=6605