### PR TITLE
Added document##.activeElement method.

### DIFF
--- a/lib/dom_html.ml
+++ b/lib/dom_html.ml
@@ -1099,6 +1099,7 @@ class type document = object
   method createRange : range t meth
   method readyState : js_string t readonly_prop
   method getElementsByClassName : js_string t -> element Dom.nodeList t meth
+  method activeElement : element t opt readonly_prop
 
   inherit eventTarget
 end

--- a/lib/dom_html.mli
+++ b/lib/dom_html.mli
@@ -1053,6 +1053,7 @@ class type document = object
   method createRange : range t meth
   method readyState : js_string t readonly_prop
   method getElementsByClassName : js_string t -> element Dom.nodeList t meth
+  method activeElement : element t opt readonly_prop
 
   inherit eventTarget
 end


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/Document/activeElement

> Returns the currently focused element, that is, the element that will get keystroke events if the user types any. This attribute is read only.

> When there is no selection, the active element is the page's <body> or null. 