### PR TITLE
Convert documentation to ppx.

### DIFF
--- a/doc/manual/src/bindings.wiki
+++ b/doc/manual/src/bindings.wiki
@@ -4,11 +4,11 @@
 Write in .ml:
 
 <<code language="ocaml"|
-let v = (Js.Unsafe.js_expr "window")##document
+let v = (Js.Unsafe.js_expr "window")##.document
 >>
 Alternatively, the global object can be used. In the browser, it refers to {{{window}}}.
 <<code language="ocaml"|
-let v = Js.Unsafe.global##document
+let v = Js.Unsafe.global##.document
 >>
 
 and in .mli:
@@ -35,7 +35,7 @@ Have a look at the <<a_api | module Js.Unsafe >> module API.
 Write in .ml:
 
 <<code language="ocaml"|
-let f = Js.Unsafe.global##_F
+let f = Js.Unsafe.global##._F
 >>
 and in .mli:
 
@@ -57,12 +57,12 @@ it has been dynamically added by a library), you can access using unsafe
 features:
 
 <<code language="ocaml"|
-(Js.Unsafe.coerce elt)##blah
+(Js.Unsafe.coerce elt)##.blah
 >>
 
 If you want to add yourself a new property:
 <<code language="ocaml"|
-(Js.Unsafe.coerce elt)##blah <- v
+(Js.Unsafe.coerce elt)##.blah := v
 >>
 
 Here, {{{v}}} may be a JS value or an OCaml value.
@@ -77,10 +77,10 @@ Write in .ml and in .mli:
 <<code language="ocaml"|
 class type my_js_type = object
 
