### PR TITLE
Dom_html: Add selection attributes to textarea.

### DIFF
--- a/lib/dom_html.ml
+++ b/lib/dom_html.ml
@@ -576,6 +576,9 @@ class type textAreaElement = object ('self)
   method name : js_string t readonly_prop
   method readOnly : bool t prop
   method rows : int prop
+  method selectionDirection : js_string t prop
+  method selectionEnd : int prop
+  method selectionStart : int prop
   method tabIndex : int prop
   method _type : js_string t readonly_prop
   method value : js_string t prop

--- a/lib/dom_html.mli
+++ b/lib/dom_html.mli
@@ -522,6 +522,9 @@ class type textAreaElement = object ('self)
   method name : js_string t readonly_prop (* Cannot be changed under IE *)
   method readOnly : bool t prop
   method rows : int prop
+  method selectionDirection : js_string t prop
+  method selectionEnd : int prop
+  method selectionStart : int prop
   method tabIndex : int prop
   method _type : js_string t readonly_prop (* Cannot be changed under IE *)
   method value : js_string t prop


### PR DESCRIPTION
Readonly attribs for now. According to https://developer.mozilla.org/en-US/docs/Web/API/HTMLTextAreaElement there is also an setSelectionRange method to set these attributes, but unimplemented at the moment.