### PR TITLE
Lib: Add support for 'addEventListener' with options object

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,7 @@
  ** Misc: remove cppo dependency
  ** Misc: remove ppx_tools_versioned dependency in ppx_deriving_json
  ** Misc: support for ocaml 4.09
+ ** Lib: Add support for 'addEventListener' with options object
 
  * Bug fixes:
  ** Compiler: don't generate source if no-source-map passed (#780)

--- a/CHANGES
+++ b/CHANGES
@@ -11,7 +11,7 @@
  ** Misc: remove cppo dependency
  ** Misc: remove ppx_tools_versioned dependency in ppx_deriving_json
  ** Misc: support for ocaml 4.09
- ** Lib: Add support for 'addEventListener' with options object
+ ** Lib: Add support for 'addEventListener' with options
 
  * Bug fixes:
  ** Compiler: don't generate source if no-source-map passed (#780)

--- a/lib/js_of_ocaml/dom.ml
+++ b/lib/js_of_ocaml/dom.ml
@@ -352,7 +352,14 @@ end
 
 type event_listener_id = unit -> unit
 
-let addEventListener (e : (< .. > as 'a) t) typ h capt =
+class type event_listener_options =
+  object
+    method capture : bool t readonly_prop
+    method once : bool t readonly_prop
+    method passive : bool t readonly_prop
+  end
+
+let addEventListenerWithOptions (e : (< .. > as 'a) t) typ h opts =
   if (Js.Unsafe.coerce e)##.addEventListener == Js.undefined
   then
     let ev = (Js.string "on")##concat typ in
@@ -360,8 +367,17 @@ let addEventListener (e : (< .. > as 'a) t) typ h capt =
     let () = (Js.Unsafe.coerce e)##attachEvent ev callback in
     fun () -> (Js.Unsafe.coerce e)##detachEvent ev callback
   else
-    let () = (Js.Unsafe.coerce e)##addEventListener typ h capt in
-    fun () -> (Js.Unsafe.coerce e)##removeEventListener typ h capt
+    let () = (Js.Unsafe.coerce e)##addEventListener typ h opts in
+    fun () -> (Js.Unsafe.coerce e)##removeEventListener typ h opts
+
+let addEventListener (e : (< .. > as 'a) t) typ h capt =
+  let opts = object%js
+    val capture = capt
+    val once = Js.bool false
+    val passive = Js.bool false
+  end
+  in
+  addEventListenerWithOptions e typ h opts
 
 let removeEventListener id = id ()
 

--- a/lib/js_of_ocaml/dom.ml
+++ b/lib/js_of_ocaml/dom.ml
@@ -370,14 +370,14 @@ let addEventListenerWithOptions (e : (< .. > as 'a) t) typ ?capture ?once ?passi
     fun () -> (Js.Unsafe.coerce e)##detachEvent ev callback
   else
     let opts : event_listener_options t = Js.Unsafe.obj [||] in
-    let set t f =
+    let iter t f =
       match t with
       | None -> ()
       | Some b -> f b
     in
-    set capture (fun b -> opts##.capture := b);
-    set once (fun b -> opts##.once := b);
-    set passive (fun b -> opts##.passive := b);
+    iter capture (fun b -> opts##.capture := b);
+    iter once (fun b -> opts##.once := b);
+    iter passive (fun b -> opts##.passive := b);
     let () = (Js.Unsafe.coerce e)##addEventListener typ h opts in
     fun () -> (Js.Unsafe.coerce e)##removeEventListener typ h opts
 

--- a/lib/js_of_ocaml/dom.mli
+++ b/lib/js_of_ocaml/dom.mli
@@ -334,6 +334,23 @@ module Event : sig
   val make : string -> 'a typ
 end
 
+class type event_listener_options =
+  object
+    method capture : bool t readonly_prop
+    method once : bool t readonly_prop
+    method passive : bool t readonly_prop
+  end
+
+val addEventListenerWithOptions :
+     (< .. > t as 'a)
+  -> 'b Event.typ
+  -> ('a, 'b) event_listener
+  -> #event_listener_options t
+  -> event_listener_id
+(** Add an event listener.  This function matches the
+      option-object variant of the [addEventListener] DOM method,
+      except that it returns an id for removing the listener. *)
+
 val addEventListener :
      (< .. > t as 'a)
   -> 'b Event.typ
@@ -341,8 +358,8 @@ val addEventListener :
   -> bool t
   -> event_listener_id
 (** Add an event listener.  This function matches the
-      [addEventListener] DOM method, except that it returns
-      an id for removing the listener. *)
+      useCapture boolean variant of the [addEventListener] DOM method,
+      except that it returns an id for removing the listener. *)
 
 val removeEventListener : event_listener_id -> unit
 (** Remove the given event listener. *)

--- a/lib/js_of_ocaml/dom.mli
+++ b/lib/js_of_ocaml/dom.mli
@@ -334,18 +334,13 @@ module Event : sig
   val make : string -> 'a typ
 end
 
-class type event_listener_options =
-  object
-    method capture : bool t readonly_prop
-    method once : bool t readonly_prop
-    method passive : bool t readonly_prop
-  end
-
 val addEventListenerWithOptions :
      (< .. > t as 'a)
   -> 'b Event.typ
+  -> ?capture:bool t
+  -> ?once:bool t
+  -> ?passive:bool t
   -> ('a, 'b) event_listener
-  -> #event_listener_options t
   -> event_listener_id
 (** Add an event listener.  This function matches the
       option-object variant of the [addEventListener] DOM method,

--- a/lib/js_of_ocaml/dom_html.ml
+++ b/lib/js_of_ocaml/dom_html.ml
@@ -814,11 +814,6 @@ end
 
 type event_listener_id = Dom.event_listener_id
 
-class type event_listener_options =
-  object
-    inherit Dom.event_listener_options
-  end
-
 let addEventListener = Dom.addEventListener
 
 let addEventListenerWithOptions = Dom.addEventListenerWithOptions

--- a/lib/js_of_ocaml/dom_html.ml
+++ b/lib/js_of_ocaml/dom_html.ml
@@ -814,7 +814,14 @@ end
 
 type event_listener_id = Dom.event_listener_id
 
+class type event_listener_options =
+  object
+    inherit Dom.event_listener_options
+  end
+
 let addEventListener = Dom.addEventListener
+
+let addEventListenerWithOptions = Dom.addEventListenerWithOptions
 
 let removeEventListener = Dom.removeEventListener
 

--- a/lib/js_of_ocaml/dom_html.mli
+++ b/lib/js_of_ocaml/dom_html.mli
@@ -2365,6 +2365,21 @@ end
 
 type event_listener_id = Dom.event_listener_id
 
+class type event_listener_options =
+  object
+    inherit Dom.event_listener_options
+  end
+
+val addEventListenerWithOptions :
+     (#eventTarget t as 'a)
+  -> 'b Event.typ
+  -> ('a, 'b) event_listener
+  -> #event_listener_options t
+  -> event_listener_id
+(** Add an event listener.  This function matches the
+      option-object variant of the [addEventListener] DOM method,
+      except that it returns an id for removing the listener. *)
+
 val addEventListener :
      (#eventTarget t as 'a)
   -> 'b Event.typ
@@ -2372,8 +2387,8 @@ val addEventListener :
   -> bool t
   -> event_listener_id
 (** Add an event listener.  This function matches the
-      [addEventListener] DOM method, except that it returns
-      an id for removing the listener. *)
+      useCapture boolean variant of the [addEventListener] DOM method,
+      except that it returns an id for removing the listener. *)
 
 val removeEventListener : event_listener_id -> unit
 (** Remove the given event listener. *)

--- a/lib/js_of_ocaml/dom_html.mli
+++ b/lib/js_of_ocaml/dom_html.mli
@@ -2365,16 +2365,13 @@ end
 
 type event_listener_id = Dom.event_listener_id
 
-class type event_listener_options =
-  object
-    inherit Dom.event_listener_options
-  end
-
 val addEventListenerWithOptions :
      (#eventTarget t as 'a)
   -> 'b Event.typ
+  -> ?capture:bool t
+  -> ?once:bool t
+  -> ?passive:bool t
   -> ('a, 'b) event_listener
-  -> #event_listener_options t
   -> event_listener_id
 (** Add an event listener.  This function matches the
       option-object variant of the [addEventListener] DOM method,


### PR DESCRIPTION
The library seemed to be missing an accessible interface to give options to `addEventListener` as described in the specifications ( https://dom.spec.whatwg.org/#interface-eventtarget , https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#Syntax , ... )

I added a function to do that.
Maybe the new class type will need to be moved, maybe some compatibility issues rise from the way I implemented this (some old browsers don't support the object variant. Maybe add a check for that ?)

Note: most times, users would need to pass only one option and keep the others at default. I don't know which is better between helper functions that take one argument and build the appropriate object, and additional class types with fewer methods.