### PR TITLE
Runtime: fix caml_call gen

### DIFF
--- a/lib/tests/test_fun_call.ml
+++ b/lib/tests/test_fun_call.ml
@@ -21,8 +21,7 @@ open Js_of_ocaml
 let%expect_test _ =
   let f = Js.wrap_callback (fun _ -> print_endline "done") in
   let () = Js.Unsafe.fun_call f [| Js.Unsafe.inject 1; Js.Unsafe.inject 2 |] in
-  [%expect.unreachable]
-[@@expect.uncaught_exn {| ("TypeError: args.slice is not a function") |}]
+  [%expect{| done |}]
 
 let%expect_test _ =
   let f = Js.wrap_callback (fun _ _ _ -> print_endline "done") in
@@ -31,5 +30,4 @@ let%expect_test _ =
       (Js.Unsafe.fun_call f [| Js.Unsafe.inject 1; Js.Unsafe.inject 2 |])
       [| Js.Unsafe.inject 1; Js.Unsafe.inject 2 |]
   in
-  [%expect.unreachable]
-[@@expect.uncaught_exn {| ("TypeError: args.concat is not a function") |}]
+  [%expect{| done |}]

--- a/lib/tests/test_fun_call.ml
+++ b/lib/tests/test_fun_call.ml
@@ -39,8 +39,8 @@ let%expect_test _ =
   let sum3 =
     Js.Unsafe.fun_call f [| Js.Unsafe.inject 1; Js.Unsafe.inject 2; Js.Unsafe.inject 3 |]
   in
-  Printf.printf "%d" sum1;
-  [%expect {| function(a1){return f.apply(null,args.concat([a1]))} |}];
+  Printf.printf "%d" ((sum1 : int -> int) 2);
+  [%expect {| 3 |}];
   Printf.printf "%d" sum2;
   [%expect {| 3 |}];
   Printf.printf "%d" sum3;

