### PR TITLE
deriving_Json.mli: fix spelling of "Conversion".

### DIFF
--- a/lib/deriving_json/deriving_Json.mli
+++ b/lib/deriving_json/deriving_Json.mli
@@ -57,7 +57,7 @@ module type Json = sig
 end
 
 (**/**)
-(** {2 Convertion } *)
+(** {2 Conversion } *)
 
 (** [convert (t : 'a t) (from_ : 'a -> 'b) (to_ : 'b -> 'a)]
     generate a JSON parser/printer for value of type ['b] using the parser/printer of type ['a]


### PR DESCRIPTION
The deriving_Json.mli file has "Convertion" written in it; the proper spelling is "Conversion".