### PR TITLE
Build: wrap js_of_ocaml lib

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@
  ** Runtime: weak.js loaded by default
  ** Compiler: compile an OCaml program into a named javascript function (fix #599)
  ** Misc: move ppx_deriving_json in its own opam package (Rudi Grinberg)
+ ** Misc: always use namespace for the js_of_ocaml library
  ** Compiler: static eval of float negation
  ** Compiler: improve constant sharing.
  ** Ppx: add support for writeonly_prop and optdef_prop in object litteral.

--- a/lib/jbuild
+++ b/lib/jbuild
@@ -3,7 +3,6 @@
  ((name js_of_ocaml)
   (public_name js_of_ocaml)
   (libraries (uchar bytes))
-  (wrapped false)
   (c_names (js_of_ocaml_stubs))
   (preprocess (pps (ppx_js_internal)))))
 


### PR DESCRIPTION
One will have to explicitly open `Js_of_ocaml`.
@balat, @vouillon, any objection ?