### PR TITLE
Runtime: fix caml_call gen (Alternative)

### DIFF
--- a/compiler/lib-runtime/jsoo_runtime.ml
+++ b/compiler/lib-runtime/jsoo_runtime.ml
@@ -40,6 +40,7 @@ let runtime =
     ; nat
     ; parsing
     ; stdlib
+    ; stdlib_modern
     ; unix
     ; weak
     ]

--- a/compiler/lib-runtime/jsoo_runtime.ml
+++ b/compiler/lib-runtime/jsoo_runtime.ml
@@ -40,7 +40,6 @@ let runtime =
     ; nat
     ; parsing
     ; stdlib
-    ; stdlib_modern
     ; unix
     ; weak
     ]

--- a/compiler/tests-compiler/js_parser_printer.ml
+++ b/compiler/tests-compiler/js_parser_printer.ml
@@ -208,8 +208,7 @@ let%expect_test "multiline string" =
     "
     42
 |};
-  [%expect
-    {|
+  [%expect {|
     2: 4:42,
     3: 4:"    ",
     5: 4:42, |}];

--- a/compiler/tests-compiler/macro.ml
+++ b/compiler/tests-compiler/macro.ml
@@ -112,3 +112,19 @@ let%expect_test "FIELD(a, -1)" =
 let%expect_test "ISBLOCK(a)" =
   print_macro_transformed "ISBLOCK(a)";
   [%expect {| typeof a !== "number"; |}]
+
+let%expect_test "INLINE_BLIT(from, from_pos, to, to_pos, len)" =
+  print_macro_transformed "INLINE_BLIT(from, from_pos, to, to_pos, len)";
+  [%expect {| for(var $i=0;$i < len;$i++)to[$i + to_pos] = from[$i + from_pos]; |}]
+
+let%expect_test "INLINE_BLIT(from, from_pos, to, to_pos, len)" =
+  print_macro_transformed "INLINE_BLIT(from, from_pos, to, to_pos, len)";
+  [%expect {| for(var $i=0;$i < len;$i++)to[$i + to_pos] = from[$i + from_pos]; |}];
+  print_macro_transformed "INLINE_BLIT(from, 0, to, to_pos, len)";
+  [%expect {| for(var $i=0;$i < len;$i++)to[$i + to_pos] = from[$i]; |}];
+  print_macro_transformed "INLINE_BLIT(from, from_pos, to, 0, len)";
+  [%expect {| for(var $i=0;$i < len;$i++)to[$i] = from[$i + from_pos]; |}];
+  print_macro_transformed "INLINE_BLIT(from, 1, to, 1, len)";
+  [%expect {| for(var $i=0;$i < len;$i++)to[$i + 1] = from[$i + 1]; |}];
+  print_macro_transformed "INLINE_BLIT(from, 0, to, 0, len)";
+  [%expect {| for(var $i=0;$i < len;$i++)to[$i] = from[$i]; |}]

--- a/compiler/tests-compiler/obj_dup.ml
+++ b/compiler/tests-compiler/obj_dup.ml
@@ -50,8 +50,7 @@ let%expect_test _ =
       Bytes.set s' 1 'a';
       print_bool (s <> s')
   |};
-  [%expect
-    {|
+  [%expect {|
     true
     true
     true
@@ -86,8 +85,7 @@ let%expect_test _ =
       Bytes.set s' 1 'a';
       print_bool (s <> s')
   |};
-  [%expect
-    {|
+  [%expect {|
     true
     true
     true

--- a/compiler/tests-compiler/tailcall.ml
+++ b/compiler/tests-compiler/tailcall.ml
@@ -42,7 +42,8 @@ let%expect_test _ =
   [%expect {| Success! |}];
   let program = Util.compile_and_parse prog in
   Util.print_fun_decl program (Some "fun1");
-  [%expect {|
+  [%expect
+    {|
     function fun1(param)
      {function odd$0(counter,x)
        {if(0 === x)return 0;

--- a/lib/tests/test_fun_call.ml
+++ b/lib/tests/test_fun_call.ml
@@ -21,8 +21,7 @@ open Js_of_ocaml
 let%expect_test _ =
   let f = Js.wrap_callback (fun _ -> print_endline "done") in
   let () = Js.Unsafe.fun_call f [| Js.Unsafe.inject 1; Js.Unsafe.inject 2 |] in
-  [%expect.unreachable]
-[@@expect.uncaught_exn {| ("TypeError: args.slice is not a function") |}]
+  [%expect{| done |}]
 
 let%expect_test _ =
   let f = Js.wrap_callback (fun _ _ _ -> print_endline "done") in
@@ -31,5 +30,4 @@ let%expect_test _ =
       (Js.Unsafe.fun_call f [| Js.Unsafe.inject 1; Js.Unsafe.inject 2 |])
       [| Js.Unsafe.inject 1; Js.Unsafe.inject 2 |]
   in
-  [%expect.unreachable]
-[@@expect.uncaught_exn {| ("TypeError: args.concat is not a function") |}]
+  [%expect{| done |}]

--- a/lib/tests/test_fun_call.ml
+++ b/lib/tests/test_fun_call.ml
@@ -41,7 +41,8 @@ let%expect_test _ =
   in
   Printf.printf "%d" sum1;
   [%expect {|
-    function(a1){return f(...args,a1)} |}];
+    function(a1)
+                  {return f.apply(null,Array.prototype.concat.call(args,[a1]))} |}];
   Printf.printf "%d" sum2;
   [%expect {| 3 |}];
   Printf.printf "%d" sum3;

--- a/lib/tests/test_fun_call.ml
+++ b/lib/tests/test_fun_call.ml
@@ -40,7 +40,8 @@ let%expect_test _ =
     Js.Unsafe.fun_call f [| Js.Unsafe.inject 1; Js.Unsafe.inject 2; Js.Unsafe.inject 3 |]
   in
   Printf.printf "%d" sum1;
-  [%expect {| function(a1){return f.apply(null,args.concat([a1]))} |}];
+  [%expect {|
+    function(a1){return f(...args,a1)} |}];
   Printf.printf "%d" sum2;
   [%expect {| 3 |}];
   Printf.printf "%d" sum3;

--- a/lib/tests/test_fun_call.ml
+++ b/lib/tests/test_fun_call.ml
@@ -35,14 +35,15 @@ let%expect_test _ =
 let%expect_test _ =
   let f = Js.wrap_callback (fun a b -> a + b) in
   let sum1 = Js.Unsafe.fun_call f [| Js.Unsafe.inject 1 |] in
+  let sum1' = Js.Unsafe.fun_call sum1 [| Js.Unsafe.inject 2 |] in
   let sum2 = Js.Unsafe.fun_call f [| Js.Unsafe.inject 1; Js.Unsafe.inject 2 |] in
   let sum3 =
     Js.Unsafe.fun_call f [| Js.Unsafe.inject 1; Js.Unsafe.inject 2; Js.Unsafe.inject 3 |]
   in
-  Printf.printf "%d" sum1;
-  [%expect {|
-    function(a1)
-                  {return f.apply(null,Array.prototype.concat.call(args,[a1]))} |}];
+  Printf.printf "%d" ((Obj.magic sum1 : int -> int) 2);
+  [%expect {| 3 |}];
+  Printf.printf "%d" (Obj.magic sum1');
+  [%expect {| 3 |}];
   Printf.printf "%d" sum2;
   [%expect {| 3 |}];
   Printf.printf "%d" sum3;

--- a/lib/tests/test_fun_call.ml
+++ b/lib/tests/test_fun_call.ml
@@ -1,0 +1,35 @@
+(* Js_of_ocaml tests
+ * http://www.ocsigen.org/js_of_ocaml/
+ * Copyright (C) 2020 Hugo Heuzard
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+open Js_of_ocaml
+
+let%expect_test _ =
+  let f = Js.wrap_callback (fun _ -> print_endline "done") in
+  let () = Js.Unsafe.fun_call f [| Js.Unsafe.inject 1; Js.Unsafe.inject 2 |] in
+  [%expect.unreachable]
+[@@expect.uncaught_exn {| ("TypeError: args.slice is not a function") |}]
+
+let%expect_test _ =
+  let f = Js.wrap_callback (fun _ _ _ -> print_endline "done") in
+  let () =
+    Js.Unsafe.fun_call
+      (Js.Unsafe.fun_call f [| Js.Unsafe.inject 1; Js.Unsafe.inject 2 |])
+      [| Js.Unsafe.inject 1; Js.Unsafe.inject 2 |]
+  in
+  [%expect.unreachable]
+[@@expect.uncaught_exn {| ("TypeError: args.concat is not a function") |}]

--- a/lib/tests/test_fun_call.ml
+++ b/lib/tests/test_fun_call.ml
@@ -34,12 +34,13 @@ let%expect_test _ =
 
 let%expect_test _ =
   let f = Js.wrap_callback (fun a b -> a + b) in
-  let sum2 =
-    Js.Unsafe.fun_call f [| Js.Unsafe.inject 1; Js.Unsafe.inject 2; Js.Unsafe.inject 3 |]
-  in
+  let sum1 = Js.Unsafe.fun_call f [| Js.Unsafe.inject 1 |] in
+  let sum2 = Js.Unsafe.fun_call f [| Js.Unsafe.inject 1; Js.Unsafe.inject 2 |] in
   let sum3 =
     Js.Unsafe.fun_call f [| Js.Unsafe.inject 1; Js.Unsafe.inject 2; Js.Unsafe.inject 3 |]
   in
+  Printf.printf "%d" sum1;
+  [%expect {| function(a1){return f.apply(null,args.concat([a1]))} |}];
   Printf.printf "%d" sum2;
   [%expect {| 3 |}];
   Printf.printf "%d" sum3;

--- a/lib/tests/test_fun_call.ml
+++ b/lib/tests/test_fun_call.ml
@@ -31,3 +31,16 @@ let%expect_test _ =
       [||]
   in
   [%expect {| done |}]
+
+let%expect_test _ =
+  let f = Js.wrap_callback (fun a b -> a + b) in
+  let sum2 =
+    Js.Unsafe.fun_call f [| Js.Unsafe.inject 1; Js.Unsafe.inject 2; Js.Unsafe.inject 3 |]
+  in
+  let sum3 =
+    Js.Unsafe.fun_call f [| Js.Unsafe.inject 1; Js.Unsafe.inject 2; Js.Unsafe.inject 3 |]
+  in
+  Printf.printf "%d" sum2;
+  [%expect {| 3 |}];
+  Printf.printf "%d" sum3;
+  [%expect {| 3 |}]

--- a/lib/tests/test_fun_call.ml
+++ b/lib/tests/test_fun_call.ml
@@ -21,7 +21,7 @@ open Js_of_ocaml
 let%expect_test _ =
   let f = Js.wrap_callback (fun _ -> print_endline "done") in
   let () = Js.Unsafe.fun_call f [| Js.Unsafe.inject 1; Js.Unsafe.inject 2 |] in
-  [%expect{| done |}]
+  [%expect {| done |}]
 
 let%expect_test _ =
   let f = Js.wrap_callback (fun _ _ _ -> print_endline "done") in
@@ -30,4 +30,4 @@ let%expect_test _ =
       (Js.Unsafe.fun_call f [| Js.Unsafe.inject 1; Js.Unsafe.inject 2 |])
       [| Js.Unsafe.inject 1; Js.Unsafe.inject 2 |]
   in
-  [%expect{| done |}]
+  [%expect {| done |}]

--- a/lib/tests/test_fun_call.ml
+++ b/lib/tests/test_fun_call.ml
@@ -28,6 +28,6 @@ let%expect_test _ =
   let () =
     Js.Unsafe.fun_call
       (Js.Unsafe.fun_call f [| Js.Unsafe.inject 1; Js.Unsafe.inject 2 |])
-      [| Js.Unsafe.inject 1; Js.Unsafe.inject 2 |]
+      [||]
   in
   [%expect {| done |}]

--- a/runtime/jslib_js_of_ocaml.js
+++ b/runtime/jslib_js_of_ocaml.js
@@ -140,7 +140,7 @@ function caml_js_wrap_callback_arguments(f) {
 function caml_js_wrap_callback_strict(arity, f) {
   return function () {
     var args = new Array(arity);
-    var len = Math.max(arguments.length, arity);
+    var len = Math.min(arguments.length, arity);
     INLINE_BLIT(arguments, 0, args, 0, len)
     return caml_call_gen(f, args);
   };
@@ -171,7 +171,7 @@ function caml_js_wrap_meth_callback_arguments(f) {
 function caml_js_wrap_meth_callback_strict(arity, f) {
   return function () {
     var args_len = arity + 1;
-    var len = Math.max(arguments.length, arity);
+    var len = Math.min(arguments.length, arity);
     var args = new Array(args_len);
     args[0] = this;
     INLINE_BLIT(arguments, 0, args, 1, len)

--- a/runtime/stdlib.js
+++ b/runtime/stdlib.js
@@ -55,10 +55,7 @@ function caml_call_gen(f, args) {
     }
     else if (d < 0) {
       if (!args_copied) {
-        if(!args.slice)
-          args = Array.prototype.slice.call(args);
-        else
-          args = args.slice();
+        args = Array.prototype.slice.call(args);
         args_copied = true;
       }
 

--- a/runtime/stdlib.js
+++ b/runtime/stdlib.js
@@ -34,6 +34,7 @@ function raw_array_cons (a,x) {
 }
 
 //Provides: caml_call_gen (const, shallow)
+//Requires: caml_failwith
 //Weakdef
 function caml_call_gen(f, args) {
   var args_copied = false
@@ -43,12 +44,9 @@ function caml_call_gen(f, args) {
       f = f.fun;
       continue;
     }
-    if(typeof f !== "function") {
-      // TODO, fail instead of silently absobing arguments
-      return function (a1) {
-        return caml_call_gen(f, args);
-      }
-    }
+    // WHAT TO DO HERE
+    if (typeof f !== "function") return f;
+
     var n = f.length | 0;
     var argsLen = args.length | 0;
     var d = n - argsLen | 0;

--- a/runtime/stdlib.js
+++ b/runtime/stdlib.js
@@ -24,11 +24,6 @@ function raw_array_sub (a,i,l) {
   return a.slice(i, i + l);
 }
 
-//Provides: raw_array_copy
-function raw_array_copy (a) {
-  return a.slice();
-}
-
 //Provides: raw_array_cons
 function raw_array_cons (a,x) {
   var l = a.length;
@@ -1485,4 +1480,11 @@ function caml_spacetime_only_works_for_native_code() {
 //Provides: caml_is_js
 function caml_is_js() {
   return 1;
+}
+
+//Deprecated
+
+//Provides: raw_array_copy
+function raw_array_copy (a) {
+  return a.slice();
 }

--- a/runtime/stdlib.js
+++ b/runtime/stdlib.js
@@ -258,10 +258,10 @@ function caml_obj_block (tag, size) {
 
 //Provides: caml_obj_with_tag
 function caml_obj_with_tag(tag,x) {
-  var l = x.length;
-  var a = new Array(l);
+  var len = x.length;
+  var a = new Array(len);
+  INLINE_BLIT(x,0,a,0,len);
   a[0] = tag;
-  for(var i = 1; i < l; i++ ) a[i] = x[i];
   return a;
 }
 
@@ -269,7 +269,7 @@ function caml_obj_with_tag(tag,x) {
 function caml_obj_dup (x) {
   var l = x.length;
   var a = new Array(l);
-  for(var i = 0; i < l; i++ ) a[i] = x[i];
+  INLINE_BLIT(x,0,a,0,l);
   return a;
 }
 
@@ -1172,21 +1172,20 @@ function caml_sys_system_command(cmd){
 function caml_array_sub (a, i, len) {
   var a2 = new Array(len+1);
   a2[0]=0;
-  for(var i2 = 1, i1= i+1; i2 <= len; i2++,i1++ ){
-    a2[i2]=a[i1];
-  }
+  var from = i + 1;
+  INLINE_BLIT(a,from,a2,1,len)
   return a2;
 }
 
 //Provides: caml_array_append mutable
 function caml_array_append(a1, a2) {
-  var l1 = a1.length, l2 = a2.length;
-  var l = l1+l2-1
+  var l1 = a1.length - 1, l2 = a2.length -1;
+  var l = l1+l2+1
   var a = new Array(l);
   a[0] = 0;
-  var i = 1,j = 1;
-  for(;i<l1;i++) a[i]=a1[i];
-  for(;i<l;i++,j++) a[i]=a2[j];
+  INLINE_BLIT(a1,1,a,1,l1);
+  var a_pos = l1 + 1;
+  INLINE_BLIT(a2,1,a,a_pos,l2);
   return a;
 }
 

--- a/runtime/stdlib.js
+++ b/runtime/stdlib.js
@@ -34,7 +34,6 @@ function raw_array_cons (a,x) {
 }
 
 //Provides: caml_call_gen (const, shallow)
-//Requires: caml_failwith
 //Weakdef
 function caml_call_gen(f, args) {
   var args_copied = false
@@ -44,7 +43,7 @@ function caml_call_gen(f, args) {
       f = f.fun;
       continue;
     }
-    // WHAT TO DO HERE
+    // TODO: This can happen with over-application. Should we fail here ?
     if (typeof f !== "function") return f;
 
     var n = f.length | 0;

--- a/runtime/stdlib.js
+++ b/runtime/stdlib.js
@@ -24,15 +24,6 @@ function raw_array_sub (a,i,l) {
   return a.slice(i, i + l);
 }
 
-//Provides: raw_array_cons
-function raw_array_cons (a,x) {
-  var l = a.length;
-  var b = new Array(l+1);
-  b[0]=x;
-  for(var i = 1; i <= l; i++ ) b[i] = a[i-1];
-  return b
-}
-
 //Provides: caml_call_gen (const, shallow)
 //Weakdef
 function caml_call_gen(f, args) {
@@ -55,7 +46,7 @@ function caml_call_gen(f, args) {
     }
     else if (d < 0) {
       if (!args_copied) {
-        args = Array.prototype.slice.call(args);
+        args = args.slice();
         args_copied = true;
       }
 
@@ -68,29 +59,29 @@ function caml_call_gen(f, args) {
     else {
       switch (d) {
       case 1: return function (a1) {
-        return f.apply(null, Array.prototype.concat.call(args, [a1]));
+        return f.apply(null, args.concat([a1]));
       }
       case 2: return function (a1, a2) {
-        return f.apply(null, Array.prototype.concat.call(args, [a1, a2]));
+        return f.apply(null, args.concat([a1, a2]));
       }
       case 3: return function (a1, a2, a3) {
-        return f.apply(null, Array.prototype.concat.call(args, [a1, a2, a3]));
+        return f.apply(null, args.concat([a1, a2, a3]));
       }
       case 4: return function (a1, a2, a3, a4) {
-        return f.apply(null, Array.prototype.concat.call(args, [a1, a2, a3, a4]));
+        return f.apply(null, args.concat([a1, a2, a3, a4]));
       }
       case 5: return function (a1, a2, a3, a4, a5) {
-        return f.apply(null, Array.prototype.concat.call(args, [a1, a2, a3, a4, a5]));
+        return f.apply(null, args.concat([a1, a2, a3, a4, a5]));
       }
       case 6: return function (a1, a2, a3, a4, a5, a6) {
-        return f.apply(null, Array.prototype.concat.call(args, [a1, a2, a3, a4, a5, a6]));
+        return f.apply(null, args.concat([a1, a2, a3, a4, a5, a6]));
       }
       case 7: return function (a1, a2, a3, a4, a5, a6, a7) {
-        return f.apply(null, Array.prototype.concat.call(args, [a1, a2, a3, a4, a5, a6, a7]));
+        return f.apply(null, args.concat([a1, a2, a3, a4, a5, a6, a7]));
       }
       default:
         return function (a1, a2, a3, a4, a5, a6, a7, a8) {
-          return caml_call_gen(f, Array.prototype.concat.call(args,[a1, a2, a3, a4, a5, a6, a7, a8]));
+          return caml_call_gen(f, args.concat([a1, a2, a3, a4, a5, a6, a7, a8]));
         };
       }
     }
@@ -1489,4 +1480,13 @@ function caml_is_js() {
 //Provides: raw_array_copy
 function raw_array_copy (a) {
   return a.slice();
+}
+
+//Provides: raw_array_cons
+function raw_array_cons (a,x) {
+  var l = a.length;
+  var b = new Array(l+1);
+  b[0]=x;
+  for(var i = 1; i <= l; i++ ) b[i] = a[i-1];
+  return b
 }

--- a/runtime/stdlib.js
+++ b/runtime/stdlib.js
@@ -53,6 +53,9 @@ function caml_call_gen(f, args) {
     }
     else if (d < 0) {
       if (!args_copied) {
+        if(!args.slice)
+          args = Array.prototype.slice.call(args);
+        else
           args = args.slice();
         args_copied = true;
       }
@@ -64,6 +67,8 @@ function caml_call_gen(f, args) {
       args = after;
     }
     else {
+      if(!args.concat)
+        args = Array.prototype.slice.call(args);
       switch (d) {
       case 1: return function (a1) {
         return f.apply(null, args.concat([a1]));

--- a/runtime/stdlib.js
+++ b/runtime/stdlib.js
@@ -58,7 +58,7 @@ function caml_call_gen(f, args) {
     }
     else if (d < 0) {
       if (!args_copied) {
-        args = args.slice();
+          args = args.slice();
         args_copied = true;
       }
 

--- a/runtime/stdlib.js
+++ b/runtime/stdlib.js
@@ -43,10 +43,15 @@ function caml_call_gen(f, args) {
       f = f.fun;
       continue;
     }
-
-    var n = f.length;
-    var argsLen = args.length;
-    var d = n - argsLen;
+    if(typeof f !== "function") {
+      // TODO, fail instead of silently absobing arguments
+      return function (a1) {
+        return caml_call_gen(f, args);
+      }
+    }
+    var n = f.length | 0;
+    var argsLen = args.length | 0;
+    var d = n - argsLen | 0;
 
     if (d == 0) {
       return f.apply(null, args);

--- a/runtime/stdlib.js
+++ b/runtime/stdlib.js
@@ -66,33 +66,31 @@ function caml_call_gen(f, args) {
       args = after;
     }
     else {
-      if(!args.concat)
-        args = Array.prototype.slice.call(args);
       switch (d) {
       case 1: return function (a1) {
-        return f.apply(null, args.concat([a1]));
+        return f.apply(null, Array.prototype.concat.call(args, [a1]));
       }
       case 2: return function (a1, a2) {
-        return f.apply(null, args.concat([a1, a2]));
+        return f.apply(null, Array.prototype.concat.call(args, [a1, a2]));
       }
       case 3: return function (a1, a2, a3) {
-        return f.apply(null, args.concat([a1, a2, a3]));
+        return f.apply(null, Array.prototype.concat.call(args, [a1, a2, a3]));
       }
       case 4: return function (a1, a2, a3, a4) {
-        return f.apply(null, args.concat([a1, a2, a3, a4]));
+        return f.apply(null, Array.prototype.concat.call(args, [a1, a2, a3, a4]));
       }
       case 5: return function (a1, a2, a3, a4, a5) {
-        return f.apply(null, args.concat([a1, a2, a3, a4, a5]));
+        return f.apply(null, Array.prototype.concat.call(args, [a1, a2, a3, a4, a5]));
       }
       case 6: return function (a1, a2, a3, a4, a5, a6) {
-        return f.apply(null, args.concat([a1, a2, a3, a4, a5, a6]));
+        return f.apply(null, Array.prototype.concat.call(args, [a1, a2, a3, a4, a5, a6]));
       }
       case 7: return function (a1, a2, a3, a4, a5, a6, a7) {
-        return f.apply(null, args.concat([a1, a2, a3, a4, a5, a6, a7]));
+        return f.apply(null, Array.prototype.concat.call(args, [a1, a2, a3, a4, a5, a6, a7]));
       }
       default:
         return function (a1, a2, a3, a4, a5, a6, a7, a8) {
-          return caml_call_gen(f, args.concat([a1, a2, a3, a4, a5, a6, a7, a8]));
+          return caml_call_gen(f, Array.prototype.concat.call(args,[a1, a2, a3, a4, a5, a6, a7, a8]));
         };
       }
     }

--- a/runtime/stdlib_modern.js
+++ b/runtime/stdlib_modern.js
@@ -17,7 +17,6 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
 //Provides: caml_call_gen (const, shallow)
-//Requires: caml_failwith
 function caml_call_gen(f, args) {
   var args_copied = false;
 

--- a/runtime/stdlib_modern.js
+++ b/runtime/stdlib_modern.js
@@ -25,7 +25,13 @@ function caml_call_gen(f, args) {
       f = f.fun;
       continue;
     }
-
+    if(typeof f !== "function") {
+      // This can happen when over applying functions
+      // TODO, fail instead of silently absobing arguments
+      return function (a1) {
+        return caml_call_gen(f, args);
+      }
+    }
     var n = f.length | 0;
     var argsLen = args.length | 0;
     var d = (n - argsLen) | 0;
@@ -35,13 +41,15 @@ function caml_call_gen(f, args) {
     }
     else if (d < 0) {
       if (!args_copied) {
-        args = args.slice();
+        if(!args.slice)
+          args = Array.prototype.slice.call(args);
+        else
+          args = args.slice();
         args_copied = true;
       }
 
       var before = args;
       var after = before.splice(n);
-
       f = f(...before);
       args = after;
     }

--- a/runtime/stdlib_modern.js
+++ b/runtime/stdlib_modern.js
@@ -70,7 +70,7 @@ function caml_call_gen(f, args) {
       }
       default:
         return function (a1, a2, a3, a4, a5, a6, a7, a8) {
-          return caml_call_gen(f, Array.prototype.concat.call(args, [a1, a2, a3, a4, a5, a6, a7, a8]));
+          return caml_call_gen(f, args.concat([a1, a2, a3, a4, a5, a6, a7, a8]));
         };
       }
     }

--- a/runtime/stdlib_modern.js
+++ b/runtime/stdlib_modern.js
@@ -36,10 +36,7 @@ function caml_call_gen(f, args) {
     }
     else if (d < 0) {
       if (!args_copied) {
-        if(!args.slice)
-          args = Array.prototype.slice.call(args);
-        else
-          args = args.slice();
+        args = Array.prototype.slice.call(args);
         args_copied = true;
       }
 
@@ -73,7 +70,7 @@ function caml_call_gen(f, args) {
       }
       default:
         return function (a1, a2, a3, a4, a5, a6, a7, a8) {
-          return caml_call_gen(f, args.concat([a1, a2, a3, a4, a5, a6, a7, a8]));
+          return caml_call_gen(f, Array.prototype.concat.call(args, [a1, a2, a3, a4, a5, a6, a7, a8]));
         };
       }
     }

--- a/runtime/stdlib_modern.js
+++ b/runtime/stdlib_modern.js
@@ -17,6 +17,7 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
 //Provides: caml_call_gen (const, shallow)
+//Requires: caml_failwith
 function caml_call_gen(f, args) {
   var args_copied = false;
 
@@ -25,13 +26,8 @@ function caml_call_gen(f, args) {
       f = f.fun;
       continue;
     }
-    if(typeof f !== "function") {
-      // This can happen when over applying functions
-      // TODO, fail instead of silently absobing arguments
-      return function (a1) {
-        return caml_call_gen(f, args);
-      }
-    }
+    // TODO: This can happen with over-application. Should we fail here ?
+    if (typeof f !== "function") return f;
     var n = f.length | 0;
     var argsLen = args.length | 0;
     var d = (n - argsLen) | 0;

--- a/runtime/stdlib_modern.js
+++ b/runtime/stdlib_modern.js
@@ -36,7 +36,7 @@ function caml_call_gen(f, args) {
     }
     else if (d < 0) {
       if (!args_copied) {
-        args = Array.prototype.slice.call(args);
+        args = args.slice();
         args_copied = true;
       }
 


### PR DESCRIPTION
This is an alternative to #993 

Based on https://github.com/petkaantonov/bluebird/wiki/Optimization-killers, leaking `arguments` is bad.

>What is safe arguments usage?
> Only use
> 
> - arguments.length
> - arguments[i] where i is always a valid integer index into the arguments, and can not be out of bound
> - Never use arguments directly without .length or [i]
> - STRICTLY fn.apply(y, arguments) is ok, nothing else is, e.g. .slice. Function#apply is special.

This PR changes the runtime so that caml_call_gen is never called with an `Arguments` value.