### PR TITLE
Specify deriving dir in camlp4 META

### DIFF
--- a/META.js_of_ocaml-camlp4
+++ b/META.js_of_ocaml-camlp4
@@ -4,6 +4,7 @@ requires(syntax) = "camlp4"
 archive(syntax,preprocessor) = "pa_js.cma"
 
 package "deriving" (
+  directory = "deriving"
   exists_if = "pa_deriving_Json.cma pa_deriving_Json.cmxs"
   description = "Safe \"IO in JSON\" class for deriving."
   version = "[distributed with js_of_ocaml-camlp4]"


### PR DESCRIPTION
The `deriving` Camlp4 modules end up in the `deriving` subdirectory of `js_of_ocaml-camlp4`. We can use the `directory` directive in `META` to point to them.