### PR TITLE
Improved detection of global object

### DIFF
--- a/compiler/lib/driver.ml
+++ b/compiler/lib/driver.ml
@@ -385,14 +385,13 @@ let pack ~global js =
       | `Custom name ->
         J.ECall (f, [J.EVar (J.S {J.name;var=None})], J.N)
       | `Auto ->
-        let global =
-          J.ECall (
-            J.EFun (None, [], [
-              J.Statement (
-                J.Return_statement(
-                  Some (J.EVar (J.S {J.name="this";var=None})))),
-              J.N
-            ], J.N), [], J.N) in
+          let global =
+            J.ECall (
+              J.ECall (
+                (J.EVar (J.S {J.name="Function";var=None})),
+                [EStr ("return this", `Bytes)],
+                J.N),
+              [], J.N) in
         J.ECall (f, [global], J.N)
     in
     match global with


### PR DESCRIPTION
Generate `Function("return this")()` instead of `function(){return this}()`. The former works in strict mode (for example under `node --use_strict` or when bundled using webpack), the latter doesn't.

Fixes #699.