### PR TITLE
Hotfix runtime stdlib.js

### DIFF
--- a/compiler/tests/call_gen.ml
+++ b/compiler/tests/call_gen.ml
@@ -20,8 +20,8 @@
 open Util
 
 module M1 = struct
-let code =
-  {|
+  let code =
+    {|
   let f_prime g = g 1 2
   let f g = f_prime g 3 4
   (* [g] will be unknown as long as [f] is not inlined. *)
@@ -39,35 +39,35 @@ let code =
   let () = m 8 10; print_newline ()
 |}
 
-let%expect_test "executed code" =
-  compile_and_run code;
-  [%expect {|
+  let%expect_test "executed code" =
+    compile_and_run code;
+    [%expect {|
     10
     10
     14
     25 |}]
 
-let%expect_test "generated code" =
-  let generated =
-    code
-    |> Filetype.ocaml_text_of_string
-    |> Filetype.write_ocaml
-    |> compile_ocaml_to_cmo
-    |> compile_cmo_to_javascript ~pretty:true
-    |> fst
-    |> parse_js
-  in
-  print_fun_decl generated (Some "f");
-  print_fun_decl generated (Some "f_prime");
-  print_fun_decl generated (Some "g");
-  print_fun_decl generated (Some "h");
-  print_fun_decl generated (Some "k");
-  print_fun_decl generated (Some "l");
-  print_fun_decl generated (Some "m");
-  print_fun_decl generated (Some "caml_call1");
-  print_fun_decl generated (Some "caml_call2");
-  [%expect
-    {|
+  let%expect_test "generated code" =
+    let generated =
+      code
+      |> Filetype.ocaml_text_of_string
+      |> Filetype.write_ocaml
+      |> compile_ocaml_to_cmo
+      |> compile_cmo_to_javascript ~pretty:true
+      |> fst
+      |> parse_js
+    in
+    print_fun_decl generated (Some "f");
+    print_fun_decl generated (Some "f_prime");
+    print_fun_decl generated (Some "g");
+    print_fun_decl generated (Some "h");
+    print_fun_decl generated (Some "k");
+    print_fun_decl generated (Some "l");
+    print_fun_decl generated (Some "m");
+    print_fun_decl generated (Some "caml_call1");
+    print_fun_decl generated (Some "caml_call2");
+    [%expect
+      {|
     function f(g){return caml_call2(f_prime(g),3,4)}
     function f_prime(g){return caml_call2(g,1,2)}
     function g(param)
@@ -90,7 +90,8 @@ let%expect_test "generated code" =
 end
 
 module M2 = struct
-  let code = {|
+  let code =
+    {|
   let f _ a b c d e (_f: int -> int -> int -> int -> int -> unit -> unit) =
       print_int (a + b + c + d + e);
       print_newline ();;
@@ -117,14 +118,14 @@ module M2 = struct
     print_fun_decl generated (Some "f_prime");
     print_fun_decl generated (Some "f_prime_prime");
     print_fun_decl generated (Some "g");
-    [%expect {|
+    [%expect
+      {|
       function f(param,a,b,c,d,e,f)
        {caml_call1(Stdlib[44],(((a + b | 0) + c | 0) + d | 0) + e | 0);
         return caml_call1(Stdlib[47],0)}
       function f_prime(f){return caml_call1(f,1)}
       function f_prime_prime(f){return caml_call1(f,0)}
       function g(a,b,c,d,e,f){return caml_call1(Stdlib[2],cst_printed_g)} |}]
-  ;;
 
   let%expect_test _ =
     compile_and_run code;

--- a/compiler/tests/call_gen.ml
+++ b/compiler/tests/call_gen.ml
@@ -90,15 +90,6 @@ let%expect_test "generated code" =
 end
 
 module M2 = struct
-   (* XCR toverby for hheuzard: I can't get this to reproduce.  Even
-      though 'f' is not inlined, calls to 'f_prime' and 'f_prime_prime'
-      know the arity.  My intuition for what causes arity information to
-      be lost appears to be misguided.
-
-      hheuzard: I updated the test to make f unknown. It seems to reproduce the issue
-      correctly. I'll let you update the GPR.
-   *)
-
   let code = {|
   let f _ a b c d e (_f: int -> int -> int -> int -> int -> unit -> unit) =
       print_int (a + b + c + d + e);

--- a/compiler/tests/call_gen.ml
+++ b/compiler/tests/call_gen.ml
@@ -129,10 +129,8 @@ module M2 = struct
   let%expect_test _ =
     compile_and_run code;
     [%expect {|
-      process exited with error code 1
-       /j/office/app/nodejs/prod/v10.16.3/bin/node /usr/local/home/hheuzard/workspaces/jane/js-of-ocaml/callgen-repro/+share+/.jenga.tmp/jsoo_test5379f7.js
-      /usr/local/home/hheuzard/workspaces/jane/js-of-ocaml/callgen-repro/+share+/.jenga.tmp/jsoo_test5379f7.js:2273
-          function failwith(s){throw [0,Failure,s]}
-                               ^
-      0,248,Failure,-3,printed g! |}]
+      15
+      20
+      15
+      20 |}]
 end

--- a/runtime/stdlib.js
+++ b/runtime/stdlib.js
@@ -89,15 +89,15 @@ function caml_call_gen(f, args) {
       case 5: return function (a, b, c, d, e) {
         return f.apply(null, args.concat([a, b, c, d, e]));
       }
-      case 6: return function (a, b, c, d, e, f) {
-        return f.apply(null, args.concat([a, b, c, d, e, f]));
+      case 6: return function (a, b, c, d, e, f_) {
+        return f.apply(null, args.concat([a, b, c, d, e, f_]));
       }
-      case 7: return function (a, b, c, d, e, f, g) {
-        return f.apply(null, args.concat([a, b, c, d, e, f, g]));
+      case 7: return function (a, b, c, d, e, f_, g) {
+        return f.apply(null, args.concat([a, b, c, d, e, f_, g]));
       }
       default:
-        return function (a, b, c, d, e, f, g, h) {
-          return caml_call_gen(f, args.concat([a, b, c, d, e, f, g, h]));
+        return function (a, b, c, d, e, f_, g, h) {
+          return caml_call_gen(f, args.concat([a, b, c, d, e, f_, g, h]));
         };
       }
     }

--- a/runtime/stdlib.js
+++ b/runtime/stdlib.js
@@ -74,30 +74,30 @@ function caml_call_gen(f, args) {
     }
     else {
       switch (d) {
-      case 1: return function (a) {
-        return f.apply(null, args.concat([a]));
+      case 1: return function (a1) {
+        return f.apply(null, args.concat([a1]));
       }
-      case 2: return function (a, b) {
-        return f.apply(null, args.concat([a, b]));
+      case 2: return function (a1, a2) {
+        return f.apply(null, args.concat([a1, a2]));
       }
-      case 3: return function (a, b, c) {
-        return f.apply(null, args.concat([a, b, c]));
+      case 3: return function (a1, a2, a3) {
+        return f.apply(null, args.concat([a1, a2, a3]));
       }
-      case 4: return function (a, b, c, d) {
-        return f.apply(null, args.concat([a, b, c, d]));
+      case 4: return function (a1, a2, a3, a4) {
+        return f.apply(null, args.concat([a1, a2, a3, a4]));
       }
-      case 5: return function (a, b, c, d, e) {
-        return f.apply(null, args.concat([a, b, c, d, e]));
+      case 5: return function (a1, a2, a3, a4, a5) {
+        return f.apply(null, args.concat([a1, a2, a3, a4, a5]));
       }
-      case 6: return function (a, b, c, d, e, f_) {
-        return f.apply(null, args.concat([a, b, c, d, e, f_]));
+      case 6: return function (a1, a2, a3, a4, a5, a6) {
+        return f.apply(null, args.concat([a1, a2, a3, a4, a5, a6]));
       }
-      case 7: return function (a, b, c, d, e, f_, g) {
-        return f.apply(null, args.concat([a, b, c, d, e, f_, g]));
+      case 7: return function (a1, a2, a3, a4, a5, a6, a7) {
+        return f.apply(null, args.concat([a1, a2, a3, a4, a5, a6, a7]));
       }
       default:
-        return function (a, b, c, d, e, f_, g, h) {
-          return caml_call_gen(f, args.concat([a, b, c, d, e, f_, g, h]));
+        return function (a1, a2, a3, a4, a5, a6, a7, a8) {
+          return caml_call_gen(f, args.concat([a1, a2, a3, a4, a5, a6, a7, a8]));
         };
       }
     }


### PR DESCRIPTION
A bug in the caml_callgen code was introduced in jane/js-of-ocaml/micro-optimze-runtime.                                                                                                                           
                                                                                                                                                                                                                     
  This bug manifests itself in this call-stack:                                                                                                                                                                      
                                                                                                                                                                                                                     
  > Uncaught TypeError: f.apply is not a function                                                                                                                                                                    
  >    at caml_call_gen (stdlib.js:72)                                                                                                                                                                               
  >    at stdlib.js:100                                                                                                                                                                                              
  >    at Object.caml_call_gen (stdlib.js:72)                                                                                                                                                                        
  >    at caml_call9 (style.ml:0)                                                                                                                                                                                    
                                                                                                                                                                                                                     
  The bug is caused by aliasing a variable in the callgen code, overwriting the                                                                                                                                      
  function which will be called with one of its arguments.                                                                                                                                                           
                                                                                                                                                                                                                     
  The bug can be triggered with the following:                                                                                                                                                                       
  1. Call a function that has an arity of 7 with 1 argument (currying the rest).                                                                                                                                     
  2. Call the resulting function with all 6 remaining arguments.                                                                                                                                                     
  3. Instead of actually calling the function, it will (attempt to) call the 6th                                                                                                                                     
     argument with the args list.                   