### PR TITLE
Use javascript string by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -71,6 +71,7 @@ Runtime: fix caml_read_file_content
 * Runtime: add support for unix_opendir, unix_readdir, unix_closedir, win_findfirst, win_findnext, win_findclose
 * Runtime: Dont use require when target-env is browser
 * Runtime: Implements Parsing.set_trace (#1308)
+* Runtime: ocaml string are represented as javascript ones.
 * Test: track external used in the stdlib and unix
 
 ## Bug fixes

--- a/compiler/lib/config.ml
+++ b/compiler/lib/config.ml
@@ -88,7 +88,7 @@ module Flag = struct
 
   let safe_string = o ~name:"safestring" ~default:true
 
-  let use_js_string = o ~name:"use-js-string" ~default:false
+  let use_js_string = o ~name:"use-js-string" ~default:true
 
   let check_magic = o ~name:"check-magic-number" ~default:true
 

--- a/compiler/tests-check-prim/main.output
+++ b/compiler/tests-check-prim/main.output
@@ -161,10 +161,12 @@ caml_marshal_constants
 From +mlBytes.js:
 caml_array_of_bytes
 caml_array_of_string
+caml_bytes_of_utf16_jsstring
 caml_new_string
 caml_string_set16
 caml_string_set32
 caml_string_set64
+caml_string_unsafe_set
 caml_to_js_string
 
 From +nat.js:

--- a/compiler/tests-check-prim/main.output5
+++ b/compiler/tests-check-prim/main.output5
@@ -144,9 +144,11 @@ caml_marshal_constants
 From +mlBytes.js:
 caml_array_of_bytes
 caml_array_of_string
+caml_bytes_of_utf16_jsstring
 caml_string_set16
 caml_string_set32
 caml_string_set64
+caml_string_unsafe_set
 caml_to_js_string
 
 From +nat.js:

--- a/compiler/tests-check-prim/unix-unix.output
+++ b/compiler/tests-check-prim/unix-unix.output
@@ -270,10 +270,12 @@ caml_marshal_constants
 From +mlBytes.js:
 caml_array_of_bytes
 caml_array_of_string
+caml_bytes_of_utf16_jsstring
 caml_new_string
 caml_string_set16
 caml_string_set32
 caml_string_set64
+caml_string_unsafe_set
 caml_to_js_string
 
 From +nat.js:

--- a/compiler/tests-check-prim/unix-unix.output5
+++ b/compiler/tests-check-prim/unix-unix.output5
@@ -253,9 +253,11 @@ caml_marshal_constants
 From +mlBytes.js:
 caml_array_of_bytes
 caml_array_of_string
+caml_bytes_of_utf16_jsstring
 caml_string_set16
 caml_string_set32
 caml_string_set64
+caml_string_unsafe_set
 caml_to_js_string
 
 From +nat.js:

--- a/compiler/tests-check-prim/unix-win32.output
+++ b/compiler/tests-check-prim/unix-win32.output
@@ -235,10 +235,12 @@ caml_marshal_constants
 From +mlBytes.js:
 caml_array_of_bytes
 caml_array_of_string
+caml_bytes_of_utf16_jsstring
 caml_new_string
 caml_string_set16
 caml_string_set32
 caml_string_set64
+caml_string_unsafe_set
 caml_to_js_string
 
 From +nat.js:


### PR DESCRIPTION
In that mode, an OCaml string will be represented as a JavaScript string containing a sequence of bytes. Converting the string to utf16 is still required for interaction with the DOM, or other javascript API.  

This current alternative representation of strings (implemented in #923) is not set in stone and could be changed based on benchmarks and usability.

Here are a bunch of things to consider:
- Wrap JavaScript string inside an object (`MlString`) to ease debugging.
- Update `string.ml` to make more optimization possible (`String.sub`, `(^)`, ..)
- Add more optimization in jsoo itself https://github.com/ocsigen/js_of_ocaml/pull/977  

**The PR is useful to check that existing program don't make any assumption about the internal representation of strings.**
- [x] Test JaneStreet libraries
- [x] Test jscoq
- [x] Test the jsoo toplevel
- [x] Merge #984 
- [x] Benchmark the two representations
