### PR TITLE
add stub for unix_isatty

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 * Misc: support for ocaml 4.10
 * Misc: Cleanup Meta files (e.g. `js_of_ocaml.tyxml` is no longer valid library name)
 * Runtime: remove many old polyfill
+* Runtime: add unix_isatty
 
 ## Bug fixes
 

--- a/runtime/unix.js
+++ b/runtime/unix.js
@@ -53,3 +53,14 @@ function win_cleanup() {}
 
 //Provides: win_handle_fd const
 function win_handle_fd(x) {return x;}
+
+//Provides: unix_isatty 
+//Requires: fs_node_supported
+function unix_isatty(fileDescriptor) {
+  if(fs_node_supported()) {
+    var tty = require('tty');
+    return tty.isatty(fileDescriptor);
+  } else {
+    return false;
+  }
+}


### PR DESCRIPTION
Addresses https://github.com/ocsigen/js_of_ocaml/issues/913 and https://github.com/facebookexperimental/reason-native/issues/207

I tested this by running some JS tests compiled with Rely normally in a terminal and by piping the output to `cat` which should not be a tty. I also console logged the result of calling Unix.isatty on Unix.stdin to verify the function was returning the correct values. I thought I would need to provide values for Unix.stdin etc, but it was not necessary. I verified that the unix.isatty returns false and does not error in chrome as well.

I couldn't figure out the test structure of this repo and this change is fairly simple, so I did not add any automated tests, but could do so if desired with some help.

![image](https://user-images.githubusercontent.com/5252755/69285550-2a9fdb80-0bbf-11ea-814f-fde5e632982e.png)

![image](https://user-images.githubusercontent.com/5252755/69285499-0cd27680-0bbf-11ea-8aac-47e9f7b5bf37.png)

![image](https://user-images.githubusercontent.com/5252755/69285665-6d61b380-0bbf-11ea-907e-5972652df128.png)