--- a/lib/tests/test_fun_call.ml
+++ b/lib/tests/test_fun_call.ml
@@ -1,0 +1,35 @@
+(* Js_of_ocaml tests
+ * http://www.ocsigen.org/js_of_ocaml/
+ * Copyright (C) 2020 Hugo Heuzard
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+open Js_of_ocaml
+
+let%expect_test _ =
+  let f = Js.wrap_callback (fun _ -> print_endline "done") in
+  let () = Js.Unsafe.fun_call f [| Js.Unsafe.inject 1; Js.Unsafe.inject 2 |] in
+  [%expect.unreachable]
+[@@expect.uncaught_exn {| ("TypeError: args.slice is not a function") |}]
+
+let%expect_test _ =
+  let f = Js.wrap_callback (fun _ _ _ -> print_endline "done") in
+  let () =
+    Js.Unsafe.fun_call
+      (Js.Unsafe.fun_call f [| Js.Unsafe.inject 1; Js.Unsafe.inject 2 |])
+      [| Js.Unsafe.inject 1; Js.Unsafe.inject 2 |]
+  in
+  [%expect.unreachable]
+[@@expect.uncaught_exn {| ("TypeError: args.concat is not a function") |}]

--- a/lib/tests/test_fun_call.ml
+++ b/lib/tests/test_fun_call.ml
@@ -34,12 +34,13 @@ let%expect_test _ =
 
 let%expect_test _ =
   let f = Js.wrap_callback (fun a b -> a + b) in
-  let sum2 =
-    Js.Unsafe.fun_call f [| Js.Unsafe.inject 1; Js.Unsafe.inject 2; Js.Unsafe.inject 3 |]
-  in
+  let sum1 = Js.Unsafe.fun_call f [| Js.Unsafe.inject 1 |] in
+  let sum2 = Js.Unsafe.fun_call f [| Js.Unsafe.inject 1; Js.Unsafe.inject 2 |] in
   let sum3 =
     Js.Unsafe.fun_call f [| Js.Unsafe.inject 1; Js.Unsafe.inject 2; Js.Unsafe.inject 3 |]
   in
+  Printf.printf "%d" sum1;
+  [%expect {| function(a1){return f.apply(null,args.concat([a1]))} |}];
   Printf.printf "%d" sum2;
   [%expect {| 3 |}];
   Printf.printf "%d" sum3;

--- a/lib/tests/test_fun_call.ml
+++ b/lib/tests/test_fun_call.ml
@@ -31,3 +31,16 @@ let%expect_test _ =
       [||]
   in
   [%expect {| done |}]
+
+let%expect_test _ =
+  let f = Js.wrap_callback (fun a b -> a + b) in
+  let sum2 =
+    Js.Unsafe.fun_call f [| Js.Unsafe.inject 1; Js.Unsafe.inject 2; Js.Unsafe.inject 3 |]
+  in
+  let sum3 =
+    Js.Unsafe.fun_call f [| Js.Unsafe.inject 1; Js.Unsafe.inject 2; Js.Unsafe.inject 3 |]
+  in
+  Printf.printf "%d" sum2;
+  [%expect {| 3 |}];
+  Printf.printf "%d" sum3;
+  [%expect {| 3 |}]

--- a/lib/tests/test_fun_call.ml
+++ b/lib/tests/test_fun_call.ml
@@ -21,7 +21,7 @@ open Js_of_ocaml
 let%expect_test _ =
   let f = Js.wrap_callback (fun _ -> print_endline "done") in
   let () = Js.Unsafe.fun_call f [| Js.Unsafe.inject 1; Js.Unsafe.inject 2 |] in
-  [%expect{| done |}]
+  [%expect {| done |}]
 
 let%expect_test _ =
   let f = Js.wrap_callback (fun _ _ _ -> print_endline "done") in
@@ -30,4 +30,4 @@ let%expect_test _ =
       (Js.Unsafe.fun_call f [| Js.Unsafe.inject 1; Js.Unsafe.inject 2 |])
       [| Js.Unsafe.inject 1; Js.Unsafe.inject 2 |]
   in
-  [%expect{| done |}]
+  [%expect {| done |}]

--- a/lib/tests/test_fun_call.ml
+++ b/lib/tests/test_fun_call.ml
@@ -28,6 +28,6 @@ let%expect_test _ =
   let () =
     Js.Unsafe.fun_call
       (Js.Unsafe.fun_call f [| Js.Unsafe.inject 1; Js.Unsafe.inject 2 |])
-      [| Js.Unsafe.inject 1; Js.Unsafe.inject 2 |]
+      [||]
   in
   [%expect {| done |}]

--- a/runtime/stdlib.js
+++ b/runtime/stdlib.js
@@ -55,10 +55,7 @@ function caml_call_gen(f, args) {
     }
     else if (d < 0) {
       if (!args_copied) {
-        if(!args.slice)
-          args = Array.prototype.slice.call(args);
-        else
-          args = args.slice();
+        args = Array.prototype.slice.call(args);
         args_copied = true;
       }
 

--- a/runtime/stdlib.js
+++ b/runtime/stdlib.js
@@ -34,6 +34,7 @@ function raw_array_cons (a,x) {
 }
 
 //Provides: caml_call_gen (const, shallow)
+//Requires: caml_failwith
 //Weakdef
 function caml_call_gen(f, args) {
   var args_copied = false
@@ -43,12 +44,9 @@ function caml_call_gen(f, args) {
       f = f.fun;
       continue;
     }
-    if(typeof f !== "function") {
-      // TODO, fail instead of silently absobing arguments
-      return function (a1) {
-        return caml_call_gen(f, args);
-      }
-    }
+    // WHAT TO DO HERE
+    if (typeof f !== "function") return f;
+
     var n = f.length | 0;
     var argsLen = args.length | 0;
     var d = n - argsLen | 0;

--- a/runtime/stdlib.js
+++ b/runtime/stdlib.js
@@ -24,11 +24,6 @@ function raw_array_sub (a,i,l) {
   return a.slice(i, i + l);
 }
 
-//Provides: raw_array_copy
-function raw_array_copy (a) {
-  return a.slice();
-}
-
 //Provides: raw_array_cons
 function raw_array_cons (a,x) {
   var l = a.length;
@@ -1485,4 +1480,11 @@ function caml_spacetime_only_works_for_native_code() {
 //Provides: caml_is_js
 function caml_is_js() {
   return 1;
+}
+
+//Deprecated
+
+//Provides: raw_array_copy
+function raw_array_copy (a) {
+  return a.slice();
 }

--- a/runtime/stdlib.js
+++ b/runtime/stdlib.js
@@ -34,7 +34,6 @@ function raw_array_cons (a,x) {
 }
 
 //Provides: caml_call_gen (const, shallow)
-//Requires: caml_failwith
 //Weakdef
 function caml_call_gen(f, args) {
   var args_copied = false
@@ -44,7 +43,7 @@ function caml_call_gen(f, args) {
       f = f.fun;
       continue;
     }
-    // WHAT TO DO HERE
+    // TODO: This can happen with over-application. Should we fail here ?
     if (typeof f !== "function") return f;
 
     var n = f.length | 0;

--- a/runtime/stdlib.js
+++ b/runtime/stdlib.js
@@ -53,6 +53,9 @@ function caml_call_gen(f, args) {
     }
     else if (d < 0) {
       if (!args_copied) {
+        if(!args.slice)
+          args = Array.prototype.slice.call(args);
+        else
           args = args.slice();
         args_copied = true;
       }
@@ -64,6 +67,8 @@ function caml_call_gen(f, args) {
       args = after;
     }
     else {
+      if(!args.concat)
+        args = Array.prototype.slice.call(args);
       switch (d) {
       case 1: return function (a1) {
         return f.apply(null, args.concat([a1]));

--- a/runtime/stdlib.js
+++ b/runtime/stdlib.js
@@ -58,7 +58,7 @@ function caml_call_gen(f, args) {
     }
     else if (d < 0) {
       if (!args_copied) {
-        args = args.slice();
+          args = args.slice();
         args_copied = true;
       }
 

--- a/runtime/stdlib.js
+++ b/runtime/stdlib.js
@@ -43,10 +43,15 @@ function caml_call_gen(f, args) {
       f = f.fun;
       continue;
     }
-
-    var n = f.length;
-    var argsLen = args.length;
-    var d = n - argsLen;
+    if(typeof f !== "function") {
+      // TODO, fail instead of silently absobing arguments
+      return function (a1) {
+        return caml_call_gen(f, args);
+      }
+    }
+    var n = f.length | 0;
+    var argsLen = args.length | 0;
+    var d = n - argsLen | 0;
 
     if (d == 0) {
       return f.apply(null, args);

--- a/runtime/stdlib_modern.js
+++ b/runtime/stdlib_modern.js
@@ -17,7 +17,6 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
 //Provides: caml_call_gen (const, shallow)
-//Requires: caml_failwith
 function caml_call_gen(f, args) {
   var args_copied = false;
 

--- a/runtime/stdlib_modern.js
+++ b/runtime/stdlib_modern.js
@@ -25,7 +25,13 @@ function caml_call_gen(f, args) {
       f = f.fun;
       continue;
     }
-
+    if(typeof f !== "function") {
+      // This can happen when over applying functions
+      // TODO, fail instead of silently absobing arguments
+      return function (a1) {
+        return caml_call_gen(f, args);
+      }
+    }
     var n = f.length | 0;
     var argsLen = args.length | 0;
     var d = (n - argsLen) | 0;
@@ -35,13 +41,15 @@ function caml_call_gen(f, args) {
     }
     else if (d < 0) {
       if (!args_copied) {
-        args = args.slice();
+        if(!args.slice)
+          args = Array.prototype.slice.call(args);
+        else
+          args = args.slice();
         args_copied = true;
       }
 
       var before = args;
       var after = before.splice(n);
-
       f = f(...before);
       args = after;
     }

--- a/runtime/stdlib_modern.js
+++ b/runtime/stdlib_modern.js
@@ -17,6 +17,7 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
 //Provides: caml_call_gen (const, shallow)
+//Requires: caml_failwith
 function caml_call_gen(f, args) {
   var args_copied = false;
 
@@ -25,13 +26,8 @@ function caml_call_gen(f, args) {
       f = f.fun;
       continue;
     }
-    if(typeof f !== "function") {
-      // This can happen when over applying functions
-      // TODO, fail instead of silently absobing arguments
-      return function (a1) {
-        return caml_call_gen(f, args);
-      }
-    }
+    // TODO: This can happen with over-application. Should we fail here ?
+    if (typeof f !== "function") return f;
     var n = f.length | 0;
     var argsLen = args.length | 0;
     var d = (n - argsLen) | 0;

--- a/runtime/stdlib_modern.js
+++ b/runtime/stdlib_modern.js
@@ -36,10 +36,7 @@ function caml_call_gen(f, args) {
     }
     else if (d < 0) {
       if (!args_copied) {
-        if(!args.slice)
-          args = Array.prototype.slice.call(args);
-        else
-          args = args.slice();
+        args = Array.prototype.slice.call(args);
         args_copied = true;
       }
 
@@ -49,6 +46,8 @@ function caml_call_gen(f, args) {
       args = after;
     }
     else {
+      if(!args.concat)
+        args = Array.prototype.slice.call(args);
       switch (d) {
       case 1: return function (a1) {
         return f(...args, a1);


### PR DESCRIPTION
Fix regression introduced in #926
The main issue is that caml_call_gen can be called with `arguments` (instance of `Arguments`) which doesn't have any of the array methods. 