### PR TITLE
Handle browserfs in fs_node detection logic

### DIFF
--- a/runtime/fs_node.js
+++ b/runtime/fs_node.js
@@ -22,7 +22,8 @@ function fs_node_supported () {
   return (
     typeof joo_global_object.process !== 'undefined'
       && typeof joo_global_object.process.versions !== 'undefined'
-      && typeof joo_global_object.process.versions.node !== 'undefined')
+      && typeof joo_global_object.process.versions.node !== 'undefined'
+      && joo_global_object.process.platform !== "browser")
 }
 
 //Provides: MlNodeDevice


### PR DESCRIPTION
As discussed on ocamllabs slack, when a website includes Browserfs, it passes all the current `fs_node` detection logic but failed at runtime because `require` is undefined.

This PR handles this case by checking for `process.platform`  