### PR TITLE
Fix caml_ml_out_channels_list

### DIFF
--- a/runtime/io.js
+++ b/runtime/io.js
@@ -102,7 +102,7 @@ function caml_ml_out_channels_list () {
   var l = 0;
   for(var c = 0; c < caml_ml_channels.length; c++){
     if(caml_ml_channels[c] && caml_ml_channels[c].opened && caml_ml_channels[c].out)
-      l=[0,caml_ml_channels[c],l];
+      l=[0,caml_ml_channels[c].fd,l];
   }
   return l;
 }


### PR DESCRIPTION
This PR fixes a runtime bug: the function `caml_ml_out_channels_list` should return a list of `chanid`'s (file descriptors), not a list of channel *objects*.  This function is only used in the implementation of `flush_all`, and the bug has been present for a long time, but it only became visible after the commit https://github.com/ocaml/ocaml/commit/1fc6ccb0877c282c93e78619882525fc4ab9209c#diff-9e690569dd7558fbf79622f41868ade5L335 which allowed the exception to escape.

Thanks to @Nevor for invaluable help finding the bug.