### PR TITLE
runtime: Fix GH-657

### DIFF
--- a/runtime/stdlib.js
+++ b/runtime/stdlib.js
@@ -388,7 +388,8 @@ function caml_compare_val (a, b, total) {
                  (b instanceof Array && b[0] === (b[0]|0))) {
         return -1;
       } else if (typeof a != "number" && a && a.compare) {
-        return a.compare(b,total);
+        var cmp = a.compare(b,total);
+        if (cmp != 0) return cmp;
       } else if (typeof a == "function") {
         caml_invalid_argument("compare: functional value");
       } else {


### PR DESCRIPTION
Comparing 'a' and 'b' is not enough: we also need to compare the rest of the
values that they were found in.

The current implementation was introduced in
4cb510f71f633c3ce5b85061244d324149822a88, but it wasn't compatible with the
change introduced in 71d0192cc1015802ab8f5aa5204b0660168fb097.

I haven't look at the surrounding code enough to know whether that's the right fix in all cases — I just know that it fixes the example I posted :)