### PR TITLE
Fix ppx_deriving_json for types with both manifest and definition

### DIFF
--- a/lib/ppx/ppx_deriving_json.cppo.ml
+++ b/lib/ppx/ppx_deriving_json.cppo.ml
@@ -596,12 +596,12 @@ let json_decls_of_record d l =
 let json_str_of_decl ({Parsetree.ptype_loc} as d) =
   Ast_helper.with_default_loc ptype_loc @@ fun () ->
   match d with
-  | { Parsetree.ptype_manifest = Some y } ->
-    json_decls_of_type d y
-  | { ptype_kind = Ptype_variant l } ->
+  | { Parsetree.ptype_kind = Ptype_variant l } ->
     json_decls_of_variant d l
   | { ptype_kind = Ptype_record l } ->
     json_decls_of_record d l
+  | { ptype_manifest = Some y } ->
+    json_decls_of_type d y
   | _ ->
     Location.raise_errorf "%s cannot be derived for %s" deriver
       (Ppx_deriving.mangle_type_decl (`Suffix "") d)


### PR DESCRIPTION
Consider a type definition like

```ocaml
type a = b = A | ...
```

Our `ppx_deriving_json` plugin used to rely on the deriver for `b`, which does not necessarily exist (e.g., if `b` comes from a lower-level library that does not provide derivers). This patch produces a new deriver instead.

This came up while translating Eliom to PPX.

