### PR TITLE
Add the Jstable module

### DIFF
--- a/doc/api/index
+++ b/doc/api/index
@@ -23,6 +23,7 @@ Typed_array
 WebGL
 WebSockets
 Geolocation
+Jstable
 }
 
 {1 Ppx - API Reference}

--- a/lib/.depend
+++ b/lib/.depend
@@ -16,6 +16,8 @@ firebug.cmo : js.cmi dom.cmi firebug.cmi
 firebug.cmx : js.cmx dom.cmx firebug.cmi
 form.cmo : js.cmi file.cmi dom_html.cmi form.cmi
 form.cmx : js.cmx file.cmx dom_html.cmx form.cmi
+geolocation.cmo : js.cmi geolocation.cmi
+geolocation.cmx : js.cmx geolocation.cmi
 js.cmo : js.cmi
 js.cmx : js.cmi
 json.cmo : js.cmi json.cmi
@@ -24,6 +26,8 @@ jsonp.cmo : url.cmi lwt_js.cmi js.cmi firebug.cmi dom_html.cmi dom.cmi \
     jsonp.cmi
 jsonp.cmx : url.cmx lwt_js.cmx js.cmx firebug.cmx dom_html.cmx dom.cmx \
     jsonp.cmi
+jstable.cmo : js.cmi jstable.cmi
+jstable.cmx : js.cmx jstable.cmi
 keycode.cmo : keycode.cmi
 keycode.cmx : keycode.cmi
 lib_version.cmo :
@@ -52,8 +56,6 @@ xmlHttpRequest.cmo : url.cmi typed_array.cmi js.cmi form.cmi file.cmi \
     dom_html.cmi dom.cmi xmlHttpRequest.cmi
 xmlHttpRequest.cmx : url.cmx typed_array.cmx js.cmx form.cmx file.cmx \
     dom_html.cmx dom.cmx xmlHttpRequest.cmi
-geolocation.cmo : js.cmi geolocation.cmi
-geolocation.cmx : js.cmx geolocation.cmi
 cSS.cmi : js.cmi
 dom_events.cmi : js.cmi dom_html.cmi
 dom_html.cmi : js.cmi file.cmi dom.cmi
@@ -63,9 +65,11 @@ eventSource.cmi : js.cmi dom.cmi
 file.cmi : typed_array.cmi js.cmi dom.cmi
 firebug.cmi : js.cmi dom.cmi
 form.cmi : js.cmi file.cmi dom_html.cmi
+geolocation.cmi : js.cmi
 js.cmi :
 json.cmi : js.cmi
 jsonp.cmi :
+jstable.cmi : js.cmi
 keycode.cmi :
 lwt_js_events.cmi : js.cmi dom_html.cmi
 lwt_js.cmi :
@@ -77,7 +81,6 @@ webGL.cmi : typed_array.cmi js.cmi dom_html.cmi
 webSockets.cmi : typed_array.cmi js.cmi file.cmi dom_html.cmi dom.cmi
 xmlHttpRequest.cmi : url.cmi typed_array.cmi js.cmi form.cmi file.cmi \
     dom.cmi
-geolocation.cmi : js.cmi
 log/lwt_log_js.cmo : js.cmi firebug.cmi log/lwt_log_js.cmi
 log/lwt_log_js.cmx : js.cmx firebug.cmx log/lwt_log_js.cmi
 log/lwt_log_js.cmi :

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,4 +1,4 @@
-MLOBJS= js.cmo dom.cmo typed_array.cmo dom_html.cmo dom_svg.cmo file.cmo dom_events.cmo firebug.cmo lwt_js.cmo sys_js.cmo regexp.cmo cSS.cmo url.cmo form.cmo xmlHttpRequest.cmo lwt_js_events.cmo json.cmo jsonp.cmo webGL.cmo webSockets.cmo keycode.cmo eventSource.cmo geolocation.cmo
+MLOBJS= js.cmo dom.cmo typed_array.cmo dom_html.cmo dom_svg.cmo file.cmo dom_events.cmo firebug.cmo lwt_js.cmo sys_js.cmo regexp.cmo cSS.cmo url.cmo form.cmo xmlHttpRequest.cmo lwt_js_events.cmo json.cmo jsonp.cmo webGL.cmo webSockets.cmo keycode.cmo eventSource.cmo geolocation.cmo jstable.cmo
 MLINTFS= $(MLOBJS:.cmo=.mli)
 COBJS= stubs$(OBJEXT)
 OBJS=lib_version.cmo $(MLOBJS) $(COBJS)

--- a/lib/jstable.ml
+++ b/lib/jstable.ml
@@ -1,0 +1,46 @@
+(* Js_of_ocaml
+ * http://www.ocsigen.org
+ * Copyright Pierre Chambart 2012.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+
+type 'a t = < > Js.t
+
+let obj = Js.Unsafe.global##_Object
+
+let create () : 'a t = jsnew obj ()
+
+let add (t:'a t) (k:Js.js_string Js.t) (v:'a) =
+  (* '_' is added to avoid conflicts with objects methods *)
+  Js.Unsafe.set t (k##concat(Js.string "_")) v
+
+let find (t:'a t) (k:Js.js_string Js.t) : 'a Js.Optdef.t =
+  Js.Unsafe.get t (k##concat(Js.string "_"))
+
+let keys (t:'a t) : Js.js_string Js.t list =
+  let key_array : Js.js_string Js.t Js.js_array Js.t =
+    Js.Unsafe.global##_Object##keys(t)
+  in
+  let res = ref [] in
+  for i = 0 to pred key_array##length do
+    let key =
+      Js.Optdef.get
+        (Js.array_get key_array i)
+        (fun () -> failwith "Jstable.keys")
+    in
+    res := key##substring(0, pred key##length) :: !res
+  done;
+  List.rev !res

--- a/lib/jstable.mli
+++ b/lib/jstable.mli
@@ -1,0 +1,34 @@
+(* Js_of_ocaml
+ * http://www.ocsigen.org
+ * Copyright Pierre Chambart 2012.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+
+(** A minimal table implementation specialized for {!Js.js_string} keys.
+    This is faster than regular OCaml hashtables.
+
+    This implementation does not emulate the backtracking behavior of {!Hashtbl}.
+*)
+
+type 'a t
+
+val create : unit -> 'a t
+
+val add : 'a t -> Js.js_string Js.t -> 'a -> unit
+
+val find : 'a t -> Js.js_string Js.t -> 'a Js.optdef
+
+val keys : 'a t -> Js.js_string Js.t list


### PR DESCRIPTION
This module is backported from Eliom where it lived a very quiet life since its original commit 4 years ago.

For now, It's exactly the same as the one that was in eliom, but I think it would be interesting to see if there is a faster solution now.
@hhugo, I believe you did several such benchmark, any insights ?

I also wonder if we should change the API a little bit, so that to (partially) respect Hashtbl.S, but I'll wait for the above question to be answered first.