### PR TITLE
Let all SVG elements respond to "global event attributes."

### DIFF
--- a/lib/js_of_ocaml/dom_html.ml
+++ b/lib/js_of_ocaml/dom_html.ml
@@ -468,6 +468,11 @@ and eventTarget =
     method ondrag : ('self t, dragEvent t) event_listener writeonly_prop
 
     method ondrop : ('self t, dragEvent t) event_listener writeonly_prop
+  end
+
+and htmlEventTarget =
+  object
+    inherit eventTarget
 
     method onanimationstart : ('self t, animationEvent t) event_listener writeonly_prop
 
@@ -629,7 +634,7 @@ and element =
 
     method blur : unit meth
 
-    inherit eventTarget
+    inherit htmlEventTarget
   end
 
 and clientRect =

--- a/lib/js_of_ocaml/dom_html.mli
+++ b/lib/js_of_ocaml/dom_html.mli
@@ -480,6 +480,11 @@ and eventTarget =
     method ondrag : ('self t, dragEvent t) event_listener writeonly_prop
 
     method ondrop : ('self t, dragEvent t) event_listener writeonly_prop
+  end
+
+and htmlEventTarget =
+  object
+    inherit eventTarget
 
     method onanimationstart : ('self t, animationEvent t) event_listener writeonly_prop
 
@@ -648,7 +653,7 @@ and element =
 
     method blur : unit meth
 
-    inherit eventTarget
+    inherit htmlEventTarget
   end
 
 (** Rectangular box (used for element bounding boxes) *)

--- a/lib/js_of_ocaml/dom_svg.ml
+++ b/lib/js_of_ocaml/dom_svg.ml
@@ -195,6 +195,8 @@ class type element =
   object
     inherit Dom.element
 
+    inherit Dom_html.eventTarget
+
     method id : js_string t prop
 
     method xmlbase : js_string t prop
@@ -547,8 +549,6 @@ and gElement =
     inherit stylable
 
     inherit transformable
-
-    inherit Dom_html.eventTarget
   end
 
 (* interface SVGDefsElement *)
@@ -601,8 +601,6 @@ and symbolElement =
     inherit stylable
 
     inherit fitToViewBox
-
-    inherit Dom_html.eventTarget
   end
 
 (* interface SVGUseElement *)
@@ -637,8 +635,6 @@ and useElement =
 
 and elementInstance =
   object
-    inherit Dom_html.eventTarget
-
     method correspondingElement : element t readonly_prop
 
     method correspondingUseElement : useElement t readonly_prop
@@ -1124,8 +1120,6 @@ class type lineElement =
 
     inherit transformable
 
-    inherit Dom_html.eventTarget
-
     method x1 : animatedLength t readonly_prop
 
     method y1 : animatedLength t readonly_prop
@@ -1191,8 +1185,6 @@ and textContentElement =
     inherit externalResourcesRequired
 
     inherit stylable
-
-    inherit Dom_html.eventTarget
 
     method textLength : animatedLength t readonly_prop
 

--- a/lib/js_of_ocaml/dom_svg.mli
+++ b/lib/js_of_ocaml/dom_svg.mli
@@ -199,6 +199,8 @@ class type element =
   object
     inherit Dom.element
 
+    inherit Dom_html.eventTarget
+
     method id : js_string t prop
 
     method xmlbase : js_string t prop
@@ -550,8 +552,6 @@ and gElement =
     inherit stylable
 
     inherit transformable
-
-    inherit Dom_html.eventTarget
   end
 
 (* interface SVGDefsElement *)
@@ -604,8 +604,6 @@ and symbolElement =
     inherit stylable
 
     inherit fitToViewBox
-
-    inherit Dom_html.eventTarget
   end
 
 (* interface SVGUseElement *)
@@ -640,8 +638,6 @@ and useElement =
 
 and elementInstance =
   object
-    inherit Dom_html.eventTarget
-
     method correspondingElement : element t readonly_prop
 
     method correspondingUseElement : useElement t readonly_prop
@@ -1126,8 +1122,6 @@ class type lineElement =
     inherit stylable
 
     inherit transformable
-
-    inherit Dom_html.eventTarget
 
     method x1 : animatedLength t readonly_prop
 


### PR DESCRIPTION
I am writing a program that requires SVG elements to handle events. I saw #519 and decided to make a contribution.

Skimming through https://www.w3.org/TR/SVG2/, it seems that every SVG element supports "global event attributes," so I figured that it was safe for me to make `Dom_svg.element` implement `Dom_html.eventTarget`. However, I may have missed some elements that do not support the interface. (Previously, a few SVG elements individually inherited `Dom_html.eventTarget`.)

However, `Dom_html.eventTarget` lists a few events (the "animation" ones) that are not "global event attributes." I factored out those events into a new class called `Dom_html.htmlEventTarget`.

I would like to comment that `Dom_html.event` inherits from `Dom.event` but sets the generic type parameter to `Dom_html.element`. Does this design make sense if `Dom_svg.element` can handle these events as well?

I assume that these changes work, but I want to add some tests just in case. Because events require interactivity, I think that I should mock up a sample web page that uses SVG events, but `lib/tests` doesn't seem to support interactivity. What is the best way for me to test this change?