### PR TITLE
Runtime: change representation of int64 

### DIFF
--- a/lib/deriving_json/tests/json_convert.ml
+++ b/lib/deriving_json/tests/json_convert.ml
@@ -68,3 +68,9 @@ type w = int seq [@@deriving json]
 let%expect_test _ =
   test w_json (SS (1, SS (2, SS (3, ZZ))));
   [%expect {||}]
+
+type i64 = int64 [@@deriving json]
+
+let%expect_test _ =
+  test i64_json 100000000000000000L;
+  [%expect {||}]

--- a/lib/js_of_ocaml/js_of_ocaml_stubs.c
+++ b/lib/js_of_ocaml/js_of_ocaml_stubs.c
@@ -20,6 +20,10 @@ void caml_create_file () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_create_file!\n");
   exit(1);
 }
+void caml_int64_create_lo_mi_hi () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_int64_create_lo_mi_hi!\n");
+  exit(1);
+}
 void caml_js_call () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_call!\n");
   exit(1);

--- a/lib/js_of_ocaml/json.ml
+++ b/lib/js_of_ocaml/json.ml
@@ -42,7 +42,8 @@ external to_byte_MlBytes : js_string t -> string = "caml_js_to_byte_string"
 
 external to_byte_jsstring : 'a t -> js_string t = "caml_jsbytes_of_string"
 
-external create_int64_lo_mi_hi : int -> int -> int -> Int64.t = "caml_int64_create_lo_mi_hi"
+external create_int64_lo_mi_hi : int -> int -> int -> Int64.t
+  = "caml_int64_create_lo_mi_hi"
 
 let input_reviver =
   let reviver _this _key value =
@@ -52,11 +53,11 @@ let input_reviver =
             && value##.length == 4
             && Unsafe.get value 0 == 255
     then
-      Obj.repr (
-          create_int64_lo_mi_hi
-            (Unsafe.get value 1)
-            (Unsafe.get value 2)
-            (Unsafe.get value 3))
+      Obj.repr
+        (create_int64_lo_mi_hi
+           (Unsafe.get value 1)
+           (Unsafe.get value 2)
+           (Unsafe.get value 3))
     else Obj.repr value
   in
   wrap_meth_callback reviver
@@ -73,7 +74,7 @@ let mlString_constr =
   let dummy_obj : obj t = Obj.magic dummy_string in
   dummy_obj##.constructor
 
-  let mlInt64_constr =
+let mlInt64_constr =
   let dummy_int64 = 1L in
   let dummy_obj : obj t = Obj.magic dummy_int64 in
   dummy_obj##.constructor
@@ -82,7 +83,7 @@ let output_reviver _key value =
   if instanceof value mlString_constr
   then Obj.repr (to_byte_jsstring (Unsafe.coerce value))
   else if instanceof value mlInt64_constr
