### PR TITLE
Continue caml_call_gen cleanup

### DIFF
--- a/compiler/lib/generate.ml
+++ b/compiler/lib/generate.ml
@@ -711,7 +711,7 @@ let apply_fun_raw ctx f params =
     , ecall f params J.N
     , ecall
         (runtime_fun ctx "caml_call_gen")
-        [ f; J.EArr (List.map params ~f:(fun x -> Some x)) ]
+        [ f; J.EArr (List.map params ~f:(fun x -> Some x)); J.EBool false ]
         J.N )
 
 let generate_apply_fun ctx n =

--- a/compiler/tests-compiler/call_gen.ml
+++ b/compiler/tests-compiler/call_gen.ml
@@ -75,9 +75,9 @@ module M1 = struct
     function l(_g_,_h_){return k(_b_,_a_,_g_,_h_)}
     function m(_e_,_f_){return k(_d_,_c_,_e_,_f_)}
     function caml_call1(f,a0)
-     {return f.length == 1?f(a0):runtime.caml_call_gen(f,[a0])}
+     {return f.length == 1?f(a0):runtime.caml_call_gen(f,[a0],false)}
     function caml_call2(f,a0,a1)
-     {return f.length == 2?f(a0,a1):runtime.caml_call_gen(f,[a0,a1])}
+     {return f.length == 2?f(a0,a1):runtime.caml_call_gen(f,[a0,a1],false)}
     |}]
 end
 

--- a/runtime/jslib_js_of_ocaml.js
+++ b/runtime/jslib_js_of_ocaml.js
@@ -118,9 +118,9 @@ function caml_js_wrap_callback(f) {
     if(len > 0){
       var args = new Array(len);
       INLINE_BLIT(arguments, 0, args, 0, len);
-      return caml_call_gen(f, args);
+      return caml_call_gen(f, args, true);
     } else {
-      return caml_call_gen(f, [undefined]);
+      return caml_call_gen(f, [undefined], false);
     }
   }
 }
@@ -132,7 +132,7 @@ function caml_js_wrap_callback_arguments(f) {
     var len = arguments.length
     var args = new Array(len);
     INLINE_BLIT(arguments, 0, args, 0, len);
-    return caml_call_gen(f,[args]);
+    return caml_call_gen(f,[args], false);
   }
 }
 //Provides: caml_js_wrap_callback_strict const
@@ -142,7 +142,7 @@ function caml_js_wrap_callback_strict(arity, f) {
     var args = new Array(arity);
     var len = Math.min(arguments.length, arity);
     INLINE_BLIT(arguments, 0, args, 0, len)
-    return caml_call_gen(f, args);
+    return caml_call_gen(f, args, false);
   };
 }
 //Provides: caml_js_wrap_meth_callback const (const)
@@ -153,7 +153,7 @@ function caml_js_wrap_meth_callback(f) {
     var args = new Array(len + 1);
     args[0] = this;
     INLINE_BLIT(arguments, 0, args, 1, len);
-    return caml_call_gen(f,args);
+    return caml_call_gen(f,args, true);
   }
 }
 //Provides: caml_js_wrap_meth_callback_arguments const (const)
@@ -163,7 +163,7 @@ function caml_js_wrap_meth_callback_arguments(f) {
     var len = arguments.length
     var args = new Array(len);
     INLINE_BLIT(arguments, 0, args, 0, len);
-    return caml_call_gen(f,[this,args]);
+    return caml_call_gen(f,[this,args], false);
   }
 }
 //Provides: caml_js_wrap_meth_callback_strict const
@@ -175,11 +175,10 @@ function caml_js_wrap_meth_callback_strict(arity, f) {
     var args = new Array(args_len);
     args[0] = this;
     INLINE_BLIT(arguments, 0, args, 1, len)
-    return caml_call_gen(f, args);
+    return caml_call_gen(f, args, false);
   };
 }
 //Provides: caml_js_wrap_meth_callback_unsafe const (const)
-//Requires: caml_call_gen
 function caml_js_wrap_meth_callback_unsafe(f) {
   return function () {
     var len = arguments.length;


### PR DESCRIPTION
Following #994, here is an experiment to further improve caml_call_gen:

- control the behavior when too many arguments are given: raise error or ignore them
- never copy the `args` array argument in caml_call_gen and happily mutate it. 