### PR TITLE
Lib: fix DataTransfer class interface

### DIFF
--- a/lib/dom_html.ml
+++ b/lib/dom_html.ml
@@ -243,7 +243,7 @@ and dataTransfer = object
   method dropEffect : js_string t prop
   method effectAllowed : js_string t prop
   method files : File.fileList t readonly_prop
-  method types : Dom.stringList t readonly_prop
+  method types : js_string t js_array t readonly_prop
   method addElement : element t -> unit meth
   method clearData : js_string t -> unit meth
   method clearData_all : unit meth

--- a/lib/dom_html.mli
+++ b/lib/dom_html.mli
@@ -250,7 +250,7 @@ and dataTransfer = object
   method dropEffect : js_string t prop
   method effectAllowed : js_string t prop
   method files : File.fileList t readonly_prop
-  method types : Dom.stringList t readonly_prop
+  method types : js_string t js_array t readonly_prop
   method addElement : element t -> unit meth
   method clearData : js_string t -> unit meth
   method clearData_all : unit meth


### PR DESCRIPTION
Fix DataTransfer class to match the interface: https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer

`DataTransfer.types` should be an array of strings