### PR TITLE
Fix the dependencies of the Lwt logger

### DIFF
--- a/js_of_ocaml-lwt.opam
+++ b/js_of_ocaml-lwt.opam
@@ -17,6 +17,6 @@ depends: [
   "js_of_ocaml-ppx"
 ]
 
-depopts: [ "graphics" ]
+depopts: [ "graphics" "lwt_log" ]
 
 available: [ ocaml-version >= "4.02.0" ]

--- a/lib/lwt/log/jbuild
+++ b/lib/lwt/log/jbuild
@@ -4,5 +4,5 @@
   (public_name js_of_ocaml-lwt.logger)
   (synopsis "Lwt logger for js_of_ocaml.")
   (optional)
-  (libraries (js_of_ocaml lwt lwt_log))
+  (libraries (js_of_ocaml lwt lwt_log.core))
   (preprocess (pps (js_of_ocaml-ppx)))))


### PR DESCRIPTION
`lwt_log` depends on `lwt_unix` which we cannot compile to JavaScript...