### PR TITLE
Fix the type of blur and focus event to be focusEvent

### DIFF
--- a/lib/js_of_ocaml/dom_html.mli
+++ b/lib/js_of_ocaml/dom_html.mli
@@ -2281,9 +2281,9 @@ module Event : sig
 
   val scroll : event t typ
 
-  val focus : event t typ
+  val focus : focusEvent t typ
 
-  val blur : event t typ
+  val blur : focusEvent t typ
 
   val load : event t typ
 


### PR DESCRIPTION
When adding focusEvent to event type, I forgot to include the update for the event  type in dom_html. This pull request updates that.