### PR TITLE
store/access javascript error (with backtrace) within ocaml exceptions. 

### DIFF
--- a/compiler/generate.ml
+++ b/compiler/generate.ml
@@ -211,9 +211,9 @@ module Share = struct
       gen s
 
 
-  let get_apply gen n t =
+  let get_apply gen loc n t =
     if not t.alias_apply
-    then gen n
+    then gen loc n
     else try
         J.EVar (IntMap.find n t.vars.applies)
       with Not_found ->
@@ -677,15 +677,15 @@ let parallel_renaming params args continuation queue =
 
 (****)
 
-let apply_fun_raw f params =
+let apply_fun_raw loc f params =
   let n = List.length params in
   J.ECond (J.EBin (J.EqEq, J.EDot (f, "length"),
                    J.ENum (float n)),
-           J.ECall (f, params, J.N),
+           J.ECall (f, params, loc),
            J.ECall (s_var "caml_call_gen",
-                    [f; J.EArr (List.map (fun x -> Some x) params)], J.N))
+                    [f; J.EArr (List.map (fun x -> Some x) params)], loc))
 
-let generate_apply_fun n =
+let generate_apply_fun loc n =
   let f' = Var.fresh () in
   let f = J.V f' in
   Code.Var.name f' "fun";
@@ -700,14 +700,14 @@ let generate_apply_fun n =
   J.EFun (None, f :: params,
           [J.Statement
               (J.Return_statement
-                 (Some (apply_fun_raw f' params'))), J.N],
-          J.N)
+                 (Some (apply_fun_raw loc f' params'))), loc],
+          loc)
 
 let apply_fun ctx f params loc =
   if Option.Optim.inline_callgen ()
-  then apply_fun_raw f params
+  then apply_fun_raw loc f params
   else
-    let y = Share.get_apply generate_apply_fun (List.length params) ctx.Ctx.share in
+    let y = Share.get_apply generate_apply_fun loc (List.length params) ctx.Ctx.share in
     J.ECall (y, f::params, loc)
 
 (****)
@@ -1432,7 +1432,10 @@ else begin
               J.Eq,
               J.EVar (J.V x),
               J.ECall (Share.get_prim s_var "caml_wrap_exception" st.ctx.Ctx.share,
-                       [J.EVar (J.V x)], J.N))),J.N)
+                       [J.EVar (J.V x);
+                        if Option.Optim.record_js_backtrace ()
+                        then one
+                        else zero ], J.N))),J.N)
             ::handler
           else handler in
         let x =
@@ -1680,6 +1683,11 @@ and compile_conditional st queue pc last handler backs frontier interm succs =
       flush_all queue [J.Return_statement (Some cx), loc]
   | Raise x ->
       let ((_px, cx), queue) = access_queue queue x in
+      let cx =
+        if Option.Optim.record_js_backtrace ()
+        then J.ECall (s_var "caml_exn_with_js_error", [cx; zero], loc)
+        else cx
+      in
       flush_all queue [J.Throw_statement cx, loc]
   | Stop ->
       flush_all queue [J.Return_statement None, loc]
@@ -1871,7 +1879,7 @@ let generate_shared_value ctx =
   if not (Option.Optim.inline_callgen ())
   then
     let applies = List.map (fun (n,v) ->
-        match generate_apply_fun n with
+        match generate_apply_fun J.N n with
         | J.EFun (_,param,body,nid) ->
           J.Function_declaration (v,param,body,nid), J.U
         | _ -> assert false) (IntMap.bindings ctx.Ctx.share.Share.vars.Share.applies) in

--- a/compiler/option.ml
+++ b/compiler/option.ml
@@ -98,6 +98,7 @@ module Optim = struct
   let debugger = o ~name:"debugger" ~default:true
   let genprim = o ~name:"genprim" ~default:true
   let excwrap = o ~name:"excwrap" ~default:true
+  let record_js_backtrace = o ~name:"jsbacktrace" ~default:false
   let include_cmis = o ~name:"withcmi" ~default: true
   let warn_unused = o ~name:"warn-unused"  ~default: false
 

