### PR TITLE
Do not add "Content-Type: multipart/form-data" to HTTP POST requests

### DIFF
--- a/lib/lwt/lwt_xmlHttpRequest.ml
+++ b/lib/lwt/lwt_xmlHttpRequest.ml
@@ -170,9 +170,7 @@ let perform_raw
         | `Fields _strings ->
           override_method "POST",
           override_content_type "application/x-www-form-urlencoded"
-        | `FormData _ ->
-          override_method "POST",
-          override_content_type "multipart/form-data"
+        | `FormData _ -> override_method "POST", content_type
       )
     | Some (`String _ | `Blob _) -> override_method "POST", content_type
   in


### PR DESCRIPTION
Instead we let the Browser figure out the header on its own. This relieves us of implementing the "boundary=..." argument which is missing in the current implementation.