### PR TITLE
Fix homepage's redirection target.

### DIFF
--- a/.howdocgen
+++ b/.howdocgen
@@ -59,7 +59,7 @@ cat >$f <<EOF
 EOF
 quickdop -f doc _doc -t json -c $f -viu
 
-make-redir "$LATEST/manual/intro" _doc/index.html
+make-redir "$LATEST/manual/overview" _doc/index.html
 make-man-redir 1.4 1.0.9
 make-man-redir 1.4 1.1.1
 make-man-redir 1.4 1.2


### PR DESCRIPTION
The `index.html` page (that Github Pages reads for url `ocsigen.org/js_of_ocaml/`) now redirects to the correct page.