--- a/compiler/option.ml
+++ b/compiler/option.ml
@@ -98,7 +98,7 @@ module Optim = struct
   let debugger = o ~name:"debugger" ~default:true
   let genprim = o ~name:"genprim" ~default:true
   let excwrap = o ~name:"excwrap" ~default:true
-  let record_js_backtrace = o ~name:"jsbacktrace" ~default:false
+  let record_js_error = o ~name:"with-js-error" ~default:true
   let include_cmis = o ~name:"withcmi" ~default: true
   let warn_unused = o ~name:"warn-unused"  ~default: false
 

--- a/compiler/option.mli
+++ b/compiler/option.mli
@@ -41,6 +41,7 @@ module Optim : sig
   val stable_var : unit -> bool
   val debuginfo : unit -> bool
   val excwrap : unit -> bool
+  val record_js_backtrace : unit -> bool
   val include_cmis: unit -> bool
 
   val warn_unused : unit -> bool

--- a/compiler/option.mli
+++ b/compiler/option.mli
@@ -41,7 +41,7 @@ module Optim : sig
   val stable_var : unit -> bool
   val debuginfo : unit -> bool
   val excwrap : unit -> bool
-  val record_js_backtrace : unit -> bool
+  val record_js_error : unit -> bool
   val include_cmis: unit -> bool
 
   val warn_unused : unit -> bool

--- a/lib/js.ml
+++ b/lib/js.ml
@@ -389,15 +389,17 @@ class type error = object
 end
 
 exception Error of error t
-let error_constr = Unsafe.global##_Error
+let error_constr : (js_string t -> error t) constr = Unsafe.global##_Error
 let _ = Callback.register_exception "jsError" (Error (Unsafe.obj [||]))
 
-external with_js_exn : exn -> bool -> exn = "caml_exn_with_js_error"
-external extract_js_exn  : exn -> error t optdef = "caml_js_error_of_exn"
-external raise_js_exn : error t -> 'a = "caml_js_error_raise"
+external exn_with_js_error : exn -> bool -> exn = "caml_exn_with_js_error"
+external js_error_of_exception       : exn -> error t opt = "caml_js_error_of_exception"
+external raise_js_error : error t -> 'a = "caml_js_error_raise"
 
-let record_js_exn ?(force=false) exn = with_js_exn exn force
-let extract_js_exn exn = Optdef.to_option (extract_js_exn exn)
+let record_js_error exn = exn_with_js_error exn true
+
+let extract_js_error (exn : exn) : error t option =
+  Opt.to_option (js_error_of_exception exn)
 
 class type json = object
   method parse : js_string t -> 'a meth

--- a/lib/js.ml
+++ b/lib/js.ml
@@ -392,6 +392,13 @@ exception Error of error t
 let error_constr = Unsafe.global##_Error
 let _ = Callback.register_exception "jsError" (Error (Unsafe.obj [||]))
 
+external with_js_exn : exn -> bool -> exn = "caml_exn_with_js_error"
+external extract_js_exn  : exn -> error t optdef = "caml_js_error_of_exn"
+external raise_js_exn : error t -> 'a = "caml_js_error_raise"
+
+let record_js_exn ?(force=false) exn = with_js_exn exn force
+let extract_js_exn exn = Optdef.to_option (extract_js_exn exn)
+
 class type json = object
   method parse : js_string t -> 'a meth
   method stringify: 'a -> js_string t meth

--- a/lib/js.mli
+++ b/lib/js.mli
@@ -509,9 +509,16 @@ val error_constr : (js_string t -> error t) constr
 
 val string_of_error : error t -> string
 
