### PR TITLE
Add bindings to WebWorker

### DIFF
--- a/lib/.depend
+++ b/lib/.depend
@@ -54,6 +54,8 @@ webSockets.cmo : typed_array.cmi js.cmi file.cmi dom_html.cmi dom.cmi \
     webSockets.cmi
 webSockets.cmx : typed_array.cmx js.cmx file.cmx dom_html.cmx dom.cmx \
     webSockets.cmi
+worker.cmo : js.cmi dom_html.cmi worker.cmi
+worker.cmx : js.cmx dom_html.cmx worker.cmi
 xmlHttpRequest.cmo : url.cmi typed_array.cmi js.cmi form.cmi file.cmi \
     dom_html.cmi dom.cmi xmlHttpRequest.cmi
 xmlHttpRequest.cmx : url.cmx typed_array.cmx js.cmx form.cmx file.cmx \
@@ -82,6 +84,7 @@ typed_array.cmi : js.cmi
 url.cmi :
 webGL.cmi : typed_array.cmi js.cmi dom_html.cmi
 webSockets.cmi : typed_array.cmi js.cmi file.cmi dom_html.cmi dom.cmi
+worker.cmi : js.cmi dom_html.cmi
 xmlHttpRequest.cmi : url.cmi typed_array.cmi js.cmi form.cmi file.cmi \
     dom.cmi
 log/lwt_log_js.cmo : js.cmi firebug.cmi log/lwt_log_js.cmi

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,4 +1,4 @@
-MLOBJS= js.cmo dom.cmo typed_array.cmo dom_html.cmo dom_svg.cmo file.cmo dom_events.cmo firebug.cmo lwt_js.cmo sys_js.cmo regexp.cmo cSS.cmo url.cmo form.cmo xmlHttpRequest.cmo lwt_js_events.cmo json.cmo jsonp.cmo webGL.cmo webSockets.cmo keycode.cmo eventSource.cmo geolocation.cmo jstable.cmo mutationObserver.cmo
+MLOBJS= js.cmo dom.cmo typed_array.cmo dom_html.cmo dom_svg.cmo file.cmo dom_events.cmo firebug.cmo lwt_js.cmo sys_js.cmo regexp.cmo cSS.cmo url.cmo form.cmo xmlHttpRequest.cmo lwt_js_events.cmo json.cmo jsonp.cmo webGL.cmo webSockets.cmo keycode.cmo eventSource.cmo geolocation.cmo jstable.cmo mutationObserver.cmo worker.cmo
 MLINTFS= $(MLOBJS:.cmo=.mli)
 COBJS= stubs$(OBJEXT)
 OBJS=lib_version.cmo $(MLOBJS) $(COBJS)

--- a/lib/worker.ml
+++ b/lib/worker.ml
@@ -1,0 +1,63 @@
+(* Js_of_ocaml library
+ * http://www.ocsigen.org/js_of_ocaml/
+ * Copyright (C) 2015 OCamlPro: Grégoire Henry, Çağdaş Bozman.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+
+open Js
+open Dom_html
+
+class type ['a, 'b] worker = object ('self)
+  inherit eventTarget
+  method onerror: ('self t, errorEvent t) event_listener writeonly_prop
+  method onmessage: ('self t, 'b messageEvent t) event_listener writeonly_prop
+  method postMessage: 'a -> unit meth
+  method terminate: unit meth
+end
+
+and errorEvent = object
+  inherit event
+  method msg: js_string t readonly_prop
+  method filename: js_string t readonly_prop
+  method lineno: int t readonly_prop
+  method colno: int t readonly_prop
+  method error: Unsafe.any -> unit meth
+end
+
+and ['a] messageEvent = object
+  inherit event
+  method data: 'a readonly_prop
+end
+
+let create script = jsnew (Unsafe.global##_Worker) (string script)
+
+let import_scripts scripts : unit =
+  if Unsafe.global##importScripts == undefined then
+    invalid_arg "Worker.import_scripts is undefined";
+  Unsafe.fun_call
+    (Unsafe.global##importScripts)
+    (Array.map (fun s -> Unsafe.inject @@ string s) (Array.of_list scripts))
+
+let set_onmessage handler =
+  if Unsafe.global##onmessage == undefined then
+    invalid_arg "Worker.onmessage is undefined";
+  let js_handler (ev : 'a messageEvent Js.t) = handler (ev##data) in
+  Unsafe.global##onmessage <- wrap_callback js_handler
+
+let post_message msg =
+  if Unsafe.global##postMessage == undefined then
+    invalid_arg "Worker.onmessage is undefined";
+  Unsafe.global##postMessage (msg)

--- a/lib/worker.mli
+++ b/lib/worker.mli
@@ -1,0 +1,58 @@
+(* Js_of_ocaml library
+ * http://www.ocsigen.org/js_of_ocaml/
+ * Copyright (C) 2015 OCamlPro: Grégoire Henry, Çağdaş Bozman.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+
+(** Low-level bindgins to javascript Web Workers.
+
+    See [https://developer.mozilla.org/en-US/docs/Web/API/Worker]
+    and [https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers].
+
+ *)
+
+open Js
+open Dom_html
+
+class type ['a, 'b] worker = object ('self)
+  inherit eventTarget
+  method onerror: ('self t, errorEvent t) event_listener writeonly_prop
+  method onmessage: ('self t, 'b messageEvent t) event_listener writeonly_prop
+  method postMessage: 'a -> unit meth
+  method terminate: unit meth
+end
+
+and errorEvent = object
+  inherit event
+  method msg: js_string t readonly_prop
+  method filename: js_string t readonly_prop
+  method lineno: int t readonly_prop
+  method colno: int t readonly_prop
+  method error: Unsafe.any -> unit meth
+end
+
+and ['a] messageEvent = object
+  inherit event
+  method data: 'a readonly_prop
+end
+
+val create: string -> ('a, 'b) worker t
+
+(** Global function to be used by the worker *)
+
+val import_scripts: string list -> unit
+val set_onmessage: ('a -> unit) -> unit
+val post_message: 'a -> unit

--- a/lib/worker.mli
+++ b/lib/worker.mli
@@ -19,8 +19,10 @@
 
 (** Low-level bindgins to javascript Web Workers.
 
-    See [https://developer.mozilla.org/en-US/docs/Web/API/Worker]
-    and [https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers].
+    See {{:https://developer.mozilla.org/en-US/docs/Web/API/Worker}
+    the documented Javascript API} and some more general documentation
+    {{:https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers}
+    about the usage of WebWorker}.
 
  *)
 


### PR DESCRIPTION
This code was developped for the OCaml MOOC. An embedding of the
toplevel into a WebWorker should follow in another PR.