### PR TITLE
Build deriving_[Jj]son.cm* even without deriving package

### DIFF
--- a/Makefile.filelist
+++ b/Makefile.filelist
@@ -7,16 +7,18 @@ endif
 INTF := lib/*.cmi
 
 IMPL := lib/$(LIBNAME).cma   \
-        lib/syntax/pa_js.cmo \
         lib/dll$(LIBNAME)$(DLLEXT) \
         lib/lib$(LIBNAME)$(LIBEXT)
 
 INTF += lib/log/*.cmi
 IMPL += lib/log/logger.cma
 
+ifeq "${WITH_CAMLP4}" "YES"
+IMPL += lib/syntax/pa_js.cmo
 ifeq "${BEST}" "opt"
 ifeq "${NATDYNLINK}" "YES"
 IMPL += lib/syntax/pa_js.cmx lib/syntax/pa_js.cmxs
+endif
 endif
 endif
 
@@ -122,17 +124,12 @@ endif
 
 IMPL += $(addprefix ocamlbuild/_build/,$(OCAMLBUILD_IMPL))
 
-ifeq "${WITH_DERIVING}" "YES"
-
 JSON := lib/deriving_json/deriving_Json.cmi       \
         lib/deriving_json/deriving_Json_lexer.cmi
 
 INTF += $(JSON)
-INTF += lib/syntax/pa_deriving_Json.cmi
 
-IMPL += lib/syntax/pa_deriving_Json.cmo \
-        lib/syntax/pa_deriving_Json.cmi \
-        lib/deriving_json.cma
+IMPL += lib/deriving_json.cma
 
 NATIMPL := lib/deriving_json.cmxa     \
 	   lib/deriving_json.cmxs     \
@@ -140,17 +137,24 @@ NATIMPL := lib/deriving_json.cmxa     \
 
 NATIMPL += $(JSON:.cmi=.cmx)
 
+ifeq "${WITH_CAMLP4}${WITH_DERIVING}" "YESYES"
+
+INTF += lib/syntax/pa_deriving_Json.cmi
+
+IMPL += lib/syntax/pa_deriving_Json.cmo \
+        lib/syntax/pa_deriving_Json.cmi
+
 ifeq "${NATDYNLINK}" "YES"
 NATIMPL += lib/syntax/pa_deriving_Json.cmx \
            lib/syntax/pa_deriving_Json.cmxs
 COMP_IMPL += $(COMP_NATDYN_IMPL)
 endif
 
+endif
+
 ifeq "${BEST}" "opt"
 IMPL += $(NATIMPL)
 COMP_IMPL += $(COMP_NAT_IMPL)
-endif
-
 endif
 
 DOC := ${INTF:.cmi=.mli}

--- a/lib/META
+++ b/lib/META
@@ -50,9 +50,9 @@ package "deriving" (
   archive(byte) = "deriving_json.cma"
   archive(native) = "deriving_json.cmxa"
   requires = "bytes"
-  requires(syntax) = "js_of_ocaml.deriving.syntax"
 
   package "syntax" (
+    exists_if = "pa_deriving_Json.cmo pa_deriving_Json.cmxs"
     description = "Safe \"IO in JSON\" class for deriving."
     version = "[distributed with js_of_ocaml]"
     archive(syntax, preprocessor) = "pa_deriving_Json.cmo"

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -12,11 +12,13 @@ include ../Makefile.conf
 -include ../Makefile.local
 
 DERIVING_JSON=deriving_json.cma
+ifeq "$(BEST)" "opt"
+DERIVING_JSON += deriving_json.cmxs
+endif
 ifeq "${WITH_CAMLP4}" "YES"
 ifeq "${WITH_DERIVING}" "YES"
 PA_DERIVING=syntax/pa_deriving_Json.cmo
 ifeq "$(BEST)" "opt"
-DERIVING_JSON += deriving_json.cmxs
 ifeq "${NATDYNLINK}" "YES"
 PA_DERIVING_NDL= syntax/pa_deriving_Json.cmx syntax/pa_deriving_Json.cmxs
 endif


### PR DESCRIPTION
Our runtime `deriving` components (`deriving_[Jj]son*` files, `js_of_ocaml.deriving` Findlib package) do not technically depend on the `deriving` package. They are used by both the `deriving` and `ppx_deriving` plugins. This PR updates the  build system to install the runtime components by default, so that they will be there for PPX.

We could make installation conditional on `deriving | ppx_deriving`, but it is not a lot of code, and theoretically somebody may want to use only the runtime part (say, for JSON-aware API but without directly using any deriver).

@Drup, would that fix #509 ?
