### PR TITLE
Runtime: fix encoding to standard outputs

### DIFF
--- a/compiler/tests/channel.ml
+++ b/compiler/tests/channel.ml
@@ -1,4 +1,4 @@
-(* Js_of_ocaml compiler
+(* Js_of_ocaml tests
  * http://www.ocsigen.org/js_of_ocaml/
  * Copyright (C) 2019 Hugo Heuzard
  *
@@ -33,7 +33,8 @@ let%expect_test _ =
     let () = seek_out oc 0
     let () = print_int (out_channel_length oc)
  |};
-  [%expect {| 00448 |}]
+  [%expect {|
+    00448 |}]
 
 let%expect_test _ =
   let oc = open_out "b.txt" in

--- a/compiler/tests/stdio.ml
+++ b/compiler/tests/stdio.ml
@@ -1,0 +1,24 @@
+(* Js_of_ocaml tests
+ * http://www.ocsigen.org/js_of_ocaml/
+ * Copyright (C) 2019 Hugo Heuzard
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+*)
+
+let%expect_test _ =
+  Util.compile_and_run {|
+    let () = print_endline "the • and › characters"
+ |};
+  [%expect {| the • and › characters |}]

--- a/runtime/jslib.js
+++ b/runtime/jslib.js
@@ -87,7 +87,9 @@ function caml_trampoline_return(f,args) {
 }
 
 //Provides: js_print_stdout (const)
+//Requires: caml_utf16_of_utf8
 function js_print_stdout(s) {
+  var s = caml_utf16_of_utf8(s);
   var g = joo_global_object;
   if (g.process && g.process.stdout && g.process.stdout.write) {
     g.process.stdout.write(s)
@@ -101,7 +103,9 @@ function js_print_stdout(s) {
   }
 }
 //Provides: js_print_stderr (const)
+//Requires: caml_utf16_of_utf8
 function js_print_stderr(s) {
+  var s = caml_utf16_of_utf8(s);
   var g = joo_global_object;
   if (g.process && g.process.stdout && g.process.stdout.write) {
     g.process.stderr.write(s)


### PR DESCRIPTION
Fix #798 