### PR TITLE
Dynlink/toplevel: export all units when no export file is specified

### DIFF
--- a/compiler/lib/parse_bytecode.ml
+++ b/compiler/lib/parse_bytecode.ml
@@ -2166,7 +2166,7 @@ let from_exe
     with Not_found -> (
       match exported_unit with
       | Some l -> List.mem s ~set:l
-      | None -> false)
+      | None -> true)
   in
   let crcs = List.filter ~f:(fun (unit, _crc) -> keep unit) orig_crcs in
   let symbols =


### PR DESCRIPTION
That was the behavior of previous versions of Js_of_ocaml.