### PR TITLE
runtime: refactor marshal for custom blocks

### DIFF
--- a/compiler/tests/obj.ml
+++ b/compiler/tests/obj.ml
@@ -32,6 +32,7 @@ let%expect_test "static eval of string get" =
   let program =
     run_test
       {|
+    [@@@ocaml.warning "-3"]
     let my_is_block x = Obj.is_block (Obj.repr x)
     let my_is_int x = Obj.is_int (Obj.repr x)
     let my_tag x = Obj.tag (Obj.repr [x])

--- a/compiler/tests/test_marshal.ml
+++ b/compiler/tests/test_marshal.ml
@@ -117,3 +117,11 @@ let%expect_test _ =
      let v = Marshal.from_string data 0
      let () = assert (1L = v) |};
   [%expect {||}]
+
+let%expect_test _ =
+  Util.compile_and_run {|Printf.printf "%S" (Marshal.to_string 1L [])|};
+  [%expect
+    {| "\132\149\166\190\000\000\000\012\000\000\000\001\000\000\000\004\000\000\000\003\025_j\000\000\000\000\000\000\000\000\001" |}];
+  Printf.printf "%S" (Marshal.to_string 1L []);
+  [%expect
+    {| "\132\149\166\190\000\000\000\012\000\000\000\001\000\000\000\004\000\000\000\003\025_j\000\000\000\000\000\000\000\000\001" |}]


### PR DESCRIPTION
This should allow one to add support for other custom blocks (e.g. bigarray, zarith Z.t)
cc @TyOverby 