-  (* read only property, read value with t##prop1 *)
+  (* read only property, read value with t##.prop1 *)
   method prop1 : int readonly_prop
 
-  (* write only property, write value with t##prop2 <- 3.14 *)
+  (* write only property, write value with t##.prop2 := 3.14 *)
   method prop2 : float writeonly_prop
 
   (* both read and write *)
@@ -128,7 +128,7 @@ end
 and in .ml:
 
 <<code language="ocaml"|
-let theclass = (Js.Unsafe.js_expr "thelib")##_Theclass
+let theclass = (Js.Unsafe.js_expr "thelib")##._Theclass
 >>
 
 and in .mli:
@@ -139,29 +139,18 @@ val theclass : theclass t
 
 ==Constructing JS objects manually
 If you want to construct a JS object manually
-   (without calling a function or a constructor), use
-function {{{Js.Unsafe.obj}}}
-and create the corresponding object type.
+(without calling a function or a constructor), you can use
+the <<a_api text="Ppx"|module Ppx_js>> syntax extension.
 
-You can also create an empty object of this type ({{{Js.Unsafe.obj [||]}}})
-and set all fields manually using {{{o##prop <- ...}}}.
-
-For example, write in .mli:
-
+For example:
 <<code language="ocaml"|
-class type options = object
-  method propOne : int writeonly_prop
-  method propTwo : js_string t writeonly_prop
+let options = object%js
+  val x = 3 (* read-only prop *)
+  val mutable y = 4 (* read/write prop *)
 end
-
-val empty_options : unit -> options t
 >>
 
-and in the .ml file of your library:
-
-<<code language="ocaml"|
-let empty_options () = Js.Unsafe.obj [||]
->>
+You can also use the unsafe <<a_api |val Js.Unsafe.obj>>.
 
 == Set/get variables
 
@@ -170,8 +159,8 @@ You can access every variable through the global javascript object ({{{window}}}
 If the variable {{{var}}} has type {{{t Js.t}}}
 
 <<code language="ocaml"|
-let set (x:t Js.t) = Js.Unsafe.global##var <- x
-let get x : t Js.t = Js.Unsafe.global##var
+let set (x:t Js.t) = Js.Unsafe.global##.var := x
+let get x : t Js.t = Js.Unsafe.global##.var
 >>
 
 == Object property with multiple types
@@ -190,7 +179,7 @@ end
 
 let obj : obj Js.t = Js.Unsafe.js_expr "obj"
 
-let string_constr : Js.js_string Js.t Js.constr = Js.Unsafe.global##_String
+let string_constr : Js.js_string Js.t Js.constr = Js.Unsafe.global##._String
 
 let cast_string (x:dom_or_string Js.t) : Js.js_string Js.t Js.opt =
   if Js.instanceof x string_constr
@@ -213,5 +202,5 @@ It is frequent that some method are not to be implemented in some browser.
 To check the presence of method {{{met}}}:
 
 <<code language="ocaml"|
-let check_met obj = Js.Optdef.test ((Js.Unsafe.coerce obj)##met)
+let check_met obj = Js.Optdef.test ((Js.Unsafe.coerce obj)##.met)
 >>

--- a/doc/manual/src/camlp4.wiki
+++ b/doc/manual/src/camlp4.wiki
@@ -1,0 +1,36 @@
+= The Camlp4 syntax extension
+
+A Camlp4 syntax extension is available for manipulating object properties,
+invoking methods and creating objects.
+We advise to use the <<a_api text="Ppx"|module Ppx_js>> syntax
+extension instead.
+
+The syntax and typing rules are as follows:
+
+        * Getting a property
+{{{
+            obj : <m : u prop> Js.t
+            -----------------------
+                 obj##m : u
+}}}
+        * Setting a property
+{{{
+            obj : <m : u prop> Js.t
+              e : u
+            -----------------------
+               obj##m <- e : unit
+}}}
+        * Invoking a method
+{{{
+            obj : <m : t_1 -> ... -> t_n -> u meth; ..> Js.t
+                e_i : t_i               (1 <= i <= n)
+            -------------------------------------------------
+                      obj##m(e_1, ..., e_n) : u
+}}}
+        * Creating an object
+{{{
+            constr : (t_1 -> ... -> t_n -> u Js.t) Js.constr
+            e_i : t_i               (1 <= i <= n)
+            ------------------------------------------------
+                    jsnew constr (e1, ..., en) : u
+}}}

--- a/doc/manual/src/library.wiki
+++ b/doc/manual/src/library.wiki
@@ -131,35 +131,15 @@ it can be called from Javascript.
 To call an OCaml function from Javascript, follow this example:
 <<code language="ocaml"|
 
-Js.Unsafe.global##plop <- Js.wrap_callback f
+Js.Unsafe.global##.plop := Js.wrap_callback f
 >>
 
 Or, to create a JS object with OCaml methods:
 <<code language="ocaml"|
-Js.Unsafe.global##plop <-
-  Js.Unsafe.obj [| ("f", Js.Unsafe.inject (Js.wrap_meth_callback f));
-                   ("g", Js.Unsafe.inject (Js.wrap_meth_callback g)) |]
->>
-
-Variant: create an empty JavaScript object (typed or not) and
-set its properties afterward
-
-<<code language="ocaml"|
-
-(* Optionnal : type the exported JavaScript object. *)
-class type exported = object
-  method addFloat : (float -> float -> float) callback writeonly_prop
-  method printInt : (int -> unit) callback writeonly_prop
-end
-
-let exported : exported Js.t =
-  let empty = Js.Unsafe.obj [||] in
-  Js.Unsafe.global##exportModuleA <- empty;
-  empty
-
-let _ =
-  exported##printInt <- Js.wrap_callback (fun i -> print_int i );
-  exported##addFloat <- Js.wrap_callback (fun x y -> x +. y)
+Js.Unsafe.global##.plop := object%js
+    method f i = print_int i
+    method g x y = g x +. y
+  end
 >>
 
 == IO ==

--- a/doc/manual/src/library.wiki
+++ b/doc/manual/src/library.wiki
@@ -82,37 +82,9 @@ end
 
 == Syntax extension ==
 
-A syntax extension is available for manipulating object properties,
-invoking methods and creating objects.  The syntax and typing rules
-are as follows:
-
-        * Getting a property
-{{{
-            obj : <m : u prop> Js.t
-            -----------------------
-                 obj##m : u
-}}}
-        * Setting a property
-{{{
-            obj : <m : u prop> Js.t
-              e : u
-            -----------------------
-               obj##m <- e : unit
-}}}
-        * Invoking a method
-{{{
-            obj : <m : t_1 -> ... -> t_n -> u meth; ..> Js.t
-                e_i : t_i               (1 <= i <= n)
-            -------------------------------------------------
-                      obj##m(e_1, ..., e_n) : u
-}}}
-        * Creating an object
-{{{
-            constr : (t_1 -> ... -> t_n -> u Js.t) Js.constr
-            e_i : t_i               (1 <= i <= n)
-            ------------------------------------------------
-                    jsnew constr (e1, ..., en) : u
-}}}
+Two syntax extensions are provided: the <<a_api text="Ppx"|module Ppx_js>>
+one and the <<a_manual chapter="camlp4"|Camlp4>> one. This manual is written
+using the ppx extension, which we advise.
 
 == OCaml and Javascript functions ==
 

--- a/doc/manual/src/menu.wiki
+++ b/doc/manual/src/menu.wiki
@@ -5,6 +5,7 @@
 ==[[linker|Link javascript code]]
 ==[[options|Command line options]]
 ==[[performances|Performances]]
+==[[camlp4|Camlp4 syntax extension]]
 ==Examples
 ===<<a_file src="toplevel/index.html"|An OCaml toplevel running in the browser>>
 ===<<a_file src="planet/index.html" |An animated 3D view of the Earth>>

--- a/lib/dom.mli
+++ b/lib/dom.mli
@@ -172,24 +172,24 @@ val insertBefore : #node t -> #node t -> #node t opt -> unit
   (** [insertBefore p n c] inserts node [n] as child of node [p],
       just before node [c], or as last child if [p] is empty.
       The expression [insertBefore n c p] behave the same as
-      [p##insertBefore(n, c)] but avoid the need of coercing the
+      [p##insertBefore n c] but avoid the need of coercing the
       different objects to [node t]. *)
 
 val replaceChild : #node t -> #node t -> #node t -> unit
   (** The expression [replaceChild p n c] behave the same as
-      [p##replaceChild(n, c)] (replace [c] by [n] in [p])
+      [p##replaceChild n c] (replace [c] by [n] in [p])
       but avoid the need of coercing the
       different objects to [node t]. *)
 
 val removeChild : #node t -> #node t -> unit
   (** The expression [removeChild n c] behave the same as
-      [n##removeChild(c)] (remove [c] from [n])
+      [n##removeChild c] (remove [c] from [n])
       but avoid the need of coercing the
       different objects to [node t]. *)
 
 val appendChild : #node t -> #node t -> unit
   (** The expression [appendChild n c] behave the same as
-      [n##appendChild(c)] (appends [c] to [n])
+      [n##appendChild c] (appends [c] to [n])
       but avoid the need of coercing the
       different objects to [node t]. *)
 

--- a/lib/dom_html.mli
+++ b/lib/dom_html.mli
@@ -1617,7 +1617,7 @@ end
 
 type timeout_id_safe
 
-(** Same as [Dom_html.window##setTimeout(cb,ms)] but prevents overflow
+(** Same as [Dom_html.window##setTimeout cb ms] but prevents overflow
     with delay greater than 24 days. *)
 val setTimeout : (unit -> unit) -> float -> timeout_id_safe
 val clearTimeout : timeout_id_safe -> unit

--- a/lib/geolocation.mli
+++ b/lib/geolocation.mli
@@ -24,18 +24,18 @@
   if (Geolocation.is_supported()) then
     let geo = Geolocation.geolocation in
     let options = Geolocation.empty_position_options() in
-    let () = options##enableHighAccuracy <- true in
+    let () = options##.enableHighAccuracy := true in
     let f_success pos =
-      let coords = pos##coords in
-      let latitude = coords##latitude in
-      Firebug.console##debug(latitude) ;
+      let coords = pos##.coords in
+      let latitude = coords##.latitude in
+      Firebug.console##debug latitude ;
     in
     let f_error err =
-      let code = err##code in
-      let msg = err##message in
-      if code = err##_TIMEOUT then Firebug.console##debug(msg)
+      let code = err##.code in
+      let msg = err##.message in
+      if code = err##._TIMEOUT then Firebug.console##debug(msg)
     in
-    geo##getCurrentPosition(Js.wrap_callback f_success, Js.wrap_callback f_error, options)
+    geo##getCurrentPosition (Js.wrap_callback f_success) (Js.wrap_callback f_error) options
   ]}
   @see <https://developer.mozilla.org/en-US/docs/Web/API/Geolocation> for API documentation.
   @see <http://www.w3.org/TR/geolocation-API/> for the W3C Recommendation. *)

--- a/lib/js.mli
+++ b/lib/js.mli
@@ -603,7 +603,7 @@ val coerce_opt : 'a Opt.t -> ('a -> 'b Opt.t) -> ('a -> 'b) -> 'b
       If [v] is [null] or the coercion returns [null], function [f] is
       called.
       Typical usage is the following:
-      {[Js.coerce_opt (Dom_html.document##getElementById(id))
+      {[Js.coerce_opt (Dom_html.document##getElementById id)
       Dom_html.CoerceTo.div (fun _ -> assert false)]} *)
 
 (** {2 Type checking operators.} *)

--- a/lib/lwt_js_events.mli
+++ b/lib/lwt_js_events.mli
@@ -47,7 +47,7 @@
 
    {[let rec esc elt =
       lwt ev = keydown elt in
-      if ev##keyCode = 27
+      if ev##.keyCode = 27
       then Lwt.return ev
       else esc elt]}
 

--- a/lib/mutationObserver.mli
+++ b/lib/mutationObserver.mli
@@ -24,13 +24,13 @@
     if (MutationObserver.is_supported()) then
       let doc = Dom_html.document in
       let target =
-        Js.Opt.get (doc##getElementById(Js.string "observed"))
+        Js.Opt.get (doc##getElementById (Js.string "observed"))
           (fun () -> assert false)
       in
       let node = (target :> Dom.node Js.t) in
       let f records observer =
-        Firebug.console##debug(records) ;
-        Firebug.console##debug(observer)
+        Firebug.console##debug records ;
+        Firebug.console##debug observer
       in
       MutationObserver.observe ~node ~f
         ~attributes:true ~child_list:true ~character_data:true

--- a/lib/url.mli
+++ b/lib/url.mli
@@ -20,7 +20,7 @@
 
 (** This module provides functions for tampering with Url. It's main goal is to
     allow one to stay in the Ocaml realm without wandering into the
-    {!Dom_html.window}##location object. *)
+    {!Dom_html.window}##.location object. *)
 
 
 (** The first functions are mainly from and to string conversion functions for


### PR DESCRIPTION
I think I converted all of it.
The internals and the examples are still camlp4.

@hhugo @vouillon Should I convert the examples ? In this case, the ppx
should be loaded in the toplevel, instead of the camlp4 extension.