### PR TITLE
Bundling external js files get more isolation.

### DIFF
--- a/compiler/lib/linker.mli
+++ b/compiler/lib/linker.mli
@@ -18,18 +18,31 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 *)
 
-val parse_file : string ->
-  ((Parse_info.t option * string * Jsoo_primitive.kind * Jsoo_primitive.kind_arg list option) option * (* provide *)
-   string list * (* require *)
-   ((int -> int -> bool) * string) list list * (* version constraint *)
-   bool *
-   Javascript.program) list
+type fragment =
+  { provides : (Parse_info.t option * string * Jsoo_primitive.kind * Jsoo_primitive.kind_arg list option) option
+  ; requires : string list
+  ; version_constraint : ((int -> int -> bool) * string) list list
+  ; weakdef : bool
+  ; code : Javascript.program
+  }
+
+val parse_file : string -> fragment list
 
 val load_files : string list -> unit
 
 type state
+
+type always_required =
+  { filename : string;
+    program : Javascript.program }
+
+type output = {
+  runtime_code: Javascript.program ;
+  always_required_codes: always_required list;
+}
+
 val init : unit -> state
 val resolve_deps : ?linkall:bool -> state -> Util.StringSet.t -> state * Util.StringSet.t
-val link : Javascript.program -> state -> Javascript.program
+val link : Javascript.program -> state -> output
 val get_provided : unit -> Util.StringSet.t
 val all : state -> string list


### PR DESCRIPTION
This commit changes the linker to wrap each fragment in an immediately invoked function expression.  This prevents variables defined in one fragment from interfering with variable use defined in another, as well as preventing "use strict" from propagating across fragments.