### PR TITLE
Add _opam in gitignore for OPAM 2.0 local switch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,5 @@ doc/manual/files/toplevel/
 doc/manual/files/webgl/
 doc/manual/files/wiki/
 doc/manual/files/wysiwyg/
+
+_opam


### PR DESCRIPTION
OPAM 2.0 allows to have a local configuration and compiler (see https://opam.ocaml.org/blog/opam-2-0-preview/). This configuration is put in `_opam` directory.
Useful for people who wants to contribute to `js_of_ocaml` without having to install all dependencies in another switch.