### PR TITLE
WIP Added filesystem support via requestFileSystemSync (need help)

### DIFF
--- a/runtime/dune
+++ b/runtime/dune
@@ -8,7 +8,7 @@
    (run %{bin:jsoo_link} -o %{targets}
     %{dep:mlString.js} %{dep:ieee_754.js} %{dep:int64.js} %{dep:md5.js} %{dep:marshal.js}
     %{dep:lexing.js} %{dep:parsing.js} %{dep:bigarray.js} %{dep:unix.js}
-    %{dep:stdlib.js} %{dep:io.js} %{dep:fs.js} %{dep:fs_fake.js} %{dep:fs_node.js} %{dep:jslib.js}
+    %{dep:stdlib.js} %{dep:io.js} %{dep:fs.js} %{dep:fs_fake.js} %{dep:fs_node.js} %{dep:fs_fss.js} %{dep:jslib.js}
     %{dep:jslib_js_of_ocaml.js}
     %{dep:internalMod.js} %{dep:gc.js} %{dep:polyfill/json2.js} %{dep:bigstring.js} %{dep:weak.js})))
 
@@ -22,6 +22,7 @@
     fs.js
     fs_fake.js
     fs_node.js
+    fs_fss.js
     gc.js
     graphics.js
     ieee_754.js

--- a/runtime/fs.js
+++ b/runtime/fs.js
@@ -20,8 +20,11 @@
 ///////////// Dummy filesystem
 
 //Provides: caml_current_dir
+//Requires: fs_fss_supported
 if(joo_global_object.process && joo_global_object.process.cwd)
   var caml_current_dir = joo_global_object.process.cwd().replace(/\\/g,'/');
+else if (fs_fss_supported())
+  var caml_current_dir = "/"    // FIXME
 else
   var caml_current_dir =  "/static";
 if(caml_current_dir.slice(-1) !== "/") caml_current_dir += "/"
@@ -55,14 +58,16 @@ function caml_make_path (name) {
 }
 
 //Provides:jsoo_mount_point
-//Requires: MlFakeDevice, MlNodeDevice, caml_root, fs_node_supported
+//Requires: MlFakeDevice, MlNodeDevice, MlFssDevice, caml_root, fs_node_supported, fs_fss_supported
 var jsoo_mount_point = []
 if (fs_node_supported()) {
     jsoo_mount_point.push({path:caml_root,device:new MlNodeDevice(caml_root)});
+} else if (fs_fss_supported()) {
+    jsoo_mount_point.push({path:caml_root,device:new MlFssDevice(caml_root)});
 } else {
     jsoo_mount_point.push({path:caml_root,device:new MlFakeDevice(caml_root)});
 }
-jsoo_mount_point.push({path:caml_root+"static/", device:new MlFakeDevice(caml_root+"static/")});
+// jsoo_mount_point.push({path:caml_root+"static/", device:new MlFakeDevice(caml_root+"static/")});
 
 //Provides:caml_list_mount_point
 //Requires: jsoo_mount_point, caml_new_string

--- a/runtime/fs_fss.js
+++ b/runtime/fs_fss.js
@@ -1,0 +1,126 @@
+// Js_of_ocaml runtime support
+// http://www.ocsigen.org/js_of_ocaml/
+// Copyright (C) 2014 Jérôme Vouillon, Hugo Heuzard
+// Laboratoire PPS - CNRS Université Paris Diderot
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, with linking exception;
+// either version 2.1 of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+// Provides: fs_fss_supported
+function fs_fss_supported () {
+    return (typeof joo_global_object.webkitRequestFileSystemSync !== 'undefined'
+            || typeof joo_global_object.requestFileSystemSync !== 'undefined')
+}
+
+// Provides: MlFssDevice
+// Requires: MlFssFile
+var MlFssDevice = function (root) {
+    var device = this ;
+    this.root = root ;
+    this.fs =
+        (joo_global_object.webkitRequestFileSystemSync
+         || joo_global_object.requestFileSystemSync) (joo_global_object.PERSISTENT, 0) ;
+}
+
+MlFssDevice.prototype.nm = function (name) {
+    return (this.root + name) ;
+}
+
+MlFssDevice.prototype.exists = function (name) {
+    try {
+        var path = this.nm (name) ;
+        this.fs.root.getFile(path, {create: false}) ;
+        return 1 ;
+    } catch (e) {
+        return 0 ;
+    }
+}
+
+MlFssDevice.prototype.is_dir = function (name) {
+    try {
+        var path = this.nm (name) ;
+        this.fs.root.getDirectory(path, {create: false}) ;
+        return 1 ;
+    } catch (e) {
+        return 0 ;
+    }
+}
+
+MlFssDevice.prototype.unlink = function (name) {
+    try {
+        var path = this.nm (name) ;
+        this.fs.root.getFile(path, {create: false}).remove () ;
+        return true ;
+    } catch (e) {
+        return false ;
+    }
+}
+
+//Requires: MlFssFile, caml_new_string, caml_string_of_array
+MlFssDevice.prototype.open = function(name, flags) {
+    var path = this.nm (name) ;
+    var file = this.fs.root.getFile(path, {create:flags.create, exclusive:flags.excl }) ;
+    var contents ;
+    if (flags.truncate) {
+        contents = caml_create_bytes(0) ;
+    } else {
+        var f = file.file () ;
+        var reader = new joo_global_object.FileReaderSync () ;
+        // FIXME: Use reasAsArrayBuffer?
+        contents = caml_new_string(reader.readAsBinaryString(f)) ;
+    }
+    return new MlFssFile (file, contents) ;
+}
+
+MlFssDevice.prototype.constructor = MlFssDevice
+
+//Provides: MlFssFile
+//Requires: MlFile, MlFakeFile, MlBytes
+function MlFssFile(fileEntry, content) {
+    this.needSync = false ;
+    this.fake = new MlFakeFile(content) ;
+    this.fileEntry = fileEntry ;
+}
+MlFssFile.prototype.truncate = function(len) {
+    this.needSync = true ;
+    return this.fake.truncate(len) ;
+}
+MlFssFile.prototype.length = function () {
+  return this.fake.length() ;
+}
+MlFssFile.prototype.read = function (offset, buf, pos, len) {
+    this.fake.read (offset, buf, pos, len) ;
+}
+MlFssFile.prototype.read_one = function (offset) {
+    this.fake.read_one (offset) ;
+}
+//Requires: caml_array_of_string
+MlFssFile.prototype.close = function () {
+    if (this.needSync) {
+        // FIXME: marshalled data are corrupted (probably here but it could be on open() )
+        var data = caml_array_of_string (this.fake.data) ;
+        if(! (data instanceof joo_global_object.Uint8Array))
+            data = new joo_global_object.Uint8Array(data);
+        var blob = new joo_global_object.Blob ([ data ], {type:'application/octet-stream'}) ;
+        (this.fileEntry.createWriter ()).write (blob) ;
+    }
+    return (this.fake.close ()) ;
+}
+MlFssFile.prototype.write = function(offset, buf, pos, len) {
+    var res = this.fake.write (offset, buf, pos, len) ;
+    this.needSync = true ;
+    return res ;
+}
+
+MlFssFile.prototype.constructor = MlFssFile


