### PR TITLE
Lwt_js_events: added `passive` option. Dom, Dom_html: added customEvent and pointer events

### DIFF
--- a/lib/js_of_ocaml/dom.ml
+++ b/lib/js_of_ocaml/dom.ml
@@ -292,11 +292,12 @@ class type ['a] event =
     method srcElement : 'a t opt readonly_prop
   end
 
-class type ['a, 'b] customEvent = object
-  inherit ['a] event
+class type ['a, 'b] customEvent =
+  object
+    inherit ['a] event
 
-  method detail : 'b Js.opt Js.readonly_prop
-end
+    method detail : 'b Js.opt Js.readonly_prop
+  end
 
 let no_handler : ('a, 'b) event_listener = Js.null
 
@@ -398,15 +399,21 @@ let preventDefault ev =
   else (Js.Unsafe.coerce ev)##.returnValue := Js.bool false
 
 let createCustomEvent ?bubbles ?cancelable ?detail typ =
-  let opt_iter f = function None -> () | Some x -> f x in
+  let opt_iter f = function
+    | None -> ()
+    | Some x -> f x
+  in
   let opts = Unsafe.obj [||] in
   opt_iter (fun x -> opts##.bubbles := bool x) bubbles;
   opt_iter (fun x -> opts##.cancelable := bool x) cancelable;
   opt_iter (fun x -> opts##.detail := some x) detail;
-  let constr : (   ('a, 'b) #customEvent Js.t Event.typ
-                -> < detail : 'b opt prop > t
-                -> ('a, 'b) customEvent t) constr =
-    Unsafe.global##._CustomEvent in
+  let constr :
+      (   ('a, 'b) #customEvent Js.t Event.typ
+       -> < detail : 'b opt prop > t
+       -> ('a, 'b) customEvent t)
+      constr =
+    Unsafe.global##._CustomEvent
+  in
   new%js constr typ opts
 
 (* IE < 9 *)

--- a/lib/js_of_ocaml/dom.ml
+++ b/lib/js_of_ocaml/dom.ml
@@ -292,6 +292,12 @@ class type ['a] event =
     method srcElement : 'a t opt readonly_prop
   end
 
+class type ['a, 'b] customEvent = object
+  inherit ['a] event
+
+  method detail : 'b Js.opt Js.readonly_prop
+end
+
 let no_handler : ('a, 'b) event_listener = Js.null
 
 let window_event () : 'a #event t = Js.Unsafe.pure_js_expr "event"
@@ -390,6 +396,18 @@ let preventDefault ev =
   if Js.Optdef.test (Js.Unsafe.coerce ev)##.preventDefault (* IE hack *)
   then (Js.Unsafe.coerce ev)##preventDefault
   else (Js.Unsafe.coerce ev)##.returnValue := Js.bool false
+
+let createCustomEvent ?bubbles ?cancelable ?detail typ =
+  let opt_iter f = function None -> () | Some x -> f x in
+  let opts = Unsafe.obj [||] in
+  opt_iter (fun x -> opts##.bubbles := bool x) bubbles;
+  opt_iter (fun x -> opts##.cancelable := bool x) cancelable;
+  opt_iter (fun x -> opts##.detail := some x) detail;
+  let constr : (   ('a, 'b) #customEvent Js.t Event.typ
+                -> < detail : 'b opt prop > t
+                -> ('a, 'b) customEvent t) constr =
+    Unsafe.global##._CustomEvent in
+  new%js constr typ opts
 
 (* IE < 9 *)
 

--- a/lib/js_of_ocaml/dom.mli
+++ b/lib/js_of_ocaml/dom.mli
@@ -304,11 +304,12 @@ class type ['a] event =
     method srcElement : 'a t opt readonly_prop
   end
 
-class type ['a, 'b] customEvent = object
-  inherit ['a] event
+class type ['a, 'b] customEvent =
+  object
+    inherit ['a] event
 
-  method detail : 'b Js.opt Js.readonly_prop
-end
+    method detail : 'b Js.opt Js.readonly_prop
+  end
 
 (** {2 Event handlers} *)
 

--- a/lib/js_of_ocaml/dom.mli
+++ b/lib/js_of_ocaml/dom.mli
@@ -304,6 +304,12 @@ class type ['a] event =
     method srcElement : 'a t opt readonly_prop
   end
 
+class type ['a, 'b] customEvent = object
+  inherit ['a] event
+
+  method detail : 'b Js.opt Js.readonly_prop
+end
+
 (** {2 Event handlers} *)
 
 val no_handler : ('a, 'b) event_listener
@@ -362,6 +368,14 @@ val removeEventListener : event_listener_id -> unit
 val preventDefault : 'a #event Js.t -> unit
 (** Call this to prevent the default handler for the event.
     To stop propagation of the event, call {!Dom_html.stopPropagation}. *)
+
+val createCustomEvent :
+     ?bubbles:bool
+  -> ?cancelable:bool
+  -> ?detail:'b
+  -> ('a, 'b) #customEvent Js.t Event.typ
+  -> ('a, 'b) customEvent Js.t
+(** Create a custom event of given type. *)
 
 (** {2 Other DOM objects} *)
 

--- a/lib/js_of_ocaml/dom_html.ml
+++ b/lib/js_of_ocaml/dom_html.ml
@@ -266,6 +266,11 @@ class type event =
     inherit [element] Dom.event
   end
 
+and ['a] customEvent =
+  object
+    inherit [element, 'a] Dom.customEvent
+  end
+
 and mouseEvent =
   object
     inherit event
@@ -497,6 +502,8 @@ and eventTarget =
     method onpointerover : ('self t, pointerEvent t) event_listener writeonly_prop
 
     method onpointerup : ('self t, pointerEvent t) event_listener writeonly_prop
+
+    method dispatchEvent : event t -> bool t meth
   end
 
 and popStateEvent =
@@ -884,6 +891,8 @@ let addEventListener = Dom.addEventListener
 let addEventListenerWithOptions = Dom.addEventListenerWithOptions
 
 let removeEventListener = Dom.removeEventListener
+
+let createCustomEvent = Dom.createCustomEvent
 
 class type ['node] collection =
   object

--- a/lib/js_of_ocaml/dom_html.ml
+++ b/lib/js_of_ocaml/dom_html.ml
@@ -2748,19 +2748,24 @@ let hasMousewheelEvents () =
   d##setAttribute (Js.string "onmousewheel") (Js.string "return;");
   Js.typeof (Js.Unsafe.get d (Js.string "onmousewheel")) == Js.string "function"
 
-let addMousewheelEventListener e h capt =
+let addMousewheelEventListenerWithOptions e ?capture ?once ?passive h =
   if hasMousewheelEvents ()
   then
-    addEventListener
+    addEventListenerWithOptions
+      ?capture
+      ?once
+      ?passive
       e
       Event.mousewheel
       (handler (fun (e : mousewheelEvent t) ->
            let dx = -Optdef.get e##.wheelDeltaX (fun () -> 0) / 40 in
            let dy = -Optdef.get e##.wheelDeltaY (fun () -> e##.wheelDelta) / 40 in
            h (e :> mouseEvent t) ~dx ~dy))
-      capt
   else
-    addEventListener
+    addEventListenerWithOptions
+      ?capture
+      ?once
+      ?passive
       e
       Event._DOMMouseScroll
       (handler (fun (e : mouseScrollEvent t) ->
@@ -2768,7 +2773,9 @@ let addMousewheelEventListener e h capt =
            if e##.axis == e##._HORIZONTAL_AXIS
            then h (e :> mouseEvent t) ~dx:d ~dy:0
            else h (e :> mouseEvent t) ~dx:0 ~dy:d))
-      capt
+
+let addMousewheelEventListener e h capt =
+  addMousewheelEventListenerWithOptions ~capture:capt e h
 
 (*****)
 

--- a/lib/js_of_ocaml/dom_html.ml
+++ b/lib/js_of_ocaml/dom_html.ml
@@ -477,6 +477,26 @@ and eventTarget =
       ('self t, animationEvent t) event_listener writeonly_prop
 
     method onanimationcancel : ('self t, animationEvent t) event_listener writeonly_prop
+
+    method ongotpointercapture : ('self t, pointerEvent t) event_listener writeonly_prop
+
+    method onlostpointercapture : ('self t, pointerEvent t) event_listener writeonly_prop
+
+    method onpointerenter : ('self t, pointerEvent t) event_listener writeonly_prop
+
+    method onpointercancel : ('self t, pointerEvent t) event_listener writeonly_prop
+
+    method onpointerdown : ('self t, pointerEvent t) event_listener writeonly_prop
+
+    method onpointerleave : ('self t, pointerEvent t) event_listener writeonly_prop
+
+    method onpointermove : ('self t, pointerEvent t) event_listener writeonly_prop
+
+    method onpointerout : ('self t, pointerEvent t) event_listener writeonly_prop
+
+    method onpointerover : ('self t, pointerEvent t) event_listener writeonly_prop
+
+    method onpointerup : ('self t, pointerEvent t) event_listener writeonly_prop
   end
 
 and popStateEvent =
@@ -539,6 +559,31 @@ and animationEvent =
 and mediaEvent =
   object
     inherit event
+  end
+
+and pointerEvent =
+  object
+    inherit mouseEvent
+
+    method pointerId : int Js.readonly_prop
+
+    method width : float Js.readonly_prop
+
+    method height : float Js.readonly_prop
+
+    method pressure : float Js.readonly_prop
+
+    method tangentialPressure : float Js.readonly_prop
+
+    method tiltX : int Js.readonly_prop
+
+    method tiltY : int Js.readonly_prop
+
+    method twist : int Js.readonly_prop
+
+    method pointerType : Js.js_string Js.t Js.readonly_prop
+
+    method isPrimary : bool Js.t Js.readonly_prop
   end
 
 and nodeSelector =
@@ -783,17 +828,37 @@ module Event = struct
 
   let ended = Dom.Event.make "ended"
 
+  let gotpointercapture = Dom.Event.make "gotpointercapture"
+
   let loadeddata = Dom.Event.make "loadeddata"
 
   let loadedmetadata = Dom.Event.make "loadedmetadata"
 
   let loadstart = Dom.Event.make "loadstart"
 
+  let lostpointercapture = Dom.Event.make "lostpointercapture"
+
   let pause = Dom.Event.make "pause"
 
   let play = Dom.Event.make "play"
 
   let playing = Dom.Event.make "playing"
+
+  let pointerenter = Dom.Event.make "pointerenter"
+
+  let pointercancel = Dom.Event.make "pointercancel"
+
+  let pointerdown = Dom.Event.make "pointerdown"
+
+  let pointerleave = Dom.Event.make "pointerleave"
+
+  let pointermove = Dom.Event.make "pointermove"
+
+  let pointerout = Dom.Event.make "pointerout"
+
+  let pointerover = Dom.Event.make "pointerover"
+
+  let pointerup = Dom.Event.make "pointerup"
 
   let ratechange = Dom.Event.make "ratechange"
 

--- a/lib/js_of_ocaml/dom_html.mli
+++ b/lib/js_of_ocaml/dom_html.mli
@@ -2390,12 +2390,25 @@ val addEventListener :
 val removeEventListener : event_listener_id -> unit
 (** Remove the given event listener. *)
 
+val addMousewheelEventListenerWithOptions :
+     (#eventTarget t as 'a)
+  -> ?capture:bool t
+  -> ?once:bool t
+  -> ?passive:bool t
+  -> (mouseEvent t -> dx:int -> dy:int -> bool t)
+  -> event_listener_id
+(** Add a mousewheel event listener with option-object variant of the
+      [addEventListener] DOM method.  The callback is provided the
+      event and the numbers of ticks the mouse wheel moved.  Positive
+      means down / right. *)
+
 val addMousewheelEventListener :
      (#eventTarget t as 'a)
   -> (mouseEvent t -> dx:int -> dy:int -> bool t)
   -> bool t
   -> event_listener_id
-(** Add a mousewheel event listener.  The callback is provided the
+(** Add a mousewheel event listener with the useCapture boolean variant
+      of the [addEventListener] DOM method.  The callback is provided the
       event and the numbers of ticks the mouse wheel moved.  Positive
       means down / right. *)
 

--- a/lib/js_of_ocaml/dom_html.mli
+++ b/lib/js_of_ocaml/dom_html.mli
@@ -271,6 +271,11 @@ class type event =
     inherit [element] Dom.event
   end
 
+and ['a] customEvent =
+  object
+    inherit [element, 'a] Dom.customEvent
+  end
+
 and mouseEvent =
   object
     inherit event
@@ -509,6 +514,8 @@ and eventTarget =
     method onpointerover : ('self t, pointerEvent t) event_listener writeonly_prop
 
     method onpointerup : ('self t, pointerEvent t) event_listener writeonly_prop
+
+    method dispatchEvent : event t -> bool t meth
   end
 
 and popStateEvent =
@@ -2477,6 +2484,14 @@ val addMousewheelEventListener :
       of the [addEventListener] DOM method.  The callback is provided the
       event and the numbers of ticks the mouse wheel moved.  Positive
       means down / right. *)
+
+val createCustomEvent :
+     ?bubbles:bool
+  -> ?cancelable:bool
+  -> ?detail:'a
+  -> 'a #customEvent Js.t Event.typ
+  -> 'a customEvent Js.t
+(** See [Dom.createCustomEvent] *)
 
 (****)
 

--- a/lib/js_of_ocaml/dom_html.mli
+++ b/lib/js_of_ocaml/dom_html.mli
@@ -489,6 +489,26 @@ and eventTarget =
       ('self t, animationEvent t) event_listener writeonly_prop
 
     method onanimationcancel : ('self t, animationEvent t) event_listener writeonly_prop
+
+    method ongotpointercapture : ('self t, pointerEvent t) event_listener writeonly_prop
+
+    method onlostpointercapture : ('self t, pointerEvent t) event_listener writeonly_prop
+
+    method onpointerenter : ('self t, pointerEvent t) event_listener writeonly_prop
+
+    method onpointercancel : ('self t, pointerEvent t) event_listener writeonly_prop
+
+    method onpointerdown : ('self t, pointerEvent t) event_listener writeonly_prop
+
+    method onpointerleave : ('self t, pointerEvent t) event_listener writeonly_prop
+
+    method onpointermove : ('self t, pointerEvent t) event_listener writeonly_prop
+
+    method onpointerout : ('self t, pointerEvent t) event_listener writeonly_prop
+
+    method onpointerover : ('self t, pointerEvent t) event_listener writeonly_prop
+
+    method onpointerup : ('self t, pointerEvent t) event_listener writeonly_prop
   end
 
 and popStateEvent =
@@ -552,6 +572,32 @@ and animationEvent =
 and mediaEvent =
   object
     inherit event
+  end
+
+(** @see <https://www.w3.org/TR/pointerevents/#pointerevent-interface> *)
+and pointerEvent =
+  object
+    inherit mouseEvent
+
+    method pointerId : int Js.readonly_prop
+
+    method width : float Js.readonly_prop
+
+    method height : float Js.readonly_prop
+
+    method pressure : float Js.readonly_prop
+
+    method tangentialPressure : float Js.readonly_prop
+
+    method tiltX : int Js.readonly_prop
+
+    method tiltY : int Js.readonly_prop
+
+    method twist : int Js.readonly_prop
+
+    method pointerType : Js.js_string Js.t Js.readonly_prop
+
+    method isPrimary : bool Js.t Js.readonly_prop
   end
 
 (** {2 HTML elements} *)
@@ -2334,17 +2380,37 @@ module Event : sig
 
   val ended : mediaEvent t typ
 
+  val gotpointercapture : pointerEvent t typ
+
   val loadeddata : mediaEvent t typ
 
   val loadedmetadata : mediaEvent t typ
 
   val loadstart : mediaEvent t typ
 
+  val lostpointercapture : pointerEvent t typ
+
   val pause : mediaEvent t typ
 
   val play : mediaEvent t typ
 
   val playing : mediaEvent t typ
+
+  val pointerenter : pointerEvent t typ
+
+  val pointercancel : pointerEvent t typ
+
+  val pointerdown : pointerEvent t typ
+
+  val pointerleave : pointerEvent t typ
+
+  val pointermove : pointerEvent t typ
+
+  val pointerout : pointerEvent t typ
+
+  val pointerover : pointerEvent t typ
+
+  val pointerup : pointerEvent t typ
 
   val ratechange : mediaEvent t typ
 

--- a/lib/lwt/lwt_js_events.ml
+++ b/lib/lwt/lwt_js_events.ml
@@ -344,6 +344,36 @@ let touchend ?use_capture ?passive target =
 let touchcancel ?use_capture ?passive target =
   make_event Dom_html.Event.touchcancel ?use_capture ?passive target
 
+let lostpointercapture ?use_capture ?passive target =
+  make_event Dom_html.Event.lostpointercapture ?use_capture ?passive target
+
+let gotpointercapture ?use_capture ?passive target =
+  make_event Dom_html.Event.gotpointercapture ?use_capture ?passive target
+
+let pointerenter ?use_capture ?passive target =
+  make_event Dom_html.Event.pointerenter ?use_capture ?passive target
+
+let pointercancel ?use_capture ?passive target =
+  make_event Dom_html.Event.pointercancel ?use_capture ?passive target
+
+let pointerdown ?use_capture ?passive target =
+  make_event Dom_html.Event.pointerdown ?use_capture ?passive target
+
+let pointerleave ?use_capture ?passive target =
+  make_event Dom_html.Event.pointerleave ?use_capture ?passive target
+
+let pointermove ?use_capture ?passive target =
+  make_event Dom_html.Event.pointermove ?use_capture ?passive target
+
+let pointerout ?use_capture ?passive target =
+  make_event Dom_html.Event.pointerout ?use_capture ?passive target
+
+let pointerover ?use_capture ?passive target =
+  make_event Dom_html.Event.pointerover ?use_capture ?passive target
+
+let pointerup ?use_capture ?passive target =
+  make_event Dom_html.Event.pointerup ?use_capture ?passive target
+
 let clicks ?cancel_handler ?use_capture ?passive t =
   seq_loop click ?cancel_handler ?use_capture ?passive t
 
@@ -496,6 +526,36 @@ let volumechanges ?cancel_handler ?use_capture ?passive t =
 
 let waitings ?cancel_handler ?use_capture ?passive t =
   seq_loop waiting ?cancel_handler ?use_capture ?passive t
+
+let lostpointercaptures ?cancel_handler ?use_capture ?passive t =
+  seq_loop lostpointercapture ?cancel_handler ?use_capture ?passive t
+
+let gotpointercaptures ?cancel_handler ?use_capture ?passive t =
+  seq_loop gotpointercapture ?cancel_handler ?use_capture ?passive t
+
+let pointerenters ?cancel_handler ?use_capture ?passive t =
+  seq_loop pointerenter ?cancel_handler ?use_capture ?passive t
+
+let pointercancels ?cancel_handler ?use_capture ?passive t =
+  seq_loop pointercancel ?cancel_handler ?use_capture ?passive t
+
+let pointerdowns ?cancel_handler ?use_capture ?passive t =
+  seq_loop pointerdown ?cancel_handler ?use_capture ?passive t
+
+let pointerleaves ?cancel_handler ?use_capture ?passive t =
+  seq_loop pointerleave ?cancel_handler ?use_capture ?passive t
+
+let pointermoves ?cancel_handler ?use_capture ?passive t =
+  seq_loop pointermove ?cancel_handler ?use_capture ?passive t
+
+let pointerouts ?cancel_handler ?use_capture ?passive t =
+  seq_loop pointerout ?cancel_handler ?use_capture ?passive t
+
+let pointerovers ?cancel_handler ?use_capture ?passive t =
+  seq_loop pointerover ?cancel_handler ?use_capture ?passive t
+
+let pointerups ?cancel_handler ?use_capture ?passive t =
+  seq_loop pointerup ?cancel_handler ?use_capture ?passive t
 
 let transition_evn =
   lazy

--- a/lib/lwt/lwt_js_events.ml
+++ b/lib/lwt/lwt_js_events.ml
@@ -24,7 +24,9 @@ let ( >>= ) = Lwt.bind
 
 let async f = Lwt.async (fun () -> Lwt_js.yield () >>= f)
 
-let map f = function None -> None | Some x -> Some (f x)
+let map f = function
+  | None -> None
+  | Some x -> Some (f x)
 
 let make_event event_kind ?use_capture ?passive target =
   let el = ref Js.null in
@@ -44,8 +46,7 @@ let make_event event_kind ?use_capture ?passive target =
               Js.bool true))
          (* true because we do not want to prevent default ->
                               the user can use the preventDefault function
-                              above. *)
-      );
+                              above. *));
   t
 
 let catch_cancel f x =
@@ -324,8 +325,7 @@ let mousewheel ?use_capture ?passive target =
            Js.bool true)
          (* true because we do not want to prevent default ->
                            the user can use the preventDefault function
-                           above. *)
-      );
+                           above. *));
   t
 
 (* let _DOMMouseScroll ?use_capture ?passive target =
@@ -652,7 +652,8 @@ let limited_onresizes ?elapsed_time t =
   limited_loop (fun ?use_capture:_ ?passive:_ () -> onresize ()) ?elapsed_time () t
 
 let limited_onorientationchanges ?elapsed_time t =
-  limited_loop (fun ?use_capture:_ ?passive:_ () -> onorientationchange ())
+  limited_loop
+    (fun ?use_capture:_ ?passive:_ () -> onorientationchange ())
     ?elapsed_time
     ()
     t

--- a/lib/lwt/lwt_js_events.ml
+++ b/lib/lwt/lwt_js_events.ml
@@ -24,7 +24,7 @@ let ( >>= ) = Lwt.bind
 
 let async f = Lwt.async (fun () -> Lwt_js.yield () >>= f)
 
-let map f = function
+let opt_map f = function
   | None -> None
   | Some x -> Some (f x)
 
@@ -36,8 +36,8 @@ let make_event event_kind ?use_capture ?passive target =
   el :=
     Js.some
       (Dom.addEventListenerWithOptions
-         ?capture:(map Js.bool use_capture)
-         ?passive:(map Js.bool passive)
+         ?capture:(opt_map Js.bool use_capture)
+         ?passive:(opt_map Js.bool passive)
          target
          event_kind
          (Dom_html.handler (fun (ev : #Dom_html.event Js.t) ->
@@ -315,8 +315,8 @@ let mousewheel ?use_capture ?passive target =
   el :=
     Js.some
       (Dom_html.addMousewheelEventListenerWithOptions
-         ?capture:(map Js.bool use_capture)
-         ?passive:(map Js.bool passive)
+         ?capture:(opt_map Js.bool use_capture)
+         ?passive:(opt_map Js.bool passive)
          target
          (fun (ev : #Dom_html.event Js.t) ~dx ~dy ->
            Firebug.console##log ev;

--- a/lib/lwt/lwt_js_events.ml
+++ b/lib/lwt/lwt_js_events.ml
@@ -24,14 +24,18 @@ let ( >>= ) = Lwt.bind
 
 let async f = Lwt.async (fun () -> Lwt_js.yield () >>= f)
 
-let make_event event_kind ?(use_capture = false) target =
+let map f = function None -> None | Some x -> Some (f x)
+
+let make_event event_kind ?use_capture ?passive target =
   let el = ref Js.null in
   let t, w = Lwt.task () in
   let cancel () = Js.Opt.iter !el Dom_html.removeEventListener in
   Lwt.on_cancel t cancel;
   el :=
     Js.some
-      (Dom.addEventListener
+      (Dom.addEventListenerWithOptions
+         ?capture:(map Js.bool use_capture)
+         ?passive:(map Js.bool passive)
          target
          event_kind
          (Dom_html.handler (fun (ev : #Dom_html.event Js.t) ->
@@ -41,7 +45,7 @@ let make_event event_kind ?(use_capture = false) target =
          (* true because we do not want to prevent default ->
                               the user can use the preventDefault function
                               above. *)
-         (Js.bool use_capture));
+      );
   t
 
 let catch_cancel f x =
@@ -58,7 +62,7 @@ let with_error_log f x =
       Firebug.console##log (Js.string (Printexc.to_string e));
       Lwt.return ())
 
-let seq_loop evh ?(cancel_handler = false) ?use_capture target handler =
+let seq_loop evh ?(cancel_handler = false) ?use_capture ?passive target handler =
   let cancelled = ref false in
   let cur = ref (Lwt.fail (Failure "Lwt_js_event")) in
   (* Using Lwt.fail as default, to be polymorphic *)
@@ -74,7 +78,7 @@ let seq_loop evh ?(cancel_handler = false) ?use_capture target handler =
                          during the previous handler,
                          we do not reinstall the event handler *)
     then (
-      let t = evh ?use_capture target in
+      let t = evh ?use_capture ?passive target in
       cur := t;
       t
       >>= fun e ->
@@ -85,7 +89,7 @@ let seq_loop evh ?(cancel_handler = false) ?use_capture target handler =
   Lwt.async (catch_cancel aux);
   lt
 
-let async_loop evh ?use_capture target handler =
+let async_loop evh ?use_capture ?passive target handler =
   let cancelled = ref false in
   let cur = ref (Lwt.fail (Failure "Lwt_js_event")) in
   let lt, _lw = Lwt.task () in
@@ -95,7 +99,7 @@ let async_loop evh ?use_capture target handler =
   let rec aux () =
     if not !cancelled
     then (
-      let t = evh ?use_capture target in
+      let t = evh ?use_capture ?passive target in
       cur := t;
       t
       >>= fun e ->
@@ -111,6 +115,7 @@ let buffered_loop
     ?(cancel_handler = false)
     ?(cancel_queue = true)
     ?use_capture
+    ?passive
     target
     handler =
   let cancelled = ref false in
@@ -127,7 +132,7 @@ let buffered_loop
   let rec spawner () =
     if not !cancelled
     then (
-      let t = evh ?use_capture target in
+      let t = evh ?use_capture ?passive target in
       cur := t;
       t
       >>= fun e ->
@@ -152,9 +157,9 @@ let buffered_loop
   Lwt.async runner;
   lt
 
-let func_limited_loop event limited_func ?use_capture target handler =
+let func_limited_loop event limited_func ?use_capture ?passive target handler =
   let count = ref 0 in
-  async_loop event ?use_capture target (fun ev lt ->
+  async_loop event ?use_capture ?passive target (fun ev lt ->
       incr count;
       let nb = !count in
       limited_func () >>= fun _ -> if !count = nb then handler ev lt else Lwt.return ())
@@ -162,121 +167,155 @@ let func_limited_loop event limited_func ?use_capture target handler =
 let limited_loop event ?(elapsed_time = 0.1) =
   func_limited_loop event (fun () -> Lwt_js.sleep elapsed_time)
 
-let click ?use_capture target = make_event Dom_html.Event.click ?use_capture target
+let click ?use_capture ?passive target =
+  make_event Dom_html.Event.click ?use_capture ?passive target
 
-let dblclick ?use_capture target = make_event Dom_html.Event.dblclick ?use_capture target
+let dblclick ?use_capture ?passive target =
+  make_event Dom_html.Event.dblclick ?use_capture ?passive target
 
-let mousedown ?use_capture target =
-  make_event Dom_html.Event.mousedown ?use_capture target
+let mousedown ?use_capture ?passive target =
+  make_event Dom_html.Event.mousedown ?use_capture ?passive target
 
-let mouseup ?use_capture target = make_event Dom_html.Event.mouseup ?use_capture target
+let mouseup ?use_capture ?passive target =
+  make_event Dom_html.Event.mouseup ?use_capture ?passive target
 
-let mouseover ?use_capture target =
-  make_event Dom_html.Event.mouseover ?use_capture target
+let mouseover ?use_capture ?passive target =
+  make_event Dom_html.Event.mouseover ?use_capture ?passive target
 
-let mousemove ?use_capture target =
-  make_event Dom_html.Event.mousemove ?use_capture target
+let mousemove ?use_capture ?passive target =
+  make_event Dom_html.Event.mousemove ?use_capture ?passive target
 
-let mouseout ?use_capture target = make_event Dom_html.Event.mouseout ?use_capture target
+let mouseout ?use_capture ?passive target =
+  make_event Dom_html.Event.mouseout ?use_capture ?passive target
 
-let keypress ?use_capture target = make_event Dom_html.Event.keypress ?use_capture target
+let keypress ?use_capture ?passive target =
+  make_event Dom_html.Event.keypress ?use_capture ?passive target
 
-let keydown ?use_capture target = make_event Dom_html.Event.keydown ?use_capture target
+let keydown ?use_capture ?passive target =
+  make_event Dom_html.Event.keydown ?use_capture ?passive target
 
-let keyup ?use_capture target = make_event Dom_html.Event.keyup ?use_capture target
+let keyup ?use_capture ?passive target =
+  make_event Dom_html.Event.keyup ?use_capture ?passive target
 
-let change ?use_capture target = make_event Dom_html.Event.change ?use_capture target
+let change ?use_capture ?passive target =
+  make_event Dom_html.Event.change ?use_capture ?passive target
 
-let input ?use_capture target = make_event Dom_html.Event.input ?use_capture target
+let input ?use_capture ?passive target =
+  make_event Dom_html.Event.input ?use_capture ?passive target
 
-let timeupdate ?use_capture target =
-  make_event Dom_html.Event.timeupdate ?use_capture target
+let timeupdate ?use_capture ?passive target =
+  make_event Dom_html.Event.timeupdate ?use_capture ?passive target
 
-let dragstart ?use_capture target =
-  make_event Dom_html.Event.dragstart ?use_capture target
+let dragstart ?use_capture ?passive target =
+  make_event Dom_html.Event.dragstart ?use_capture ?passive target
 
-let dragend ?use_capture target = make_event Dom_html.Event.dragend ?use_capture target
+let dragend ?use_capture ?passive target =
+  make_event Dom_html.Event.dragend ?use_capture ?passive target
 
-let dragenter ?use_capture target =
-  make_event Dom_html.Event.dragenter ?use_capture target
+let dragenter ?use_capture ?passive target =
+  make_event Dom_html.Event.dragenter ?use_capture ?passive target
 
-let dragover ?use_capture target = make_event Dom_html.Event.dragover ?use_capture target
+let dragover ?use_capture ?passive target =
+  make_event Dom_html.Event.dragover ?use_capture ?passive target
 
-let dragleave ?use_capture target =
-  make_event Dom_html.Event.dragleave ?use_capture target
+let dragleave ?use_capture ?passive target =
+  make_event Dom_html.Event.dragleave ?use_capture ?passive target
 
-let drag ?use_capture target = make_event Dom_html.Event.drag ?use_capture target
+let drag ?use_capture ?passive target =
+  make_event Dom_html.Event.drag ?use_capture ?passive target
 
-let drop ?use_capture target = make_event Dom_html.Event.drop ?use_capture target
+let drop ?use_capture ?passive target =
+  make_event Dom_html.Event.drop ?use_capture ?passive target
 
-let focus ?use_capture target = make_event Dom_html.Event.focus ?use_capture target
+let focus ?use_capture ?passive target =
+  make_event Dom_html.Event.focus ?use_capture ?passive target
 
-let blur ?use_capture target = make_event Dom_html.Event.blur ?use_capture target
+let blur ?use_capture ?passive target =
+  make_event Dom_html.Event.blur ?use_capture ?passive target
 
-let scroll ?use_capture target = make_event Dom_html.Event.scroll ?use_capture target
+let scroll ?use_capture ?passive target =
+  make_event Dom_html.Event.scroll ?use_capture ?passive target
 
-let submit ?use_capture target = make_event Dom_html.Event.submit ?use_capture target
+let submit ?use_capture ?passive target =
+  make_event Dom_html.Event.submit ?use_capture ?passive target
 
-let select ?use_capture target = make_event Dom_html.Event.select ?use_capture target
+let select ?use_capture ?passive target =
+  make_event Dom_html.Event.select ?use_capture ?passive target
 
-let abort ?use_capture target = make_event Dom_html.Event.abort ?use_capture target
+let abort ?use_capture ?passive target =
+  make_event Dom_html.Event.abort ?use_capture ?passive target
 
-let error ?use_capture target = make_event Dom_html.Event.error ?use_capture target
+let error ?use_capture ?passive target =
+  make_event Dom_html.Event.error ?use_capture ?passive target
 
-let load ?use_capture target = make_event Dom_html.Event.load ?use_capture target
+let load ?use_capture ?passive target =
+  make_event Dom_html.Event.load ?use_capture ?passive target
 
-let canplay ?use_capture target = make_event Dom_html.Event.canplay ?use_capture target
+let canplay ?use_capture ?passive target =
+  make_event Dom_html.Event.canplay ?use_capture ?passive target
 
-let canplaythrough ?use_capture target =
-  make_event Dom_html.Event.canplaythrough ?use_capture target
+let canplaythrough ?use_capture ?passive target =
+  make_event Dom_html.Event.canplaythrough ?use_capture ?passive target
 
-let durationchange ?use_capture target =
-  make_event Dom_html.Event.durationchange ?use_capture target
+let durationchange ?use_capture ?passive target =
+  make_event Dom_html.Event.durationchange ?use_capture ?passive target
 
-let emptied ?use_capture target = make_event Dom_html.Event.emptied ?use_capture target
+let emptied ?use_capture ?passive target =
+  make_event Dom_html.Event.emptied ?use_capture ?passive target
 
-let ended ?use_capture target = make_event Dom_html.Event.ended ?use_capture target
+let ended ?use_capture ?passive target =
+  make_event Dom_html.Event.ended ?use_capture ?passive target
 
-let loadeddata ?use_capture target =
-  make_event Dom_html.Event.loadeddata ?use_capture target
+let loadeddata ?use_capture ?passive target =
+  make_event Dom_html.Event.loadeddata ?use_capture ?passive target
 
-let loadedmetadata ?use_capture target =
-  make_event Dom_html.Event.loadedmetadata ?use_capture target
+let loadedmetadata ?use_capture ?passive target =
+  make_event Dom_html.Event.loadedmetadata ?use_capture ?passive target
 
-let loadstart ?use_capture target =
-  make_event Dom_html.Event.loadstart ?use_capture target
+let loadstart ?use_capture ?passive target =
+  make_event Dom_html.Event.loadstart ?use_capture ?passive target
 
-let pause ?use_capture target = make_event Dom_html.Event.pause ?use_capture target
+let pause ?use_capture ?passive target =
+  make_event Dom_html.Event.pause ?use_capture ?passive target
 
-let play ?use_capture target = make_event Dom_html.Event.play ?use_capture target
+let play ?use_capture ?passive target =
+  make_event Dom_html.Event.play ?use_capture ?passive target
 
-let playing ?use_capture target = make_event Dom_html.Event.playing ?use_capture target
+let playing ?use_capture ?passive target =
+  make_event Dom_html.Event.playing ?use_capture ?passive target
 
-let ratechange ?use_capture target =
-  make_event Dom_html.Event.ratechange ?use_capture target
+let ratechange ?use_capture ?passive target =
+  make_event Dom_html.Event.ratechange ?use_capture ?passive target
 
-let seeked ?use_capture target = make_event Dom_html.Event.seeked ?use_capture target
+let seeked ?use_capture ?passive target =
+  make_event Dom_html.Event.seeked ?use_capture ?passive target
 
-let seeking ?use_capture target = make_event Dom_html.Event.seeking ?use_capture target
+let seeking ?use_capture ?passive target =
+  make_event Dom_html.Event.seeking ?use_capture ?passive target
 
-let stalled ?use_capture target = make_event Dom_html.Event.stalled ?use_capture target
+let stalled ?use_capture ?passive target =
+  make_event Dom_html.Event.stalled ?use_capture ?passive target
 
-let suspend ?use_capture target = make_event Dom_html.Event.suspend ?use_capture target
+let suspend ?use_capture ?passive target =
+  make_event Dom_html.Event.suspend ?use_capture ?passive target
 
-let volumechange ?use_capture target =
-  make_event Dom_html.Event.volumechange ?use_capture target
+let volumechange ?use_capture ?passive target =
+  make_event Dom_html.Event.volumechange ?use_capture ?passive target
 
-let waiting ?use_capture target = make_event Dom_html.Event.waiting ?use_capture target
+let waiting ?use_capture ?passive target =
+  make_event Dom_html.Event.waiting ?use_capture ?passive target
 
 (* special case for mousewheel, because it depends on the browser *)
-let mousewheel ?(use_capture = false) target =
+let mousewheel ?use_capture ?passive target =
   let el = ref Js.null in
   let t, w = Lwt.task () in
   let cancel () = Js.Opt.iter !el Dom_html.removeEventListener in
   Lwt.on_cancel t cancel;
   el :=
     Js.some
-      (Dom_html.addMousewheelEventListener
+      (Dom_html.addMousewheelEventListenerWithOptions
+         ?capture:(map Js.bool use_capture)
+         ?passive:(map Js.bool passive)
          target
          (fun (ev : #Dom_html.event Js.t) ~dx ~dy ->
            Firebug.console##log ev;
@@ -286,164 +325,177 @@ let mousewheel ?(use_capture = false) target =
          (* true because we do not want to prevent default ->
                            the user can use the preventDefault function
                            above. *)
-         (Js.bool use_capture));
+      );
   t
 
-(* let _DOMMouseScroll ?use_capture target =
-  make_event Dom_html.Event._DOMMouseScroll ?use_capture target
+(* let _DOMMouseScroll ?use_capture ?passive target =
+  make_event Dom_html.Event._DOMMouseScroll ?use_capture ?passive target
 *)
 
-let touchstart ?use_capture target =
-  make_event Dom_html.Event.touchstart ?use_capture target
+let touchstart ?use_capture ?passive target =
+  make_event Dom_html.Event.touchstart ?use_capture ?passive target
 
-let touchmove ?use_capture target =
-  make_event Dom_html.Event.touchmove ?use_capture target
+let touchmove ?use_capture ?passive target =
+  make_event Dom_html.Event.touchmove ?use_capture ?passive target
 
-let touchend ?use_capture target = make_event Dom_html.Event.touchend ?use_capture target
+let touchend ?use_capture ?passive target =
+  make_event Dom_html.Event.touchend ?use_capture ?passive target
 
-let touchcancel ?use_capture target =
-  make_event Dom_html.Event.touchcancel ?use_capture target
+let touchcancel ?use_capture ?passive target =
+  make_event Dom_html.Event.touchcancel ?use_capture ?passive target
 
-let clicks ?cancel_handler ?use_capture t = seq_loop click ?cancel_handler ?use_capture t
+let clicks ?cancel_handler ?use_capture ?passive t =
+  seq_loop click ?cancel_handler ?use_capture ?passive t
 
-let dblclicks ?cancel_handler ?use_capture t =
-  seq_loop dblclick ?cancel_handler ?use_capture t
+let dblclicks ?cancel_handler ?use_capture ?passive t =
+  seq_loop dblclick ?cancel_handler ?use_capture ?passive t
 
-let mousedowns ?cancel_handler ?use_capture t =
-  seq_loop mousedown ?cancel_handler ?use_capture t
+let mousedowns ?cancel_handler ?use_capture ?passive t =
+  seq_loop mousedown ?cancel_handler ?use_capture ?passive t
 
-let mouseups ?cancel_handler ?use_capture t =
-  seq_loop mouseup ?cancel_handler ?use_capture t
+let mouseups ?cancel_handler ?use_capture ?passive t =
+  seq_loop mouseup ?cancel_handler ?use_capture ?passive t
 
-let mouseovers ?cancel_handler ?use_capture t =
-  seq_loop mouseover ?cancel_handler ?use_capture t
+let mouseovers ?cancel_handler ?use_capture ?passive t =
+  seq_loop mouseover ?cancel_handler ?use_capture ?passive t
 
-let mousemoves ?cancel_handler ?use_capture t =
-  seq_loop mousemove ?cancel_handler ?use_capture t
+let mousemoves ?cancel_handler ?use_capture ?passive t =
+  seq_loop mousemove ?cancel_handler ?use_capture ?passive t
 
-let mouseouts ?cancel_handler ?use_capture t =
-  seq_loop mouseout ?cancel_handler ?use_capture t
+let mouseouts ?cancel_handler ?use_capture ?passive t =
+  seq_loop mouseout ?cancel_handler ?use_capture ?passive t
 
-let keypresses ?cancel_handler ?use_capture t =
-  seq_loop keypress ?cancel_handler ?use_capture t
+let keypresses ?cancel_handler ?use_capture ?passive t =
+  seq_loop keypress ?cancel_handler ?use_capture ?passive t
 
-let keydowns ?cancel_handler ?use_capture t =
-  seq_loop keydown ?cancel_handler ?use_capture t
+let keydowns ?cancel_handler ?use_capture ?passive t =
+  seq_loop keydown ?cancel_handler ?use_capture ?passive t
 
-let keyups ?cancel_handler ?use_capture t = seq_loop keyup ?cancel_handler ?use_capture t
+let keyups ?cancel_handler ?use_capture ?passive t =
+  seq_loop keyup ?cancel_handler ?use_capture ?passive t
 
-let changes ?cancel_handler ?use_capture t =
-  seq_loop change ?cancel_handler ?use_capture t
+let changes ?cancel_handler ?use_capture ?passive t =
+  seq_loop change ?cancel_handler ?use_capture ?passive t
 
-let inputs ?cancel_handler ?use_capture t = seq_loop input ?cancel_handler ?use_capture t
+let inputs ?cancel_handler ?use_capture ?passive t =
+  seq_loop input ?cancel_handler ?use_capture ?passive t
 
-let timeupdates ?cancel_handler ?use_capture t =
-  seq_loop timeupdate ?cancel_handler ?use_capture t
+let timeupdates ?cancel_handler ?use_capture ?passive t =
+  seq_loop timeupdate ?cancel_handler ?use_capture ?passive t
 
-let dragstarts ?cancel_handler ?use_capture t =
-  seq_loop dragstart ?cancel_handler ?use_capture t
+let dragstarts ?cancel_handler ?use_capture ?passive t =
+  seq_loop dragstart ?cancel_handler ?use_capture ?passive t
 
-let dragends ?cancel_handler ?use_capture t =
-  seq_loop dragend ?cancel_handler ?use_capture t
+let dragends ?cancel_handler ?use_capture ?passive t =
+  seq_loop dragend ?cancel_handler ?use_capture ?passive t
 
-let dragenters ?cancel_handler ?use_capture t =
-  seq_loop dragenter ?cancel_handler ?use_capture t
+let dragenters ?cancel_handler ?use_capture ?passive t =
+  seq_loop dragenter ?cancel_handler ?use_capture ?passive t
 
-let dragovers ?cancel_handler ?use_capture t =
-  seq_loop dragover ?cancel_handler ?use_capture t
+let dragovers ?cancel_handler ?use_capture ?passive t =
+  seq_loop dragover ?cancel_handler ?use_capture ?passive t
 
-let dragleaves ?cancel_handler ?use_capture t =
-  seq_loop dragleave ?cancel_handler ?use_capture t
+let dragleaves ?cancel_handler ?use_capture ?passive t =
+  seq_loop dragleave ?cancel_handler ?use_capture ?passive t
 
-let drags ?cancel_handler ?use_capture t = seq_loop drag ?cancel_handler ?use_capture t
+let drags ?cancel_handler ?use_capture ?passive t =
+  seq_loop drag ?cancel_handler ?use_capture ?passive t
 
-let drops ?cancel_handler ?use_capture t = seq_loop drop ?cancel_handler ?use_capture t
+let drops ?cancel_handler ?use_capture ?passive t =
+  seq_loop drop ?cancel_handler ?use_capture ?passive t
 
-let mousewheels ?cancel_handler ?use_capture t =
-  seq_loop mousewheel ?cancel_handler ?use_capture t
+let mousewheels ?cancel_handler ?use_capture ?passive t =
+  seq_loop mousewheel ?cancel_handler ?use_capture ?passive t
 
-let touchstarts ?cancel_handler ?use_capture t =
-  seq_loop touchstart ?cancel_handler ?use_capture t
+let touchstarts ?cancel_handler ?use_capture ?passive t =
+  seq_loop touchstart ?cancel_handler ?use_capture ?passive t
 
-let touchmoves ?cancel_handler ?use_capture t =
-  seq_loop touchmove ?cancel_handler ?use_capture t
+let touchmoves ?cancel_handler ?use_capture ?passive t =
+  seq_loop touchmove ?cancel_handler ?use_capture ?passive t
 
-let touchends ?cancel_handler ?use_capture t =
-  seq_loop touchend ?cancel_handler ?use_capture t
+let touchends ?cancel_handler ?use_capture ?passive t =
+  seq_loop touchend ?cancel_handler ?use_capture ?passive t
 
-let touchcancels ?cancel_handler ?use_capture t =
-  seq_loop touchcancel ?cancel_handler ?use_capture t
+let touchcancels ?cancel_handler ?use_capture ?passive t =
+  seq_loop touchcancel ?cancel_handler ?use_capture ?passive t
 
-let focuses ?cancel_handler ?use_capture t =
-  seq_loop focus ?cancel_handler ?use_capture t
+let focuses ?cancel_handler ?use_capture ?passive t =
+  seq_loop focus ?cancel_handler ?use_capture ?passive t
 
-let blurs ?cancel_handler ?use_capture t = seq_loop blur ?cancel_handler ?use_capture t
+let blurs ?cancel_handler ?use_capture ?passive t =
+  seq_loop blur ?cancel_handler ?use_capture ?passive t
 
-let scrolls ?cancel_handler ?use_capture t =
-  seq_loop scroll ?cancel_handler ?use_capture t
+let scrolls ?cancel_handler ?use_capture ?passive t =
+  seq_loop scroll ?cancel_handler ?use_capture ?passive t
 
-let submits ?cancel_handler ?use_capture t =
-  seq_loop submit ?cancel_handler ?use_capture t
+let submits ?cancel_handler ?use_capture ?passive t =
+  seq_loop submit ?cancel_handler ?use_capture ?passive t
 
-let selects ?cancel_handler ?use_capture t =
-  seq_loop select ?cancel_handler ?use_capture t
+let selects ?cancel_handler ?use_capture ?passive t =
+  seq_loop select ?cancel_handler ?use_capture ?passive t
 
-let aborts ?cancel_handler ?use_capture t = seq_loop abort ?cancel_handler ?use_capture t
+let aborts ?cancel_handler ?use_capture ?passive t =
+  seq_loop abort ?cancel_handler ?use_capture ?passive t
 
-let errors ?cancel_handler ?use_capture t = seq_loop error ?cancel_handler ?use_capture t
+let errors ?cancel_handler ?use_capture ?passive t =
+  seq_loop error ?cancel_handler ?use_capture ?passive t
 
-let loads ?cancel_handler ?use_capture t = seq_loop load ?cancel_handler ?use_capture t
+let loads ?cancel_handler ?use_capture ?passive t =
+  seq_loop load ?cancel_handler ?use_capture ?passive t
 
-let canplays ?cancel_handler ?use_capture t =
-  seq_loop canplay ?cancel_handler ?use_capture t
+let canplays ?cancel_handler ?use_capture ?passive t =
+  seq_loop canplay ?cancel_handler ?use_capture ?passive t
 
-let canplaythroughs ?cancel_handler ?use_capture t =
-  seq_loop canplaythrough ?cancel_handler ?use_capture t
+let canplaythroughs ?cancel_handler ?use_capture ?passive t =
+  seq_loop canplaythrough ?cancel_handler ?use_capture ?passive t
 
-let durationchanges ?cancel_handler ?use_capture t =
-  seq_loop durationchange ?cancel_handler ?use_capture t
+let durationchanges ?cancel_handler ?use_capture ?passive t =
+  seq_loop durationchange ?cancel_handler ?use_capture ?passive t
 
-let emptieds ?cancel_handler ?use_capture t =
-  seq_loop emptied ?cancel_handler ?use_capture t
+let emptieds ?cancel_handler ?use_capture ?passive t =
+  seq_loop emptied ?cancel_handler ?use_capture ?passive t
 
-let endeds ?cancel_handler ?use_capture t = seq_loop ended ?cancel_handler ?use_capture t
+let endeds ?cancel_handler ?use_capture ?passive t =
+  seq_loop ended ?cancel_handler ?use_capture ?passive t
 
-let loadeddatas ?cancel_handler ?use_capture t =
-  seq_loop loadeddata ?cancel_handler ?use_capture t
+let loadeddatas ?cancel_handler ?use_capture ?passive t =
+  seq_loop loadeddata ?cancel_handler ?use_capture ?passive t
 
-let loadedmetadatas ?cancel_handler ?use_capture t =
-  seq_loop loadedmetadata ?cancel_handler ?use_capture t
+let loadedmetadatas ?cancel_handler ?use_capture ?passive t =
+  seq_loop loadedmetadata ?cancel_handler ?use_capture ?passive t
 
-let loadstarts ?cancel_handler ?use_capture t =
-  seq_loop loadstart ?cancel_handler ?use_capture t
+let loadstarts ?cancel_handler ?use_capture ?passive t =
+  seq_loop loadstart ?cancel_handler ?use_capture ?passive t
 
-let pauses ?cancel_handler ?use_capture t = seq_loop pause ?cancel_handler ?use_capture t
+let pauses ?cancel_handler ?use_capture ?passive t =
+  seq_loop pause ?cancel_handler ?use_capture ?passive t
 
-let plays ?cancel_handler ?use_capture t = seq_loop play ?cancel_handler ?use_capture t
+let plays ?cancel_handler ?use_capture ?passive t =
+  seq_loop play ?cancel_handler ?use_capture ?passive t
 
-let playings ?cancel_handler ?use_capture t =
-  seq_loop playing ?cancel_handler ?use_capture t
+let playings ?cancel_handler ?use_capture ?passive t =
+  seq_loop playing ?cancel_handler ?use_capture ?passive t
 
-let ratechanges ?cancel_handler ?use_capture t =
-  seq_loop ratechange ?cancel_handler ?use_capture t
+let ratechanges ?cancel_handler ?use_capture ?passive t =
+  seq_loop ratechange ?cancel_handler ?use_capture ?passive t
 
-let seekeds ?cancel_handler ?use_capture t =
-  seq_loop seeked ?cancel_handler ?use_capture t
+let seekeds ?cancel_handler ?use_capture ?passive t =
+  seq_loop seeked ?cancel_handler ?use_capture ?passive t
 
-let seekings ?cancel_handler ?use_capture t =
-  seq_loop seeking ?cancel_handler ?use_capture t
+let seekings ?cancel_handler ?use_capture ?passive t =
+  seq_loop seeking ?cancel_handler ?use_capture ?passive t
 
-let stalleds ?cancel_handler ?use_capture t =
-  seq_loop stalled ?cancel_handler ?use_capture t
+let stalleds ?cancel_handler ?use_capture ?passive t =
+  seq_loop stalled ?cancel_handler ?use_capture ?passive t
 
-let suspends ?cancel_handler ?use_capture t =
-  seq_loop suspend ?cancel_handler ?use_capture t
+let suspends ?cancel_handler ?use_capture ?passive t =
+  seq_loop suspend ?cancel_handler ?use_capture ?passive t
 
-let volumechanges ?cancel_handler ?use_capture t =
-  seq_loop volumechange ?cancel_handler ?use_capture t
+let volumechanges ?cancel_handler ?use_capture ?passive t =
+  seq_loop volumechange ?cancel_handler ?use_capture ?passive t
 
-let waitings ?cancel_handler ?use_capture t =
-  seq_loop waiting ?cancel_handler ?use_capture t
+let waitings ?cancel_handler ?use_capture ?passive t =
+  seq_loop waiting ?cancel_handler ?use_capture ?passive t
 
 let transition_evn =
   lazy
@@ -466,7 +518,7 @@ let transitionend elt =
 
 let transitionends ?cancel_handler elt f =
   seq_loop
-    (fun ?use_capture:_ target -> transitionend target)
+    (fun ?use_capture:_ ?passive:_ target -> transitionend target)
     ?cancel_handler
     elt
     (fun _ cancel -> f cancel)
@@ -524,27 +576,30 @@ let onhashchange () = make_event Dom_html.Event.hashchange Dom_html.window
 
 let onorientationchange_or_onresize () = Lwt.pick [onresize (); onorientationchange ()]
 
-let onresizes t = seq_loop (fun ?use_capture:_ () -> onresize ()) () t
+let onresizes t = seq_loop (fun ?use_capture:_ ?passive:_ () -> onresize ()) () t
 
 let onorientationchanges t =
-  seq_loop (fun ?use_capture:_ () -> onorientationchange ()) () t
+  seq_loop (fun ?use_capture:_ ?passive:_ () -> onorientationchange ()) () t
 
-let onpopstates t = seq_loop (fun ?use_capture:_ () -> onpopstate ()) () t
+let onpopstates t = seq_loop (fun ?use_capture:_ ?passive:_ () -> onpopstate ()) () t
 
-let onhashchanges t = seq_loop (fun ?use_capture:_ () -> onhashchange ()) () t
+let onhashchanges t = seq_loop (fun ?use_capture:_ ?passive:_ () -> onhashchange ()) () t
 
 let onorientationchanges_or_onresizes t =
-  seq_loop (fun ?use_capture:_ () -> onorientationchange_or_onresize ()) () t
+  seq_loop (fun ?use_capture:_ ?passive:_ () -> onorientationchange_or_onresize ()) () t
 
 let limited_onresizes ?elapsed_time t =
-  limited_loop (fun ?use_capture:_ () -> onresize ()) ?elapsed_time () t
+  limited_loop (fun ?use_capture:_ ?passive:_ () -> onresize ()) ?elapsed_time () t
 
 let limited_onorientationchanges ?elapsed_time t =
-  limited_loop (fun ?use_capture:_ () -> onorientationchange ()) ?elapsed_time () t
+  limited_loop (fun ?use_capture:_ ?passive:_ () -> onorientationchange ())
+    ?elapsed_time
+    ()
+    t
 
 let limited_onorientationchanges_or_onresizes ?elapsed_time t =
   limited_loop
-    (fun ?use_capture:_ () -> onorientationchange_or_onresize ())
+    (fun ?use_capture:_ ?passive:_ () -> onorientationchange_or_onresize ())
     ?elapsed_time
     ()
     t

--- a/lib/lwt/lwt_js_events.mli
+++ b/lib/lwt/lwt_js_events.mli
@@ -613,7 +613,8 @@ val mousemoves :
 
 val mouseouts :
      ?cancel_handler:bool
-  -> ?use_capture:bool -> ?passive:bool
+  -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.mouseEvent Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t

--- a/lib/lwt/lwt_js_events.mli
+++ b/lib/lwt/lwt_js_events.mli
@@ -371,6 +371,66 @@ val touchcancel :
 val transitionend : #Dom_html.eventTarget Js.t -> unit Lwt.t
 (** Returns when a CSS transition terminates on the element. *)
 
+val lostpointercapture :
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.pointerEvent Js.t Lwt.t
+
+val gotpointercapture :
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.pointerEvent Js.t Lwt.t
+
+val pointerenter :
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.pointerEvent Js.t Lwt.t
+
+val pointercancel :
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.pointerEvent Js.t Lwt.t
+
+val pointerdown :
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.pointerEvent Js.t Lwt.t
+
+val pointerleave :
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.pointerEvent Js.t Lwt.t
+
+val pointermove :
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.pointerEvent Js.t Lwt.t
+
+val pointerout :
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.pointerEvent Js.t Lwt.t
+
+val pointerover :
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.pointerEvent Js.t Lwt.t
+
+val pointerup :
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.pointerEvent Js.t Lwt.t
+
 val transitionends :
      ?cancel_handler:bool
   -> #Dom_html.eventTarget Js.t
@@ -908,6 +968,86 @@ val waitings :
   -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.event Js.t -> unit Lwt.t -> unit Lwt.t)
+  -> unit Lwt.t
+
+val lostpointercaptures :
+     ?cancel_handler:bool
+  -> ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> (Dom_html.pointerEvent Js.t -> unit Lwt.t -> unit Lwt.t)
+  -> unit Lwt.t
+
+val gotpointercaptures :
+     ?cancel_handler:bool
+  -> ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> (Dom_html.pointerEvent Js.t -> unit Lwt.t -> unit Lwt.t)
+  -> unit Lwt.t
+
+val pointerenters :
+     ?cancel_handler:bool
+  -> ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> (Dom_html.pointerEvent Js.t -> unit Lwt.t -> unit Lwt.t)
+  -> unit Lwt.t
+
+val pointercancels :
+     ?cancel_handler:bool
+  -> ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> (Dom_html.pointerEvent Js.t -> unit Lwt.t -> unit Lwt.t)
+  -> unit Lwt.t
+
+val pointerdowns :
+     ?cancel_handler:bool
+  -> ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> (Dom_html.pointerEvent Js.t -> unit Lwt.t -> unit Lwt.t)
+  -> unit Lwt.t
+
+val pointerleaves :
+     ?cancel_handler:bool
+  -> ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> (Dom_html.pointerEvent Js.t -> unit Lwt.t -> unit Lwt.t)
+  -> unit Lwt.t
+
+val pointermoves :
+     ?cancel_handler:bool
+  -> ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> (Dom_html.pointerEvent Js.t -> unit Lwt.t -> unit Lwt.t)
+  -> unit Lwt.t
+
+val pointerouts :
+     ?cancel_handler:bool
+  -> ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> (Dom_html.pointerEvent Js.t -> unit Lwt.t -> unit Lwt.t)
+  -> unit Lwt.t
+
+val pointerovers :
+     ?cancel_handler:bool
+  -> ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> (Dom_html.pointerEvent Js.t -> unit Lwt.t -> unit Lwt.t)
+  -> unit Lwt.t
+
+val pointerups :
+     ?cancel_handler:bool
+  -> ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> (Dom_html.pointerEvent Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
 
 val request_animation_frame : unit -> unit Lwt.t

--- a/lib/lwt/lwt_js_events.mli
+++ b/lib/lwt/lwt_js_events.mli
@@ -60,6 +60,7 @@ open Js_of_ocaml
 val make_event :
      (#Dom_html.event as 'a) Js.t Dom_html.Event.typ
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> 'a Js.t Lwt.t
 (** [make_event ev target] creates a Lwt thread that waits
@@ -69,12 +70,16 @@ val make_event :
     the event will be caught during the capture phase,
     otherwise it is caught during the bubbling phase
     (default).
+    If you set the optional parameter [~passive:true],
+    the user agent will ignore [preventDefault] calls
+    inside the event callback.
 *)
 
 val seq_loop :
-     (?use_capture:bool -> 'target -> 'event Lwt.t)
+     (?use_capture:bool -> ?passive:bool -> 'target -> 'event Lwt.t)
   -> ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> 'target
   -> ('event -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -86,7 +91,7 @@ val seq_loop :
 
     For example, the [clicks] function below is defined by:
 
-    [let clicks ?use_capture t = seq_loop click ?use_capture t]
+    [let clicks ?use_capture ?passive t = seq_loop click ?use_capture ?passive t]
 
     The thread returned is cancellable using [Lwt.cancel].
     In order for the loop thread to be canceled from within the handler,
@@ -98,8 +103,9 @@ val seq_loop :
 *)
 
 val async_loop :
-     (?use_capture:bool -> 'target -> 'event Lwt.t)
+     (?use_capture:bool -> ?passive:bool -> 'target -> 'event Lwt.t)
   -> ?use_capture:bool
+  -> ?passive:bool
   -> 'target
   -> ('event -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -113,10 +119,11 @@ val async_loop :
 *)
 
 val buffered_loop :
-     (?use_capture:bool -> 'target -> 'event Lwt.t)
+     (?use_capture:bool -> ?passive:bool -> 'target -> 'event Lwt.t)
   -> ?cancel_handler:bool
   -> ?cancel_queue:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> 'target
   -> ('event -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -137,7 +144,7 @@ val buffered_loop :
     parameters [cancel_handler] and [cancel_queue].
 *)
 
-val async : (unit -> unit Lwt.t) -> unit
+val async : (unit -> 'a Lwt.t) -> unit
 (** [async t] records a thread to be executed later.
     It is implemented by calling yield, then Lwt.async.
     This is useful if you want to create a new event listener
@@ -147,9 +154,10 @@ val async : (unit -> unit Lwt.t) -> unit
 *)
 
 val func_limited_loop :
-     (?use_capture:bool -> 'a -> 'b Lwt.t)
+     (?use_capture:bool -> ?passive:bool -> 'a -> 'b Lwt.t)
   -> (unit -> 'a Lwt.t)
   -> ?use_capture:bool
+  -> ?passive:bool
   -> 'a
   -> ('b -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -164,9 +172,10 @@ val func_limited_loop :
     several instances of your handler could be run in same time **)
 
 val limited_loop :
-     (?use_capture:bool -> 'a -> 'b Lwt.t)
+     (?use_capture:bool -> ?passive:bool -> 'a -> 'b Lwt.t)
   -> ?elapsed_time:float
   -> ?use_capture:bool
+  -> ?passive:bool
   -> 'a
   -> ('b -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -176,75 +185,158 @@ val limited_loop :
 (**  {2 Predefined functions for some types of events} *)
 
 val click :
-  ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.mouseEvent Js.t Lwt.t
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.mouseEvent Js.t Lwt.t
 
 val dblclick :
-  ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.mouseEvent Js.t Lwt.t
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.mouseEvent Js.t Lwt.t
 
 val mousedown :
-  ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.mouseEvent Js.t Lwt.t
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.mouseEvent Js.t Lwt.t
 
 val mouseup :
-  ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.mouseEvent Js.t Lwt.t
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.mouseEvent Js.t Lwt.t
 
 val mouseover :
-  ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.mouseEvent Js.t Lwt.t
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.mouseEvent Js.t Lwt.t
 
 val mousemove :
-  ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.mouseEvent Js.t Lwt.t
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.mouseEvent Js.t Lwt.t
 
 val mouseout :
-  ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.mouseEvent Js.t Lwt.t
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.mouseEvent Js.t Lwt.t
 
 val keypress :
-  ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.keyboardEvent Js.t Lwt.t
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.keyboardEvent Js.t Lwt.t
 
 val keydown :
-  ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.keyboardEvent Js.t Lwt.t
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.keyboardEvent Js.t Lwt.t
 
 val keyup :
-  ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.keyboardEvent Js.t Lwt.t
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.keyboardEvent Js.t Lwt.t
 
-val input : ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.event Js.t Lwt.t
+val input :
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.event Js.t Lwt.t
 
 val timeupdate :
-  ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.event Js.t Lwt.t
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.event Js.t Lwt.t
 
-val change : ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.event Js.t Lwt.t
+val change :
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.event Js.t Lwt.t
 
 val dragstart :
-  ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.dragEvent Js.t Lwt.t
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.dragEvent Js.t Lwt.t
 
 val dragend :
-  ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.dragEvent Js.t Lwt.t
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.dragEvent Js.t Lwt.t
 
 val dragenter :
-  ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.dragEvent Js.t Lwt.t
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.dragEvent Js.t Lwt.t
 
 val dragover :
-  ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.dragEvent Js.t Lwt.t
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.dragEvent Js.t Lwt.t
 
 val dragleave :
-  ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.dragEvent Js.t Lwt.t
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.dragEvent Js.t Lwt.t
 
 val drag :
-  ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.dragEvent Js.t Lwt.t
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.dragEvent Js.t Lwt.t
 
 val drop :
-  ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.dragEvent Js.t Lwt.t
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.dragEvent Js.t Lwt.t
 
-val focus : ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.event Js.t Lwt.t
+val focus :
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.event Js.t Lwt.t
 
-val blur : ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.event Js.t Lwt.t
+val blur :
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.event Js.t Lwt.t
 
-val scroll : ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.event Js.t Lwt.t
+val scroll :
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.event Js.t Lwt.t
 
-val submit : ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.event Js.t Lwt.t
+val submit :
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.event Js.t Lwt.t
 
-val select : ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.event Js.t Lwt.t
+val select :
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.event Js.t Lwt.t
 
 val mousewheel :
      ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.mouseEvent Js.t * (int * int)) Lwt.t
 (** This function returns the event,
@@ -253,16 +345,28 @@ val mousewheel :
     This interface is compatible with all (recent) browsers. *)
 
 val touchstart :
-  ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.touchEvent Js.t Lwt.t
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.touchEvent Js.t Lwt.t
 
 val touchmove :
-  ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.touchEvent Js.t Lwt.t
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.touchEvent Js.t Lwt.t
 
 val touchend :
-  ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.touchEvent Js.t Lwt.t
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.touchEvent Js.t Lwt.t
 
 val touchcancel :
-  ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.touchEvent Js.t Lwt.t
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.touchEvent Js.t Lwt.t
 
 val transitionend : #Dom_html.eventTarget Js.t -> unit Lwt.t
 (** Returns when a CSS transition terminates on the element. *)
@@ -273,65 +377,136 @@ val transitionends :
   -> (unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
 
-val load : ?use_capture:bool -> #Dom_html.imageElement Js.t -> Dom_html.event Js.t Lwt.t
+val load :
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.imageElement Js.t
+  -> Dom_html.event Js.t Lwt.t
 
-val error : ?use_capture:bool -> #Dom_html.imageElement Js.t -> Dom_html.event Js.t Lwt.t
+val error :
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.imageElement Js.t
+  -> Dom_html.event Js.t Lwt.t
 
-val abort : ?use_capture:bool -> #Dom_html.imageElement Js.t -> Dom_html.event Js.t Lwt.t
+val abort :
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.imageElement Js.t
+  -> Dom_html.event Js.t Lwt.t
 
 val canplay :
-  ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.event Js.t Lwt.t
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.event Js.t Lwt.t
 
 val canplaythrough :
-  ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.event Js.t Lwt.t
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.event Js.t Lwt.t
 
 val durationchange :
-  ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.event Js.t Lwt.t
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.event Js.t Lwt.t
 
 val emptied :
-  ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.event Js.t Lwt.t
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.event Js.t Lwt.t
 
-val ended : ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.event Js.t Lwt.t
+val ended :
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.event Js.t Lwt.t
 
 val loadeddata :
-  ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.event Js.t Lwt.t
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.event Js.t Lwt.t
 
 val loadedmetadata :
-  ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.event Js.t Lwt.t
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.event Js.t Lwt.t
 
 val loadstart :
-  ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.event Js.t Lwt.t
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.event Js.t Lwt.t
 
-val pause : ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.event Js.t Lwt.t
+val pause :
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.event Js.t Lwt.t
 
-val play : ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.event Js.t Lwt.t
+val play :
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.event Js.t Lwt.t
 
 val playing :
-  ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.event Js.t Lwt.t
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.event Js.t Lwt.t
 
 val ratechange :
-  ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.event Js.t Lwt.t
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.event Js.t Lwt.t
 
-val seeked : ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.event Js.t Lwt.t
+val seeked :
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.event Js.t Lwt.t
 
 val seeking :
-  ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.event Js.t Lwt.t
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.event Js.t Lwt.t
 
 val stalled :
-  ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.event Js.t Lwt.t
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.event Js.t Lwt.t
 
 val suspend :
-  ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.event Js.t Lwt.t
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.event Js.t Lwt.t
 
 val volumechange :
-  ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.event Js.t Lwt.t
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.event Js.t Lwt.t
 
 val waiting :
-  ?use_capture:bool -> #Dom_html.eventTarget Js.t -> Dom_html.event Js.t Lwt.t
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.event Js.t Lwt.t
 
 val clicks :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.mouseEvent Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -339,6 +514,7 @@ val clicks :
 val dblclicks :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.mouseEvent Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -346,6 +522,7 @@ val dblclicks :
 val mousedowns :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.mouseEvent Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -353,6 +530,7 @@ val mousedowns :
 val mouseups :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.mouseEvent Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -360,6 +538,7 @@ val mouseups :
 val mouseovers :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.mouseEvent Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -367,13 +546,14 @@ val mouseovers :
 val mousemoves :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.mouseEvent Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
 
 val mouseouts :
      ?cancel_handler:bool
-  -> ?use_capture:bool
+  -> ?use_capture:bool -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.mouseEvent Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -381,6 +561,7 @@ val mouseouts :
 val keypresses :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.keyboardEvent Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -388,6 +569,7 @@ val keypresses :
 val keydowns :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.keyboardEvent Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -395,6 +577,7 @@ val keydowns :
 val keyups :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.keyboardEvent Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -402,6 +585,7 @@ val keyups :
 val inputs :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.event Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -409,6 +593,7 @@ val inputs :
 val timeupdates :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.event Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -416,6 +601,7 @@ val timeupdates :
 val changes :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.event Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -423,6 +609,7 @@ val changes :
 val dragstarts :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.dragEvent Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -430,6 +617,7 @@ val dragstarts :
 val dragends :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.dragEvent Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -437,6 +625,7 @@ val dragends :
 val dragenters :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.dragEvent Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -444,6 +633,7 @@ val dragenters :
 val dragovers :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.dragEvent Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -451,6 +641,7 @@ val dragovers :
 val dragleaves :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.dragEvent Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -458,6 +649,7 @@ val dragleaves :
 val drags :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.dragEvent Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -465,6 +657,7 @@ val drags :
 val drops :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.dragEvent Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -472,6 +665,7 @@ val drops :
 val mousewheels :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.mouseEvent Js.t * (int * int) -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -479,6 +673,7 @@ val mousewheels :
 val touchstarts :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.touchEvent Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -486,6 +681,7 @@ val touchstarts :
 val touchmoves :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.touchEvent Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -493,6 +689,7 @@ val touchmoves :
 val touchends :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.touchEvent Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -500,6 +697,7 @@ val touchends :
 val touchcancels :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.touchEvent Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -507,6 +705,7 @@ val touchcancels :
 val focuses :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.event Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -514,6 +713,7 @@ val focuses :
 val blurs :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.event Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -521,6 +721,7 @@ val blurs :
 val scrolls :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.event Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -528,6 +729,7 @@ val scrolls :
 val submits :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.event Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -535,6 +737,7 @@ val submits :
 val selects :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.event Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -542,6 +745,7 @@ val selects :
 val loads :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.imageElement Js.t
   -> (Dom_html.event Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -549,6 +753,7 @@ val loads :
 val errors :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.imageElement Js.t
   -> (Dom_html.event Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -556,6 +761,7 @@ val errors :
 val aborts :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.imageElement Js.t
   -> (Dom_html.event Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -563,6 +769,7 @@ val aborts :
 val canplays :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.event Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -570,6 +777,7 @@ val canplays :
 val canplaythroughs :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.event Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -577,6 +785,7 @@ val canplaythroughs :
 val durationchanges :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.event Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -584,6 +793,7 @@ val durationchanges :
 val emptieds :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.event Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -591,6 +801,7 @@ val emptieds :
 val endeds :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.event Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -598,6 +809,7 @@ val endeds :
 val loadeddatas :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.event Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -605,6 +817,7 @@ val loadeddatas :
 val loadedmetadatas :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.event Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -612,6 +825,7 @@ val loadedmetadatas :
 val loadstarts :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.event Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -619,6 +833,7 @@ val loadstarts :
 val pauses :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.event Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -626,6 +841,7 @@ val pauses :
 val plays :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.event Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -633,6 +849,7 @@ val plays :
 val playings :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.event Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -640,6 +857,7 @@ val playings :
 val ratechanges :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.event Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -647,6 +865,7 @@ val ratechanges :
 val seekeds :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.event Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -654,6 +873,7 @@ val seekeds :
 val seekings :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.event Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -661,6 +881,7 @@ val seekings :
 val stalleds :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.event Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -668,6 +889,7 @@ val stalleds :
 val suspends :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.event Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -675,6 +897,7 @@ val suspends :
 val volumechanges :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.event Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
@@ -682,6 +905,7 @@ val volumechanges :
 val waitings :
      ?cancel_handler:bool
   -> ?use_capture:bool
+  -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.event Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t


### PR DESCRIPTION
## `passive` argument for `Lwt_js_events` 
Added `passive` optional argument to all relevant functions of `Lwt_js_events` module

## Pointer events
* Added `pointerEvent` type (see [MDN](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent))
* Added pointer event types to `Dom_html.Event` module
* Added helper functions for pointer events handling to `Lwt_js_events` module
* Added pointer event related methods to `eventTarget` object type

## CustomEvent
* Added `customEvent` object type
* Added `Dom.createCustomEvent` and `Dom_html.createCustomEvent` helper functions to allow creation of custom events
* Added `eventTarget##dispatchEvent` method to allow dispatching of custom (and other) events