-val record_js_exn  : ?force:bool -> exn -> exn
-val extract_js_exn : exn -> error t option
-val raise_js_exn   : error t -> 'a
+val raise_js_error   : error t -> 'a
+val extract_js_error : exn -> error t option
+val record_js_error  : exn -> exn
+(** [record_js_error exn] records, inside the ocaml exception, a javascript [Error]
+    that contains the current javascript stacktrace.
+    This error can later be retrieved using [extract_js_error exn] to provide
+    a proper stacktrace (integrating well with sourcemap).
+    Note: You should probably not use this directly and rather use the js_of_ocaml
+    compiler flag [--enable with-js-error] that will wrap every thrown exception.
+*)
 
 exception Error of error t
   (** The [Error] exception wrap javascript exceptions when catched by ocaml code.

--- a/lib/js.mli
+++ b/lib/js.mli
@@ -509,6 +509,10 @@ val error_constr : (js_string t -> error t) constr
 
 val string_of_error : error t -> string
 
+val record_js_exn  : ?force:bool -> exn -> exn
+val extract_js_exn : exn -> error t option
+val raise_js_exn   : error t -> 'a
+
 exception Error of error t
   (** The [Error] exception wrap javascript exceptions when catched by ocaml code.
       In case the javascript exception is not an instance of javascript [Error],

--- a/runtime/stdlib.js
+++ b/runtime/stdlib.js
@@ -142,28 +142,53 @@ function caml_failwith (msg) {
   caml_raise_with_string(caml_global_data.Failure, msg);
 }
 
-//Provides: caml_wrap_exception const (const)
+//Provides: caml_wrap_exception const (const, const)
 //Requires: caml_global_data,caml_js_to_string,caml_named_value
 //Requires: caml_return_exn_constant
-function caml_wrap_exception(e) {
+function caml_wrap_exception(e,record_js_exn) {
   if(e instanceof Array) return e;
+  var exn;
   //Stack_overflow: chrome, safari
   if(joo_global_object.RangeError
      && e instanceof joo_global_object.RangeError
      && e.message
-     && e.message.match(/maximum call stack/i))
-    return caml_return_exn_constant(caml_global_data.Stack_overflow);
+     && e.message.match(/maximum call stack/i)) {
+    exn = caml_return_exn_constant(caml_global_data.Stack_overflow);
+  }
   //Stack_overflow: firefox
-  if(joo_global_object.InternalError
+  else if(joo_global_object.InternalError
      && e instanceof joo_global_object.InternalError
      && e.message
-     && e.message.match(/too much recursion/i))
-    return caml_return_exn_constant(caml_global_data.Stack_overflow);
+     && e.message.match(/too much recursion/i)) {
+    exn = caml_return_exn_constant(caml_global_data.Stack_overflow);
+  }
   //Wrap Error in Js.Error exception
-  if(e instanceof joo_global_object.Error)
-    return [0,caml_named_value("jsError"),e];
+  else if(e instanceof joo_global_object.Error) {
+    exn = [0,caml_named_value("jsError"),e];
+  }
   //fallback: wrapped in Failure
-  return [0,caml_global_data.Failure,caml_js_to_string (String(e))];
+  else {
+    exn = [0,caml_global_data.Failure,caml_js_to_string (String(e))];
+  }
+  if(record_js_exn) exn.js_exn = e;
+  return exn
+}
+
+//Provides: caml_exn_with_js_error
+function caml_exn_with_js_error(exn, force) {
+  if(!exn.js_exn || force)
+    exn.js_exn = new joo_global_object.Error("Exception with backstrace");
+  return exn
+}
+
+//Provides: caml_js_error_of_exn
+function caml_js_error_of_exn(exn) {
+  return exn.js_exn
+}
+
+//Provides: caml_js_error_raise
+function caml_js_error_raise(exn) {
+  throw exn
 }
 
 //Provides: caml_invalid_argument (const)

--- a/runtime/stdlib.js
+++ b/runtime/stdlib.js
@@ -177,7 +177,7 @@ function caml_wrap_exception(e,record_js_exn) {
 //Provides: caml_exn_with_js_error
 function caml_exn_with_js_error(exn, force) {
   if(!exn.js_exn || force)
-    exn.js_exn = new joo_global_object.Error("Exception with backstrace");
+    exn.js_exn = new joo_global_object.Error("Exception with backtrace");
   return exn
 }
 


### PR DESCRIPTION
optionally store javascript [Error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error) in ocaml exception.
This Error contains the call stack at creation point. It can later be outputted in the console (with locations handled by sourcemap). 