### PR TITLE
Lib: change responseText signature

### DIFF
--- a/lib/js_of_ocaml/xmlHttpRequest.ml
+++ b/lib/js_of_ocaml/xmlHttpRequest.ml
@@ -75,7 +75,7 @@ class type xmlHttpRequest =
 
     method response : File.file_any readonly_prop
 
-    method responseText : js_string t readonly_prop
+    method responseText : js_string t opt readonly_prop
 
     method responseXML : Dom.element Dom.document t opt readonly_prop
 

--- a/lib/js_of_ocaml/xmlHttpRequest.mli
+++ b/lib/js_of_ocaml/xmlHttpRequest.mli
@@ -77,7 +77,7 @@ class type xmlHttpRequest =
 
     method response : File.file_any readonly_prop
 
-    method responseText : js_string t readonly_prop
+    method responseText : js_string t opt readonly_prop
 
     method responseXML : Dom.element Dom.document t opt readonly_prop
 

--- a/lib/lwt/lwt_xmlHttpRequest.ml
+++ b/lib/lwt/lwt_xmlHttpRequest.ml
@@ -48,7 +48,7 @@ exception Wrong_headers of (int * (string -> string option))
 let default_response url code headers req =
   { url
   ; code
-  ; content = Js.to_string req##.responseText
+  ; content = Js.Opt.case req##.responseText (fun () -> "") (fun x -> Js.to_string x)
   ; content_xml =
       (fun () ->
         match Js.Opt.to_option req##.responseXML with
@@ -59,7 +59,7 @@ let default_response url code headers req =
 let text_response url code headers req =
   { url
   ; code
-  ; content = req##.responseText
+  ; content = Js.Opt.case req##.responseText (fun () -> Js.string "") (fun x -> x)
   ; content_xml = (fun () -> assert false)
   ; headers }
 


### PR DESCRIPTION
From https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseText
> A DOMString which contains either the textual data received using the XMLHttpRequest or null if the request failed or "" if the request has not yet been sent by calling send().