### PR TITLE
Compiler: fix vardecl optim

### DIFF
--- a/compiler/lib/config.ml
+++ b/compiler/lib/config.ml
@@ -82,7 +82,6 @@ module Flag = struct
 
   let check_magic = o ~name:"check-magic-number" ~default:true
 
-  (* this does not optimize properly *)
   let compact_vardecl = o ~name:"vardecl" ~default:false
 end
 

--- a/compiler/lib/javascript.ml
+++ b/compiler/lib/javascript.ml
@@ -284,11 +284,11 @@ and source_element =
 let compare_ident t1 t2 =
   match t1, t2 with
   | V v1, V v2 -> Code.Var.compare v1 v2
-  | S { name = s1; var = v1; loc = l1 }, S { name = s2; var = v2; loc = l2 } -> (
+  | S { name = s1; var = v1; loc = _l1 }, S { name = s2; var = v2; loc = _l2 } -> (
       match String.compare s1 s2 with
       | 0 -> (
           match Option.compare Code.Var.compare v1 v2 with
-          | 0 -> Poly.compare l1 l2
+          | 0 -> 0
           | n -> n)
       | n -> n)
   | S _, V _ -> -1

--- a/compiler/lib/javascript.ml
+++ b/compiler/lib/javascript.ml
@@ -284,12 +284,10 @@ and source_element =
 let compare_ident t1 t2 =
   match t1, t2 with
   | V v1, V v2 -> Code.Var.compare v1 v2
-  | S { name = s1; var = v1; loc = _l1 }, S { name = s2; var = v2; loc = _l2 } -> (
+  | S { name = s1; var = v1; loc = _ }, S { name = s2; var = v2; loc = _ } -> (
+      (* ignore locations *)
       match String.compare s1 s2 with
-      | 0 -> (
-          match Option.compare Code.Var.compare v1 v2 with
-          | 0 -> 0
-          | n -> n)
+      | 0 -> Option.compare Code.Var.compare v1 v2
       | n -> n)
   | S _, V _ -> -1
   | V _, S _ -> 1

--- a/compiler/lib/js_traverse.ml
+++ b/compiler/lib/js_traverse.ml
@@ -702,6 +702,13 @@ class compact_vardecl =
             | _ -> (x, loc) :: acc)
       in
       List.rev l
+
+    method program p =
+      let p = super#program p in
+      m#merge_info m;
+      let all = IdentSet.diff insert_ exc_ in
+      let body = m#pack all p in
+      body
   end
 
 class clean =

--- a/compiler/tests/util/util.ml
+++ b/compiler/tests/util/util.ml
@@ -185,8 +185,8 @@ let compile_to_javascript ?(flags = []) ~pretty ~sourcemap file =
 let compile_bc_to_javascript ?flags ?(pretty = true) ?(sourcemap = true) file =
   Filetype.path_of_bc_file file |> compile_to_javascript ?flags ~pretty ~sourcemap
 
-let compile_cmo_to_javascript ?(pretty = true) ?(sourcemap = true) file =
-  Filetype.path_of_cmo_file file |> compile_to_javascript ~pretty ~sourcemap
+let compile_cmo_to_javascript ?flags ?(pretty = true) ?(sourcemap = true) file =
+  Filetype.path_of_cmo_file file |> compile_to_javascript ?flags ~pretty ~sourcemap
 
 let compile_ocaml_to_cmo ?(debug = true) file =
   let file = Filetype.path_of_ocaml_file file in

--- a/compiler/tests/util/util.mli
+++ b/compiler/tests/util/util.mli
@@ -30,7 +30,8 @@ val compile_ocaml_to_bc : Filetype.ocaml_file -> Filetype.bc_file
 val compile_lib : Filetype.cmo_file list -> string -> Filetype.cmo_file
 
 val compile_cmo_to_javascript :
-     ?pretty:bool
+     ?flags:string list
+  -> ?pretty:bool
   -> ?sourcemap:bool
   -> Filetype.cmo_file
   -> Filetype.js_file * Filetype.sourcemap_file option

--- a/compiler/tests/variable_declaration_output.ml
+++ b/compiler/tests/variable_declaration_output.ml
@@ -73,25 +73,46 @@ let%expect_test _ =
       {|
     let match_expr = function
       | [] | [None] | _ :: None :: _ -> 1
-      | _ -> 2
+      | [ Some None ] -> 2
+      | [ Some (Some 2) ] -> 3
+      | _ -> 4
     |}
   in
   print_fun_decl (program ~enable:true) (Some "match_expr");
   [%expect
     {|
     function match_expr(param)
-     {var switch$1,switch$0,_a_;
+     {var switch$1,switch$0,_c_,_b_,_a_;
       if(param)
-       {switch$0 = param[1]?0:param[2]?0:1;
+       {_a_ = param[1];
+        if(_a_)
+         {_b_ = _a_[1];
+          if(_b_)
+           if(2 === _b_[1]){if(! param[2])return 3;switch$0 = 0}else switch$0 = 0;
+          else
+           {if(! param[2])return 2;switch$0 = 0}}
+        else
+         switch$0 = param[2]?0:1;
         if(! switch$0)
-         {_a_ = param[2];switch$1 = _a_?_a_[1]?0:1:0;if(! switch$1)return 2}}
+         {_c_ = param[2];switch$1 = _c_?_c_[1]?0:1:0;if(! switch$1)return 4}}
       return 1} |}];
   print_fun_decl (program ~enable:false) (Some "match_expr");
   [%expect
     {|
     function match_expr(param)
      {if(param)
-       {var switch$0=param[1]?0:param[2]?0:1;
+       {var _a_=param[1];
+        if(_a_)
+         {var _b_=_a_[1];
+          if(_b_)
+           if(2 === _b_[1])
+            {if(! param[2])return 3;var switch$0=0}
+           else
+            var switch$0=0;
+          else
+           {if(! param[2])return 2;var switch$0=0}}
+        else
+         var switch$0=param[2]?0:1;
         if(! switch$0)
-         {var _a_=param[2],switch$1=_a_?_a_[1]?0:1:0;if(! switch$1)return 2}}
+         {var _c_=param[2],switch$1=_c_?_c_[1]?0:1:0;if(! switch$1)return 4}}
       return 1} |}]


### PR DESCRIPTION
Attempt to fix the `--enable vardecl` option.
- [x] add some tests

partially fix #945 