### PR DESCRIPTION
This PR enable I/O to filesystem in context supporting `requestFileSystemSync` (which is chrome browser, in a web worker). I'm using it in a cordova app.

It almost works, but data get corrupted somewhere. Probably on writing since reading should work as you can see later in this post.

**I can't find what function to use to encode/decode data, this is why I need help.**

Some files are marshaled data.

This is how I initialize files:

On javascript side (main thread):
```javascript
    input.onchange = function () {
        var files = input.files ;
        for (var i = 0; i < files.length; i++) {
            (function (i) {
                var file = files[i] ;
                console.log ("Reading " + file.name) ;
                var fr = new FileReader () ;
                fr.onload = function () { data.push({ name: file.name, data: fr.result }) ; }
                fr.readAsBinaryString (file) ;
            }) (i) ;
        }
        var loop = function () {
            if (data.length == files.length) {
                console.log ('Sending') ;
                console.log (data) ;
                w.postMessage ({type: 'loadFiles', data:data}) ;
                w.postMessage ({type: 'openBase'})
            }
            else { console.log ('loop ' + data.length + '/' + files.length) ; setTimeout (loop, 500) ; }
        } ;
        loop () ;
    }
```

On OCaml side (Web Worker `w` in the main thread)
```ocaml
  Worker.set_onmessage (fun e ->
      Firebug.console##log("Message received from main script") ;
      Firebug.console##log(e) ;
      Firebug.console##log(Js.typeof e) ;
      match Js.to_string e##.type_ with
      | "loadFiles" ->
        e##.data##forEach
          (Js.wrap_callback @@ fun x _i ->
           let name = Js.to_string @@ Js.Unsafe.get x (Js.string "name") in
           let data = Js.to_bytestring @@ Js.Unsafe.get x (Js.string "data") in
           let oc = open_out @@ bdir ^ name in
           let () = output_string oc data in
           let () = close_out oc in
           print_endline @@ "Saved " ^ bdir ^ name) ;
...
```
---

If I use the fake filesystem, I can read the files with no error, but it is not a suitable solution for my app, because I need writing rights and persistent storage.
```
let file_reader file callback =
  let reader = new%js File.fileReader in
  let () = reader##.onload := Dom.handler (fun e ->
      Js.Opt.case
        (e##.target)
        (fun () -> Js.bool false)
        (fun target ->
           Js.Opt.case
             (File.CoerceTo.string target##.result)
             (fun () -> Js.bool false)
             (fun result ->
                callback (Js.to_bytestring result) ) ) ) (* caml_new_string *)
  in
  reader##readAsBinaryString file

...
   input##.onchange := Dom.handler begin fun _e ->
       Js.Optdef.case (input##.files) (fun () -> failwith __LOC__) @@ fun files ->
       let len = files##.length in
       for i = 0 to len - 1 do
         Js.Opt.case (files##item i) (fun () -> failwith __LOC__) @@ fun file ->
         let name = Js.to_string file##.name in
         file_reader (Js.Unsafe.coerce file)
           (fun blob ->
              Sys_js.create_file ~name:fname ~content:blob ;
              (List.assoc name check)##setAttribute
                (Js.string "style")
                (Js.string "background-color:green;color:white;") ;
              Js.bool true)

...

```

