### PR TITLE
Dom: move `click` from `InputElement` to `HTMLElement`

### DIFF
--- a/lib/dom_html.ml
+++ b/lib/dom_html.ml
@@ -336,6 +336,8 @@ and element = object
 
   method scrollIntoView: bool t -> unit meth
 
+  method click : unit meth
+
   inherit eventTarget
 end
 
@@ -555,7 +557,6 @@ class type inputElement = object ('self)
   method blur : unit meth
   method focus : unit meth
   method select : unit meth
-  method click : unit meth
   method files : File.fileList t optdef readonly_prop
   method placeholder : js_string t writeonly_prop
   method onselect : ('self t, event t) event_listener prop

--- a/lib/dom_html.mli
+++ b/lib/dom_html.mli
@@ -350,6 +350,8 @@ and element = object
 
   method scrollIntoView: bool t -> unit meth
 
+  method click : unit meth
+
   inherit eventTarget
 end
 
@@ -501,7 +503,6 @@ class type inputElement = object ('self)
   method blur : unit meth
   method focus : unit meth
   method select : unit meth
-  method click : unit meth
   method files : File.fileList t optdef readonly_prop
   method placeholder : js_string t writeonly_prop (* Not supported by IE 9 *)
   method onselect : ('self t, event t) event_listener prop


### PR DESCRIPTION
This where it belongs according to:

  https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/click