### PR TITLE
add focus event

### DIFF
--- a/lib/js_of_ocaml/dom_html.ml
+++ b/lib/js_of_ocaml/dom_html.ml
@@ -271,6 +271,13 @@ and ['a] customEvent =
     inherit [element, 'a] Dom.customEvent
   end
 
+and focusEvent =
+  object
+    inherit event
+
+    method relatedTarget : element t opt optdef readonly_prop
+  end
+
 and mouseEvent =
   object
     inherit event
@@ -1062,9 +1069,9 @@ class type inputElement =
 
     method oninput : ('self t, event t) event_listener prop
 
-    method onblur : ('self t, event t) event_listener prop
+    method onblur : ('self t, focusEvent t) event_listener prop
 
-    method onfocus : ('self t, event t) event_listener prop
+    method onfocus : ('self t, focusEvent t) event_listener prop
   end
 
 class type textAreaElement =
@@ -1111,9 +1118,9 @@ class type textAreaElement =
 
     method oninput : ('self t, event t) event_listener prop
 
-    method onblur : ('self t, event t) event_listener prop
+    method onblur : ('self t, focusEvent t) event_listener prop
 
-    method onfocus : ('self t, event t) event_listener prop
+    method onfocus : ('self t, focusEvent t) event_listener prop
   end
 
 class type buttonElement =
@@ -2220,9 +2227,9 @@ class type window =
 
     method onbeforeunload : (window t, event t) event_listener prop
 
-    method onblur : (window t, event t) event_listener prop
+    method onblur : (window t, focusEvent t) event_listener prop
 
-    method onfocus : (window t, event t) event_listener prop
+    method onfocus : (window t, focusEvent t) event_listener prop
 
     method onresize : (window t, event t) event_listener prop
 

--- a/lib/js_of_ocaml/dom_html.mli
+++ b/lib/js_of_ocaml/dom_html.mli
@@ -276,6 +276,13 @@ and ['a] customEvent =
     inherit [element, 'a] Dom.customEvent
   end
 
+and focusEvent =
+  object
+    inherit event
+
+    method relatedTarget : element t opt optdef readonly_prop
+  end
+
 and mouseEvent =
   object
     inherit event
@@ -922,9 +929,9 @@ class type inputElement =
 
     method oninput : ('self t, event t) event_listener prop
 
-    method onblur : ('self t, event t) event_listener prop
+    method onblur : ('self t, focusEvent t) event_listener prop
 
-    method onfocus : ('self t, event t) event_listener prop
+    method onfocus : ('self t, focusEvent t) event_listener prop
   end
 
 class type textAreaElement =
@@ -975,9 +982,9 @@ class type textAreaElement =
 
     method oninput : ('self t, event t) event_listener prop
 
-    method onblur : ('self t, event t) event_listener prop
+    method onblur : ('self t, focusEvent t) event_listener prop
 
-    method onfocus : ('self t, event t) event_listener prop
+    method onfocus : ('self t, focusEvent t) event_listener prop
   end
 
 class type buttonElement =
@@ -2114,9 +2121,9 @@ class type window =
 
     method onbeforeunload : (window t, event t) event_listener prop
 
-    method onblur : (window t, event t) event_listener prop
+    method onblur : (window t, focusEvent t) event_listener prop
 
-    method onfocus : (window t, event t) event_listener prop
+    method onfocus : (window t, focusEvent t) event_listener prop
 
     method onresize : (window t, event t) event_listener prop
 


### PR DESCRIPTION
according to https://developer.mozilla.org/en-US/docs/Web/API/FocusEvent, we have
[focusEvent] type which can be applied to [onblur] and [onfocus]. It
has one extra property than [Event] which is [relatedTarget]. This can
be useful in the case of focusable elements to trace down where the
focus has gone to or where the focus came from.
