### PR TITLE
Compiler: cleanup usage of IString (now NativeString) vs String

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 * Compiler: speedup emitting js files (#1174)
 * Compiler: simplify (a | 0) >>> 0 into (a >>> 0) (#1177)
 * Compiler: improve static evaluation of cond (#1178)
+* Compiler: be more consistant dealing with js vs ocaml strings (#984)
 * Lib: add messageEvent to Dom_html (#1164)
 * Lib: add PerformanceObserver API (#1164)
 * Lib: add CSSStyleDeclaration.{setProperty, getPropertyValue, getPropertyPriority, removeProperty} (#1170)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 * Compiler: speedup emitting js files (#1174)
 * Compiler: simplify (a | 0) >>> 0 into (a >>> 0) (#1177)
 * Compiler: improve static evaluation of cond (#1178)
-* Compiler: be more consistant dealing with js vs ocaml strings (#984)
+* Compiler: be more consistent dealing with js vs ocaml strings (#984)
 * Lib: add messageEvent to Dom_html (#1164)
 * Lib: add PerformanceObserver API (#1164)
 * Lib: add CSSStyleDeclaration.{setProperty, getPropertyValue, getPropertyPriority, removeProperty} (#1170)

--- a/compiler/bin-js_of_ocaml/build_fs.ml
+++ b/compiler/bin-js_of_ocaml/build_fs.ml
@@ -49,10 +49,10 @@ let options =
 let f { files; output_file; include_dirs } =
   let code =
     {|
-//Provides: caml_create_file_extern
-function caml_create_file_extern(name,content){
-  if(joo_global_object.caml_create_file)
-    joo_global_object.caml_create_file(name,content);
+//Provides: jsoo_create_file_extern
+function jsoo_create_file_extern(name,content){
+  if(joo_global_object.jsoo_create_file)
+    joo_global_object.jsoo_create_file(name,content);
   else {
     if(!joo_global_object.caml_fs_tmp) joo_global_object.caml_fs_tmp = [];
     joo_global_object.caml_fs_tmp.push({name:name,content:content});
@@ -64,11 +64,7 @@ function caml_create_file_extern(name,content){
   let fragments = Linker.parse_string code in
   Linker.load_fragments ~target_env:Isomorphic ~filename:"<dummy>" fragments;
   let instr =
-    Pseudo_fs.f
-      ~prim:`caml_create_file_extern
-      ~cmis:StringSet.empty
-      ~files
-      ~paths:include_dirs
+    Pseudo_fs.f ~prim:`create_file_extern ~cmis:StringSet.empty ~files ~paths:include_dirs
   in
   let code = Code.prepend Code.empty instr in
   Filename.gen_file output_file (fun chan ->

--- a/compiler/bin-jsoo_fs/jsoo_fs.ml
+++ b/compiler/bin-jsoo_fs/jsoo_fs.ml
@@ -76,8 +76,8 @@ let info =
 let f { files; output_file; include_dirs } =
   let code =
     {|
-//Provides: caml_create_file_extern
-function caml_create_file_extern(name,content){
+//Provides: jsoo_create_file_extern
+function jsoo_create_file_extern(name,content){
   if(joo_global_object.caml_create_file)
     joo_global_object.caml_create_file(name,content);
   else {
@@ -91,11 +91,7 @@ function caml_create_file_extern(name,content){
   let fragments = Linker.parse_string code in
   Linker.load_fragments ~target_env:Isomorphic ~filename:"<dummy>" fragments;
   let instr =
-    Pseudo_fs.f
-      ~prim:`caml_create_file_extern
-      ~cmis:StringSet.empty
-      ~files
-      ~paths:include_dirs
+    Pseudo_fs.f ~prim:`create_file_extern ~cmis:StringSet.empty ~files ~paths:include_dirs
   in
   let code = Code.prepend Code.empty instr in
   Filename.gen_file output_file (fun chan ->

--- a/compiler/lib/code.ml
+++ b/compiler/lib/code.ml
@@ -259,7 +259,7 @@ type array_or_not =
 
 type constant =
   | String of string
-  | IString of string
+  | NativeString of string
   | Float of float
   | Float_array of float array
   | Int64 of int64
@@ -269,7 +269,7 @@ type constant =
 let rec constant_equal a b =
   match a, b with
   | String a, String b -> Some (String.equal a b)
-  | IString a, IString b -> Some (String.equal a b)
+  | NativeString a, NativeString b -> Some (String.equal a b)
   | Tuple (ta, a, _), Tuple (tb, b, _) ->
       if ta <> tb || Array.length a <> Array.length b
       then Some false
@@ -286,21 +286,21 @@ let rec constant_equal a b =
   | Float_array a, Float_array b -> Some (Array.equal Float.equal a b)
   | Int a, Int b -> Some (Int32.equal a b)
   | Float a, Float b -> Some (Float.equal a b)
-  | String _, IString _ | IString _, String _ -> None
+  | String _, NativeString _ | NativeString _, String _ -> None
   | Int _, Float _ | Float _, Int _ -> None
   | Tuple ((0 | 254), _, _), Float_array _ -> None
   | Float_array _, Tuple ((0 | 254), _, _) -> None
-  | Tuple _, (String _ | IString _ | Int64 _ | Int _ | Float _ | Float_array _) ->
+  | Tuple _, (String _ | NativeString _ | Int64 _ | Int _ | Float _ | Float_array _) ->
       Some false
-  | Float_array _, (String _ | IString _ | Int64 _ | Int _ | Float _ | Tuple _) ->
+  | Float_array _, (String _ | NativeString _ | Int64 _ | Int _ | Float _ | Tuple _) ->
       Some false
   | String _, (Int64 _ | Int _ | Float _ | Tuple _ | Float_array _) -> Some false
-  | IString _, (Int64 _ | Int _ | Float _ | Tuple _ | Float_array _) -> Some false
-  | Int64 _, (String _ | IString _ | Int _ | Float _ | Tuple _ | Float_array _) ->
+  | NativeString _, (Int64 _ | Int _ | Float _ | Tuple _ | Float_array _) -> Some false
+  | Int64 _, (String _ | NativeString _ | Int _ | Float _ | Tuple _ | Float_array _) ->
       Some false
-  | Float _, (String _ | IString _ | Float_array _ | Int64 _ | Tuple (_, _, _)) ->
+  | Float _, (String _ | NativeString _ | Float_array _ | Int64 _ | Tuple (_, _, _)) ->
       Some false
-  | Int _, (String _ | IString _ | Float_array _ | Int64 _ | Tuple (_, _, _)) ->
+  | Int _, (String _ | NativeString _ | Float_array _ | Int64 _ | Tuple (_, _, _)) ->
       Some false
 
 type prim_arg =
@@ -360,7 +360,7 @@ module Print = struct
   let rec constant f x =
     match x with
     | String s -> Format.fprintf f "%S" s
-    | IString s -> Format.fprintf f "%S" s
+    | NativeString s -> Format.fprintf f "%Sj" s
     | Float fl -> Format.fprintf f "%.12g" fl
     | Float_array a ->
         Format.fprintf f "[|";

--- a/compiler/lib/code.mli
+++ b/compiler/lib/code.mli
@@ -142,7 +142,7 @@ type array_or_not =
 
 type constant =
   | String of string
-  | IString of string
+  | NativeString of string
   | Float of float
   | Float_array of float array
   | Int64 of int64

--- a/compiler/lib/flow.ml
+++ b/compiler/lib/flow.ml
@@ -306,7 +306,7 @@ let the_def_of info x =
         info
         (fun x ->
           match info.info_defs.(Var.idx x) with
-          | Expr (Constant (Float _ | Int _ | IString _) as e) -> Some e
+          | Expr (Constant (Float _ | Int _ | NativeString _) as e) -> Some e
           | Expr (Constant (String _) as e) when Config.Flag.safe_string () -> Some e
           | Expr e -> if info.info_possibly_mutable.(Var.idx x) then None else Some e
           | _ -> None)
@@ -322,7 +322,7 @@ let the_const_of info x =
         info
         (fun x ->
           match info.info_defs.(Var.idx x) with
-          | Expr (Constant ((Float _ | Int _ | IString _) as c)) -> Some c
+          | Expr (Constant ((Float _ | Int _ | NativeString _) as c)) -> Some c
           | Expr (Constant (String _ as c)) when Config.Flag.safe_string () -> Some c
           | Expr (Constant c) ->
               if info.info_possibly_mutable.(Var.idx x) then None else Some c
@@ -342,7 +342,12 @@ let the_int info x =
 
 let the_string_of info x =
   match the_const_of info x with
-  | Some (String i | IString i) -> Some i
+  | Some (String i) -> Some i
+  | _ -> None
+
+let the_native_string_of info x =
+  match the_const_of info x with
+  | Some (NativeString i) -> Some i
   | _ -> None
 
 (*XXX Maybe we could iterate? *)

--- a/compiler/lib/flow.mli
+++ b/compiler/lib/flow.mli
@@ -58,6 +58,8 @@ val the_const_of : info -> Code.prim_arg -> Code.constant option
 
 val the_string_of : info -> Code.prim_arg -> string option
 
+val the_native_string_of : info -> Code.prim_arg -> string option
+
 val the_int : info -> Code.prim_arg -> int32 option
 
 val update_def : info -> Code.Var.t -> Code.expr -> unit

--- a/compiler/lib/inline.ml
+++ b/compiler/lib/inline.ml
@@ -152,7 +152,7 @@ let simple blocks cont mapping =
       | `Ok (x, exp), Return ret when Code.Var.compare x (find_mapping mapping ret) = 0
         -> (
           match exp with
-          | Constant (Float _ | Int64 _ | Int _ | IString _) -> `Exp exp
+          | Constant (Float _ | Int64 _ | Int _ | NativeString _) -> `Exp exp
           | Apply (f, args, true) ->
               `Exp (Apply (map_var mapping f, List.map args ~f:(map_var mapping), true))
           | Prim (prim, args) ->
@@ -257,7 +257,8 @@ let inline closures live_vars outer_optimizable pc (blocks, free_pc) =
                    && Primitive.has_arity prim len
                    && args_equal l args
                 then
-                  Let (x, Prim (Extern "%closure", [ Pc (IString prim) ])) :: rem, state
+                  ( Let (x, Prim (Extern "%closure", [ Pc (NativeString prim) ])) :: rem
+                  , state )
                 else i :: rem, state
             | _ -> i :: rem, state)
         | _ -> i :: rem, state)

--- a/compiler/lib/parse_bytecode.ml
+++ b/compiler/lib/parse_bytecode.ml
@@ -2533,7 +2533,7 @@ let from_compilation_units ~includes:_ ~toplevel ~debug_data l =
                 let l = register_global globals i l in
                 let cst = globals.constants.(i) in
                 (match cst, Code.Var.get_name x with
-                | (String str | NativeString str), None ->
+                | String str, None ->
                     Code.Var.name x (Printf.sprintf "cst_%s" str)
                 | _ -> ());
                 Let (x, Constant cst) :: l

--- a/compiler/lib/parse_bytecode.ml
+++ b/compiler/lib/parse_bytecode.ml
@@ -2533,8 +2533,7 @@ let from_compilation_units ~includes:_ ~toplevel ~debug_data l =
                 let l = register_global globals i l in
                 let cst = globals.constants.(i) in
                 (match cst, Code.Var.get_name x with
-                | String str, None ->
-                    Code.Var.name x (Printf.sprintf "cst_%s" str)
+                | String str, None -> Code.Var.name x (Printf.sprintf "cst_%s" str)
                 | _ -> ());
                 Let (x, Constant cst) :: l
             | Some name ->

--- a/compiler/lib/parse_bytecode.ml
+++ b/compiler/lib/parse_bytecode.ml
@@ -442,7 +442,7 @@ end = struct
       Int (Int32.of_int_warning_on_overflow i)
 
   let inlined = function
-    | String _ | IString _ -> false
+    | String _ | NativeString _ -> false
     | Float _ -> true
     | Float_array _ -> false
     | Int64 _ -> false
@@ -712,8 +712,11 @@ let register_global ?(force = false) g i rem =
       match g.named_value.(i) with
       | None -> []
       | Some name ->
-          Code.Var.name (access_global g i) name;
-          [ Pc (IString name) ]
+          if String.is_ascii name
+          then (
+            Code.Var.name (access_global g i) name;
+            [ Pc (NativeString name) ])
+          else []
     in
     Let
       ( Var.fresh ()
@@ -2132,7 +2135,7 @@ let override_global =
   | `V4_13 -> []
   | `V4_04 | `V4_06 | `V4_07 | `V4_08 | `V4_09 | `V4_10 | `V4_11 | `V4_12 ->
       let jsmodule name func =
-        Prim (Extern "%overrideMod", [ Pc (String name); Pc (String func) ])
+        Prim (Extern "%overrideMod", [ Pc (NativeString name); Pc (NativeString func) ])
       in
       [ ( "CamlinternalMod"
         , fun _orig instrs ->
@@ -2332,12 +2335,14 @@ let from_exe
       in
       let body =
         List.fold_left infos ~init:body ~f:(fun rem (name, const) ->
+            assert (String.is_ascii name);
             need_gdata := true;
             let c = Var.fresh () in
             Let (c, Constant const)
             :: Let
                  ( Var.fresh ()
-                 , Prim (Extern "caml_js_set", [ Pv gdata; Pc (String name); Pv c ]) )
+                 , Prim (Extern "caml_js_set", [ Pv gdata; Pc (NativeString name); Pv c ])
+                 )
             :: rem)
       in
       if !need_gdata
@@ -2528,15 +2533,25 @@ let from_compilation_units ~includes:_ ~toplevel ~debug_data l =
                 let l = register_global globals i l in
                 let cst = globals.constants.(i) in
                 (match cst, Code.Var.get_name x with
-                | (String str | IString str), None ->
+                | (String str | NativeString str), None ->
                     Code.Var.name x (Printf.sprintf "cst_%s" str)
                 | _ -> ());
                 Let (x, Constant cst) :: l
             | Some name ->
                 Var.name x name;
                 need_gdata := true;
-                Let (x, Prim (Extern "caml_js_get", [ Pv gdata; Pc (IString name) ])) :: l
-            )
+                if String.is_ascii name
+                then
+                  Let
+                    (x, Prim (Extern "caml_js_get", [ Pv gdata; Pc (NativeString name) ]))
+                  :: l
+                else
+                  let name_js = Var.fresh () in
+                  Let
+                    ( name_js
+                    , Prim (Extern "caml_jsstring_of_string", [ Pc (String name) ]) )
+                  :: Let (x, Prim (Extern "caml_js_get", [ Pv gdata; Pv name_js ]))
+                  :: l)
         | _ -> l)
   in
   let body =
@@ -2632,12 +2647,13 @@ let predefined_exceptions () =
   let body =
     let open Code in
     List.map predefined_exceptions ~f:(fun (index, name) ->
+        assert (String.is_ascii name);
         let exn = Var.fresh () in
         let v_name = Var.fresh () in
         let v_name_js = Var.fresh () in
         let v_index = Var.fresh () in
         [ Let (v_name, Constant (String name))
-        ; Let (v_name_js, Constant (IString name))
+        ; Let (v_name_js, Constant (NativeString name))
         ; Let
             ( v_index
             , Constant

--- a/compiler/lib/pseudo_fs.ml
+++ b/compiler/lib/pseudo_fs.ml
@@ -85,19 +85,21 @@ let find_cmi paths base =
 
 let instr_of_name_content prim ~name ~content =
   let open Code in
-  Let (Var.fresh (), Prim (Extern prim, [ Pc (IString name); Pc (IString content) ]))
+  let prim =
+    match prim with
+    | `create_file -> "jsoo_create_file"
+    | `create_file_extern -> "jsoo_create_file_extern"
+  in
+  Let
+    ( Var.fresh ()
+    , Prim (Extern prim, [ Pc (NativeString name); Pc (NativeString content) ]) )
 
 let embed_file ~name ~filename =
-  instr_of_name_content "caml_create_file_extern" ~name ~content:(Fs.read_file filename)
+  instr_of_name_content `create_file_extern ~name ~content:(Fs.read_file filename)
 
 let init () = Code.(Let (Var.fresh (), Prim (Extern "caml_fs_init", [])))
 
 let f ~prim ~cmis ~files ~paths =
-  let prim =
-    match prim with
-    | `caml_create_file -> "caml_create_file"
-    | `caml_create_file_extern -> "caml_create_file_extern"
-  in
   let cmi_files, missing_cmis =
     StringSet.fold
       (fun s (acc, missing) ->

--- a/compiler/lib/pseudo_fs.mli
+++ b/compiler/lib/pseudo_fs.mli
@@ -20,7 +20,7 @@
 open Stdlib
 
 val f :
-     prim:[ `caml_create_file | `caml_create_file_extern ]
+     prim:[ `create_file | `create_file_extern ]
   -> cmis:StringSet.t
   -> files:string list
   -> paths:string list

--- a/compiler/lib/specialize.ml
+++ b/compiler/lib/specialize.ml
@@ -27,7 +27,7 @@ let rec function_cardinality info x acc =
     (fun x ->
       match info.info_defs.(Var.idx x) with
       | Expr (Closure (l, _)) -> Some (List.length l)
-      | Expr (Prim (Extern "%closure", [ Pc (IString prim) ])) -> (
+      | Expr (Prim (Extern "%closure", [ Pc (NativeString prim) ])) -> (
           try Some (Primitive.arity prim) with Not_found -> None)
       | Expr (Apply (f, l, _)) -> (
           if List.mem f ~set:acc

--- a/compiler/lib/specialize_js.ml
+++ b/compiler/lib/specialize_js.ml
@@ -37,11 +37,13 @@ let specialize_instr info i rem =
       | Some i -> Let (x, Constant (String (Int32.to_string i)))
       | None -> i)
       :: rem
+  (* inline the String constant argument so that generate.ml can attempt to parse it *)
   | Let
       ( x
       , Prim
-          (Extern (("caml_js_var" | "caml_js_expr" | "caml_pure_js_expr") as prim), [ y ])
-      ) ->
+          ( Extern (("caml_js_var" | "caml_js_expr" | "caml_pure_js_expr") as prim)
+          , [ (Pv _ as y) ] ) )
+    when Config.Flag.safe_string () ->
       (match the_string_of info y with
       | Some s -> Let (x, Prim (Extern prim, [ Pc (String s) ]))
       | _ -> i)
@@ -69,7 +71,7 @@ let specialize_instr info i rem =
       :: rem
   | Let (x, Prim (Extern "caml_js_meth_call", [ o; m; a ])) ->
       (match the_string_of info m with
-      | Some m -> (
+      | Some m when String.is_ascii m -> (
           match the_def_of info a with
           | Some (Block (_, a, _)) ->
               let a = Array.map a ~f:(fun x -> Pv x) in
@@ -77,7 +79,7 @@ let specialize_instr info i rem =
                 ( x
                 , Prim
                     ( Extern "%caml_js_opt_meth_call"
-                    , o :: Pc (String m) :: Array.to_list a ) )
+                    , o :: Pc (NativeString m) :: Array.to_list a ) )
           | _ -> i)
       | _ -> i)
       :: rem
@@ -101,7 +103,7 @@ let specialize_instr info i rem =
                | Some (Block (_, [| k; v |], _)) ->
                    let k =
                      match the_string_of info (Pv k) with
-                     | Some s -> Pc (String s)
+                     | Some s when String.is_ascii s -> Pc (NativeString s)
                      | _ -> raise Exit
                    in
                    [ k; Pv v ]
@@ -110,24 +112,24 @@ let specialize_instr info i rem =
          Let (x, Prim (Extern "%caml_js_opt_object", List.flatten (Array.to_list a)))
        with Exit -> i)
       :: rem
-  | Let (x, Prim (Extern "caml_js_get", [ o; f ])) ->
-      (match the_string_of info f with
-      | Some s -> Let (x, Prim (Extern "caml_js_get", [ o; Pc (String s) ]))
+  | Let (x, Prim (Extern "caml_js_get", [ o; (Pv _ as f) ])) ->
+      (match the_native_string_of info f with
+      | Some s -> Let (x, Prim (Extern "caml_js_get", [ o; Pc (NativeString s) ]))
       | _ -> i)
       :: rem
-  | Let (x, Prim (Extern "caml_js_set", [ o; f; v ])) ->
-      (match the_string_of info f with
-      | Some s -> Let (x, Prim (Extern "caml_js_set", [ o; Pc (String s); v ]))
+  | Let (x, Prim (Extern "caml_js_set", [ o; (Pv _ as f); v ])) ->
+      (match the_native_string_of info f with
+      | Some s -> Let (x, Prim (Extern "caml_js_set", [ o; Pc (NativeString s); v ]))
       | _ -> i)
       :: rem
-  | Let (x, Prim (Extern "caml_js_delete", [ o; f ])) ->
-      (match the_string_of info f with
-      | Some s -> Let (x, Prim (Extern "caml_js_delete", [ o; Pc (String s) ]))
+  | Let (x, Prim (Extern "caml_js_delete", [ o; (Pv _ as f) ])) ->
+      (match the_native_string_of info f with
+      | Some s -> Let (x, Prim (Extern "caml_js_delete", [ o; Pc (NativeString s) ]))
       | _ -> i)
       :: rem
   | Let (x, Prim (Extern ("caml_jsstring_of_string" | "caml_js_from_string"), [ y ])) ->
       (match the_string_of info y with
-      | Some s when String.is_ascii s -> Let (x, Constant (IString s))
+      | Some s when String.is_ascii s -> Let (x, Constant (NativeString s))
       | _ -> i)
       :: rem
   | Let (x, Prim (Extern "%int_mul", [ y; z ])) ->

--- a/compiler/tests-check-prim/output
+++ b/compiler/tests-check-prim/output
@@ -60,8 +60,9 @@ caml_return_exn_constant
 From +fs.js:
 caml_ba_map_file
 caml_ba_map_file_bytecode
-caml_create_file_extern
 caml_fs_init
+jsoo_create_file
+jsoo_create_file_extern
 
 From +gc.js:
 caml_memprof_set

--- a/lib/js_of_ocaml/js.ml
+++ b/lib/js_of_ocaml/js.ml
@@ -214,105 +214,111 @@ module Js = struct
 
   external wrap_meth_callback : ('a -> 'b) -> ('a, 'b) meth_callback
     = "caml_js_wrap_meth_callback"
+
+  (****)
+
+  let _true = Unsafe.pure_js_expr "true"
+
+  let _false = Unsafe.pure_js_expr "false"
+
+  type match_result_handle
+
+  type string_array
+
+  class type js_string =
+    object
+      method toString : js_string t meth
+
+      method valueOf : js_string t meth
+
+      method charAt : int -> js_string t meth
+
+      method charCodeAt : int -> float meth
+
+      (* This may return NaN... *)
+      method concat : js_string t -> js_string t meth
+
+      method concat_2 : js_string t -> js_string t -> js_string t meth
+
+      method concat_3 : js_string t -> js_string t -> js_string t -> js_string t meth
+
+      method concat_4 :
+        js_string t -> js_string t -> js_string t -> js_string t -> js_string t meth
+
+      method indexOf : js_string t -> int meth
+
+      method indexOf_from : js_string t -> int -> int meth
+
+      method lastIndexOf : js_string t -> int meth
+
+      method lastIndexOf_from : js_string t -> int -> int meth
+
+      method localeCompare : js_string t -> float meth
+
+      method _match : regExp t -> match_result_handle t opt meth
+
+      method replace : regExp t -> js_string t -> js_string t meth
+
+      method replace_string : js_string t -> js_string t -> js_string t meth
+
+      method search : regExp t -> int meth
+
+      method slice : int -> int -> js_string t meth
+
+      method slice_end : int -> js_string t meth
+
+      method split : js_string t -> string_array t meth
+
+      method split_limited : js_string t -> int -> string_array t meth
+
+      method split_regExp : regExp t -> string_array t meth
+
+      method split_regExpLimited : regExp t -> int -> string_array t meth
+
+      method substring : int -> int -> js_string t meth
+
+      method substring_toEnd : int -> js_string t meth
+
+      method toLowerCase : js_string t meth
+
+      method toLocaleLowerCase : js_string t meth
+
+      method toUpperCase : js_string t meth
+
+      method toLocaleUpperCase : js_string t meth
+
+      method trim : js_string t meth
+
+      method length : int readonly_prop
+    end
+
+  and regExp =
+    object
+      method exec : js_string t -> match_result_handle t opt meth
+
+      method test : js_string t -> bool t meth
+
+      method toString : js_string t meth
+
+      method source : js_string t readonly_prop
+
+      method global : bool t readonly_prop
+
+      method ignoreCase : bool t readonly_prop
+
+      method multiline : bool t readonly_prop
+
+      method lastIndex : int prop
+    end
+
+  (* string is used by ppx_js, it needs to come before any use of the
+     new syntax in this file *)
+  external string : string -> js_string t = "caml_jsstring_of_string"
+
+  external to_string : js_string t -> string = "caml_string_of_jsstring"
 end
 
 include Js
-
-(****)
-
-let _true = Unsafe.pure_js_expr "true"
-
-let _false = Unsafe.pure_js_expr "false"
-
-type match_result_handle
-
-type string_array
-
-class type js_string =
-  object
-    method toString : js_string t meth
-
-    method valueOf : js_string t meth
-
-    method charAt : int -> js_string t meth
-
-    method charCodeAt : int -> float meth
-
-    (* This may return NaN... *)
-    method concat : js_string t -> js_string t meth
-
-    method concat_2 : js_string t -> js_string t -> js_string t meth
-
-    method concat_3 : js_string t -> js_string t -> js_string t -> js_string t meth
-
-    method concat_4 :
-      js_string t -> js_string t -> js_string t -> js_string t -> js_string t meth
-
-    method indexOf : js_string t -> int meth
-
-    method indexOf_from : js_string t -> int -> int meth
-
-    method lastIndexOf : js_string t -> int meth
-
-    method lastIndexOf_from : js_string t -> int -> int meth
-
-    method localeCompare : js_string t -> float meth
-
-    method _match : regExp t -> match_result_handle t opt meth
-
-    method replace : regExp t -> js_string t -> js_string t meth
-
-    method replace_string : js_string t -> js_string t -> js_string t meth
-
-    method search : regExp t -> int meth
-
-    method slice : int -> int -> js_string t meth
-
-    method slice_end : int -> js_string t meth
-
-    method split : js_string t -> string_array t meth
-
-    method split_limited : js_string t -> int -> string_array t meth
-
-    method split_regExp : regExp t -> string_array t meth
-
-    method split_regExpLimited : regExp t -> int -> string_array t meth
-
-    method substring : int -> int -> js_string t meth
-
-    method substring_toEnd : int -> js_string t meth
-
-    method toLowerCase : js_string t meth
-
-    method toLocaleLowerCase : js_string t meth
-
-    method toUpperCase : js_string t meth
-
-    method toLocaleUpperCase : js_string t meth
-
-    method trim : js_string t meth
-
-    method length : int readonly_prop
-  end
-
-and regExp =
-  object
-    method exec : js_string t -> match_result_handle t opt meth
-
-    method test : js_string t -> bool t meth
-
-    method toString : js_string t meth
-
-    method source : js_string t readonly_prop
-
-    method global : bool t readonly_prop
-
-    method ignoreCase : bool t readonly_prop
-
-    method multiline : bool t readonly_prop
-
-    method lastIndex : int prop
-  end
 
 class type string_constr =
   object
@@ -707,10 +713,6 @@ let unescape (s : js_string t) : js_string t =
 external bool : bool -> bool t = "caml_js_from_bool"
 
 external to_bool : bool t -> bool = "caml_js_to_bool"
-
-external string : string -> js_string t = "caml_jsstring_of_string"
-
-external to_string : js_string t -> string = "caml_string_of_jsstring"
 
 external array : 'a array -> 'a js_array t = "caml_js_from_array"
 

--- a/ppx/ppx_js/lib_internal/ppx_js_internal.ml
+++ b/ppx/ppx_js/lib_internal/ppx_js_internal.ml
@@ -95,7 +95,7 @@ let tuple ?loc ?attrs = function
   | [ x ] -> x
   | xs -> Exp.tuple ?loc ?attrs xs
 
-let str ?loc ?attrs s = Exp.constant ?loc ?attrs (Const.string s)
+let ocaml_str ?loc ?attrs s = Exp.constant ?loc ?attrs (Const.string s)
 
 (** Check if an expression is an identifier and returns it.
     Raise a Location.error if it's not.
@@ -158,6 +158,8 @@ end = struct
 
   let fun_ = apply_ ~where:js_dot
 end
+
+let javascript_str ?loc ?attrs s = Js.fun_ "string" ?loc [ ocaml_str ?loc ?attrs s ]
 
 let unescape lab =
   if lab = ""
@@ -303,7 +305,7 @@ let method_call ~loc ~apply_loc obj (meth, meth_loc) args =
         | [] -> assert false
         | eobj :: eargs ->
             let eargs = inject_args eargs in
-            Js.unsafe "meth_call" [ eobj; str (unescape meth); eargs ])
+            Js.unsafe "meth_call" [ eobj; ocaml_str (unescape meth); eargs ])
       (Arg.make () :: List.map args ~f:(fun (label, _) -> Arg.make ~label ()))
   in
   Exp.apply
@@ -347,7 +349,7 @@ let prop_get ~loc obj prop =
       (fun eargs ->
         match eargs with
         | [] | _ :: _ :: _ -> assert false
-        | [ only_arg ] -> Js.unsafe "get" [ only_arg; str (unescape prop) ])
+        | [ only_arg ] -> Js.unsafe "get" [ only_arg; javascript_str (unescape prop) ])
       [ Arg.make () ]
   in
   Exp.apply
@@ -398,7 +400,8 @@ let prop_set ~loc ~prop_loc obj prop value =
         let loc = !default_loc in
         js_dot_t_the_first_arg args, [%type: unit])
       (function
-        | [ obj; arg ] -> Js.unsafe "set" [ obj; str (unescape prop); inject_arg arg ]
+        | [ obj; arg ] ->
+            Js.unsafe "set" [ obj; javascript_str (unescape prop); inject_arg arg ]
         | _ -> assert false)
       [ Arg.make (); Arg.make () ]
   in
@@ -681,7 +684,7 @@ let literal_object self_id (fields : field_desc list) =
           [ Exp.array
               (List.map2 fields args ~f:(fun f arg ->
                    tuple
-                     [ str (unescape (name f).txt)
+                     [ ocaml_str (unescape (name f).txt)
                      ; inject_arg
                          (match f with
                          | Val _ -> arg

--- a/ppx/ppx_js/tests/ppx.mlt
+++ b/ppx/ppx_js/tests/ppx.mlt
@@ -1,5 +1,8 @@
 module Js_of_ocaml = struct
   module Js = struct
+
+    class type js_string = object end
+
     type +'a t
 
     type (-'a, +'b) meth_callback
@@ -44,6 +47,8 @@ module Js_of_ocaml = struct
 
     let wrap_meth_callback : ('a -> 'b) -> ('a, 'b) meth_callback = fun _ -> assert false
 
+    let string : string -> js_string t = fun _ -> assert false
+
     let undefined : unit -> 'a optdef = fun () -> assert false
 
     let def : 'a -> 'a optdef = fun _ -> assert false
@@ -58,6 +63,7 @@ module Js_of_ocaml :
   sig
     module Js :
       sig
+        class type js_string = object  end
         type +'a t
         type (-'a, +'b) meth_callback
         type +'a opt
@@ -81,6 +87,7 @@ module Js_of_ocaml :
             val obj : (string * any) array -> 'a
           end
         val wrap_meth_callback : ('a -> 'b) -> ('a, 'b) meth_callback
+        val string : string -> js_string t
         val undefined : unit -> 'a optdef
         val def : 'a -> 'a optdef
       end

--- a/runtime/fs.js
+++ b/runtime/fs.js
@@ -280,10 +280,10 @@ function caml_ba_map_file_bytecode(argv,argn){
   return caml_ba_map_file(argv[0],argv[1],argv[2],argv[3],argv[4],argv[5]);
 }
 
-//Provides: caml_create_file_extern
-function caml_create_file_extern(name,content){
-  if(joo_global_object.caml_create_file)
-    joo_global_object.caml_create_file(name,content);
+//Provides: jsoo_create_file_extern
+function jsoo_create_file_extern(name,content){
+  if(joo_global_object.jsoo_create_file)
+    joo_global_object.jsoo_create_file(name,content);
   else {
     if(!joo_global_object.caml_fs_tmp) joo_global_object.caml_fs_tmp = [];
     joo_global_object.caml_fs_tmp.push({name:name,content:content});
@@ -292,15 +292,15 @@ function caml_create_file_extern(name,content){
 }
 
 //Provides: caml_fs_init
-//Requires: caml_create_file
+//Requires: jsoo_create_file
 function caml_fs_init (){
   var tmp=joo_global_object.caml_fs_tmp
   if(tmp){
     for(var i = 0; i < tmp.length; i++){
-      caml_create_file(tmp[i].name,tmp[i].content);
+      jsoo_create_file(tmp[i].name,tmp[i].content);
     }
   }
-  joo_global_object.caml_create_file = caml_create_file;
+  joo_global_object.jsoo_create_file = jsoo_create_file;
   joo_global_object.caml_fs_tmp = [];
   return 0;
 }
@@ -308,13 +308,21 @@ function caml_fs_init (){
 //Provides: caml_create_file
 //Requires: caml_failwith, resolve_fs_device, caml_string_of_jsbytes
 function caml_create_file(name,content) {
-  var name = (typeof name == "string")?caml_string_of_jsbytes(name):name;
-  var content = (typeof content == "string")?caml_string_of_jsbytes(content):content;
   var root = resolve_fs_device(name);
   if(! root.device.register) caml_failwith("cannot register file");
   root.device.register(root.rest,content);
   return 0;
 }
+
+
+//Provides: jsoo_create_file
+//Requires: caml_create_file, caml_string_of_jsbytes
+function jsoo_create_file(name,content) {
+  var name = caml_string_of_jsbytes(name);
+  var content = caml_string_of_jsbytes(content);
+  return caml_create_file(name, content);
+}
+
 
 //Provides: caml_read_file_content
 //Requires: resolve_fs_device, caml_raise_no_such_file, caml_create_bytes, caml_string_of_bytes

--- a/runtime/fs.js
+++ b/runtime/fs.js
@@ -306,7 +306,7 @@ function caml_fs_init (){
 }
 
 //Provides: caml_create_file
-//Requires: caml_failwith, resolve_fs_device, caml_string_of_jsbytes
+//Requires: caml_failwith, resolve_fs_device
 function caml_create_file(name,content) {
   var root = resolve_fs_device(name);
   if(! root.device.register) caml_failwith("cannot register file");


### PR DESCRIPTION
`IString` was introduced in #22 as a way to represent JavaScript strings and allow for more optimizations.

For example:
```ocaml
| Let(x, Prim (Extern "caml_js_from_string", Pc (String x))) when String.is_ascii s ->
  Let(x, Constant (IString x))
```

Over time, this distinction got lost a bit and new code started to use `String` and `IString` inconsistently.

What this PR does:
- rename `IString` into `NativeString` to be more descriptive.
- go over the codebase and review all usage.

Note for reviewers:
- `NativeString` represent a js string (`Js.js_string Js.t`)
- `String` represent an ocaml string 