### PR TITLE
Fix `Js.string` for deserialized strings

### DIFF
--- a/compiler/generate.ml
+++ b/compiler/generate.ml
@@ -914,8 +914,6 @@ let _ =
   register_un_prim "caml_js_from_bool" `Pure
     (fun cx _ -> J.EUn (J.Not, J.EUn (J.Not, cx)));
   register_un_prim "caml_js_to_bool" `Pure (fun cx _ -> to_int cx);
-  register_un_prim "caml_js_from_string" `Mutable
-    (fun cx loc -> J.ECall (J.EDot (cx, "toString"), [], loc));
   register_tern_prim "caml_js_set"
     (fun cx cy cz _ -> J.EBin (J.Eq, J.EAccess (cx, cy), cz));
   register_bin_prim "caml_js_get" `Mutable

--- a/runtime/jslib_js_of_ocaml.js
+++ b/runtime/jslib_js_of_ocaml.js
@@ -28,8 +28,8 @@ function caml_js_from_float(x) { return x; }
 //Provides: caml_js_to_float const (const)
 function caml_js_to_float(x) { return x; }
 //Provides: caml_js_from_string mutable (const)
-//Requires: MlString
-function caml_js_from_string(s) { return s.toString(); }
+//Requires: caml_to_js_string
+function caml_js_from_string(s) { return caml_to_js_string(s); }
 //Provides: caml_js_from_array mutable (shallow)
 //Requires: raw_array_sub
 function caml_js_from_array(a) { return raw_array_sub(a,1,a.length-1); }


### PR DESCRIPTION
The implementation of `Js.to_string` uses `caml_js_from_string`, which is implemented in terms of the `toString` method. This is problematic if the string has been produced by deserializing, in which case we do not have our own `toString` method, and we get back JS strings that look like this: `[object Object]`.

I think it is safer to call the `caml_to_js_string` primitive.

For context, this came up while experimenting with the serialization [provided by IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm) (ocsigen/ocaml-indexeddb@ac2715fe1ecedbcedc43babda001d7a42334b2db). This should cover most objects we care to store (including strings I think), without any explicit conversions.