### PR TITLE
Correct build alias from DEFAULT to default in examples/README.md

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -2,12 +2,12 @@
 
 Build all projects:
 ```
-$> dune build @examples/DEFAULT
+$> dune build @examples/default
 ```
 
 Or a single one:
 ```
-$> dune build @examples/<path-to-example-project>/DEFAULT
+$> dune build @examples/<path-to-example-project>/default
 ```
 
 Compilation artifacts can be found in `${REPO_ROOT}/_build/default/examples/`.


### PR DESCRIPTION
Running the command as given in the readme resulted in

```
$ dune build @examples/DEFAULT
Error: Alias "DEFAULT" specified on the command line is empty.
It is not defined in examples or any of its descendants.
```

but the lower case alias worked as expected (as should be the case, given the dune files).