### PR TITLE
Fix Dom_svg.createForeignObject

### DIFF
--- a/lib/js_of_ocaml/dom_svg.ml
+++ b/lib/js_of_ocaml/dom_svg.ml
@@ -2023,7 +2023,7 @@ let createFontFaceSrc doc : fontElement t = unsafeCreateElement doc "font-face-s
 let createFontFaceUri doc : fontElement t = unsafeCreateElement doc "font-face-uri"
 
 let createForeignObject doc : foreignObjectElement t =
-  unsafeCreateElement doc "foreignobject"
+  unsafeCreateElement doc "foreignObject"
 
 let createG doc : gElement t = unsafeCreateElement doc "g"
 


### PR DESCRIPTION
Due to a typo ("foreignobject" instead of "foreignObject"),
Dom_svg.createForeignObject did not work. This PR fixes the
typo.