### PR TITLE
Create stdlib_modern.js

### DIFF
--- a/compiler/jsoo_minify.ml
+++ b/compiler/jsoo_minify.ml
@@ -50,8 +50,8 @@ let f { MinifyArg.common; output_file; use_stdin; files } =
       match pi with
       | { Parse_info.name = Some src; line; col; _ }
       | { Parse_info.src = Some src; line; col; _ } ->
-          error "error at file:%S l:%d col:%d" src line col
-      | { Parse_info.line; col; _ } -> error "error at l:%d col:%d" line col
+          error "error at file:%S l:%d col:%d" src (line + 1) col
+      | { Parse_info.line; col; _ } -> error "error at l:%d col:%d" (line + 1) col
     in
     let p =
       List.flatten

--- a/compiler/lib/linker.ml
+++ b/compiler/lib/linker.ml
@@ -125,7 +125,7 @@ let parse_from_lex ~filename lex =
             "cannot parse file %S (orig:%S from l:%d, c:%d)@."
             filename
             name
-            pi.Parse_info.line
+            (pi.Parse_info.line + 1)
             pi.Parse_info.col)
   in
   res

--- a/compiler/tests/js_parser_printer.ml
+++ b/compiler/tests/js_parser_printer.ml
@@ -100,3 +100,18 @@ let%expect_test "preserve number literals in property_name" =
     var number_as_key = { 100000000000000000000 : 2 }; |};
   [%expect {|
     var number_as_key={100000000000000000000:2}; |}]
+
+let%expect_test "error reporting" =
+  (try print ~compact:false {|
+    var x = 2;
+    {
+    var = 5;
+    }
+    |}
+   with Js_of_ocaml_compiler.Parse_js.Parsing_error pi ->
+     Printf.printf
+       "cannot parse js (from l:%d, c:%d)@."
+       (pi.Parse_info.line + 1)
+       pi.Parse_info.col);
+  [%expect {|
+    cannot parse js (from l:4, c:8)@. |}]

--- a/runtime/dune
+++ b/runtime/dune
@@ -31,6 +31,11 @@
     %{dep:weak.js}
 )))
 
+(alias 
+  (name runtest)
+  (deps stdlib_modern.js)
+  (action (run %{bin:jsoo_minify} %{dep:stdlib_modern.js})))
+
 (install
   (section lib)
   (package js_of_ocaml-compiler)

--- a/runtime/stdlib.js
+++ b/runtime/stdlib.js
@@ -21,17 +21,12 @@
 
 //Provides: raw_array_sub
 function raw_array_sub (a,i,l) {
-  var b = new Array(l);
-  for(var j = 0; j < l; j++) b[j] = a[i+j];
-  return b
+  return a.slice(i, i + l);
 }
 
 //Provides: raw_array_copy
 function raw_array_copy (a) {
-  var l = a.length;
-  var b = new Array(l);
-  for(var i = 0; i < l; i++ ) b[i] = a[i];
-  return b
+  return a.slice();
 }
 
 //Provides: raw_array_cons
@@ -44,6 +39,7 @@ function raw_array_cons (a,x) {
 }
 
 //Provides: caml_call_gen (const, shallow)
+//Weakdef
 function caml_call_gen(f, args) {
   var args_copied = false
 

--- a/runtime/stdlib_modern.js
+++ b/runtime/stdlib_modern.js
@@ -1,0 +1,69 @@
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+///////////// Core
+
+//Provides: caml_call_gen (const, shallow)
+function caml_call_gen(f, args) {
+  var args_copied = false
+
+  while (true) {
+    if (f.fun) {
+      f = f.fun;
+      continue;
+    }
+
+    var n = f.length;
+    var argsLen = args.length;
+    var d = n - argsLen;
+
+    if (d == 0) {
+      return f(...args);
+    }
+    else if (d < 0) {
+      if (!args_copied) {
+        args = args.slice();
+        args_copied = true;
+      }
+
+      var before = args;
+      var after = before.splice(n);
+
+      f = f(...before);
+      args = after;
+    }
+    else {
+      switch (d) {
+      case 1: return function (a1) {
+        return f(...args, a1)
+      }
+      case 2: return function (a1, a2) {
+        return f(...args, a1, a2);
+      }
+      case 3: return function (a1, a2, a3) {
+        return f(...args, a1, a2, a3);
+      }
+      case 4: return function (a1, a2, a3, a4) {
+        return f(...args, a1, a2, a3, a4);
+      }
+      case 5: return function (a1, a2, a3, a4, a5) {
+        return f(...args, a1, a2, a3, a4, a5);
+      }
+      case 6: return function (a1, a2, a3, a4, a5, a6) {
+        return f(...args, a1, a2, a3, a4, a5, a6);
+      }
+      case 7: return function (a1, a2, a3, a4, a5, a6, a7) {
+        return f(...args, a1, a2, a3, a4, a5, a6, a7);
+      }
+      default:
+        return function (a1, a2, a3, a4, a5, a6, a7, a8) {
+          return caml_call_gen(f, args.concat([a1, a2, a3, a4, a5, a6, a7, a8]));
+        };
+      }
+    }
+  }
+}

--- a/runtime/stdlib_modern.js
+++ b/runtime/stdlib_modern.js
@@ -9,7 +9,7 @@
 
 //Provides: caml_call_gen (const, shallow)
 function caml_call_gen(f, args) {
-  var args_copied = false
+  var args_copied = false;
 
   while (true) {
     if (f.fun) {
@@ -17,11 +17,11 @@ function caml_call_gen(f, args) {
       continue;
     }
 
-    var n = f.length;
-    var argsLen = args.length;
-    var d = n - argsLen;
+    var n = f.length | 0;
+    var argsLen = args.length | 0;
+    var d = (n - argsLen) | 0;
 
-    if (d == 0) {
+    if (d === 0) {
       return f(...args);
     }
     else if (d < 0) {
@@ -39,7 +39,7 @@ function caml_call_gen(f, args) {
     else {
       switch (d) {
       case 1: return function (a1) {
-        return f(...args, a1)
+        return f(...args, a1);
       }
       case 2: return function (a1, a2) {
         return f(...args, a1, a2);


### PR DESCRIPTION
Depends on https://github.com/ocsigen/js_of_ocaml/pull/937

* Uses the spread operator in callgen to avoid allocating more arrays
* Uses `List.slice` to implement some primitives