### PR TITLE
Change type of Dom_html.storageEvent

### DIFF
--- a/lib/dom_html.ml
+++ b/lib/dom_html.ml
@@ -290,7 +290,7 @@ and storageEvent = object
   inherit event
   method key : js_string t opt readonly_prop
   method oldValue : js_string t opt readonly_prop
-  method keynewValue : js_string t opt readonly_prop
+  method newValue : js_string t opt readonly_prop
   method url : js_string t readonly_prop
   method storageArea : storage t opt readonly_prop
 end

--- a/lib/dom_html.ml
+++ b/lib/dom_html.ml
@@ -288,7 +288,7 @@ end
 
 and storageEvent = object
   inherit event
-  method key : js_string t readonly_prop
+  method key : js_string t opt readonly_prop
   method oldValue : js_string t opt readonly_prop
   method keynewValue : js_string t opt readonly_prop
   method url : js_string t readonly_prop

--- a/lib/dom_html.mli
+++ b/lib/dom_html.mli
@@ -299,7 +299,7 @@ and storageEvent = object
   inherit event
   method key : js_string t opt readonly_prop
   method oldValue : js_string t opt readonly_prop
-  method keynewValue : js_string t opt readonly_prop
+  method newValue : js_string t opt readonly_prop
   method url : js_string t readonly_prop
   method storageArea : storage t opt readonly_prop
 end

--- a/lib/dom_html.mli
+++ b/lib/dom_html.mli
@@ -297,7 +297,7 @@ end
 
 and storageEvent = object
   inherit event
-  method key : js_string t readonly_prop
+  method key : js_string t opt readonly_prop
   method oldValue : js_string t opt readonly_prop
   method keynewValue : js_string t opt readonly_prop
   method url : js_string t readonly_prop


### PR DESCRIPTION
When we use `aStorage##clear()`, the key value could be null. 