### PR TITLE
Fixes the tanh implementation. The current implementation is coth

### DIFF
--- a/runtime/ieee_754.js
+++ b/runtime/ieee_754.js
@@ -247,5 +247,5 @@ function caml_sinh_float (x) { return (Math.exp(x) - Math.exp(-x)) / 2; }
 //Provides: caml_tanh_float const
 function caml_tanh_float (x) {
   var y = Math.exp(x), z = Math.exp(-x);
-  return (y + z) / (y - z);
+  return (y - z) / (y + z);
 }


### PR DESCRIPTION
I was having a strange behavior when running a numeric program after converted to Js. I track down the problem and seems that the implementation of tanh is incorrect.

I used this mathematica code to check my implementation:

```
y = Exp[x];
z = Exp[-x];
FullSimplify[(y + z)/(y - z)] // This gives Coth[x]
FullSimplify[(y - z)/(y + z)] // This is Tanh[x]
```