### PR TITLE
Runtime: flush output buffer before accessing offset.

### DIFF
--- a/runtime/io.js
+++ b/runtime/io.js
@@ -394,26 +394,32 @@ function caml_output_value (chanid,v,_flags) {
 
 
 //Provides: caml_ml_seek_out
-//Requires: caml_ml_channels
+//Requires: caml_ml_channels, caml_ml_flush
 function caml_ml_seek_out(chanid,pos){
+  caml_ml_flush(chanid);
   caml_ml_channels[chanid].offset = pos;
   return 0;
 }
 
 //Provides: caml_ml_seek_out_64
-//Requires: caml_int64_to_float, caml_ml_channels
+//Requires: caml_int64_to_float, caml_ml_channels, caml_ml_flush
 function caml_ml_seek_out_64(chanid,pos){
+  caml_ml_flush(chanid);
   caml_ml_channels[chanid].offset = caml_int64_to_float(pos);
   return 0;
 }
 
 //Provides: caml_ml_pos_out
-//Requires: caml_ml_channels
-function caml_ml_pos_out(chanid) {return caml_ml_channels[chanid].offset}
+//Requires: caml_ml_channels, caml_ml_flush
+function caml_ml_pos_out(chanid) {
+  caml_ml_flush(chanid);
+  return caml_ml_channels[chanid].offset;
+}
 
 //Provides: caml_ml_pos_out_64
-//Requires: caml_int64_of_float, caml_ml_channels
+//Requires: caml_int64_of_float, caml_ml_channels, caml_ml_flush
 function caml_ml_pos_out_64(chanid) {
+  caml_ml_flush(chanid);
   return caml_int64_of_float (caml_ml_channels[chanid].offset);
 }
 


### PR DESCRIPTION
The simplest solution to #777 would be to flush the buffer first and ask questions later.

I suspect that any performance degradation resulting from this would be unnoticeable.