### PR TITLE
Compiler: dynlink javascript files

### DIFF
--- a/compiler/generate.ml
+++ b/compiler/generate.ml
@@ -227,10 +227,11 @@ module Ctx = struct
     { mutable blocks : block AddrMap.t;
       live : int array;
       share: Share.t;
-      debug : Parse_bytecode.Debug.data }
+      debug : Parse_bytecode.Debug.data;
+      exported_runtime : bool }
 
-  let initial blocks live share debug =
-    { blocks; live; share; debug }
+  let initial ~exported_runtime blocks live share debug =
+    { blocks; live; share; debug; exported_runtime }
 
 end
 
@@ -266,6 +267,11 @@ let float_const f = val_float (J.ENum f)
 
 let s_var name = J.EVar (J.S {J.name=name; J.var = None})
 
+let runtime_fun ctx name =
+  if ctx.Ctx.exported_runtime
+  then J.EDot (J.EDot (s_var Option.global_object, "jsoo_runtime"), name)
+  else s_var name
+
 let str_js s = J.EStr (s,`Bytes)
 
 
@@ -296,7 +302,7 @@ let rec constant_rec ~ctx x level instrs =
   match x with
     String s ->
       let e = Share.get_string str_js s ctx.Ctx.share in
-      let p = Share.get_prim s_var "caml_new_string" ctx.Ctx.share in
+      let p = Share.get_prim (runtime_fun ctx) "caml_new_string" ctx.Ctx.share in
       J.ECall (p,[e],J.N), instrs
   | IString s ->
       Share.get_string str_js s ctx.Ctx.share, instrs
@@ -328,7 +334,7 @@ let rec constant_rec ~ctx x level instrs =
           let (js, instrs) = constant_rec ~ctx elt level instrs in
           (Some js)::arr, instrs) ([], instrs) elts_rev
         in
-        let p = Share.get_prim s_var "caml_list_of_js_array" ctx.Ctx.share in
+        let p = Share.get_prim (runtime_fun ctx) "caml_list_of_js_array" ctx.Ctx.share in
         J.ECall (p,[J.EArr arr],J.N), instrs
       | None ->
       let split = level = constant_max_depth in
@@ -672,15 +678,15 @@ let parallel_renaming params args continuation queue =
 
 (****)
 
-let apply_fun_raw f params =
+let apply_fun_raw ctx f params =
   let n = List.length params in
   J.ECond (J.EBin (J.EqEq, J.EDot (f, "length"),
                    J.ENum (float n)),
            J.ECall (f, params, J.N),
-           J.ECall (s_var "caml_call_gen",
+           J.ECall (runtime_fun ctx "caml_call_gen",
                     [f; J.EArr (List.map (fun x -> Some x) params)], J.N))
 
-let generate_apply_fun n =
+let generate_apply_fun ctx n =
   let f' = Var.fresh_n "f" in
   let f = J.V f' in
   let params =
@@ -693,14 +699,14 @@ let generate_apply_fun n =
   J.EFun (None, f :: params,
           [J.Statement
               (J.Return_statement
-                 (Some (apply_fun_raw f' params'))), J.N],
+                 (Some (apply_fun_raw ctx f' params'))), J.N],
           J.N)
 
 let apply_fun ctx f params loc =
   if Option.Optim.inline_callgen ()
-  then apply_fun_raw f params
+  then apply_fun_raw ctx f params
   else
-    let y = Share.get_apply generate_apply_fun (List.length params) ctx.Ctx.share in
+    let y = Share.get_apply (generate_apply_fun ctx) (List.length params) ctx.Ctx.share in
     J.ECall (y, f::params, loc)
 
 (****)
@@ -831,7 +837,7 @@ let register_bin_math_prim name prim =
 let _ =
   register_un_prim_ctx  "%caml_format_int_special" `Pure
     (fun ctx cx loc ->
-      let p = Share.get_prim s_var "caml_new_string" ctx.Ctx.share in
+      let p = Share.get_prim (runtime_fun ctx) "caml_new_string" ctx.Ctx.share in
       J.ECall (p, [J.EBin (J.Plus,str_js "",cx)], loc));
   register_bin_prim "caml_array_unsafe_get" `Mutable
     (fun cx cy _ -> J.EAccess (cx, plus_int cy one));
@@ -1014,7 +1020,7 @@ let rec translate_expr ctx queue loc _x e level : _ * J.statement_list =
         in
         J.EArr (List.map (fun x -> Some x) args), prop, queue
       | Extern "%closure", [Pc (IString name | String name)] ->
-         let prim = Share.get_prim s_var name ctx.Ctx.share in
+         let prim = Share.get_prim (runtime_fun ctx) name ctx.Ctx.share in
          prim, const_p, queue
       | Extern "%caml_js_opt_call", Pv f :: Pv o :: l ->
         let ((pf, cf), queue) = access_queue queue f in
@@ -1073,7 +1079,7 @@ let rec translate_expr ctx queue loc _x e level : _ * J.statement_list =
         let ((po, co), queue) = access_queue queue o in
         (J.EUn(J.Delete, J.EDot (co, f)), or_p po mutator_p, queue)
       | Extern "%overrideMod", [Pc (String m | IString m);Pc (String f | IString f)] ->
-        s_var (Printf.sprintf "caml_%s_%s" m f), const_p,queue
+        runtime_fun ctx (Printf.sprintf "caml_%s_%s" m f), const_p,queue
       | Extern "%overrideMod", _ ->
         assert false
       | Extern "%caml_js_opt_object", fields ->
@@ -1112,7 +1118,7 @@ let rec translate_expr ctx queue loc _x e level : _ * J.statement_list =
             | None ->
               if name.[0] = '%'
               then failwith (Printf.sprintf "Unresolved internal primitive: %s" name);
-              let prim = Share.get_prim s_var name ctx.Ctx.share in
+              let prim = Share.get_prim (runtime_fun ctx) name ctx.Ctx.share in
               let prim_kind = kind (Primitive.kind name) in
               let (args, prop, queue) =
                 List.fold_right
@@ -1164,12 +1170,23 @@ and translate_instr ctx expr_queue loc instr =
   | Let (x, e) ->
     let (ce, prop, expr_queue),instrs =
       translate_expr ctx expr_queue loc x e 0 in
+    let keep_name x =
+      match Code.Var.get_name x with
+      | None -> false
+      | Some s ->
+        not (String.length s >= 5
+             && s.[0] = 'j'
+             && s.[1] = 's'
+             && s.[2] = 'o'
+             && s.[3] = 'o'
+             && s.[4] = '_')
+    in
     begin match ctx.Ctx.live.(Var.idx x),e with
     | 0,_ -> (* deadcode is off *)
       flush_queue expr_queue prop (instrs @ [J.Expression_statement ce, loc])
     | 1,_ when Option.Optim.compact ()
             && (not ( Option.Optim.pretty ())
-                || Code.Var.get_name x = None) ->
+                || not (keep_name x)) ->
       enqueue expr_queue prop x ce loc 1 instrs
     (* We could inline more.
        size_v : length of the variable after serialization
@@ -1322,7 +1339,7 @@ else begin
             J.EBin(
               J.Eq,
               J.EVar (J.V x),
-              J.ECall (Share.get_prim s_var "caml_wrap_exception" st.ctx.Ctx.share,
+              J.ECall (Share.get_prim (runtime_fun st.ctx) "caml_wrap_exception" st.ctx.Ctx.share,
                        [J.EVar (J.V x)], J.N))),J.N)
             ::handler
           else handler in
@@ -1753,15 +1770,21 @@ let generate_shared_value ctx =
   let strings =
     J.Statement (
       J.Variable_statement (
-        List.map (fun (s,v) -> v, Some (str_js s,J.N)) (StringMap.bindings ctx.Ctx.share.Share.vars.Share.strings)
-        @ List.map (fun (s,v) -> v, Some (s_var s,J.N)) (StringMap.bindings ctx.Ctx.share.Share.vars.Share.prims))),
+        List.map (fun (s,v) ->
+          v,
+          Some (str_js s,J.N))
+          (StringMap.bindings ctx.Ctx.share.Share.vars.Share.strings)
+        @ List.map (fun (s,v) ->
+          v,
+          Some (runtime_fun ctx s,J.N))
+          (StringMap.bindings ctx.Ctx.share.Share.vars.Share.prims))),
     J.U
   in
 
   if not (Option.Optim.inline_callgen ())
   then
     let applies = List.map (fun (n,v) ->
-        match generate_apply_fun n with
+        match generate_apply_fun ctx n with
         | J.EFun (_,param,body,nid) ->
           J.Function_declaration (v,param,body,nid), J.U
         | _ -> assert false) (IntMap.bindings ctx.Ctx.share.Share.vars.Share.applies) in
@@ -1774,10 +1797,10 @@ let compile_program ctx pc =
   if debug () then Format.eprintf "@.@.";
   res
 
-let f ((pc, blocks, _) as p) ?toplevel live_vars debug =
+let f ((pc, blocks, _) as p) ~toplevel ~exported_runtime live_vars debug =
   let t' = Util.Timer.make () in
-  let share = Share.get ?alias_prims:toplevel p in
-  let ctx = Ctx.initial blocks live_vars share debug  in
+  let share = Share.get ~alias_prims:(toplevel && Option.Optim.shortvar ()) p in
+  let ctx = Ctx.initial ~exported_runtime blocks live_vars share debug  in
   let p = compile_program ctx pc in
   if times () then Format.eprintf "  code gen.: %a@." Util.Timer.print t';
   p

--- a/compiler/generate.mli
+++ b/compiler/generate.mli
@@ -19,5 +19,6 @@
  *)
 
 val f :
-  Code.program -> ?toplevel:bool -> int array -> Parse_bytecode.Debug.data ->
+  Code.program -> toplevel:bool -> exported_runtime:bool
+  -> int array -> Parse_bytecode.Debug.data ->
   Javascript.program

--- a/compiler/jsoo_compile.ml
+++ b/compiler/jsoo_compile.ml
@@ -91,9 +91,9 @@ let f {
     if source_map <> None &&  Parse_bytecode.Debug.is_empty d
     then
       Util.warn
-	"Warning: '--source-map' is enabled but the bytecode program \
-	 was compiled with no debugging information.\n\
-	 Warning: Consider passing '-g' option to ocamlc.\n%!"
+        "Warning: '--source-map' is enabled but the bytecode program \
+         was compiled with no debugging information.\n\
+         Warning: Consider passing '-g' option to ocamlc.\n%!"
   in
   let cmis = if nocmis then Util.StringSet.empty else cmis in
   let p =

--- a/compiler/linker.ml
+++ b/compiler/linker.ml
@@ -224,15 +224,16 @@ let find_named_value code =
 let add_file f =
   List.iter
     (fun (provide,req,versions,(code:Javascript.program)) ->
-       incr last_code_id;
-       let id = !last_code_id in
        let vmatch = match versions with
          | [] -> true
          | l -> List.exists version_match l in
        if vmatch
        then begin
+         incr last_code_id;
+         let id = !last_code_id in
          (match provide with
-          | None -> always_included := id :: !always_included
+          | None ->
+            always_included := id :: !always_included
           | Some (pi,name,kind,ka) ->
             let module J = Javascript in
             let rec find = function
@@ -329,6 +330,7 @@ let resolve_deps ?(linkall = false) visited_rev used =
     then
       begin
         (* link all primitives *)
+
         let prog,set =
           Hashtbl.fold (fun nm (_id,_) (visited,set) ->
               resolve_dep_name_rev visited [] nm,
@@ -350,3 +352,12 @@ let resolve_deps ?(linkall = false) visited_rev used =
   visited_rev, missing
 
 let link program state = List.flatten (List.rev (program::state.codes))
+
+let all state =
+  IntSet.fold (fun id acc ->
+    try
+      let name,_ = Hashtbl.find provided_rev id in
+      name :: acc
+    with Not_found ->
+      acc
+  ) state.ids []

--- a/compiler/linker.mli
+++ b/compiler/linker.mli
@@ -31,3 +31,4 @@ val init : unit -> state
 val resolve_deps : ?linkall:bool -> state -> Util.StringSet.t -> state * Util.StringSet.t
 val link : Javascript.program -> state -> Javascript.program
 val get_provided : unit -> Util.StringSet.t
+val all : state -> string list

--- a/compiler/parse_bytecode.ml
+++ b/compiler/parse_bytecode.ml
@@ -1915,7 +1915,9 @@ let exe_from_channel ~includes ?(toplevel=false) ~debug ~debug_data ic =
   if toplevel then
     begin
       (* export globals *)
-      Tbl.iter (fun _ n -> globals.is_exported.(n) <- true) symbols.num_tbl;
+      Tbl.iter (fun id n ->
+        globals.named_value.(n) <- Some id.Ident.name;
+        globals.is_exported.(n) <- true) symbols.num_tbl;
       (* @vouillon: *)
       (* we should then use the -linkall option to build the toplevel. *)
       (* The OCaml compiler can generate code using this primitive but *)

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -45,7 +45,7 @@ api/wiki/index.wiki: ${MLIS} api/index
 	   -i $(shell ocamlfind query wikidoc) -g odoc_wiki.cma \
 	   ${MLIS}
 
-EX_TOPLEVEL:=index.html toplevel.js *.cmis.js
+EX_TOPLEVEL:=index.html toplevel.js test_dynlink.js *.cmis.js
 EX_BOULDER:=index.html boulderdash.js sprites
 EX_WEBGL:=index.html webgldemo.js
 EX_GRAPH:=index.html jsviewer.js

--- a/toplevel/Makefile
+++ b/toplevel/Makefile
@@ -68,7 +68,7 @@ MKTOP=jsoo_mktop -verbose $(SAFESTRING) \
 
 TOPLEVEL_NAME=toplevel
 TOPLEVEL_OBJS=colorize.cmo indent.cmo toplevel.cmo
-$(TOPLEVEL_NAME).js: $(TOPLEVEL_OBJS) examples.ml test_dynlink.cmo
+$(TOPLEVEL_NAME).js: $(TOPLEVEL_OBJS) examples.ml test_dynlink.cmo test_dynlink.js
 	$(MKTOP) \
 	$(BER) \
 	$(OCPINDENT) $(HIGLO) \
@@ -76,8 +76,12 @@ $(TOPLEVEL_NAME).js: $(TOPLEVEL_OBJS) examples.ml test_dynlink.cmo
 	${addprefix -jsopt , ${JSFILES}} \
 	${addprefix -jsopt , -I ./ --file examples.ml} \
 	${addprefix -jsopt , -I ./ --file test_dynlink.cmo} \
+	${addprefix -jsopt , -I ./ --file test_dynlink.js} \
 	-package base64 \
 	-o $(TOPLEVEL_NAME).byte
+
+test_dynlink.js: test_dynlink.cmo
+	js_of_ocaml test_dynlink.cmo --pretty
 
 EVAL_NAME=eval
 EVAL_OBJS=eval.cmo

--- a/toplevel/toplevel.cppo.ml
+++ b/toplevel/toplevel.cppo.ml
@@ -76,6 +76,8 @@ let setup_toplevel () =
     exec' (Printf.sprintf "Format.printf \"%s@.@.\";;" header3));
   exec' ("#enable \"pretty\";;");
   exec' ("#enable \"shortvar\";;");
+  Hashtbl.add Toploop.directive_table "load_js" (Toploop.Directive_string (fun name ->
+    Js.Unsafe.global##load_script_(name)));
   Sys.interactive := true;
   ()
 


### PR DESCRIPTION
Following https://github.com/ocsigen/js_of_ocaml/pull/313
Allow to dynlink precompiled ocaml units (aka javascript files).

In the toplevel, one can already do the following to compile bytecode to javascript and execute it. 
```
#load "/static/test_dynlink.cmo
```

One can now load precompiled javascript directly.
```
#load_js "test_dynlink.js"
```


https://github.com/ocsigen/js_of_ocaml/issues/369
https://github.com/ocsigen/js_of_ocaml/issues/450
