### PR TITLE
New methods and functions in Typed_array

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 * Runtime: change representation of int64  (#905)
 * Lib: add closest method to element (#930)
 * Ppx: ppx_js behave better with merlin (#933)
+* Lib: add several methods and functions to Typed_array (#970)
 
 ## Bug fixes
 * Compiler: restore optimization when generating if statements

--- a/lib/js_of_ocaml/js_of_ocaml_stubs.c
+++ b/lib/js_of_ocaml/js_of_ocaml_stubs.c
@@ -16,36 +16,16 @@ void bigstring_to_typed_array () {
   fprintf(stderr, "Unimplemented Javascript primitive bigstring_to_typed_array!\n");
   exit(1);
 }
-void caml_ba_float32_of_typed_array () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_ba_float32_of_typed_array!\n");
+void caml_ba_from_typed_array () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_ba_from_typed_array!\n");
   exit(1);
 }
-void caml_ba_float64_of_typed_array () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_ba_float64_of_typed_array!\n");
-  exit(1);
-}
-void caml_ba_int16_of_typed_array () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_ba_int16_of_typed_array!\n");
-  exit(1);
-}
-void caml_ba_int32_of_typed_array () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_ba_int32_of_typed_array!\n");
-  exit(1);
-}
-void caml_ba_int8_of_typed_array () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_ba_int8_of_typed_array!\n");
+void caml_ba_kind_of_typed_array () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_ba_kind_of_typed_array!\n");
   exit(1);
 }
 void caml_ba_to_typed_array () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_ba_to_typed_array!\n");
-  exit(1);
-}
-void caml_ba_uint16_of_typed_array () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_ba_uint16_of_typed_array!\n");
-  exit(1);
-}
-void caml_ba_uint8_of_typed_array () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_ba_uint8_of_typed_array!\n");
   exit(1);
 }
 void caml_create_file () {

--- a/lib/js_of_ocaml/js_of_ocaml_stubs.c
+++ b/lib/js_of_ocaml/js_of_ocaml_stubs.c
@@ -16,6 +16,38 @@ void bigstring_to_typed_array () {
   fprintf(stderr, "Unimplemented Javascript primitive bigstring_to_typed_array!\n");
   exit(1);
 }
+void caml_ba_float32_of_typed_array () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_ba_float32_of_typed_array!\n");
+  exit(1);
+}
+void caml_ba_float64_of_typed_array () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_ba_float64_of_typed_array!\n");
+  exit(1);
+}
+void caml_ba_int16_of_typed_array () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_ba_int16_of_typed_array!\n");
+  exit(1);
+}
+void caml_ba_int32_of_typed_array () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_ba_int32_of_typed_array!\n");
+  exit(1);
+}
+void caml_ba_int8_of_typed_array () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_ba_int8_of_typed_array!\n");
+  exit(1);
+}
+void caml_ba_to_typed_array () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_ba_to_typed_array!\n");
+  exit(1);
+}
+void caml_ba_uint16_of_typed_array () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_ba_uint16_of_typed_array!\n");
+  exit(1);
+}
+void caml_ba_uint8_of_typed_array () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_ba_uint8_of_typed_array!\n");
+  exit(1);
+}
 void caml_create_file () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_create_file!\n");
   exit(1);

--- a/lib/js_of_ocaml/typed_array.ml
+++ b/lib/js_of_ocaml/typed_array.ml
@@ -59,6 +59,10 @@ class type ['a, 'b] typedArray =
     method slice : int -> int -> ('a, 'b) typedArray t meth
 
     method slice_toEnd : int -> ('a, 'b) typedArray t meth
