### PR TITLE
Improve node environment detection

### DIFF
--- a/runtime/fs.js
+++ b/runtime/fs.js
@@ -57,7 +57,7 @@ function caml_make_path (name) {
 //Provides:jsoo_mount_point
 //Requires: MlFakeDevice, MlNodeDevice, caml_root
 var jsoo_mount_point = []
-if (typeof module !== 'undefined' && module.exports && typeof require !== "undefined") {
+if (typeof process !== 'undefined' && typeof process.versions !== 'undefined' && typeof process.versions.node !== 'undefined') {
     jsoo_mount_point.push({path:caml_root,device:new MlNodeDevice(caml_root)});
 } else {
     jsoo_mount_point.push({path:caml_root,device:new MlFakeDevice(caml_root)});


### PR DESCRIPTION
I am using the js_of_ocaml library in a typescript project, generating CommonJS modules, and executed on a browser.
The problem is that js_of_ocaml assumes an environment supporting CommonJS is always a Node.js environment, so it uses MlNodeDevice, which requires 'fs' in its constructor.
This PR uses a detection method that is true in a Node.js environment, but not necessarily true in a CommonJS environment.

Discussion on Node.js environment detection: https://stackoverflow.com/questions/4224606/how-to-check-whether-a-script-is-running-under-node-js
The code of this PR is inspired from: https://stackoverflow.com/a/35813135