### PR TITLE
spelling-fixes, as seen on lintian.debian.org

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -59,7 +59,7 @@
 ===== 2.6 (2015-07-15) =====
 
  * Features/Changes
- ** Compiler: Findlib is optionnal
+ ** Compiler: Findlib is optional
  ** Compiler: improvement of sourcemap support (ie: inlinned sourcemap)
  ** Compiler: Support for separate compilation (compile cm{o,a} -> js)
  ** Compiler: more inlining
@@ -166,7 +166,7 @@
  * Features/Changes
  ** Runtime: bigarray comparison
  ** Compiler: allow to embed directory with -file dir_name=ext1,ext2:dest_path
- ** Compiler: can now output embeded files in a differant js file
+ ** Compiler: can now output embedded files in a differant js file
  ** Lib: js_of_ocaml.graphics
  ** Lib: Js.Unsafe.expr to embed JavasScript expression
     to be used instead of Js.Unsafe.variable (or eval_string)
@@ -308,7 +308,7 @@
 
  * Compiler:
  ** Add -I option to select directories containing cmi files
- ** Fix compilation of mutually recursive functions occuring in loops
+ ** Fix compilation of mutually recursive functions occurring in loops
  ** In Javascript output, parenthesize numbers when followed by a dot
  ** Fix order of evaluation bug
  ** Fix compilation of loops in 'try ... with' body (close #263)
@@ -398,7 +398,7 @@
    ** API to generate a function instead of a standalone program
    ** option to compile an OCaml toplevel
  * Libraries:
-   ** Add an optionnal JSON deriving class
+   ** Add an optional JSON deriving class
    ** Add Math.random binding
    ** Add scrollWidth/scrollHeight element methods to the DOM
    ** Add coercion function Dom_html.CoerceTo.element

--- a/compiler/generate.ml
+++ b/compiler/generate.ml
@@ -63,7 +63,7 @@ let list_group f g l =
     list_group_rec f g r (f a) [g a] []
 
 (* like [List.map] except that it calls the function with
-   an additional argument to indicate wether we're mapping
+   an additional argument to indicate whether we're mapping
    over the last element of the list *)
 let rec map_last f l = match l with
   | [] -> assert false
@@ -1206,7 +1206,7 @@ and translate_instr ctx expr_queue loc instr =
     (* We could inline more.
        size_v : length of the variable after serialization
        size_c : length of the constant after serialization
-       num : number of occurence
+       num : number of occurrence
        size_c * n < size_v * n + size_v + 1 + size_c
     *)
     | n,(Const _| Constant (Int _|Float _)) ->

--- a/compiler/inline.ml
+++ b/compiler/inline.ml
@@ -211,7 +211,7 @@ let inline closures live_vars outer_optimizable pc (blocks,free_pc)=
                (* inlining the code of an optimizable function could make
                   this code unoptimized. (wrt to Jit compilers)
                   At the moment, V8 doesn't optimize function containing try..catch.
-                  We disable inlining if the inner and outer funcitons don't have
+                  We disable inlining if the inner and outer functions don't have
                   the same "contain_try_catch" property *)
                then
                  let (blocks, cont_pc) =

--- a/compiler/js_output.ml
+++ b/compiler/js_output.ml
@@ -1041,7 +1041,7 @@ let need_space a b =
   (* do not concat 2 differant identifier *)
   (part_of_ident a && part_of_ident b) ||
   (* do not generate end_of_line_comment.
-     handle the case of "num / /* coment */ b " *)
+     handle the case of "num / /* comment */ b " *)
   (a = '/' && b = '/')
 
 let program f ?source_map p =

--- a/compiler/js_parser.mly
+++ b/compiler/js_parser.mly
@@ -312,7 +312,7 @@ finally:
  | T_FINALLY block { $2 }
 
 (*----------------------------*)
-(* 2 auxillary statements     *)
+(* 2 auxiliary statements     *)
 (*----------------------------*)
 
 case_clause:
@@ -580,7 +580,7 @@ arguments:
  | args=parenthesised(separated_list(T_COMMA, assignment_expression)) { args }
 
 (*----------------------------*)
-(* 2 auxillary bis            *)
+(* 2 auxiliary bis            *)
 (*----------------------------*)
 
 (*************************************************************************)

--- a/compiler/parse_bytecode.ml
+++ b/compiler/parse_bytecode.ml
@@ -151,7 +151,7 @@ end = struct
     fun (events_by_pc, units) ~crcs ~includes ~orig ic ->
       let evl : debug_event list = input_value ic in
 
-      (* Work arround a bug in ocaml 4.02 *)
+      (* Work around a bug in ocaml 4.02 *)
       (* debug section in pack module may be wrong *)
       (* containing no debug_info. *)
       (* In this case, evl in not a debug_info list but a *)

--- a/compiler/pretty_print.ml
+++ b/compiler/pretty_print.ml
@@ -222,7 +222,7 @@ let newline st =
 
 (* hack on*)
 let output_substring = Pervasives.output