+
+    (* This fake method is needed for typing purposes.
+       Without it, ['b] would not be constrained. *)
+    method _content_type_ : 'b optdef readonly_prop
   end
 
 type int8Array = (int, Bigarray.int8_signed_elt) typedArray

--- a/lib/js_of_ocaml/typed_array.ml
+++ b/lib/js_of_ocaml/typed_array.ml
@@ -48,7 +48,9 @@ class type ['a, 'b] typedArray =
 
     method length : int readonly_prop
 
-    method set_fromArray : 'a js_array t -> int -> unit meth
+    method set_fromIntArray : int js_array t -> int -> unit meth
+
+    method set_fromFloatArray : float js_array t -> int -> unit meth
 
     method set_fromTypedArray : ('a, 'b) typedArray t -> int -> unit meth
 
@@ -59,25 +61,34 @@ class type ['a, 'b] typedArray =
     method slice : int -> int -> ('a, 'b) typedArray t meth
 
     method slice_toEnd : int -> ('a, 'b) typedArray t meth
-
-    method _content_type_ : 'b
   end
 
-type int8Array = (int, [ `Int8 ]) typedArray
+type int8Array = (int, Bigarray.int8_signed_elt) typedArray
 
-type uint8Array = (int, [ `Uint8 ]) typedArray
+type uint8Array = (int, Bigarray.int8_unsigned_elt) typedArray
 
-type int16Array = (int, [ `Int16 ]) typedArray
+type int16Array = (int, Bigarray.int16_signed_elt) typedArray
 
-type uint16Array = (int, [ `Uint16 ]) typedArray
+type uint16Array = (int, Bigarray.int16_unsigned_elt) typedArray
 
-type int32Array = (int, [ `Int32 ]) typedArray
+type int32Array = (int32, Bigarray.int32_elt) typedArray
 
-type uint32Array = (float, [ `Uint32 ]) typedArray
+type uint32Array = (int32, Bigarray.int32_elt) typedArray
 
-type float32Array = (float, [ `Float32 ]) typedArray
+type float32Array = (float, Bigarray.float32_elt) typedArray
 
-type float64Array = (float, [ `Float64 ]) typedArray
+type float64Array = (float, Bigarray.float64_elt) typedArray
+
+external kind : ('a, 'b) typedArray t -> ('a, 'b) Bigarray.kind
+  = "caml_ba_kind_of_typed_array"
+
+external from_genarray :
+  ('a, 'b, Bigarray.c_layout) Bigarray.Genarray.t -> ('a, 'b) typedArray t
+  = "caml_ba_to_typed_array"
+
+external to_genarray :
+  ('a, 'b) typedArray t -> ('a, 'b, Bigarray.c_layout) Bigarray.Genarray.t
+  = "caml_ba_from_typed_array"
 
 let int8Array = Js.Unsafe.global##._Int8Array
 
@@ -89,14 +100,6 @@ let int8Array_fromBuffer = int8Array
 
 let int8Array_inBuffer = int8Array
 
-external int8Array_fromGenarray :
-  (int, Bigarray.int8_signed_elt, Bigarray.c_layout) Bigarray.Genarray.t -> int8Array t
-  = "caml_ba_to_typed_array"
-
-external int8Array_toGenarray :
-  int8Array t -> (int, Bigarray.int8_signed_elt, Bigarray.c_layout) Bigarray.Genarray.t
-  = "caml_ba_int8_of_typed_array"
-
 let uint8Array = Js.Unsafe.global##._Uint8Array
 
 let uint8Array_fromArray = uint8Array
@@ -106,14 +109,6 @@ let uint8Array_fromTypedArray = uint8Array
 let uint8Array_fromBuffer = uint8Array
 
 let uint8Array_inBuffer = uint8Array
-
-external uint8Array_fromGenarray :
-  (int, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Genarray.t -> uint8Array t
-  = "caml_ba_to_typed_array"
-
-external uint8Array_toGenarray :
-  uint8Array t -> (int, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Genarray.t
-  = "caml_ba_uint8_of_typed_array"
 
 let int16Array = Js.Unsafe.global##._Int16Array
 
@@ -125,14 +120,6 @@ let int16Array_fromBuffer = int16Array
 
 let int16Array_inBuffer = int16Array
 
-external int16Array_fromGenarray :
-  (int, Bigarray.int16_signed_elt, Bigarray.c_layout) Bigarray.Genarray.t -> int16Array t
-  = "caml_ba_to_typed_array"
-
-external int16Array_toGenarray :
-  int16Array t -> (int, Bigarray.int16_signed_elt, Bigarray.c_layout) Bigarray.Genarray.t
-  = "caml_ba_int16_of_typed_array"
-
 let uint16Array = Js.Unsafe.global##._Uint16Array
 
 let uint16Array_fromArray = uint16Array
@@ -143,14 +130,6 @@ let uint16Array_fromBuffer = uint16Array
 
 let uint16Array_inBuffer = uint16Array
 
-external uint16Array_fromGenarray :
-  (int, Bigarray.int16_unsigned_elt, Bigarray.c_layout) Bigarray.Genarray.t -> uint16Array t
-  = "caml_ba_to_typed_array"
-
-external uint16Array_toGenarray :
-  uint16Array t -> (int, Bigarray.int16_unsigned_elt, Bigarray.c_layout) Bigarray.Genarray.t
-  = "caml_ba_uint16_of_typed_array"
-
 let int32Array = Js.Unsafe.global##._Int32Array
 
 let int32Array_fromArray = int32Array
@@ -160,14 +139,6 @@ let int32Array_fromTypedArray = int32Array
 let int32Array_fromBuffer = int32Array
 
 let int32Array_inBuffer = int32Array
-
-external int32Array_fromGenarray :
-  (int32, Bigarray.int32_elt, Bigarray.c_layout) Bigarray.Genarray.t -> int32Array t
-  = "caml_ba_to_typed_array"
-
-external int32Array_toGenarray :
-  int32Array t -> (int32, Bigarray.int32_elt, Bigarray.c_layout) Bigarray.Genarray.t
-  = "caml_ba_int32_of_typed_array"
 
 let uint32Array = Js.Unsafe.global##._Uint32Array
 
@@ -189,14 +160,6 @@ let float32Array_fromBuffer = float32Array
 
 let float32Array_inBuffer = float32Array
 
-external float32Array_fromGenarray :
-  (float, Bigarray.float32_elt, Bigarray.c_layout) Bigarray.Genarray.t -> float32Array t
-  = "caml_ba_to_typed_array"
-
-external float32Array_toGenarray :
-  float32Array t -> (float, Bigarray.float32_elt, Bigarray.c_layout) Bigarray.Genarray.t
-  = "caml_ba_float32_of_typed_array"
-
 let float64Array = Js.Unsafe.global##._Float64Array
 
 let float64Array_fromArray = float64Array
@@ -207,20 +170,60 @@ let float64Array_fromBuffer = float64Array
 
 let float64Array_inBuffer = float64Array
 
-external float64Array_fromGenarray :
-  (float, Bigarray.float64_elt, Bigarray.c_layout) Bigarray.Genarray.t -> float64Array t
-  = "caml_ba_to_typed_array"
-
-external float64Array_toGenarray :
-  float64Array t -> (float, Bigarray.float64_elt, Bigarray.c_layout) Bigarray.Genarray.t
-  = "caml_ba_float64_of_typed_array"
-
-let set : ('a, 'b) typedArray t -> int -> 'a -> unit =
+let set_float : ('a, 'b) typedArray t -> int -> float -> unit =
  fun a i v -> array_set (Unsafe.coerce a) i v
 
-let get : ('a, 'b) typedArray t -> int -> 'a optdef = fun a i -> Js.Unsafe.get a i
+let get_float : ('a, 'b) typedArray t -> int -> float optdef =
+ fun a i -> Js.Unsafe.get a i
 
-let unsafe_get : ('a, 'b) typedArray t -> int -> 'a = fun a i -> Js.Unsafe.get a i
+let unsafe_get_float : ('a, 'b) typedArray t -> int -> float =
+ fun a i -> Js.Unsafe.get a i
+
+let set_int : ('a, 'b) typedArray t -> int -> int -> unit =
+ fun a i v -> array_set (Unsafe.coerce a) i v
+
+let get_int : ('a, 'b) typedArray t -> int -> int optdef = fun a i -> Js.Unsafe.get a i
+
+let unsafe_get_int : ('a, 'b) typedArray t -> int -> int = fun a i -> Js.Unsafe.get a i
+
+let set : type a b. (a, b) typedArray t -> int -> a -> unit =
+ fun a i v ->
+  let kind : (a, b) Bigarray.kind = kind a in
+  match kind with
+  | Bigarray.Int8_signed -> set_int a i v
+  | Bigarray.Int8_unsigned -> set_int a i v
+  | Bigarray.Int16_signed -> set_int a i v
+  | Bigarray.Int16_unsigned -> set_int a i v
+  | Bigarray.Int32 -> set_float a i (Int32.to_float v)
+  | Bigarray.Float32 -> set_float a i v
+  | Bigarray.Float64 -> set_float a i v
+  | _ -> failwith "unreachable"
+
+let get : type a b. (a, b) typedArray t -> int -> a optdef =
+ fun a i ->
+  let kind : (a, b) Bigarray.kind = kind a in
+  match kind with
+  | Bigarray.Int8_signed -> get_int a i
+  | Bigarray.Int8_unsigned -> get_int a i
+  | Bigarray.Int16_signed -> get_int a i
+  | Bigarray.Int16_unsigned -> get_int a i
+  | Bigarray.Int32 -> Js.Optdef.map (get_float a i) Int32.of_float
+  | Bigarray.Float32 -> get_float a i
+  | Bigarray.Float64 -> get_float a i
+  | _ -> failwith "unreachable"
+
+let unsafe_get : type a b. (a, b) typedArray t -> int -> a =
+ fun a i ->
+  let kind : (a, b) Bigarray.kind = kind a in
+  match kind with
+  | Bigarray.Int8_signed -> unsafe_get_int a i
+  | Bigarray.Int8_unsigned -> unsafe_get_int a i
+  | Bigarray.Int16_signed -> unsafe_get_int a i
+  | Bigarray.Int16_unsigned -> unsafe_get_int a i
+  | Bigarray.Int32 -> unsafe_get_float a i |> Int32.of_float
+  | Bigarray.Float32 -> unsafe_get_float a i
+  | Bigarray.Float64 -> unsafe_get_float a i
+  | _ -> failwith "unreachable"
 
 class type dataView =
   object

--- a/lib/js_of_ocaml/typed_array.ml
+++ b/lib/js_of_ocaml/typed_array.ml
@@ -23,6 +23,10 @@ open Js
 class type arrayBuffer =
   object
     method byteLength : int readonly_prop
+
+    method slice : int -> int -> arrayBuffer t meth
+
+    method slice_toEnd : int -> arrayBuffer t meth
   end
 
 let arrayBuffer : (int -> arrayBuffer t) constr = Js.Unsafe.global##._ArrayBuffer
@@ -51,6 +55,10 @@ class type ['a, 'b] typedArray =
     method subarray : int -> int -> ('a, 'b) typedArray t meth
 
     method subarray_toEnd : int -> ('a, 'b) typedArray t meth
+
+    method slice : int -> int -> ('a, 'b) typedArray t meth
+
+    method slice_toEnd : int -> ('a, 'b) typedArray t meth
 
     method _content_type_ : 'b
   end
@@ -165,6 +173,8 @@ class type dataView =
     method getInt8 : int -> int meth
 
     method getUint8 : int -> int meth
+
+    method getInt16 : int -> int meth
 
     method getInt16_ : int -> bool t -> int meth
 

--- a/lib/js_of_ocaml/typed_array.ml
+++ b/lib/js_of_ocaml/typed_array.ml
@@ -89,6 +89,14 @@ let int8Array_fromBuffer = int8Array
 
 let int8Array_inBuffer = int8Array
 
+external int8Array_fromGenarray :
+  (int, Bigarray.int8_signed_elt, Bigarray.c_layout) Bigarray.Genarray.t -> int8Array t
+  = "caml_ba_to_typed_array"
+
+external int8Array_toGenarray :
+  int8Array t -> (int, Bigarray.int8_signed_elt, Bigarray.c_layout) Bigarray.Genarray.t
+  = "caml_ba_int8_of_typed_array"
+
 let uint8Array = Js.Unsafe.global##._Uint8Array
 
 let uint8Array_fromArray = uint8Array
@@ -98,6 +106,14 @@ let uint8Array_fromTypedArray = uint8Array
 let uint8Array_fromBuffer = uint8Array
 
 let uint8Array_inBuffer = uint8Array
+
+external uint8Array_fromGenarray :
+  (int, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Genarray.t -> uint8Array t
+  = "caml_ba_to_typed_array"
+
+external uint8Array_toGenarray :
+  uint8Array t -> (int, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Genarray.t
+  = "caml_ba_uint8_of_typed_array"
 
 let int16Array = Js.Unsafe.global##._Int16Array
 
@@ -109,6 +125,14 @@ let int16Array_fromBuffer = int16Array
 
 let int16Array_inBuffer = int16Array
 
+external int16Array_fromGenarray :
+  (int, Bigarray.int16_signed_elt, Bigarray.c_layout) Bigarray.Genarray.t -> int16Array t
+  = "caml_ba_to_typed_array"
+
+external int16Array_toGenarray :
+  int16Array t -> (int, Bigarray.int16_signed_elt, Bigarray.c_layout) Bigarray.Genarray.t
+  = "caml_ba_int16_of_typed_array"
+
 let uint16Array = Js.Unsafe.global##._Uint16Array
 
 let uint16Array_fromArray = uint16Array
@@ -119,6 +143,14 @@ let uint16Array_fromBuffer = uint16Array
 
 let uint16Array_inBuffer = uint16Array
 
+external uint16Array_fromGenarray :
+  (int, Bigarray.int16_unsigned_elt, Bigarray.c_layout) Bigarray.Genarray.t -> uint16Array t
+  = "caml_ba_to_typed_array"
+
+external uint16Array_toGenarray :
+  uint16Array t -> (int, Bigarray.int16_unsigned_elt, Bigarray.c_layout) Bigarray.Genarray.t
+  = "caml_ba_uint16_of_typed_array"
+
 let int32Array = Js.Unsafe.global##._Int32Array
 
 let int32Array_fromArray = int32Array
@@ -128,6 +160,14 @@ let int32Array_fromTypedArray = int32Array
 let int32Array_fromBuffer = int32Array
 
 let int32Array_inBuffer = int32Array
+
+external int32Array_fromGenarray :
+  (int, Bigarray.int32_elt, Bigarray.c_layout) Bigarray.Genarray.t -> int32Array t
+  = "caml_ba_to_typed_array"
+
+external int32Array_toGenarray :
+  int32Array t -> (int, Bigarray.int32_elt, Bigarray.c_layout) Bigarray.Genarray.t
+  = "caml_ba_int32_of_typed_array"
 
 let uint32Array = Js.Unsafe.global##._Uint32Array
 
@@ -149,6 +189,14 @@ let float32Array_fromBuffer = float32Array
 
 let float32Array_inBuffer = float32Array
 
+external float32Array_fromGenarray :
+  (float, Bigarray.float32_elt, Bigarray.c_layout) Bigarray.Genarray.t -> float32Array t
+  = "caml_ba_to_typed_array"
+
+external float32Array_toGenarray :
+  float32Array t -> (float, Bigarray.float32_elt, Bigarray.c_layout) Bigarray.Genarray.t
+  = "caml_ba_float32_of_typed_array"
+
 let float64Array = Js.Unsafe.global##._Float64Array
 
 let float64Array_fromArray = float64Array
@@ -158,6 +206,14 @@ let float64Array_fromTypedArray = float64Array
 let float64Array_fromBuffer = float64Array
 
 let float64Array_inBuffer = float64Array
+
+external float64Array_fromGenarray :
+  (float, Bigarray.float64_elt, Bigarray.c_layout) Bigarray.Genarray.t -> float64Array t
+  = "caml_ba_to_typed_array"
+
+external float64Array_toGenarray :
+  float64Array t -> (float, Bigarray.float64_elt, Bigarray.c_layout) Bigarray.Genarray.t
+  = "caml_ba_float64_of_typed_array"
 
 let set : ('a, 'b) typedArray t -> int -> 'a -> unit =
  fun a i v -> array_set (Unsafe.coerce a) i v

--- a/lib/js_of_ocaml/typed_array.ml
+++ b/lib/js_of_ocaml/typed_array.ml
@@ -48,9 +48,7 @@ class type ['a, 'b] typedArray =
 
     method length : int readonly_prop
 
-    method set_fromIntArray : int js_array t -> int -> unit meth
-
-    method set_fromFloatArray : float js_array t -> int -> unit meth
+    method set_fromArray : 'a js_array t -> int -> unit meth
 
     method set_fromTypedArray : ('a, 'b) typedArray t -> int -> unit meth
 
@@ -170,60 +168,12 @@ let float64Array_fromBuffer = float64Array
 
 let float64Array_inBuffer = float64Array
 
-let set_float : ('a, 'b) typedArray t -> int -> float -> unit =
+let set : ('a, 'b) typedArray t -> int -> 'a -> unit =
  fun a i v -> array_set (Unsafe.coerce a) i v
 
-let get_float : ('a, 'b) typedArray t -> int -> float optdef =
- fun a i -> Js.Unsafe.get a i
+let get : ('a, 'b) typedArray t -> int -> 'a optdef = fun a i -> Js.Unsafe.get a i
 
-let unsafe_get_float : ('a, 'b) typedArray t -> int -> float =
- fun a i -> Js.Unsafe.get a i
-
-let set_int : ('a, 'b) typedArray t -> int -> int -> unit =
- fun a i v -> array_set (Unsafe.coerce a) i v
-
-let get_int : ('a, 'b) typedArray t -> int -> int optdef = fun a i -> Js.Unsafe.get a i
-
-let unsafe_get_int : ('a, 'b) typedArray t -> int -> int = fun a i -> Js.Unsafe.get a i
-
-let set : type a b. (a, b) typedArray t -> int -> a -> unit =
- fun a i v ->
-  let kind : (a, b) Bigarray.kind = kind a in
-  match kind with
-  | Bigarray.Int8_signed -> set_int a i v
-  | Bigarray.Int8_unsigned -> set_int a i v
-  | Bigarray.Int16_signed -> set_int a i v
-  | Bigarray.Int16_unsigned -> set_int a i v
-  | Bigarray.Int32 -> set_float a i (Int32.to_float v)
-  | Bigarray.Float32 -> set_float a i v
-  | Bigarray.Float64 -> set_float a i v
-  | _ -> failwith "unreachable"
-
-let get : type a b. (a, b) typedArray t -> int -> a optdef =
- fun a i ->
-  let kind : (a, b) Bigarray.kind = kind a in
-  match kind with
-  | Bigarray.Int8_signed -> get_int a i
-  | Bigarray.Int8_unsigned -> get_int a i
-  | Bigarray.Int16_signed -> get_int a i
-  | Bigarray.Int16_unsigned -> get_int a i
-  | Bigarray.Int32 -> Js.Optdef.map (get_float a i) Int32.of_float
-  | Bigarray.Float32 -> get_float a i
-  | Bigarray.Float64 -> get_float a i
-  | _ -> failwith "unreachable"
-
-let unsafe_get : type a b. (a, b) typedArray t -> int -> a =
- fun a i ->
-  let kind : (a, b) Bigarray.kind = kind a in
-  match kind with
-  | Bigarray.Int8_signed -> unsafe_get_int a i
-  | Bigarray.Int8_unsigned -> unsafe_get_int a i
-  | Bigarray.Int16_signed -> unsafe_get_int a i
-  | Bigarray.Int16_unsigned -> unsafe_get_int a i
-  | Bigarray.Int32 -> unsafe_get_float a i |> Int32.of_float
-  | Bigarray.Float32 -> unsafe_get_float a i
-  | Bigarray.Float64 -> unsafe_get_float a i
-  | _ -> failwith "unreachable"
+let unsafe_get : ('a, 'b) typedArray t -> int -> 'a = fun a i -> Js.Unsafe.get a i
 
 class type dataView =
   object

--- a/lib/js_of_ocaml/typed_array.ml
+++ b/lib/js_of_ocaml/typed_array.ml
@@ -162,11 +162,11 @@ let int32Array_fromBuffer = int32Array
 let int32Array_inBuffer = int32Array
 
 external int32Array_fromGenarray :
-  (int, Bigarray.int32_elt, Bigarray.c_layout) Bigarray.Genarray.t -> int32Array t
+  (int32, Bigarray.int32_elt, Bigarray.c_layout) Bigarray.Genarray.t -> int32Array t
   = "caml_ba_to_typed_array"
 
 external int32Array_toGenarray :
-  int32Array t -> (int, Bigarray.int32_elt, Bigarray.c_layout) Bigarray.Genarray.t
+  int32Array t -> (int32, Bigarray.int32_elt, Bigarray.c_layout) Bigarray.Genarray.t
   = "caml_ba_int32_of_typed_array"
 
 let uint32Array = Js.Unsafe.global##._Uint32Array

--- a/lib/js_of_ocaml/typed_array.mli
+++ b/lib/js_of_ocaml/typed_array.mli
@@ -50,7 +50,9 @@ class type ['a, 'b] typedArray =
 
     method length : int readonly_prop
 
-    method set_fromArray : 'a js_array t -> int -> unit meth
+    method set_fromIntArray : int js_array t -> int -> unit meth
+
+    method set_fromFloatArray : float js_array t -> int -> unit meth
 
     method set_fromTypedArray : ('a, 'b) typedArray t -> int -> unit meth
 
@@ -61,25 +63,30 @@ class type ['a, 'b] typedArray =
     method slice : int -> int -> ('a, 'b) typedArray t meth
 
     method slice_toEnd : int -> ('a, 'b) typedArray t meth
-
-    method _content_type_ : 'b
   end
 
-type int8Array = (int, [ `Int8 ]) typedArray
+type int8Array = (int, Bigarray.int8_signed_elt) typedArray
 
-type uint8Array = (int, [ `Uint8 ]) typedArray
+type uint8Array = (int, Bigarray.int8_unsigned_elt) typedArray
 
-type int16Array = (int, [ `Int16 ]) typedArray
+type int16Array = (int, Bigarray.int16_signed_elt) typedArray
 
-type uint16Array = (int, [ `Uint16 ]) typedArray
+type uint16Array = (int, Bigarray.int16_unsigned_elt) typedArray
 
-type int32Array = (int, [ `Int32 ]) typedArray
+type int32Array = (int32, Bigarray.int32_elt) typedArray
 
-type uint32Array = (float, [ `Uint32 ]) typedArray
+type uint32Array = (int32, Bigarray.int32_elt) typedArray
 
-type float32Array = (float, [ `Float32 ]) typedArray
+type float32Array = (float, Bigarray.float32_elt) typedArray
 
-type float64Array = (float, [ `Float64 ]) typedArray
+type float64Array = (float, Bigarray.float64_elt) typedArray
+
+val kind : ('a, 'b) typedArray t -> ('a, 'b) Bigarray.kind
+
+val from_genarray :
+  ('a, 'b, Bigarray.c_layout) Bigarray.Genarray.t -> ('a, 'b) typedArray t
+
+val to_genarray : ('a, 'b) typedArray t -> ('a, 'b, Bigarray.c_layout) Bigarray.Genarray.t
 
 val int8Array : (int -> int8Array t) constr
 
@@ -91,12 +98,6 @@ val int8Array_fromBuffer : (arrayBuffer t -> int8Array t) constr
 
 val int8Array_inBuffer : (arrayBuffer t -> int -> int -> int8Array t) constr
 
-val int8Array_fromGenarray :
-  (int, Bigarray.int8_signed_elt, Bigarray.c_layout) Bigarray.Genarray.t -> int8Array t
-
-val int8Array_toGenarray :
-  int8Array t -> (int, Bigarray.int8_signed_elt, Bigarray.c_layout) Bigarray.Genarray.t
-
 val uint8Array : (int -> uint8Array t) constr
 
 val uint8Array_fromArray : (int js_array t -> uint8Array t) constr
@@ -106,12 +107,6 @@ val uint8Array_fromTypedArray : (uint8Array t -> uint8Array t) constr
 val uint8Array_fromBuffer : (arrayBuffer t -> uint8Array t) constr
 
 val uint8Array_inBuffer : (arrayBuffer t -> int -> int -> uint8Array t) constr
-
-val uint8Array_fromGenarray :
-  (int, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Genarray.t -> uint8Array t
-
-val uint8Array_toGenarray :
-  uint8Array t -> (int, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Genarray.t
 
 val int16Array : (int -> int16Array t) constr
 
@@ -123,12 +118,6 @@ val int16Array_fromBuffer : (arrayBuffer t -> int16Array t) constr
 
 val int16Array_inBuffer : (arrayBuffer t -> int -> int -> int16Array t) constr
 
-val int16Array_fromGenarray :
-  (int, Bigarray.int16_signed_elt, Bigarray.c_layout) Bigarray.Genarray.t -> int16Array t
-
-val int16Array_toGenarray :
-  int16Array t -> (int, Bigarray.int16_signed_elt, Bigarray.c_layout) Bigarray.Genarray.t
-
 val uint16Array : (int -> uint16Array t) constr
 
 val uint16Array_fromArray : (int js_array t -> uint16Array t) constr
@@ -139,12 +128,6 @@ val uint16Array_fromBuffer : (arrayBuffer t -> uint16Array t) constr
 
 val uint16Array_inBuffer : (arrayBuffer t -> int -> int -> uint16Array t) constr
 
-val uint16Array_fromGenarray :
-  (int, Bigarray.int16_unsigned_elt, Bigarray.c_layout) Bigarray.Genarray.t -> uint16Array t
-
-val uint16Array_toGenarray :
-  uint16Array t -> (int, Bigarray.int16_unsigned_elt, Bigarray.c_layout) Bigarray.Genarray.t
-
 val int32Array : (int -> int32Array t) constr
 
 val int32Array_fromArray : (int js_array t -> int32Array t) constr
@@ -154,12 +137,6 @@ val int32Array_fromTypedArray : (int32Array t -> int32Array t) constr
 val int32Array_fromBuffer : (arrayBuffer t -> int32Array t) constr
 
 val int32Array_inBuffer : (arrayBuffer t -> int -> int -> int32Array t) constr
-
-val int32Array_fromGenarray :
-  (int32, Bigarray.int32_elt, Bigarray.c_layout) Bigarray.Genarray.t -> int32Array t
-
-val int32Array_toGenarray :
-  int32Array t -> (int32, Bigarray.int32_elt, Bigarray.c_layout) Bigarray.Genarray.t
 
 val uint32Array : (int -> uint32Array t) constr
 
@@ -181,12 +158,6 @@ val float32Array_fromBuffer : (arrayBuffer t -> float32Array t) constr
 
 val float32Array_inBuffer : (arrayBuffer t -> int -> int -> float32Array t) constr
 
-val float32Array_fromGenarray :
-  (float, Bigarray.float32_elt, Bigarray.c_layout) Bigarray.Genarray.t -> float32Array t
-
-val float32Array_toGenarray :
-  float32Array t -> (float, Bigarray.float32_elt, Bigarray.c_layout) Bigarray.Genarray.t
-
 val float64Array : (int -> float64Array t) constr
 
 val float64Array_fromArray : (float js_array t -> float64Array t) constr
@@ -197,11 +168,17 @@ val float64Array_fromBuffer : (arrayBuffer t -> float64Array t) constr
 
 val float64Array_inBuffer : (arrayBuffer t -> int -> int -> float64Array t) constr
 
-val float64Array_fromGenarray :
-  (float, Bigarray.float64_elt, Bigarray.c_layout) Bigarray.Genarray.t -> float64Array t
+val set_float : ('a, 'b) typedArray t -> int -> float -> unit
 
-val float64Array_toGenarray :
-  float64Array t -> (float, Bigarray.float64_elt, Bigarray.c_layout) Bigarray.Genarray.t
+val get_float : ('a, 'b) typedArray t -> int -> float optdef
+
+val unsafe_get_float : ('a, 'b) typedArray t -> int -> float
+
+val set_int : ('a, 'b) typedArray t -> int -> int -> unit
+
+val get_int : ('a, 'b) typedArray t -> int -> int optdef
+
+val unsafe_get_int : ('a, 'b) typedArray t -> int -> int
 
 val set : ('a, 'b) typedArray t -> int -> 'a -> unit
 

--- a/lib/js_of_ocaml/typed_array.mli
+++ b/lib/js_of_ocaml/typed_array.mli
@@ -61,6 +61,8 @@ class type ['a, 'b] typedArray =
     method slice : int -> int -> ('a, 'b) typedArray t meth
 
     method slice_toEnd : int -> ('a, 'b) typedArray t meth
+
+    method _content_type_ : 'b optdef readonly_prop
   end
 
 type int8Array = (int, Bigarray.int8_signed_elt) typedArray

--- a/lib/js_of_ocaml/typed_array.mli
+++ b/lib/js_of_ocaml/typed_array.mli
@@ -91,6 +91,12 @@ val int8Array_fromBuffer : (arrayBuffer t -> int8Array t) constr
 
 val int8Array_inBuffer : (arrayBuffer t -> int -> int -> int8Array t) constr
 
+val int8Array_fromGenarray :
+  (int, Bigarray.int8_signed_elt, Bigarray.c_layout) Bigarray.Genarray.t -> int8Array t
+
+val int8Array_toGenarray :
+  int8Array t -> (int, Bigarray.int8_signed_elt, Bigarray.c_layout) Bigarray.Genarray.t
+
 val uint8Array : (int -> uint8Array t) constr
 
 val uint8Array_fromArray : (int js_array t -> uint8Array t) constr
@@ -100,6 +106,12 @@ val uint8Array_fromTypedArray : (uint8Array t -> uint8Array t) constr
 val uint8Array_fromBuffer : (arrayBuffer t -> uint8Array t) constr
 
 val uint8Array_inBuffer : (arrayBuffer t -> int -> int -> uint8Array t) constr
+
+val uint8Array_fromGenarray :
+  (int, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Genarray.t -> uint8Array t
+
+val uint8Array_toGenarray :
+  uint8Array t -> (int, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Genarray.t
 
 val int16Array : (int -> int16Array t) constr
 
@@ -111,6 +123,12 @@ val int16Array_fromBuffer : (arrayBuffer t -> int16Array t) constr
 
 val int16Array_inBuffer : (arrayBuffer t -> int -> int -> int16Array t) constr
 
+val int16Array_fromGenarray :
+  (int, Bigarray.int16_signed_elt, Bigarray.c_layout) Bigarray.Genarray.t -> int16Array t
+
+val int16Array_toGenarray :
+  int16Array t -> (int, Bigarray.int16_signed_elt, Bigarray.c_layout) Bigarray.Genarray.t
+
 val uint16Array : (int -> uint16Array t) constr
 
 val uint16Array_fromArray : (int js_array t -> uint16Array t) constr
@@ -121,6 +139,12 @@ val uint16Array_fromBuffer : (arrayBuffer t -> uint16Array t) constr
 
 val uint16Array_inBuffer : (arrayBuffer t -> int -> int -> uint16Array t) constr
 
+val uint16Array_fromGenarray :
+  (int, Bigarray.int16_unsigned_elt, Bigarray.c_layout) Bigarray.Genarray.t -> uint16Array t
+
+val uint16Array_toGenarray :
+  uint16Array t -> (int, Bigarray.int16_unsigned_elt, Bigarray.c_layout) Bigarray.Genarray.t
+
 val int32Array : (int -> int32Array t) constr
 
 val int32Array_fromArray : (int js_array t -> int32Array t) constr
@@ -130,6 +154,12 @@ val int32Array_fromTypedArray : (int32Array t -> int32Array t) constr
 val int32Array_fromBuffer : (arrayBuffer t -> int32Array t) constr
 
 val int32Array_inBuffer : (arrayBuffer t -> int -> int -> int32Array t) constr
+
+val int32Array_fromGenarray :
+  (int, Bigarray.int32_elt, Bigarray.c_layout) Bigarray.Genarray.t -> int32Array t
+
+val int32Array_toGenarray :
+  int32Array t -> (int, Bigarray.int32_elt, Bigarray.c_layout) Bigarray.Genarray.t
 
 val uint32Array : (int -> uint32Array t) constr
 
@@ -151,6 +181,12 @@ val float32Array_fromBuffer : (arrayBuffer t -> float32Array t) constr
 
 val float32Array_inBuffer : (arrayBuffer t -> int -> int -> float32Array t) constr
 
+val float32Array_fromGenarray :
+  (float, Bigarray.float32_elt, Bigarray.c_layout) Bigarray.Genarray.t -> float32Array t
+
+val float32Array_toGenarray :
+  float32Array t -> (float, Bigarray.float32_elt, Bigarray.c_layout) Bigarray.Genarray.t
+
 val float64Array : (int -> float64Array t) constr
 
 val float64Array_fromArray : (float js_array t -> float64Array t) constr
@@ -160,6 +196,12 @@ val float64Array_fromTypedArray : (float64Array t -> float64Array t) constr
 val float64Array_fromBuffer : (arrayBuffer t -> float64Array t) constr
 
 val float64Array_inBuffer : (arrayBuffer t -> int -> int -> float64Array t) constr
+
+val float64Array_fromGenarray :
+  (float, Bigarray.float64_elt, Bigarray.c_layout) Bigarray.Genarray.t -> float64Array t
+
+val float64Array_toGenarray :
+  float64Array t -> (float, Bigarray.float64_elt, Bigarray.c_layout) Bigarray.Genarray.t
 
 val set : ('a, 'b) typedArray t -> int -> 'a -> unit
 

--- a/lib/js_of_ocaml/typed_array.mli
+++ b/lib/js_of_ocaml/typed_array.mli
@@ -25,6 +25,10 @@ open Js
 class type arrayBuffer =
   object
     method byteLength : int readonly_prop
+
+    method slice : int -> int -> arrayBuffer t meth
+
+    method slice_toEnd : int -> arrayBuffer t meth
   end
 
 val arrayBuffer : (int -> arrayBuffer t) constr
@@ -53,6 +57,10 @@ class type ['a, 'b] typedArray =
     method subarray : int -> int -> ('a, 'b) typedArray t meth
 
     method subarray_toEnd : int -> ('a, 'b) typedArray t meth
+
+    method slice : int -> int -> ('a, 'b) typedArray t meth
+
+    method slice_toEnd : int -> ('a, 'b) typedArray t meth
 
     method _content_type_ : 'b
   end
@@ -166,6 +174,8 @@ class type dataView =
     method getInt8 : int -> int meth
 
     method getUint8 : int -> int meth
+
+    method getInt16 : int -> int meth
 
     method getInt16_ : int -> bool t -> int meth
 

--- a/lib/js_of_ocaml/typed_array.mli
+++ b/lib/js_of_ocaml/typed_array.mli
@@ -50,9 +50,7 @@ class type ['a, 'b] typedArray =
 
     method length : int readonly_prop
 
-    method set_fromIntArray : int js_array t -> int -> unit meth
-
-    method set_fromFloatArray : float js_array t -> int -> unit meth
+    method set_fromArray : 'a js_array t -> int -> unit meth
 
     method set_fromTypedArray : ('a, 'b) typedArray t -> int -> unit meth
 
@@ -167,18 +165,6 @@ val float64Array_fromTypedArray : (float64Array t -> float64Array t) constr
 val float64Array_fromBuffer : (arrayBuffer t -> float64Array t) constr
 
 val float64Array_inBuffer : (arrayBuffer t -> int -> int -> float64Array t) constr
-
-val set_float : ('a, 'b) typedArray t -> int -> float -> unit
-
-val get_float : ('a, 'b) typedArray t -> int -> float optdef
-
-val unsafe_get_float : ('a, 'b) typedArray t -> int -> float
-
-val set_int : ('a, 'b) typedArray t -> int -> int -> unit
-
-val get_int : ('a, 'b) typedArray t -> int -> int optdef
-
-val unsafe_get_int : ('a, 'b) typedArray t -> int -> int
 
 val set : ('a, 'b) typedArray t -> int -> 'a -> unit
 

--- a/lib/js_of_ocaml/typed_array.mli
+++ b/lib/js_of_ocaml/typed_array.mli
@@ -156,10 +156,10 @@ val int32Array_fromBuffer : (arrayBuffer t -> int32Array t) constr
 val int32Array_inBuffer : (arrayBuffer t -> int -> int -> int32Array t) constr
 
 val int32Array_fromGenarray :
-  (int, Bigarray.int32_elt, Bigarray.c_layout) Bigarray.Genarray.t -> int32Array t
+  (int32, Bigarray.int32_elt, Bigarray.c_layout) Bigarray.Genarray.t -> int32Array t
 
 val int32Array_toGenarray :
-  int32Array t -> (int, Bigarray.int32_elt, Bigarray.c_layout) Bigarray.Genarray.t
+  int32Array t -> (int32, Bigarray.int32_elt, Bigarray.c_layout) Bigarray.Genarray.t
 
 val uint32Array : (int -> uint32Array t) constr
 

--- a/lib/tests/typed_array.ml
+++ b/lib/tests/typed_array.ml
@@ -1,0 +1,114 @@
+open Js_of_ocaml
+open Typed_array
+open Bigarray
+
+type ('a, 'b) ba = ('a, 'b, c_layout) Genarray.t
+
+type ('a, 'b) ta = ('a, 'b) typedArray
+
+module Setup = struct
+  type (_, _) t =
+    | Int8 : (int, Bigarray.int8_signed_elt) t
+    | Uint8 : (int, Bigarray.int8_unsigned_elt) t
+    | Int16 : (int, Bigarray.int16_signed_elt) t
+    | Uint16 : (int, Bigarray.int16_unsigned_elt) t
+    | Int32 : (int32, Bigarray.int32_elt) t
+    | Float32 : (float, Bigarray.float32_elt) t
+    | Float64 : (float, Bigarray.float64_elt) t
+end
+
+let kind_of_setup : type a b. (a, b) Setup.t -> (a, b) kind = function
+  | Setup.Int8 -> Int8_signed
+  | Setup.Uint8 -> Int8_unsigned
+  | Setup.Int16 -> Int16_signed
+  | Setup.Uint16 -> Int16_unsigned
+  | Setup.Int32 -> Int32
+  | Setup.Float32 -> Float32
+  | Setup.Float64 -> Float64
+
+let ta_type_is_correct : type a b. (a, b) Setup.t -> (a, b) ta Js.t -> bool =
+ fun setup a ->
+  let get_prop prop obj = Js.Unsafe.get obj (Js.string prop) in
+  let name = a |> get_prop "constructor" |> get_prop "name" |> Js.to_string in
+  match setup, name with
+  | Setup.Float32, "Float32Array" -> true
+  | Setup.Float64, "Float64Array" -> true
+  | Setup.Int8, "Int8Array" -> true
+  | Setup.Uint8, "Uint8Array" -> true
+  | Setup.Int16, "Int16Array" -> true
+  | Setup.Uint16, "Uint16Array" -> true
+  | Setup.Int32, "Int32Array" -> true
+  | _, _ -> false
+
+let kind_field_is_correct : type a b. (a, b) Setup.t -> (a, b) ba -> bool =
+ fun setup a ->
+  (* To trigger a `false`, modify the `kind` integer hard coded in the
+   * `caml_ba_kind_of_typed_array` stub
+   *)
+  match kind_of_setup setup, Genarray.kind a with
+  | Float32, Float32 -> true
+  | Float64, Float64 -> true
+  | Int8_signed, Int8_signed -> true
+  | Int8_unsigned, Int8_unsigned -> true
+  | Int16_signed, Int16_signed -> true
+  | Int16_unsigned, Int16_unsigned -> true
+  | Int32, Int32 -> true
+  | _, _ -> false
+
+let ba_of_array : type a b. (a, b) Setup.t -> a array -> (a, b) ba =
+ fun setup a -> Array1.of_array (kind_of_setup setup) c_layout a |> genarray_of_array1
+
+let array_of_ba : type a b. (a, b) ba -> a array =
+ fun a ->
+  let a = Bigarray.array1_of_genarray a in
+  let len = Bigarray.Array1.dim a in
+  let rec aux i =
+    if i == len then [] else Bigarray.Array1.unsafe_get a i :: aux (i + 1)
+  in
+  aux 0 |> Array.of_list
+
+let array_of_ta : type a b. (a, b) Setup.t -> (a, b) ta Js.t -> a array =
+ fun _ a ->
+  let len = a##.length in
+  let rec aux i = if i == len then [] else unsafe_get a i :: aux (i + 1) in
+  aux 0 |> Array.of_list
+
+let test setup a0 =
+  let a1 = ba_of_array setup a0 in
+
+  let a2 = from_genarray a1 in
+  if not (array_of_ta setup a2 = a0) then print_endline "`a2` doesnt match `a0`";
+  if not (ta_type_is_correct setup a2) then print_endline "corrupted typedArray type";
+
+  let a3 = to_genarray a2 in
+  if not (array_of_ba a3 = a0) then print_endline "`a3` doesnt match `a0`";
+  if not (kind_field_is_correct setup a3) then print_endline "corrupted `kind`";
+  ()
+
+let%expect_test "float32" =
+  test Setup.Float32 [| Float.neg_infinity; -1.; 0.; 1.; Float.infinity |];
+  [%expect {||}]
+
+let%expect_test "float64" =
+  test Setup.Float64 [| Float.neg_infinity; -1.; 0.; 1.; Float.infinity |];
+  [%expect {||}]
+
+let%expect_test "int8" =
+  test Setup.Int8 [| -128; -1; 0; 1; 127 |];
+  [%expect {||}]
+
+let%expect_test "uint8" =
+  test Setup.Uint8 [| 0; 255 |];
+  [%expect {||}]
+
+let%expect_test "int16" =
+  test Setup.Int16 [| -32768; -1; 0; 1; 32767 |];
+  [%expect {||}]
+
+let%expect_test "uint16" =
+  test Setup.Uint16 [| 0; 65535 |];
+  [%expect {||}]
+
+let%expect_test "int32" =
+  test Setup.Int32 [| -2147483648l; -1l; 0l; 1l; 2147483647l |];
+  [%expect {||}]

--- a/runtime/bigarray.js
+++ b/runtime/bigarray.js
@@ -842,44 +842,27 @@ function caml_ba_to_typed_array(ba){
   return ba.data;
 }
 
-//Provides: caml_ba_int8_of_typed_array mutable
-//Requires: caml_ba_create_unsafe
-function caml_ba_int8_of_typed_array(ta){
-  return caml_ba_create_unsafe(2, 0, [ta.length], ta);
+//Provides: caml_ba_kind_of_typed_array mutable
+//Requires: caml_invalid_argument
+function caml_ba_kind_of_typed_array(ta){
+  var g = joo_global_object;
+  var kind;
+  if (ta instanceof g.Float32Array) kind = 0;
+  else if (ta instanceof g.Float64Array) kind = 1;
+  else if (ta instanceof g.Int8Array) kind = 2;
+  else if (ta instanceof g.Uint8Array) kind = 3;
+  else if (ta instanceof g.Int16Array) kind = 4;
+  else if (ta instanceof g.Uint16Array) kind = 5;
+  else if (ta instanceof g.Int32Array) kind = 6;
+  else if (ta instanceof g.Uint32Array) kind = 6;
+  else caml_invalid_argument("caml_ba_kind_of_typed_array: unsupported kind");
+  return kind;
 }
 
-//Provides: caml_ba_uint8_of_typed_array mutable
+//Provides: caml_ba_from_typed_array mutable
+//Requires: caml_ba_kind_of_typed_array
 //Requires: caml_ba_create_unsafe
-function caml_ba_uint8_of_typed_array(ta){
-  return caml_ba_create_unsafe(3, 0, [ta.length], ta);
-}
-
-//Provides: caml_ba_int16_of_typed_array mutable
-//Requires: caml_ba_create_unsafe
-function caml_ba_int16_of_typed_array(ta){
-  return caml_ba_create_unsafe(4, 0, [ta.length], ta);
-}
-
-//Provides: caml_ba_uint16_of_typed_array mutable
-//Requires: caml_ba_create_unsafe
-function caml_ba_uint16_of_typed_array(ta){
-  return caml_ba_create_unsafe(5, 0, [ta.length], ta);
-}
-
-//Provides: caml_ba_int32_of_typed_array mutable
-//Requires: caml_ba_create_unsafe
-function caml_ba_int32_of_typed_array(ta){
-  return caml_ba_create_unsafe(6, 0, [ta.length], ta);
-}
-
-//Provides: caml_ba_float32_of_typed_array mutable
-//Requires: caml_ba_create_unsafe
-function caml_ba_float32_of_typed_array(ta){
-  return caml_ba_create_unsafe(0, 0, [ta.length], ta);
-}
-
-//Provides: caml_ba_float64_of_typed_array mutable
-//Requires: caml_ba_create_unsafe
-function caml_ba_float64_of_typed_array(ta){
-  return caml_ba_create_unsafe(1, 0, [ta.length], ta);
+function caml_ba_from_typed_array(ta){
+  var kind = caml_ba_kind_of_typed_array(ta);
+  return caml_ba_create_unsafe(kind, 0, [ta.length], ta);
 }

--- a/runtime/bigarray.js
+++ b/runtime/bigarray.js
@@ -836,3 +836,50 @@ function caml_ba_hash(ba){
   }
   return h;
 }
+
+//Provides: caml_ba_to_typed_array mutable
+function caml_ba_to_typed_array(ba){
+  return ba.data;
+}
+
+//Provides: caml_ba_int8_of_typed_array mutable
+//Requires: caml_ba_create_unsafe
+function caml_ba_int8_of_typed_array(ta){
+  return caml_ba_create_unsafe(2, 0, [ta.length], ta);
+}
+
+//Provides: caml_ba_uint8_of_typed_array mutable
+//Requires: caml_ba_create_unsafe
+function caml_ba_uint8_of_typed_array(ta){
+  return caml_ba_create_unsafe(3, 0, [ta.length], ta);
+}
+
+//Provides: caml_ba_int16_of_typed_array mutable
+//Requires: caml_ba_create_unsafe
+function caml_ba_int16_of_typed_array(ta){
+  return caml_ba_create_unsafe(4, 0, [ta.length], ta);
+}
+
+//Provides: caml_ba_uint16_of_typed_array mutable
+//Requires: caml_ba_create_unsafe
+function caml_ba_uint16_of_typed_array(ta){
+  return caml_ba_create_unsafe(5, 0, [ta.length], ta);
+}
+
+//Provides: caml_ba_int32_of_typed_array mutable
+//Requires: caml_ba_create_unsafe
+function caml_ba_int32_of_typed_array(ta){
+  return caml_ba_create_unsafe(6, 0, [ta.length], ta);
+}
+
+//Provides: caml_ba_float32_of_typed_array mutable
+//Requires: caml_ba_create_unsafe
+function caml_ba_float32_of_typed_array(ta){
+  return caml_ba_create_unsafe(0, 0, [ta.length], ta);
+}
+
+//Provides: caml_ba_float64_of_typed_array mutable
+//Requires: caml_ba_create_unsafe
+function caml_ba_float64_of_typed_array(ta){
+  return caml_ba_create_unsafe(1, 0, [ta.length], ta);
+}


### PR DESCRIPTION
Follow-up on #969 
* Add `getInt16` do `dataView`
* Add `slice` to `typedArray ` and `arrayBuffer`
* Add `slice_toEnd` to `typedArray ` and `arrayBuffer`
* Add `*_fromGenarray` and `*_toGenarray` functions for each `typedArray` except `uint32` that is not supported by `Bigarray`

