### PR TITLE
Use jbuilder bash instead of /bin/bash

### DIFF
--- a/lib/generate_stubs.sh
+++ b/lib/generate_stubs.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 set -e -u -o pipefail
 shopt -s extglob
 

--- a/lib/jbuild
+++ b/lib/jbuild
@@ -11,7 +11,7 @@
  ((targets (js_of_ocaml_stubs.c))
   (deps ((file generate_stubs.sh)(glob_files *.ml)))
   (action (with-stdout-to ${@}
-           (run ./generate_stubs.sh)))
+           (bash ./generate_stubs.sh)))
   ))
 
 (rule


### PR DESCRIPTION
This change unbreaks the installation on FreeBSD.