-  then Obj.repr (array [|255; value##.lo;value##.mi;value##.hi |])
+  then Obj.repr (array [| 255; value##.lo; value##.mi; value##.hi |])
   else Obj.repr value
 
 let output obj = json##stringify_ obj output_reviver

--- a/lib/js_of_ocaml/json.ml
+++ b/lib/js_of_ocaml/json.ml
@@ -46,11 +46,11 @@ external create_int64_lo_mi_hi : int -> int -> int -> Int64.t
   = "caml_int64_create_lo_mi_hi"
 
 let input_reviver =
-  let reviver _this _key value =
+  let reviver _this _key (value : Unsafe.any) : Obj.t =
     if unsafe_equals (typeof value) (typeof (string "foo"))
     then Obj.repr (to_byte_MlBytes (Unsafe.coerce value))
-    else if unsafe_equals (typeof value) (string "object")
-            && value##.length == 4
+    else if instanceof value Js.array_empty
+            && (Unsafe.coerce value)##.length == 4
             && Unsafe.get value 0 == 255
     then
       Obj.repr
@@ -79,11 +79,13 @@ let mlInt64_constr =
   let dummy_obj : obj t = Obj.magic dummy_int64 in
   dummy_obj##.constructor
 
-let output_reviver _key value =
+let output_reviver _key (value : Unsafe.any) : Obj.t =
   if instanceof value mlString_constr
   then Obj.repr (to_byte_jsstring (Unsafe.coerce value))
   else if instanceof value mlInt64_constr
-  then Obj.repr (array [| 255; value##.lo; value##.mi; value##.hi |])
+  then
+    let value = Unsafe.coerce value in
+    Obj.repr (array [| 255; value##.lo; value##.mi; value##.hi |])
   else Obj.repr value
 
 let output obj = json##stringify_ obj output_reviver

--- a/runtime/ieee_754.js
+++ b/runtime/ieee_754.js
@@ -126,9 +126,9 @@ function caml_hexstring_of_float (x, prec, style) {
 
 //Provides: caml_int64_float_of_bits const
 function caml_int64_float_of_bits (x) {
-  var lo = x[1];
-  var mi = x[2];
-  var hi = x[3];
+  var lo = x.lo;
+  var mi = x.mi;
+  var hi = x.hi;
   var exp = (hi & 0x7fff) >> 4;
   if (exp == 2047) {
     if ((lo|mi|(hi&0xf)) == 0)

--- a/runtime/int64.js
+++ b/runtime/int64.js
@@ -206,10 +206,10 @@ MlInt64.prototype.toArray = function () {
           this.lo & 0xff];
 }
 MlInt64.prototype.lo32 = function () {
-  return this.lo | (this.mi << 24);
+  return this.lo | ((this.mi & 0xff) << 24);
 }
 MlInt64.prototype.hi32 = function () {
-  return (this.mi >>> 8) | (this.hi << 16);
+  return ((this.mi >>> 8) & 0xffff) | (this.hi << 16);
 }
 
 //Provides: caml_int64_ult const
@@ -358,13 +358,10 @@ function caml_int64_create_lo_hi(lo, hi){
     (hi >>> 16) & 0xffff);
 }
 //Provides: caml_int64_lo32 const
-function caml_int64_lo32(v){
-  return v.lo | ((v.mi & 0xff) << 24);
-}
+function caml_int64_lo32(v){ return v.lo32() }
+
 //Provides: caml_int64_hi32 const
-function caml_int64_hi32(v){
-  return ((v.mi >>> 8) & 0xffff) | (v.hi << 16);
-}
+function caml_int64_hi32(v){ return v.hi32() }
 
 //Provides: caml_int64_of_bytes const
 //Requires: MlInt64

--- a/runtime/marshal.js
+++ b/runtime/marshal.js
@@ -512,9 +512,9 @@ var caml_output_val = function (){
     }
 
     function extern_rec (v) {
-      if (v.caml_custom || (v instanceof Array && v[0] === 255)) {
+      if (v.caml_custom) {
         if (memo(v)) return;
-        var name = v.caml_custom || "_j";
+        var name = v.caml_custom;
         var ops = caml_custom_ops[name];
         var sz_32_64 = [0,0];
         if(!ops.serialize)

--- a/runtime/stdlib.js
+++ b/runtime/stdlib.js
@@ -895,11 +895,6 @@ function caml_hash_univ_param (count, limit, obj) {
       case 250:
         // Forward
         limit++; hash_aux(obj); break;
-      case 255:
-        // Int64
-        count --;
-        hash_accu = (hash_accu * 65599 + obj[1] + (obj[2] << 24)) | 0;
-        break;
       default:
         count --;
         hash_accu = (hash_accu * 19 + obj[0]) | 0;
@@ -1042,8 +1037,8 @@ function caml_hash_mix_string(h, v) {
 
 //Provides: caml_hash mutable
 //Requires: MlBytes
-//Requires: caml_int64_bits_of_float, caml_hash_mix_int, caml_hash_mix_final
-//Requires: caml_hash_mix_int64, caml_hash_mix_float, caml_hash_mix_string, caml_custom_ops
+//Requires: caml_hash_mix_int, caml_hash_mix_final
+//Requires: caml_hash_mix_float, caml_hash_mix_string, caml_custom_ops
 function caml_hash (count, limit, seed, obj) {
   var queue, rd, wr, sz, num, h, v, i, len;
   sz = limit;
@@ -1070,11 +1065,6 @@ function caml_hash (count, limit, seed, obj) {
       case 250:
         // Forward
         queue[--rd] = v[1];
-        break;
-      case 255:
-        // Int64
-        h = caml_hash_mix_int64 (h, v);
-        num --;
         break;
       default:
         var tag = ((v.length - 1) << 10) | v[0];

--- a/runtime/stdlib.js
+++ b/runtime/stdlib.js
@@ -429,7 +429,7 @@ function caml_compare_val_number_custom(num, custom, swap, total) {
 }
 
 //Provides: caml_compare_val (const, const, const)
-//Requires: caml_int64_compare, caml_int_compare, caml_string_compare
+//Requires: caml_int_compare, caml_string_compare
 //Requires: caml_invalid_argument, caml_compare_val_get_custom, caml_compare_val_tag
 //Requires: caml_compare_val_number_custom
 function caml_compare_val (a, b, total) {
@@ -495,12 +495,8 @@ function caml_compare_val (a, b, total) {
         // Cannot happen, handled above
         caml_invalid_argument("equal: got Double_array_tag, should not happen");
         break
-      case 255: // Int64
-        // Int64 is the only custom block implemented this way,
-        // TODO: We should rewrite the implementation and follow
-        // what we do for other custom blocks: zarith, bigint, bigarray, ...
-        var x = caml_int64_compare(a, b);
-        if (x != 0) return (x | 0);
+      case 255: // Custom_tag
+        caml_invalid_argument("equal: got Custom_tag, should not happen");
         break;
       case 1247: // Function
         caml_invalid_argument("compare: functional value");


### PR DESCRIPTION
Before we can merge this PR,
- we need to release 3.5.0 first
- update packages that depend on the current representation

- [x] zarith_js_stubs
- [x] update base