-(* for ocaml <  4.02, output_substring will be Pervasives.ouput (above)
+(* for ocaml <  4.02, output_substring will be Pervasives.output (above)
    for ocaml >= 4.02, output_substring will be taken from the locally
                       open Pervasives module *)
 let _ = output_substring

--- a/doc/manual/src/debug.wiki
+++ b/doc/manual/src/debug.wiki
@@ -21,6 +21,6 @@ After compiling with sourcemap enabled, using developers tools, one can set brea
 step through the code, and inspect variable directly in OCaml sources.
 
 == About Chrome DevTools
-Usefull setting Chrome DevTools:
+Useful setting Chrome DevTools:
 * Display variable values inline while debugging
 * Resolve variable names (hiddden DevTools Experiments, see http://islegend.com/development/how-to-enable-devtools-experiments-within-google-chrome)

--- a/doc/manual/src/library.wiki
+++ b/doc/manual/src/library.wiki
@@ -5,7 +5,7 @@
 Base values are not represented the same way in OCaml and Javascript.
 In particular, OCaml strings are mutable arrays of bytes, while
 Javascript strings are constant arrays of UTF-16 code points.  We list
-here the correspondance between base types.  Conversion functions are
+here the correspondence between base types.  Conversion functions are
 provided.
 
 |= OCaml values |= Ocaml type of Javascript values |= Actual Javascript type |
@@ -150,7 +150,7 @@ string. The unmarshaling is unsafe in the same way the OCaml
 {{{Marshal.from_string}}} function is.
 
 Type-safe unmarshaling may be achieved with the
-{{{deriving}}} library using either the optionnal {{{Json}}}
+{{{deriving}}} library using either the optional {{{Json}}}
 class or the {{{Pickle}}} class.
 
 * The {{{Json}}} class use a Json as external representation and do

--- a/doc/manual/src/options.wiki
+++ b/doc/manual/src/options.wiki
@@ -12,7 +12,7 @@
 | --debug-info            | Output debug information               |
 | -I dir                  | Add <dir> to the list of
                             include directories                    |
-| --file file[:dir]       | Register <file> to the pseudo filesytem
+| --file file[:dir]       | Register <file> to the pseudo filesystem
                             and choose the the destination
                             directory <dir> (default /)            |
 | --enable <option>       | Enable option <option>                 |

--- a/lib/OVERVIEW
+++ b/lib/OVERVIEW
@@ -5,7 +5,7 @@
 Base values are not represented the same way in OCaml and Javascript.
 In particular, OCaml strings are mutable arrays of bytes, while
 Javascript strings are constant arrays of UTF-16 code points.  We list
-here the correspondance between base types.  Conversion functions are
+here the correspondence between base types.  Conversion functions are
 provided.
 
 |= OCaml values |= Ocaml type of Javascript values |= Actual Javascript type |

--- a/lib/deriving_json/deriving_Json.ml
+++ b/lib/deriving_json/deriving_Json.ml
@@ -222,7 +222,7 @@ module Json_string = Defaults(struct
 	  Printf.bprintf buffer "\\u%04X" (int_of_char c)
       | c when c < '\x80' ->
 	  Buffer.add_char buffer s.[i]
-      | _c (* >= '\x80' *) -> (* Bytes greater than 127 are embeded in a UTF-8 sequence. *)
+      | _c (* >= '\x80' *) -> (* Bytes greater than 127 are embedded in a UTF-8 sequence. *)
 	  Buffer.add_char buffer (Char.chr (0xC2 lor (Char.code s.[i] lsr 6)));
 	  Buffer.add_char buffer (Char.chr (0x80 lor (Char.code s.[i] land 0x3F)))
     done;

--- a/lib/dom.ml
+++ b/lib/dom.ml
@@ -225,7 +225,7 @@ end
 
 let no_handler : ('a, 'b) event_listener = Js.null
 let window_event () : 'a #event t = Js.Unsafe.pure_js_expr "event"
-(* The function preventDefault must be called explicitely when
+(* The function preventDefault must be called explicitly when
    using addEventListener... *)
 let handler f =
   Js.some (Js.Unsafe.callback

--- a/lib/graphics/graphics_js.mli
+++ b/lib/graphics/graphics_js.mli
@@ -32,7 +32,7 @@ val open_graph : string -> unit
     information on the desired graphics mode, the graphics window
     size, and so on. Specification can be found at
     http://www.w3schools.com/jsref/met_win_open.asp.
-    Note: an extra specification is availble, "target",
+    Note: an extra specification is available, "target",
     to specifies the target attribute or the name of the window. *)
 
 val open_canvas : Dom_html.canvasElement Js.t -> unit

--- a/lib/regexp.mli
+++ b/lib/regexp.mli
@@ -24,7 +24,7 @@
     from the syntax used by the [Str] module from the OCaml standard
     library.
 
-    @see <https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/RegExp#section_5> Regexp object on Mozilla Developper Network.
+    @see <https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/RegExp#section_5> Regexp object on Mozilla Developer Network.
 
  *)
 

--- a/ocamlbuild/ocamlbuild_js_of_ocaml.ml
+++ b/ocamlbuild/ocamlbuild_js_of_ocaml.ml
@@ -47,7 +47,7 @@ let link_opts prod =
     ("js_of_ocaml" :: pkgs, predicates)
   in
 
-  (* Findlib usualy set pkg_* predicate for all selected packages *)
+  (* Findlib usually set pkg_* predicate for all selected packages *)
   (* It doesn't do it with 'query' command, we have to it manualy. *)
   let cmd = "-format" :: "pkg_%p" :: "-r" :: all_pkgs in
   let predicates_pkgs = ocamlfind cmd (fun ic -> input_line ic) in

--- a/runtime/nat.js
+++ b/runtime/nat.js
@@ -252,7 +252,7 @@ function div_helper(a, b, c) {
 //Requires: div_helper
 function div_digit_nat(natq, ofsq, natr, ofsr, nat1, ofs1, len, nat2, ofs2) {
 	var rem = nat1[ofs1+len-1];
-	// natq[ofsq+len-1] is guarenteed to be zero (due to the MSD requirement),
+	// natq[ofsq+len-1] is guaranteed to be zero (due to the MSD requirement),
 	// and should not be written to.
 	for(var i = len-2; i >= 0; i--) {
 			var x = div_helper(rem, nat1[ofs1+i], nat2[ofs2]);


### PR DESCRIPTION
should just contain some trivial fixes in comments