### PR TITLE
Runtime: more efficient (space-wise) marshalling.

### DIFF
--- a/compiler/tests/test_marshal.ml
+++ b/compiler/tests/test_marshal.ml
@@ -1,6 +1,6 @@
 (* Js_of_ocaml tests
  * http://www.ocsigen.org/js_of_ocaml/
- * Copyright (C) 2019 Hugo Heuzard
+ * Copyright (C) 2019 Shachar Itzhaky
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -62,11 +62,28 @@ let%expect_test _ =
       let v2' = Marshal.from_channel chan in
       Format.printf "readback = %B %B\n%!" (v1 = v1') (v2 = v2')
 |};
- [%expect {|
+  [%expect {|
    sizes = 33 40 51 (|v2| < |v2_ns|)
    readback = true true |}]
 
 (* https://github.com/ocsigen/js_of_ocaml/issues/359 *)
+
+let%expect_test _ =
+  let module M = struct
+    type loop = {mutable pointer : loop option}
+
+    let l = {pointer = None}
+
+    let () = l.pointer <- Some l
+
+    let _ =
+      let s = Marshal.to_string l [] in
+      Format.printf "%d\n%S\n%!" (String.length s) s
+  end in
+  [%expect
+    {|
+    24
+    "\132\149\166\190\000\000\000\004\000\000\000\002\000\000\000\004\000\000\000\004\144\144\004\002" |}]
 
 let%expect_test _ =
   Util.compile_and_run
@@ -77,6 +94,9 @@ let%expect_test _ =
 
     let _ =
       let s = Marshal.to_string l [] in
-      Format.printf "not stuck! %d\n%!" (String.length s)
+      Format.printf "%d\n%S\n%!" (String.length s) s
 |};
-  [%expect {| not stuck! 24 |}]
+  [%expect
+    {|
+    24
+    "\132\149\166\190\000\000\000\004\000\000\000\002\000\000\000\004\000\000\000\004\144\144\004\002" |}]

--- a/runtime/io.js
+++ b/runtime/io.js
@@ -386,8 +386,8 @@ function caml_ml_output_char (chanid,c) {
 
 //Provides: caml_output_value
 //Requires: caml_output_value_to_string, caml_ml_output,caml_ml_string_length
-function caml_output_value (chanid,v,_flags) {
-  var s = caml_output_value_to_string(v);
+function caml_output_value (chanid,v,flags) {
+  var s = caml_output_value_to_string(v, flags);
   caml_ml_output(chanid,s,0,caml_ml_string_length(s));
   return 0;
 }

--- a/runtime/marshal.js
+++ b/runtime/marshal.js
@@ -421,6 +421,7 @@ var caml_output_val = function (){
     var intern_obj_table = new MlObjectTable();
 
     function memo(v) {
+      if(no_sharing) return undefined;
       var existing_offset = no_sharing ? undefined : intern_obj_table.recall(v);
       if (existing_offset) { writer.write_shared(existing_offset); return existing_offset; }
       else intern_obj_table.store(v);

--- a/runtime/marshal.js
+++ b/runtime/marshal.js
@@ -348,7 +348,9 @@ if (typeof joo_global_object.WeakMap === 'undefined') {
         if (this.objs[i] === v) return i;
       }
     };
-    NaiveLookup.prototype.set = function() { };
+    NaiveLookup.prototype.set = function() {
+      // Do nothing here. [MlObjectTable.store] will push to [this.objs] directly.
+    };
 
     return function MlObjectTable() {
       this.objs = []; this.lookup = new NaiveLookup(this.objs);

--- a/runtime/stdlib.js
+++ b/runtime/stdlib.js
@@ -1215,6 +1215,15 @@ function caml_list_of_js_array(a){
   return l
 }
 
+//Provides: caml_list_to_js_array const (const)
+function caml_list_to_js_array(l){
+  var a = [];
+  for(; l !== 0; l = l[2]) {
+    a.push(l[1]);
+  }
+  return a;
+}
+
 //Provides: caml_runtime_warnings
 var caml_runtime_warnings = 0;
 


### PR DESCRIPTION
Modified caml_output_val to correctly reflects sharing.
As a result, it avoids duplication and saves a lot of space.

This has been thoroughly tested by compiling Coq `.vo` files, where it can reduce the file size by an order of magnitude, and produces roughly the same size as the native `coqc`.