### PR TITLE
added bindings for pointer events

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,7 @@
 * Lib: Added support for custom events (#877)
 * Lib: Added support for focus events (#885)
 * Lib: Added `passive` option support for `Lwt_js_events` module
+* Lib: Added bindings for pointer events (#894)
 
 ## Bug fixes
 * Compiler: don't generate source if no-source-map passed (#780)

--- a/lib/js_of_ocaml/dom_html.ml
+++ b/lib/js_of_ocaml/dom_html.ml
@@ -490,6 +490,26 @@ and eventTarget =
 
     method onanimationcancel : ('self t, animationEvent t) event_listener writeonly_prop
 
+    method ongotpointercapture : ('self t, pointerEvent t) event_listener writeonly_prop
+
+    method onlostpointercapture : ('self t, pointerEvent t) event_listener writeonly_prop
+
+    method onpointerenter : ('self t, pointerEvent t) event_listener writeonly_prop
+
+    method onpointercancel : ('self t, pointerEvent t) event_listener writeonly_prop
+
+    method onpointerdown : ('self t, pointerEvent t) event_listener writeonly_prop
+
+    method onpointerleave : ('self t, pointerEvent t) event_listener writeonly_prop
+
+    method onpointermove : ('self t, pointerEvent t) event_listener writeonly_prop
+
+    method onpointerout : ('self t, pointerEvent t) event_listener writeonly_prop
+
+    method onpointerover : ('self t, pointerEvent t) event_listener writeonly_prop
+
+    method onpointerup : ('self t, pointerEvent t) event_listener writeonly_prop
+
     method dispatchEvent : event t -> bool t meth
   end
 
@@ -498,6 +518,31 @@ and popStateEvent =
     inherit event
 
     method state : Js.Unsafe.any readonly_prop
+  end
+
+and pointerEvent =
+  object
+    inherit mouseEvent
+
+    method pointerId : int Js.readonly_prop
+
+    method width : float Js.readonly_prop
+
+    method height : float Js.readonly_prop
+
+    method pressure : float Js.readonly_prop
+
+    method tangentialPressure : float Js.readonly_prop
+
+    method tiltX : int Js.readonly_prop
+
+    method tiltY : int Js.readonly_prop
+
+    method twist : int Js.readonly_prop
+
+    method pointerType : Js.js_string Js.t Js.readonly_prop
+
+    method isPrimary : bool Js.t Js.readonly_prop
   end
 
 and storageEvent =
@@ -797,17 +842,37 @@ module Event = struct
 
   let ended = Dom.Event.make "ended"
 
+  let gotpointercapture = Dom.Event.make "gotpointercapture"
+
   let loadeddata = Dom.Event.make "loadeddata"
 
   let loadedmetadata = Dom.Event.make "loadedmetadata"
 
   let loadstart = Dom.Event.make "loadstart"
 
+  let lostpointercapture = Dom.Event.make "lostpointercapture"
+
   let pause = Dom.Event.make "pause"
 
   let play = Dom.Event.make "play"
 
   let playing = Dom.Event.make "playing"
+
+  let pointerenter = Dom.Event.make "pointerenter"
+
+  let pointercancel = Dom.Event.make "pointercancel"
+
+  let pointerdown = Dom.Event.make "pointerdown"
+
+  let pointerleave = Dom.Event.make "pointerleave"
+
+  let pointermove = Dom.Event.make "pointermove"
+
+  let pointerout = Dom.Event.make "pointerout"
+
+  let pointerover = Dom.Event.make "pointerover"
+
+  let pointerup = Dom.Event.make "pointerup"
 
   let ratechange = Dom.Event.make "ratechange"
 

--- a/lib/js_of_ocaml/dom_html.mli
+++ b/lib/js_of_ocaml/dom_html.mli
@@ -502,6 +502,26 @@ and eventTarget =
 
     method onanimationcancel : ('self t, animationEvent t) event_listener writeonly_prop
 
+    method ongotpointercapture : ('self t, pointerEvent t) event_listener writeonly_prop
+
+    method onlostpointercapture : ('self t, pointerEvent t) event_listener writeonly_prop
+
+    method onpointerenter : ('self t, pointerEvent t) event_listener writeonly_prop
+
+    method onpointercancel : ('self t, pointerEvent t) event_listener writeonly_prop
+
+    method onpointerdown : ('self t, pointerEvent t) event_listener writeonly_prop
+
+    method onpointerleave : ('self t, pointerEvent t) event_listener writeonly_prop
+
+    method onpointermove : ('self t, pointerEvent t) event_listener writeonly_prop
+
+    method onpointerout : ('self t, pointerEvent t) event_listener writeonly_prop
+
+    method onpointerover : ('self t, pointerEvent t) event_listener writeonly_prop
+
+    method onpointerup : ('self t, pointerEvent t) event_listener writeonly_prop
+
     method dispatchEvent : event t -> bool t meth
   end
 
@@ -510,6 +530,31 @@ and popStateEvent =
     inherit event
 
     method state : Js.Unsafe.any readonly_prop
+  end
+
+and pointerEvent =
+  object
+    inherit mouseEvent
+
+    method pointerId : int Js.readonly_prop
+
+    method width : float Js.readonly_prop
+
+    method height : float Js.readonly_prop
+
+    method pressure : float Js.readonly_prop
+
+    method tangentialPressure : float Js.readonly_prop
+
+    method tiltX : int Js.readonly_prop
+
+    method tiltY : int Js.readonly_prop
+
+    method twist : int Js.readonly_prop
+
+    method pointerType : Js.js_string Js.t Js.readonly_prop
+
+    method isPrimary : bool Js.t Js.readonly_prop
   end
 
 and storageEvent =
@@ -2350,17 +2395,37 @@ module Event : sig
 
   val ended : mediaEvent t typ
 
+  val gotpointercapture : pointerEvent t typ
+
   val loadeddata : mediaEvent t typ
 
   val loadedmetadata : mediaEvent t typ
 
   val loadstart : mediaEvent t typ
 
+  val lostpointercapture : pointerEvent t typ
+
   val pause : mediaEvent t typ
 
   val play : mediaEvent t typ
 
   val playing : mediaEvent t typ
+
+  val pointerenter : pointerEvent t typ
+
+  val pointercancel : pointerEvent t typ
+
+  val pointerdown : pointerEvent t typ
+
+  val pointerleave : pointerEvent t typ
+
+  val pointermove : pointerEvent t typ
+
+  val pointerout : pointerEvent t typ
+
+  val pointerover : pointerEvent t typ
+
+  val pointerup : pointerEvent t typ
 
   val ratechange : mediaEvent t typ
 

--- a/lib/lwt/lwt_js_events.ml
+++ b/lib/lwt/lwt_js_events.ml
@@ -344,6 +344,36 @@ let touchend ?use_capture ?passive target =
 let touchcancel ?use_capture ?passive target =
   make_event Dom_html.Event.touchcancel ?use_capture ?passive target
 
+let lostpointercapture ?use_capture ?passive target =
+  make_event Dom_html.Event.lostpointercapture ?use_capture ?passive target
+
+let gotpointercapture ?use_capture ?passive target =
+  make_event Dom_html.Event.gotpointercapture ?use_capture ?passive target
+
+let pointerenter ?use_capture ?passive target =
+  make_event Dom_html.Event.pointerenter ?use_capture ?passive target
+
+let pointercancel ?use_capture ?passive target =
+  make_event Dom_html.Event.pointercancel ?use_capture ?passive target
+
+let pointerdown ?use_capture ?passive target =
+  make_event Dom_html.Event.pointerdown ?use_capture ?passive target
+
+let pointerleave ?use_capture ?passive target =
+  make_event Dom_html.Event.pointerleave ?use_capture ?passive target
+
+let pointermove ?use_capture ?passive target =
+  make_event Dom_html.Event.pointermove ?use_capture ?passive target
+
+let pointerout ?use_capture ?passive target =
+  make_event Dom_html.Event.pointerout ?use_capture ?passive target
+
+let pointerover ?use_capture ?passive target =
+  make_event Dom_html.Event.pointerover ?use_capture ?passive target
+
+let pointerup ?use_capture ?passive target =
+  make_event Dom_html.Event.pointerup ?use_capture ?passive target
+
 let clicks ?cancel_handler ?use_capture ?passive t =
   seq_loop click ?cancel_handler ?use_capture ?passive t
 
@@ -496,6 +526,36 @@ let volumechanges ?cancel_handler ?use_capture ?passive t =
 
 let waitings ?cancel_handler ?use_capture ?passive t =
   seq_loop waiting ?cancel_handler ?use_capture ?passive t
+
+let lostpointercaptures ?cancel_handler ?use_capture ?passive t =
+  seq_loop lostpointercapture ?cancel_handler ?use_capture ?passive t
+
+let gotpointercaptures ?cancel_handler ?use_capture ?passive t =
+  seq_loop gotpointercapture ?cancel_handler ?use_capture ?passive t
+
+let pointerenters ?cancel_handler ?use_capture ?passive t =
+  seq_loop pointerenter ?cancel_handler ?use_capture ?passive t
+
+let pointercancels ?cancel_handler ?use_capture ?passive t =
+  seq_loop pointercancel ?cancel_handler ?use_capture ?passive t
+
+let pointerdowns ?cancel_handler ?use_capture ?passive t =
+  seq_loop pointerdown ?cancel_handler ?use_capture ?passive t
+
+let pointerleaves ?cancel_handler ?use_capture ?passive t =
+  seq_loop pointerleave ?cancel_handler ?use_capture ?passive t
+
+let pointermoves ?cancel_handler ?use_capture ?passive t =
+  seq_loop pointermove ?cancel_handler ?use_capture ?passive t
+
+let pointerouts ?cancel_handler ?use_capture ?passive t =
+  seq_loop pointerout ?cancel_handler ?use_capture ?passive t
+
+let pointerovers ?cancel_handler ?use_capture ?passive t =
+  seq_loop pointerover ?cancel_handler ?use_capture ?passive t
+
+let pointerups ?cancel_handler ?use_capture ?passive t =
+  seq_loop pointerup ?cancel_handler ?use_capture ?passive t
 
 let transition_evn =
   lazy

--- a/lib/lwt/lwt_js_events.mli
+++ b/lib/lwt/lwt_js_events.mli
@@ -368,6 +368,66 @@ val touchcancel :
   -> #Dom_html.eventTarget Js.t
   -> Dom_html.touchEvent Js.t Lwt.t
 
+val lostpointercapture :
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.pointerEvent Js.t Lwt.t
+
+val gotpointercapture :
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.pointerEvent Js.t Lwt.t
+
+val pointerenter :
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.pointerEvent Js.t Lwt.t
+
+val pointercancel :
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.pointerEvent Js.t Lwt.t
+
+val pointerdown :
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.pointerEvent Js.t Lwt.t
+
+val pointerleave :
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.pointerEvent Js.t Lwt.t
+
+val pointermove :
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.pointerEvent Js.t Lwt.t
+
+val pointerout :
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.pointerEvent Js.t Lwt.t
+
+val pointerover :
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.pointerEvent Js.t Lwt.t
+
+val pointerup :
+     ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> Dom_html.pointerEvent Js.t Lwt.t
+
 val transitionend : #Dom_html.eventTarget Js.t -> unit Lwt.t
 (** Returns when a CSS transition terminates on the element. *)
 
@@ -909,6 +969,86 @@ val waitings :
   -> ?passive:bool
   -> #Dom_html.eventTarget Js.t
   -> (Dom_html.event Js.t -> unit Lwt.t -> unit Lwt.t)
+  -> unit Lwt.t
+
+val lostpointercaptures :
+     ?cancel_handler:bool
+  -> ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> (Dom_html.pointerEvent Js.t -> unit Lwt.t -> unit Lwt.t)
+  -> unit Lwt.t
+
+val gotpointercaptures :
+     ?cancel_handler:bool
+  -> ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> (Dom_html.pointerEvent Js.t -> unit Lwt.t -> unit Lwt.t)
+  -> unit Lwt.t
+
+val pointerenters :
+     ?cancel_handler:bool
+  -> ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> (Dom_html.pointerEvent Js.t -> unit Lwt.t -> unit Lwt.t)
+  -> unit Lwt.t
+
+val pointercancels :
+     ?cancel_handler:bool
+  -> ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> (Dom_html.pointerEvent Js.t -> unit Lwt.t -> unit Lwt.t)
+  -> unit Lwt.t
+
+val pointerdowns :
+     ?cancel_handler:bool
+  -> ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> (Dom_html.pointerEvent Js.t -> unit Lwt.t -> unit Lwt.t)
+  -> unit Lwt.t
+
+val pointerleaves :
+     ?cancel_handler:bool
+  -> ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> (Dom_html.pointerEvent Js.t -> unit Lwt.t -> unit Lwt.t)
+  -> unit Lwt.t
+
+val pointermoves :
+     ?cancel_handler:bool
+  -> ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> (Dom_html.pointerEvent Js.t -> unit Lwt.t -> unit Lwt.t)
+  -> unit Lwt.t
+
+val pointerouts :
+     ?cancel_handler:bool
+  -> ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> (Dom_html.pointerEvent Js.t -> unit Lwt.t -> unit Lwt.t)
+  -> unit Lwt.t
+
+val pointerovers :
+     ?cancel_handler:bool
+  -> ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> (Dom_html.pointerEvent Js.t -> unit Lwt.t -> unit Lwt.t)
+  -> unit Lwt.t
+
+val pointerups :
+     ?cancel_handler:bool
+  -> ?use_capture:bool
+  -> ?passive:bool
+  -> #Dom_html.eventTarget Js.t
+  -> (Dom_html.pointerEvent Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
 
 val request_animation_frame : unit -> unit Lwt.t


### PR DESCRIPTION
Added bindings for pointer events to `Dom_html` and `Lwt_js_events` modules.
See [W3C](https://www.w3.org/TR/pointerevents/#pointerevent-interface) for pointer events API.