### PR TITLE
Revert "Compiler: Preserve ocaml names"

### DIFF
--- a/compiler/.merlin
+++ b/compiler/.merlin
@@ -1,6 +1,0 @@
-B ./**
-S ./**
-PKG cmdliner
-PKG menhirLib
-
-EXT js

--- a/compiler/code.ml
+++ b/compiler/code.ml
@@ -48,7 +48,6 @@ module Var : sig
   val compare : t -> t -> int
 
   val name : t -> string -> unit
-  val get_name : t -> string option
   val propagate_name : t -> t -> unit
 
   val reset : unit -> unit
@@ -84,8 +83,6 @@ end = struct
   let compare v1 v2 = v1 - v2
 
   let name i nm = VarPrinter.name printer i nm
-
-  let get_name i = VarPrinter.get_name printer i
   let propagate_name i j = VarPrinter.propagate_name printer i j
   let set_pretty b = VarPrinter.set_pretty printer b
   let set_stable b = VarPrinter.set_stable printer b

--- a/compiler/code.mli
+++ b/compiler/code.mli
@@ -42,7 +42,6 @@ module Var : sig
 
   val compare : t -> t -> int
 
-  val get_name : t -> string option
   val name : t -> string -> unit
   val propagate_name : t -> t -> unit
   val reset : unit -> unit

--- a/compiler/driver.ml
+++ b/compiler/driver.ml
@@ -424,7 +424,7 @@ let pack ~wrap_with_fun ?(toplevel=false) js =
 let configure formatter p =
   let pretty = Option.Optim.pretty () in
   Pretty_print.set_compact formatter (not pretty);
-  Code.Var.set_pretty (pretty && not (Option.Optim.shortvar ()));
+  Code.Var.set_pretty pretty;
   Code.Var.set_stable (Option.Optim.stable_var ());
   p
 

--- a/compiler/js_assign.ml
+++ b/compiler/js_assign.ml
@@ -18,24 +18,6 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *)
 
-open Javascript
-open Util
-let debug = Option.Debug.find "shortvar"
-
-module S = Code.VarSet
-module VM = Code.VarMap
-
-module Var = Code.Var
-
-module type Strategy = sig
-  type t
-  val create : int -> t
-  val record_block : t -> Js_traverse.t -> catch:bool -> Javascript.ident list -> unit
-  val allocate_variables : t -> count:int Javascript.IdentMap.t -> string array
-end
-
-module Min : Strategy = struct
-
 (*
 We are trying to achieve the following goals:
 (1) variable names should be as short as possible
@@ -78,309 +60,243 @@ while compiling the OCaml toplevel:
     unchanged)
 *)
 
-  type alloc =
-    { mutable first_free : int;
-      mutable used : bool array }
+open Javascript
 
-  let make_alloc_table () =
-    { first_free = 0;
-      used = Array.make 32 false }
+let debug = Option.Debug.find "shortvar"
 
-  let next_available a i =
-    let i = ref (max i a.first_free) in
+module S = Code.VarSet
+module VM = Code.VarMap
+
+module Var = Code.Var
+
+type alloc =
+  { mutable first_free : int;
+    mutable used : bool array }
+
+let make_alloc_table () =
+  { first_free = 0;
+    used = Array.make 32 false }
+
+let next_available a i =
+  let i = ref (max i a.first_free) in
+  let len = Array.length a.used in
+  while !i < len && a.used.(!i) do incr i done;
+  !i
+
+let allocate a i =
+  let len = Array.length a.used in
+  if i >= len then begin
+    let l = ref len in
+    while l := 2 * !l; i >= !l do () done;
+    let u = Array.make !l false in
+    Array.blit a.used 0 u 0 len;
+    a.used <- u
+  end;
+  assert (not a.used.(i));
+  a.used.(i) <- true;
+  if a.first_free = i then begin
+    let i = ref a.first_free in
     let len = Array.length a.used in
     while !i < len && a.used.(!i) do incr i done;
-    !i
+    a.first_free <- !i
+  end
 
-  let allocate a i =
-    let len = Array.length a.used in
-    if i >= len then begin
-      let l = ref len in
-      while l := 2 * !l; i >= !l do () done;
-      let u = Array.make !l false in
-      Array.blit a.used 0 u 0 len;
-      a.used <- u
-    end;
-    assert (not a.used.(i));
-    a.used.(i) <- true;
-    if a.first_free = i then begin
-      let i = ref a.first_free in
-      let len = Array.length a.used in
-      while !i < len && a.used.(!i) do incr i done;
-      a.first_free <- !i
-    end
+let is_available l i =
+  List.for_all (fun a -> Array.length a.used <= i || not a.used.(i)) l
 
-  let is_available l i =
-    List.for_all (fun a -> Array.length a.used <= i || not a.used.(i)) l
+let first_available l =
+  let rec find_rec n =
+    let n' = List.fold_left (fun n a -> next_available a n) n l in
+    if n = n' then n else find_rec n'
+  in
+  find_rec 0
 
-  let first_available l =
-    let rec find_rec n =
-      let n' = List.fold_left (fun n a -> next_available a n) n l in
-      if n = n' then n else find_rec n'
-    in
-    find_rec 0
+let mark_allocated l i = List.iter (fun a -> allocate a i) l
 
-  let mark_allocated l i = List.iter (fun a -> allocate a i) l
+type g = {
+  constr : alloc list array; (* Constraints on variables *)
+  mutable parameters : Var.t list array; (* Function parameters *)
+  mutable constraints : S.t list }     (* For debugging *)
 
-  type t = {
-    constr : alloc list array; (* Constraints on variables *)
-    mutable parameters : Var.t list array; (* Function parameters *)
-    mutable constraints : S.t list }     (* For debugging *)
+let create nv =
+  { constr = Array.make nv [];
+    parameters = [|[]|];
+    constraints = [] }
 
-  let create nv =
-    { constr = Array.make nv [];
-      parameters = [|[]|];
-      constraints = [] }
-
-  let output_debug_information t count =
+let output_debug_information t count =
 
 
-    let weight v = (IdentMap.find (V v) count) in
+  let weight v = (IdentMap.find (V v) count) in
 
-    let usage =
-      List.fold_left
-        (fun u s ->
-           S.fold
-             (fun v u -> VM.add v (try 1 + VM.find v u with Not_found -> 1) u)
-             s u)
-        VM.empty t.constraints
-    in
+  let usage =
+    List.fold_left
+      (fun u s ->
+         S.fold
+           (fun v u -> VM.add v (try 1 + VM.find v u with Not_found -> 1) u)
+           s u)
+      VM.empty t.constraints
+  in
 
-    let l = List.map fst (VM.bindings usage) in
+  let l = List.map fst (VM.bindings usage) in
 
-    let ch = open_out "/tmp/weights.txt" in
+  let ch = open_out "/tmp/weights.txt" in
+  List.iter
+    (fun v ->
+       Printf.fprintf ch "%d / %d / %d\n" (weight v)
+         (VM.find v usage) (Code.Var.idx v))
+    l;
+  close_out ch;
+
+  let ch = open_out "/tmp/problem.txt" in
+  Printf.fprintf ch "Maximize\n";
+  let a = Array.of_list l in
+  Printf.fprintf ch "  ";
+  for i = 0 to Array.length a - 1 do
+    let v = a.(i) in
+    let w = weight v in
+    if i > 0 then Printf.fprintf ch " + ";
+    Printf.fprintf ch "%d x%d" w (Code.Var.idx v)
+  done;
+  Printf.fprintf ch "\n";
+  Printf.fprintf ch "Subject To\n";
+  List.iter
+    (fun s ->
+      if S.cardinal s > 0 then begin
+        Printf.fprintf ch "  ";
+        let a = Array.of_list (S.elements s) in
+        for i = 0 to Array.length a - 1 do
+          if i > 0 then Printf.fprintf ch " + ";
+          Printf.fprintf ch "x%d" (Code.Var.idx a.(i))
+        done;
+        Printf.fprintf ch "<= 54\n"
+      end)
+    t.constraints;
+  Printf.fprintf ch "Binary\n  ";
+  List.iter (fun v -> Printf.fprintf ch " x%d" (Code.Var.idx v)) l;
+  Printf.fprintf ch "\nEnd\n";
+  close_out ch;
+
+  let ch = open_out "/tmp/problem2" in
+  let var x = string_of_int (Code.Var.idx x) in
+  let a = List.map (fun v -> (var v, weight v)) l in
+  let b =
+    List.map (fun s -> List.map var (S.elements s)) t.constraints in
+  let c = List.map var l in
+  output_value ch
+    ((a, b, c) : (string * int) list * string list list * string list);
+  close_out ch
+
+let allocate_variables t nv count =
+  let weight v = try IdentMap.find (V (Code.Var.of_idx v)) count with Not_found -> 0 in
+  let constr = t.constr in
+  let len = nv in
+  let idx = Array.make len 0 in
+  for i = 0 to len - 1 do
+    idx.(i) <- i
+  done;
+  Array.stable_sort (fun i j -> compare (weight j) (weight i)) idx;
+  let name = Array.make len "" in
+  let n0 = ref 0 in
+  let n1 = ref 0 in
+  let n2 = ref 0 in
+  let n3 = ref 0 in
+  let stats i n =
+    incr n0;
+    if n < 54 then begin incr n1; n2 := !n2 + (weight i) end;
+    n3 := !n3 + (weight i)
+  in
+  let nm ~origin n =
+    name.(origin) <- Var.to_string ~origin:(Var.of_idx origin) (Var.of_idx n) in
+  let total = ref 0 in
+  let bad = ref 0 in
+  for i = 0 to Array.length t.parameters - 1 do
     List.iter
-      (fun v ->
-         Printf.fprintf ch "%d / %d / %d\n" (weight v)
-           (VM.find v usage) (Var.idx v))
-      l;
-    close_out ch;
-
-    let ch = open_out "/tmp/problem.txt" in
-    Printf.fprintf ch "Maximize\n";
-    let a = Array.of_list l in
-    Printf.fprintf ch "  ";
-    for i = 0 to Array.length a - 1 do
-      let v = a.(i) in
-      let w = weight v in
-      if i > 0 then Printf.fprintf ch " + ";
-      Printf.fprintf ch "%d x%d" w (Var.idx v)
-    done;
-    Printf.fprintf ch "\n";
-    Printf.fprintf ch "Subject To\n";
-    List.iter
-      (fun s ->
-         if S.cardinal s > 0 then begin
-           Printf.fprintf ch "  ";
-           let a = Array.of_list (S.elements s) in
-           for i = 0 to Array.length a - 1 do
-             if i > 0 then Printf.fprintf ch " + ";
-             Printf.fprintf ch "x%d" (Var.idx a.(i))
-           done;
-           Printf.fprintf ch "<= 54\n"
-         end)
-      t.constraints;
-    Printf.fprintf ch "Binary\n  ";
-    List.iter (fun v -> Printf.fprintf ch " x%d" (Var.idx v)) l;
-    Printf.fprintf ch "\nEnd\n";
-    close_out ch;
-
-    let ch = open_out "/tmp/problem2" in
-    let var x = string_of_int (Var.idx x) in
-    let a = List.map (fun v -> (var v, weight v)) l in
-    let b =
-      List.map (fun s -> List.map var (S.elements s)) t.constraints in
-    let c = List.map var l in
-    output_value ch
-      ((a, b, c) : (string * int) list * string list list * string list);
-    close_out ch
-
-  let allocate_variables t ~count =
-    let weight v = try IdentMap.find (V (Var.of_idx v)) count with Not_found -> 0 in
-    let constr = t.constr in
-    let len = Array.length constr in
-    let idx = Array.make len 0 in
-    for i = 0 to len - 1 do
-      idx.(i) <- i
-    done;
-    Array.stable_sort (fun i j -> compare (weight j) (weight i)) idx;
-    let name = Array.make len "" in
-    let n0 = ref 0 in
-    let n1 = ref 0 in
-    let n2 = ref 0 in
-    let n3 = ref 0 in
-    let stats i n =
-      incr n0;
-      if n < 54 then begin incr n1; n2 := !n2 + (weight i) end;
-      n3 := !n3 + (weight i)
-    in
-    let nm ~origin n =
-      name.(origin) <- Var.to_string ~origin:(Var.of_idx origin) (Var.of_idx n) in
-    let total = ref 0 in
-    let bad = ref 0 in
-    for i = 0 to Array.length t.parameters - 1 do
-      List.iter
-        (fun x ->
-           incr total;
-           let idx = Var.idx x in
-           let l = constr.(idx) in
-           if is_available l i then begin
-             nm ~origin:idx i;
-             mark_allocated l i;
-             stats idx i
-           end else
-             incr bad)
-        (List.rev t.parameters.(i))
-    done;
-    if debug () then
-      Format.eprintf
-        "Function parameter properly assigned: %d/%d@." (!total - !bad) !total;
-    for i = 0 to len - 1 do
-      let l = constr.(idx.(i)) in
-      if l <> [] && String.length name.(idx.(i)) = 0 then begin
-        let n = first_available l in
-        let idx = idx.(i) in
-        nm ~origin:idx n;
-        mark_allocated l n;
-        stats idx n
-      end;
-      if l = [] then assert (weight (idx.(i)) = 0);
-    done;
-    if debug () then begin
-      Format.eprintf "short variable count: %d/%d@." !n1 !n0;
-      Format.eprintf "short variable occurrences: %d/%d@." !n2 !n3
+      (fun x ->
+         incr total;
+         let idx = Var.idx x in
+         let l = constr.(idx) in
+         if is_available l i then begin
+           nm ~origin:idx i;
+           mark_allocated l i;
+           stats idx i
+         end else
+           incr bad)
+      (List.rev t.parameters.(i))
+  done;
+  if debug () then
+    Format.eprintf
+      "Function parameter properly assigned: %d/%d@." (!total - !bad) !total;
+  for i = 0 to len - 1 do
+    let l = constr.(idx.(i)) in
+    if l <> [] && String.length name.(idx.(i)) = 0 then begin
+      let n = first_available l in
+      let idx = idx.(i) in
+      nm ~origin:idx n;
+      mark_allocated l n;
+      stats idx n
     end;
-    name
+    if l = [] then assert (weight (idx.(i)) = 0);
+  done;
+  if debug () then begin
+    Format.eprintf "short variable count: %d/%d@." !n1 !n0;
+    Format.eprintf "short variable occurrences: %d/%d@." !n2 !n3
+  end;
+  name
 
-  let add_constraints global u ?(offset=0) params =
-    if Option.Optim.shortvar () then begin
+let add_constraints global u ?(offset=0) params =
+  if Option.Optim.shortvar () then begin
 
-      let constr = global.constr in
-      let c = make_alloc_table () in
+    let constr = global.constr in
+    let c = make_alloc_table () in
 
-      S.iter (fun v -> let i = Var.idx v in constr.(i) <- c :: constr.(i)) u;
-      let params = Array.of_list params in
-      let len = Array.length params in
-      let len_max = len + offset in
-      if Array.length global.parameters < len_max then begin
-        let a = Array.make (2 * len_max) [] in
-        Array.blit global.parameters 0 a 0 (Array.length global.parameters);
-        global.parameters <- a
-      end;
-      for i = 0 to len - 1 do
-        match params.(i) with
+    S.iter (fun v -> let i = Code.Var.idx v in constr.(i) <- c :: constr.(i)) u;
+    let params = Array.of_list params in
+    let len = Array.length params in
+    let len_max = len + offset in
+    if Array.length global.parameters < len_max then begin
+      let a = Array.make (2 * len_max) [] in
+      Array.blit global.parameters 0 a 0 (Array.length global.parameters);
+      global.parameters <- a
+    end;
+    for i = 0 to len - 1 do
+      match params.(i) with
         | V x ->
           global.parameters.(i + offset) <- x :: global.parameters.(i + offset)
         | _ -> ()
-      done;
-      global.constraints <- u :: global.constraints
-    end
+    done;
+    global.constraints <- u :: global.constraints
+  end
 
-  let record_block state scope ~catch params =
-    let offset = if catch then 5 else 0 in
-    let all = S.union scope.Js_traverse.def scope.Js_traverse.use in
-    add_constraints state all ~offset params;
-end
-
-
-module Preserve : Strategy = struct
-  (* Try to preserve variable names.
-     - Assign the origin name if present: "{original_name}"
-     - If present but not available, derive a similar name: "{original_name}${n}" (eg. result$3).
-     - If not present, make up a name: "$${n}"
-
-     Color variables one scope/block at a time - outer scope first.
-  *)
-
-  type t = {
-    size   : int;
-    mutable scopes : Js_traverse.t list
-  }
-  let create size = { size ; scopes = [] }
-
-  let record_block t scope ~catch:_ _param =
-    t.scopes <- scope :: t.scopes
-  let allocate_variables t ~count:_ =
-    let names = Array.make t.size "" in
-    List.iter (fun state ->
-      let assigned =
-        List.fold_left StringSet.union StringSet.empty
-          [
-            state.Js_traverse.def_name;
-            state.Js_traverse.use_name;
-            Reserved.keyword
-          ]
-      in
-      let assigned = S.fold (fun var acc  ->
-        let name = names.(Var.idx var) in
-        if name <> ""
-        then StringSet.add name acc
-        else acc
-      ) (S.union state.Js_traverse.use state.Js_traverse.def) assigned  in
-      let no_name_idx = ref 0 in
-      let _assigned = S.fold (fun var assigned ->
-        if names.(Var.idx var) <> ""
-        then assigned
-        else
-          let name =
-            match Var.get_name var with
-            | Some expected_name ->
-              assert(expected_name <> "");
-              if not (StringSet.mem expected_name assigned)
-              then expected_name
-              else
-                let i = ref 0 in
-                while StringSet.mem (Printf.sprintf "%s$%d" expected_name !i) assigned do
-                  incr i
-                done;
-                Printf.sprintf "%s$%d" expected_name !i
-            | None ->
-              while StringSet.mem (Printf.sprintf "$$%d" !no_name_idx) assigned do
-                incr no_name_idx
-              done;
-              Printf.sprintf "$$%d" !no_name_idx
-          in
-          names.(Var.idx var) <- name;
-          StringSet.add name assigned
-      ) state.Js_traverse.def assigned in
-      ()
-    ) t.scopes;
-    names
-
-end
-
-class traverse record_block = object(m)
+class ['state] color (state : 'state) = object(m)
   inherit Js_traverse.free as super
-  method block ?(catch=false) params =
-    record_block m#state ~catch params;
-    super#block params
-end
 
-let program' (module Strategy : Strategy) p =
-  let nv = Var.count () in
-  let state = Strategy.create nv in
-  let mapper = new traverse (Strategy.record_block state) in
-  let p = mapper#program p in
-  mapper#block [];
-  if S.cardinal (mapper#get_free) <> 0
-  then begin
-    Util.failwith_ "Some variables escaped (#%d)" (S.cardinal (mapper#get_free))
-    (* S.iter(fun s -> (Format.eprintf "%s@." (Var.to_string s))) coloring#get_free *)
-  end;
-  let names = Strategy.allocate_variables state mapper#state.Js_traverse.count in
-  (* if debug () then output_debug_information state coloring#state.Js_traverse.count; *)
-  let color = function
-    | V v ->
-      let name = names.(Var.idx v) in
-      assert (name <> "");
-      S {name;var=Some v}
-    | x -> x
-  in
-  (new Js_traverse.subst color)#program p
+  method block ?(catch =false) params =
+    let offset = if catch then 5 else 0 in
+    let all = S.union m#state.Js_traverse.def m#state.Js_traverse.use in
+    add_constraints state all ~offset params;
+    super#block params
+
+
+end
 
 
 let program p =
-  if Option.Optim.shortvar ()
-  then program' (module Min) p
-  else program' (module Preserve) p
-
+  let color,p =
+    if Option.Optim.shortvar ()
+    then
+      let nv = Code.Var.count () in
+      let state = create nv in
+      let coloring = new color state in
+      let p = coloring#program p in
+      coloring#block [];
+      if S.cardinal (coloring#get_free) <> 0
+      then begin
+        Util.failwith_ "Some variables escaped (#%d)" (S.cardinal (coloring#get_free))
+        (* S.iter(fun s -> (Format.eprintf "%s@." (Code.Var.to_string s))) coloring#get_free *)
+      end;
+      let name = allocate_variables state nv coloring#state.Js_traverse.count in
+      if debug () then output_debug_information state coloring#state.Js_traverse.count;
+      (function V v -> S {name=name.(Code.Var.idx v);var=Some v} | x -> x),p
+    else (function V v -> S {name=Var.to_string v;var=Some v} | x -> x),p
+  in
+  (new Js_traverse.subst color)#program p

--- a/compiler/varPrinter.ml
+++ b/compiler/varPrinter.ml
@@ -64,8 +64,6 @@ let name t v nm_orig =
     then name_raw t v str
   end
 
-let get_name t v = try Some (Hashtbl.find t.names v) with Not_found -> None
-
 let rec format_ident x =
   assert (x >= 0);
   let char c x = String.make 1 (c.[x]) in

--- a/compiler/varPrinter.mli
+++ b/compiler/varPrinter.mli
@@ -25,7 +25,6 @@ val create : ?pretty:bool -> ?stable:bool -> unit -> t
 val reset : t -> unit
 val to_string : t -> ?origin:int -> int -> string
 val name : t -> int -> string -> unit
-val get_name : t -> int -> string option
 val propagate_name : t -> int -> int -> unit
 val set_pretty : t -> bool -> unit
 val set_stable : t -> bool -> unit


### PR DESCRIPTION
The invariant that a [Code.Var.t] is defined in a single scope does not hold.
We need to first fix
 - closures compilation
 - tailcall rewrite

Reverts ocsigen/js_of_ocaml#464