### PR TITLE
Fix caml_call_gen & co

### DIFF
--- a/lib/tests/test_fun_call.ml
+++ b/lib/tests/test_fun_call.ml
@@ -333,16 +333,14 @@ let%expect_test "over application, extra arguments are dropped" =
   call_and_log
     (Js.Unsafe.meth_callback cb4)
     {| (function(f){ return f.apply("this",[1,2,3,4]) }) |};
-  (* FIXME: should not return undefined *)
   [%expect {|
     got this, 1, 2, 3, done
-    Result: undefined |}]
+    Result: 0 |}]
 
 let%expect_test "partial application, extra arguments set to undefined" =
   call_and_log
     (Js.Unsafe.meth_callback cb4)
     {| (function(f){ return f.apply("this",[1,2]) }) |};
-  (* FIXME: should not return undefined *)
   [%expect {|
     got this, 1, 2, undefined, done
-    Result: undefined |}]
+    Result: 0 |}]

--- a/lib/tests/test_fun_call.ml
+++ b/lib/tests/test_fun_call.ml
@@ -276,16 +276,14 @@ let%expect_test "wrap_meth_callback_strict" =
   call_and_log
     (Js.Unsafe.meth_callback_with_arity 3 cb4)
     {| (function(f){ return f.apply("this",[1,2,3,4]) }) |};
-  (* FIXME *)
   [%expect {|
-    got this, 2, 3, 4, done
+    got this, 1, 2, 3, done
     Result: 0 |}];
   call_and_log
     (Js.Unsafe.meth_callback_with_arity 3 cb4)
     {| (function(f){ return f.apply("this",[1,2]) }) |};
-  (* FIXME *)
   [%expect {|
-    got this, 2, undefined, undefined, done
+    got this, 1, 2, undefined, done
     Result: 0 |}]
 
 let%expect_test "wrap_meth_callback_strict" =
@@ -297,9 +295,8 @@ let%expect_test "wrap_meth_callback_strict" =
   call_and_log
     (Js.Unsafe.meth_callback_with_arity 2 cb4)
     {| (function(f){ return f.apply("this",[1,2,3])(4) }) |};
-  (* FIXME *)
   [%expect {|
-    got this, 2, 3, 4, done
+    got this, 1, 2, 4, done
     Result: 0 |}];
   call_and_log
     (Js.Unsafe.meth_callback_with_arity 2 cb4)
@@ -316,20 +313,20 @@ let%expect_test "wrap_meth_callback_strict" =
   call_and_log
     (Js.Unsafe.meth_callback_with_arity 4 cb4)
     {| (function(f){ return f.apply("this",[1,2,3]) }) |};
-  (* FIXME *)
+  (* FIXME, why does this return a function *)
   [%expect {|
-    got this, 2, 3, undefined, done
+    got this, 1, 2, 3, done
     Result: function#1 |}];
   call_and_log
     (Js.Unsafe.meth_callback_with_arity 4 cb4)
     {| (function(f){ return f.apply("this",[1,2,3,4]) }) |};
+  (* Should not return a function *)
   [%expect {|
     got this, 1, 2, 3, done
     Result: function#1 |}];
   call_and_log
     (Js.Unsafe.meth_callback_with_arity 4 cb4)
     {| (function(f){ return f.apply("this",[1,2]) }) |};
-  (* FIXME *)
   [%expect {|
-    got this, 2, undefined, undefined, done
+    got this, 1, 2, undefined, done
     Result: function#1 |}]

--- a/lib/tests/test_fun_call.ml
+++ b/lib/tests/test_fun_call.ml
@@ -327,3 +327,22 @@ let%expect_test "wrap_meth_callback_strict" =
   [%expect {|
     got this, 1, 2, undefined, done
     Result: 0 |}]
+
+(* Wrap meth callback unsafe *)
+let%expect_test "over application, extra arguments are dropped" =
+  call_and_log
+    (Js.Unsafe.meth_callback cb4)
+    {| (function(f){ return f.apply("this",[1,2,3,4]) }) |};
+  (* FIXME: should not return undefined *)
+  [%expect {|
+    got this, 1, 2, 3, done
+    Result: undefined |}]
+
+let%expect_test "partial application, extra arguments set to undefined" =
+  call_and_log
+    (Js.Unsafe.meth_callback cb4)
+    {| (function(f){ return f.apply("this",[1,2]) }) |};
+  (* FIXME: should not return undefined *)
+  [%expect {|
+    got this, 1, 2, undefined, done
+    Result: undefined |}]

--- a/lib/tests/test_fun_call.ml
+++ b/lib/tests/test_fun_call.ml
@@ -57,10 +57,9 @@ let cb5 a b c d e =
 
 let%expect_test "over application, extra arguments are dropped" =
   call_and_log (Js.wrap_callback cb3) {| (function(f){ return f(1,2,3,4) }) |};
-  (* FIXME, this should not return a function *)
   [%expect {|
     got 1, 2, 3, done
-    Result: function#1 |}]
+    Result: 0 |}]
 
 let%expect_test "over application, extra arguments are dropped" =
   call_and_log (Js.wrap_callback cb3) {| (function(f){ return f(1,2)(3,4) }) |};
@@ -102,8 +101,7 @@ let%expect_test _ =
   call_and_log plus {| (function(f){ return f(1,2) }) |};
   [%expect {| Result: 3 |}];
   call_and_log plus {| (function(f){ return f(1,2,3) }) |};
-  (* FIXME *)
-  [%expect {| Result: function#1 |}]
+  [%expect {| Result: 3 |}]
 
 (* Wrap callback with argument *)
 
@@ -171,17 +169,17 @@ let%expect_test "wrap_callback_strict" =
     {| (function(f){ return f(1,2,3) }) |};
   [%expect {|
     got 1, 2, 3, done
-    Result: function#1 |}];
+    Result: 0 |}];
   call_and_log
     (Js.Unsafe.callback_with_arity 4 cb3)
     {| (function(f){ return f(1,2,3,4) }) |};
   [%expect {|
     got 1, 2, 3, done
-    Result: function#1 |}];
+    Result: 0 |}];
   call_and_log (Js.Unsafe.callback_with_arity 4 cb3) {| (function(f){ return f(1,2) }) |};
   [%expect {|
     got 1, 2, undefined, done
-    Result: function#1 |}]
+    Result: 0 |}]
 
 (* Wrap meth callback *)
 
@@ -189,10 +187,9 @@ let%expect_test "over application, extra arguments are dropped" =
   call_and_log
     (Js.wrap_meth_callback cb4)
     {| (function(f){ return f.apply("this",[1,2,3,4]) }) |};
-  (* FIXME, this should not return a function *)
   [%expect {|
     got this, 1, 2, 3, done
-    Result: function#1 |}]
+    Result: 0 |}]
 
 let%expect_test "over application, extra arguments are dropped" =
   call_and_log
@@ -243,8 +240,7 @@ let%expect_test _ =
   call_and_log plus {| (function(f){ return f(1,2) }) |};
   [%expect {| Result: 3 |}];
   call_and_log plus {| (function(f){ return f(1,2,3) }) |};
-  (* FIXME *)
-  [%expect {| Result: function#1 |}]
+  [%expect {| Result: 3 |}]
 
 (* Wrap callback with argument *)
 
@@ -313,20 +309,19 @@ let%expect_test "wrap_meth_callback_strict" =
   call_and_log
     (Js.Unsafe.meth_callback_with_arity 4 cb4)
     {| (function(f){ return f.apply("this",[1,2,3]) }) |};
-  (* FIXME, why does this return a function *)
   [%expect {|
     got this, 1, 2, 3, done
-    Result: function#1 |}];
+    Result: 0 |}];
   call_and_log
     (Js.Unsafe.meth_callback_with_arity 4 cb4)
     {| (function(f){ return f.apply("this",[1,2,3,4]) }) |};
   (* Should not return a function *)
   [%expect {|
     got this, 1, 2, 3, done
-    Result: function#1 |}];
+    Result: 0 |}];
   call_and_log
     (Js.Unsafe.meth_callback_with_arity 4 cb4)
     {| (function(f){ return f.apply("this",[1,2]) }) |};
   [%expect {|
     got this, 1, 2, undefined, done
-    Result: function#1 |}]
+    Result: 0 |}]

--- a/lib/tests/test_fun_call.ml
+++ b/lib/tests/test_fun_call.ml
@@ -96,7 +96,7 @@ let%expect_test "partial application, 0 argument call is treated like 1 argument
 let%expect_test _ =
   let plus = Js.wrap_callback (fun a b -> a + b) in
   call_and_log plus {| (function(f){ return f(1) }) |};
-  [%expect {| Result: function#1 |}];
+  [%expect {| Result: function#0 |}];
   call_and_log plus {| (function(f){ return f(1)(2) }) |};
   [%expect {| Result: 3 |}];
   call_and_log plus {| (function(f){ return f(1,2) }) |};
@@ -147,7 +147,7 @@ let%expect_test "wrap_callback_strict" =
     (Js.Unsafe.callback_with_arity 2 cb3)
     {| (function(f){ return f(1,2,3) }) |};
   [%expect {|
-    Result: function#1 |}];
+    Result: function#0 |}];
   call_and_log
     (Js.Unsafe.callback_with_arity 2 cb3)
     {| (function(f){ return f(1,2,3)(4) }) |};
@@ -162,7 +162,7 @@ let%expect_test "wrap_callback_strict" =
     Result: 0 |}];
   call_and_log (Js.Unsafe.callback_with_arity 2 cb3) {| (function(f){ return f(1,2) }) |};
   [%expect {|
-    Result: function#1 |}]
+    Result: function#0 |}]
 
 let%expect_test "wrap_callback_strict" =
   call_and_log
@@ -236,7 +236,7 @@ let%expect_test "partial application, 0 argument call is treated 1 argument (und
 let%expect_test _ =
   let plus = Js.wrap_meth_callback (fun _ a b -> a + b) in
   call_and_log plus {| (function(f){ return f(1) }) |};
-  [%expect {| Result: function#1 |}];
+  [%expect {| Result: function#0 |}];
   call_and_log plus {| (function(f){ return f(1)(2) }) |};
   [%expect {| Result: 3 |}];
   call_and_log plus {| (function(f){ return f(1,2) }) |};
@@ -289,7 +289,7 @@ let%expect_test "wrap_meth_callback_strict" =
     (Js.Unsafe.meth_callback_with_arity 2 cb4)
     {| (function(f){ return f.apply("this",[1,2,3]) }) |};
   [%expect {|
-    Result: function#1 |}];
+    Result: function#0 |}];
   call_and_log
     (Js.Unsafe.meth_callback_with_arity 2 cb4)
     {| (function(f){ return f.apply("this",[1,2,3])(4) }) |};
@@ -305,7 +305,7 @@ let%expect_test "wrap_meth_callback_strict" =
   call_and_log
     (Js.Unsafe.meth_callback_with_arity 2 cb4)
     {| (function(f){ return f.apply("this",[1,2]) }) |};
-  [%expect {| Result: function#1 |}]
+  [%expect {| Result: function#0 |}]
 
 let%expect_test "wrap_meth_callback_strict" =
   call_and_log

--- a/lib/tests/test_fun_call.ml
+++ b/lib/tests/test_fun_call.ml
@@ -111,7 +111,7 @@ let%expect_test "wrap_callback_arguments" =
     (Js.Unsafe.callback_with_arguments (Obj.magic cb1))
     {| (function(f){ return f(1,2,3,4,5) }) |};
   [%expect {|
-    got (Arguments: 1,2,3,4,5), done
+    got 1,2,3,4,5, done
     Result: 0 |}]
 
 let%expect_test "wrap_callback_arguments" =
@@ -119,7 +119,7 @@ let%expect_test "wrap_callback_arguments" =
     (Js.Unsafe.callback_with_arguments (Obj.magic cb1))
     {| (function(f){ return f() }) |};
   [%expect {|
-    got (Arguments: ), done
+    got , done
     Result: 0 |}]
 
 (* Wrap with arity *)
@@ -251,7 +251,7 @@ let%expect_test "wrap_meth_callback_arguments" =
     (Js.Unsafe.meth_callback_with_arguments (Obj.magic cb2))
     {| (function(f){ return f.apply("this",[1,2,3,4,5]) }) |};
   [%expect {|
-    got this, (Arguments: 1,2,3,4,5), done
+    got this, 1,2,3,4,5, done
     Result: 0 |}]
 
 let%expect_test "wrap_meth_callback_arguments" =
@@ -259,7 +259,7 @@ let%expect_test "wrap_meth_callback_arguments" =
     (Js.Unsafe.meth_callback_with_arguments (Obj.magic cb2))
     {| (function(f){ return f.apply("this", []) }) |};
   [%expect {|
-    got this, (Arguments: ), done
+    got this, , done
     Result: 0 |}]
 
 (* Wrap with arity *)

--- a/lib/tests/test_fun_call.ml
+++ b/lib/tests/test_fun_call.ml
@@ -69,8 +69,9 @@ let%expect_test "over application, extra arguments are dropped" =
 
 let%expect_test "partial application 1 + 2" =
   call_and_log (Js.wrap_callback cb3) {| (function(f){ return f(1)(2,3) }) |};
-  (* FIXME, this should not return a function *)
-  [%expect {| Result: function#1 |}]
+  [%expect {|
+    got 1, 2, 3, done
+    Result: 0 |}]
 
 let%expect_test "partial application 2 + 1" =
   call_and_log (Js.wrap_callback cb3) {| (function(f){ return f(1,2)(3) }) |};
@@ -203,8 +204,9 @@ let%expect_test "partial application 1 + 2" =
   call_and_log
     (Js.wrap_meth_callback cb4)
     {| (function(f){ return f.apply("this", [1])(2,3) }) |};
-  (* FIXME ..  *)
-  [%expect {| Result: function#1 |}]
+  [%expect {|
+    got this, 1, 2, 3, done
+    Result: 0 |}]
 
 let%expect_test "partial application 2 + 1" =
   call_and_log

--- a/lib/tests/test_fun_call.ml
+++ b/lib/tests/test_fun_call.ml
@@ -1,0 +1,335 @@
+(* Js_of_ocaml tests
+ * http://www.ocsigen.org/js_of_ocaml/
+ * Copyright (C) 2020 Hugo Heuzard
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+open Js_of_ocaml
+
+let s x =
+  let to_string : _ -> _ =
+    Js.Unsafe.eval_string
+      {|
+(function(x){
+    if(x === null)
+      return "null"
+    if(x === undefined)
+      return "undefined"
+    if(typeof x === "function")
+      return "function#" + x.length
+    if(x.toString() == "[object Arguments]")
+      return "(Arguments: " + Array.prototype.slice.call(x).toString() + ")";
+    return x.toString()
+})
+|}
+  in
+  Js.to_string (to_string x)
+
+let call_and_log f str =
+  let call : _ -> _ = Js.Unsafe.eval_string str in
+  let r = call f in
+  Printf.printf "Result: %s" (s r)
+
+let cb1 a = Printf.printf "got %s, done\n" (s a)
+
+let cb2 a b = Printf.printf "got %s, %s, done\n" (s a) (s b)
+
+let cb3 a b c = Printf.printf "got %s, %s, %s, done\n" (s a) (s b) (s c)
+
+let cb4 a b c d = Printf.printf "got %s, %s, %s, %s, done\n" (s a) (s b) (s c) (s d)
+
+let cb5 a b c d e =
+  Printf.printf "got %s, %s, %s, %s, %s, done\n" (s a) (s b) (s c) (s d) (s e)
+
+(* Wrap callback *)
+
+let%expect_test "over application, extra arguments are dropped" =
+  call_and_log (Js.wrap_callback cb3) {| (function(f){ return f(1,2,3,4) }) |};
+  (* FIXME, this should not return a function *)
+  [%expect {|
+    got 1, 2, 3, done
+    Result: function#1 |}]
+
+let%expect_test "over application, extra arguments are dropped" =
+  call_and_log (Js.wrap_callback cb3) {| (function(f){ return f(1,2)(3,4) }) |};
+  [%expect {|
+    got 1, 2, 3, done
+    Result: 0 |}]
+
+let%expect_test "partial application 1 + 2" =
+  call_and_log (Js.wrap_callback cb3) {| (function(f){ return f(1)(2,3) }) |};
+  (* FIXME, this should not return a function *)
+  [%expect {| Result: function#1 |}]
+
+let%expect_test "partial application 2 + 1" =
+  call_and_log (Js.wrap_callback cb3) {| (function(f){ return f(1,2)(3) }) |};
+  [%expect {|
+    got 1, 2, 3, done
+    Result: 0 |}]
+
+let%expect_test "partial application, callback is called when all arguments are available"
+    =
+  call_and_log (Js.wrap_callback cb5) {| (function(f){ return f(1)(2)(3)(4)(5) }) |};
+  [%expect {|
+    got 1, 2, 3, 4, 5, done
+    Result: 0 |}]
+
+let%expect_test "partial application, 0 argument call is treated like 1 argument \
+                 (undefined)" =
+  call_and_log (Js.wrap_callback cb5) {| (function(f){ return f(1)()(3)()(5) }) |};
+  [%expect {|
+    got 1, undefined, 3, undefined, 5, done
+    Result: 0 |}]
+
+let%expect_test _ =
+  let plus = Js.wrap_callback (fun a b -> a + b) in
+  call_and_log plus {| (function(f){ return f(1) }) |};
+  [%expect {| Result: function#1 |}];
+  call_and_log plus {| (function(f){ return f(1)(2) }) |};
+  [%expect {| Result: 3 |}];
+  call_and_log plus {| (function(f){ return f(1,2) }) |};
+  [%expect {| Result: 3 |}];
+  call_and_log plus {| (function(f){ return f(1,2,3) }) |};
+  (* FIXME *)
+  [%expect {| Result: function#1 |}]
+
+(* Wrap callback with argument *)
+
+let%expect_test "wrap_callback_arguments" =
+  call_and_log
+    (Js.Unsafe.callback_with_arguments (Obj.magic cb1))
+    {| (function(f){ return f(1,2,3,4,5) }) |};
+  [%expect {|
+    got (Arguments: 1,2,3,4,5), done
+    Result: 0 |}]
+
+let%expect_test "wrap_callback_arguments" =
+  call_and_log
+    (Js.Unsafe.callback_with_arguments (Obj.magic cb1))
+    {| (function(f){ return f() }) |};
+  [%expect {|
+    got (Arguments: ), done
+    Result: 0 |}]
+
+(* Wrap with arity *)
+
+let%expect_test "wrap_callback_strict" =
+  call_and_log
+    (Js.Unsafe.callback_with_arity 3 cb3)
+    {| (function(f){ return f(1,2,3) }) |};
+  [%expect {|
+    got 1, 2, 3, done
+    Result: 0 |}];
+  call_and_log
+    (Js.Unsafe.callback_with_arity 3 cb3)
+    {| (function(f){ return f(1,2,3,4) }) |};
+  [%expect {|
+    got 1, 2, 3, done
+    Result: 0 |}];
+  call_and_log (Js.Unsafe.callback_with_arity 3 cb3) {| (function(f){ return f(1,2) }) |};
+  [%expect {|
+    got 1, 2, undefined, done
+    Result: 0 |}]
+
+let%expect_test "wrap_callback_strict" =
+  call_and_log
+    (Js.Unsafe.callback_with_arity 2 cb3)
+    {| (function(f){ return f(1,2,3) }) |};
+  [%expect {|
+    Result: function#1 |}];
+  call_and_log
+    (Js.Unsafe.callback_with_arity 2 cb3)
+    {| (function(f){ return f(1,2,3)(4) }) |};
+  [%expect {|
+    got 1, 2, 4, done
+    Result: 0 |}];
+  call_and_log
+    (Js.Unsafe.callback_with_arity 2 cb3)
+    {| (function(f){ return f(1,2)(3) }) |};
+  [%expect {|
+    got 1, 2, 3, done
+    Result: 0 |}];
+  call_and_log (Js.Unsafe.callback_with_arity 2 cb3) {| (function(f){ return f(1,2) }) |};
+  [%expect {|
+    Result: function#1 |}]
+
+let%expect_test "wrap_callback_strict" =
+  call_and_log
+    (Js.Unsafe.callback_with_arity 4 cb3)
+    {| (function(f){ return f(1,2,3) }) |};
+  [%expect {|
+    got 1, 2, 3, done
+    Result: function#1 |}];
+  call_and_log
+    (Js.Unsafe.callback_with_arity 4 cb3)
+    {| (function(f){ return f(1,2,3,4) }) |};
+  [%expect {|
+    got 1, 2, 3, done
+    Result: function#1 |}];
+  call_and_log (Js.Unsafe.callback_with_arity 4 cb3) {| (function(f){ return f(1,2) }) |};
+  [%expect {|
+    got 1, 2, undefined, done
+    Result: function#1 |}]
+
+(* Wrap meth callback *)
+
+let%expect_test "over application, extra arguments are dropped" =
+  call_and_log
+    (Js.wrap_meth_callback cb4)
+    {| (function(f){ return f.apply("this",[1,2,3,4]) }) |};
+  (* FIXME, this should not return a function *)
+  [%expect {|
+    got this, 1, 2, 3, done
+    Result: function#1 |}]
+
+let%expect_test "over application, extra arguments are dropped" =
+  call_and_log
+    (Js.wrap_meth_callback cb4)
+    {| (function(f){ return f.apply("this",[1,2])(3,4) }) |};
+  [%expect {|
+    got this, 1, 2, 3, done
+    Result: 0 |}]
+
+let%expect_test "partial application 1 + 2" =
+  call_and_log
+    (Js.wrap_meth_callback cb4)
+    {| (function(f){ return f.apply("this", [1])(2,3) }) |};
+  (* FIXME ..  *)
+  [%expect {| Result: function#1 |}]
+
+let%expect_test "partial application 2 + 1" =
+  call_and_log
+    (Js.wrap_meth_callback cb4)
+    {| (function(f){ return f.apply("this",[1,2])(3) }) |};
+  [%expect {|
+    got this, 1, 2, 3, done
+    Result: 0 |}]
+
+let%expect_test "partial application, callback is called when all arguments are available"
+    =
+  call_and_log
+    (Js.wrap_meth_callback cb5)
+    {| (function(f){ return f.apply("this",[])(1)(2)(3)(4) }) |};
+  [%expect {|
+    got this, 1, 2, 3, 4, done
+    Result: 0 |}]
+
+let%expect_test "partial application, 0 argument call is treated 1 argument (undefined)" =
+  call_and_log
+    (Js.wrap_meth_callback cb5)
+    {| (function(f){ return f.apply("this",[])(1)()(3)() }) |};
+  [%expect {|
+    got this, 1, undefined, 3, undefined, done
+    Result: 0 |}]
+
+let%expect_test _ =
+  let plus = Js.wrap_meth_callback (fun _ a b -> a + b) in
+  call_and_log plus {| (function(f){ return f(1) }) |};
+  [%expect {| Result: function#1 |}];
+  call_and_log plus {| (function(f){ return f(1)(2) }) |};
+  [%expect {| Result: 3 |}];
+  call_and_log plus {| (function(f){ return f(1,2) }) |};
+  [%expect {| Result: 3 |}];
+  call_and_log plus {| (function(f){ return f(1,2,3) }) |};
+  (* FIXME *)
+  [%expect {| Result: function#1 |}]
+
+(* Wrap callback with argument *)
+
+let%expect_test "wrap_meth_callback_arguments" =
+  call_and_log
+    (Js.Unsafe.meth_callback_with_arguments (Obj.magic cb2))
+    {| (function(f){ return f.apply("this",[1,2,3,4,5]) }) |};
+  [%expect {|
+    got this, (Arguments: 1,2,3,4,5), done
+    Result: 0 |}]
+
+let%expect_test "wrap_meth_callback_arguments" =
+  call_and_log
+    (Js.Unsafe.meth_callback_with_arguments (Obj.magic cb2))
+    {| (function(f){ return f.apply("this", []) }) |};
+  [%expect {|
+    got this, (Arguments: ), done
+    Result: 0 |}]
+
+(* Wrap with arity *)
+
+let%expect_test "wrap_meth_callback_strict" =
+  call_and_log
+    (Js.Unsafe.meth_callback_with_arity 3 cb4)
+    {| (function(f){ return f.apply("this",[1,2,3]) }) |};
+  [%expect {|
+    got this, 1, 2, 3, done
+    Result: 0 |}];
+  call_and_log
+    (Js.Unsafe.meth_callback_with_arity 3 cb4)
+    {| (function(f){ return f.apply("this",[1,2,3,4]) }) |};
+  (* FIXME *)
+  [%expect {|
+    got this, 2, 3, 4, done
+    Result: 0 |}];
+  call_and_log
+    (Js.Unsafe.meth_callback_with_arity 3 cb4)
+    {| (function(f){ return f.apply("this",[1,2]) }) |};
+  (* FIXME *)
+  [%expect {|
+    got this, 2, undefined, undefined, done
+    Result: 0 |}]
+
+let%expect_test "wrap_meth_callback_strict" =
+  call_and_log
+    (Js.Unsafe.meth_callback_with_arity 2 cb4)
+    {| (function(f){ return f.apply("this",[1,2,3]) }) |};
+  [%expect {|
+    Result: function#1 |}];
+  call_and_log
+    (Js.Unsafe.meth_callback_with_arity 2 cb4)
+    {| (function(f){ return f.apply("this",[1,2,3])(4) }) |};
+  (* FIXME *)
+  [%expect {|
+    got this, 2, 3, 4, done
+    Result: 0 |}];
+  call_and_log
+    (Js.Unsafe.meth_callback_with_arity 2 cb4)
+    {| (function(f){ return f.apply("this",[1,2])(3) }) |};
+  [%expect {|
+    got this, 1, 2, 3, done
+    Result: 0 |}];
+  call_and_log
+    (Js.Unsafe.meth_callback_with_arity 2 cb4)
+    {| (function(f){ return f.apply("this",[1,2]) }) |};
+  [%expect {| Result: function#1 |}]
+
+let%expect_test "wrap_meth_callback_strict" =
+  call_and_log
+    (Js.Unsafe.meth_callback_with_arity 4 cb4)
+    {| (function(f){ return f.apply("this",[1,2,3]) }) |};
+  (* FIXME *)
+  [%expect {|
+    got this, 2, 3, undefined, done
+    Result: function#1 |}];
+  call_and_log
+    (Js.Unsafe.meth_callback_with_arity 4 cb4)
+    {| (function(f){ return f.apply("this",[1,2,3,4]) }) |};
+  [%expect {|
+    got this, 1, 2, 3, done
+    Result: function#1 |}];
+  call_and_log
+    (Js.Unsafe.meth_callback_with_arity 4 cb4)
+    {| (function(f){ return f.apply("this",[1,2]) }) |};
+  (* FIXME *)
+  [%expect {|
+    got this, 2, undefined, undefined, done
+    Result: function#1 |}]

--- a/runtime/jslib_js_of_ocaml.js
+++ b/runtime/jslib_js_of_ocaml.js
@@ -110,8 +110,11 @@ function caml_ojs_new_arr(c, a) {
 //Requires: caml_call_gen
 function caml_js_wrap_callback(f) {
   return function () {
-    if(arguments.length > 0){
-      return caml_call_gen(f, arguments);
+    var len = arguments.length;
+    if(len > 0){
+      var args = new Array(len);
+      for (var i = 0; i < len; i++) args[i] = arguments[i];
+      return caml_call_gen(f, args);
     } else {
       return caml_call_gen(f, [undefined]);
     }
@@ -122,7 +125,10 @@ function caml_js_wrap_callback(f) {
 //Requires: caml_call_gen
 function caml_js_wrap_callback_arguments(f) {
   return function() {
-    return caml_call_gen(f, [arguments]);
+    var len = arguments.length;
+    var args = new Array(len);
+    for (var i = 0; i < len; i++) args[i] = arguments[i];
+    return caml_call_gen(f, [args]);
   }
 }
 //Provides: caml_js_wrap_callback_strict const
@@ -152,7 +158,10 @@ function caml_js_wrap_meth_callback(f) {
 //Requires: caml_call_gen
 function caml_js_wrap_meth_callback_arguments(f) {
   return function () {
-    return caml_call_gen(f,[this,arguments]);
+    var len = arguments.length;
+    var args = new Array(len);
+    for (var i = 0; i < len; i++) args[i] = arguments[i];
+    return caml_call_gen(f,[this,args]);
   }
 }
 //Provides: caml_js_wrap_meth_callback_strict const

--- a/runtime/jslib_js_of_ocaml.js
+++ b/runtime/jslib_js_of_ocaml.js
@@ -119,10 +119,10 @@ function caml_js_wrap_callback(f) {
 }
 
 //Provides: caml_js_wrap_callback_arguments
-//Requires: caml_js_wrap_callback
+//Requires: caml_call_gen
 function caml_js_wrap_callback_arguments(f) {
   return function() {
-    return caml_js_wrap_callback(f)(arguments);
+    return caml_call_gen(f, [arguments]);
   }
 }
 //Provides: caml_js_wrap_callback_strict const
@@ -130,9 +130,10 @@ function caml_js_wrap_callback_arguments(f) {
 function caml_js_wrap_callback_strict(arity, f) {
   return function () {
     var n = arguments.length;
-    if(n == arity) return caml_call_gen(f, arguments);
+    if(n == arity && f.length == arity) return f.apply(null, arguments);
     var args = new Array(arity);
-    for (var i = 0; i < n && i < arity; i++) args[i] = arguments[i];
+    var len = Math.min(arguments.length, arity)
+    for (var i = 0; i < len; i++) args[i] = arguments[i];
     return caml_call_gen(f, args);
   };
 }

--- a/runtime/jslib_js_of_ocaml.js
+++ b/runtime/jslib_js_of_ocaml.js
@@ -178,14 +178,14 @@ function caml_js_eval_string (s) {return eval(caml_jsstring_of_string(s));}
 //Requires: js_print_stderr
 //Requires: caml_jsstring_of_string
 function caml_js_expr(s) {
-  js_print_stderr("caml_js_expr: fallback to runtime evaluation");
+  js_print_stderr("caml_js_expr: fallback to runtime evaluation\n");
   return eval(caml_jsstring_of_string(s));}
 
 //Provides: caml_pure_js_expr const (const)
 //Requires: js_print_stderr
 //Requires: caml_jsstring_of_string
 function caml_pure_js_expr (s){
-  js_print_stderr("caml_pure_js_expr: fallback to runtime evaluation");
+  js_print_stderr("caml_pure_js_expr: fallback to runtime evaluation\n");
   return eval(caml_jsstring_of_string(s));}
 
 //Provides: caml_js_object (object_literal)

--- a/runtime/jslib_js_of_ocaml.js
+++ b/runtime/jslib_js_of_ocaml.js
@@ -154,11 +154,10 @@ function caml_js_wrap_meth_callback_arguments(f) {
 //Requires: caml_call_gen, raw_array_cons
 function caml_js_wrap_meth_callback_strict(arity, f) {
   return function () {
-    var n = arguments.length;
-    if(n == arity) return caml_call_gen(f, raw_array_cons(arguments,this));
     var args = new Array(arity + 1);
+    var len = Math.min(arguments.length, arity)
     args[0] = this;
-    for (var i = 1; i < n && i <= arity; i++) args[i] = arguments[i];
+    for (var i = 0; i < len; i++) args[i+1] = arguments[i];
     return caml_call_gen(f, args);
   };
 }

--- a/runtime/jslib_js_of_ocaml.js
+++ b/runtime/jslib_js_of_ocaml.js
@@ -164,7 +164,7 @@ function caml_js_wrap_meth_callback_strict(arity, f) {
 //Provides: caml_js_wrap_meth_callback_unsafe const (const)
 //Requires: caml_call_gen,raw_array_cons
 function caml_js_wrap_meth_callback_unsafe(f) {
-  return function () { f.apply(null, raw_array_cons(arguments,this)); }
+  return function () { return f.apply(null, raw_array_cons(arguments,this)); }
 }
 //Provides: caml_js_equals mutable (const, const)
 function caml_js_equals (x, y) { return +(x == y); }

--- a/runtime/jslib_js_of_ocaml.js
+++ b/runtime/jslib_js_of_ocaml.js
@@ -138,10 +138,14 @@ function caml_js_wrap_callback_strict(arity, f) {
   };
 }
 //Provides: caml_js_wrap_meth_callback const (const)
-//Requires: caml_call_gen,raw_array_cons
+//Requires: caml_call_gen
 function caml_js_wrap_meth_callback(f) {
   return function () {
-    return caml_call_gen(f,raw_array_cons(arguments,this));
+    var len = arguments.length;
+    var args = new Array(len + 1);
+    args[0] = this;
+    for (var i = 0; i < len; i++) args[i+1] = arguments[i];
+    return caml_call_gen(f,args);
   }
 }
 //Provides: caml_js_wrap_meth_callback_arguments const (const)
@@ -152,7 +156,7 @@ function caml_js_wrap_meth_callback_arguments(f) {
   }
 }
 //Provides: caml_js_wrap_meth_callback_strict const
-//Requires: caml_call_gen, raw_array_cons
+//Requires: caml_call_gen
 function caml_js_wrap_meth_callback_strict(arity, f) {
   return function () {
     var args = new Array(arity + 1);
@@ -163,9 +167,14 @@ function caml_js_wrap_meth_callback_strict(arity, f) {
   };
 }
 //Provides: caml_js_wrap_meth_callback_unsafe const (const)
-//Requires: caml_call_gen,raw_array_cons
+//Requires: caml_call_gen
 function caml_js_wrap_meth_callback_unsafe(f) {
-  return function () { return f.apply(null, raw_array_cons(arguments,this)); }
+  return function () {
+    var len = arguments.length;
+    var args = new Array(len + 1);
+    args[0] = this;
+    for (var i = 0; i < len; i++) args[i+1] = arguments[i];
+    return f.apply(null, args); }
 }
 //Provides: caml_js_equals mutable (const, const)
 function caml_js_equals (x, y) { return +(x == y); }

--- a/runtime/stdlib.js
+++ b/runtime/stdlib.js
@@ -52,6 +52,7 @@ function caml_call_gen(f, args) {
   //FIXME, can happen with too many arguments
   if(typeof f !== "function") return f;
   var n = f.length | 0;
+  if(n === 0) return f.apply(null,args);
   var argsLen = args.length | 0;
   var d = n - argsLen | 0;
   if (d == 0)
@@ -60,18 +61,12 @@ function caml_call_gen(f, args) {
     return caml_call_gen(f.apply(null,args.slice(0,n)),args.slice(n));
   }
   else {
-    return function (x){
-      if(arguments.length <= 1) {
-        var nargs = new Array(args.length+1);
-        for(var i = 0; i < args.length; i++ ) nargs[i] = args[i];
-        nargs[args.length] = x;
-        return caml_call_gen(f, nargs)
-      } else {
-        var nargs = new Array(args.length+arguments.length);
-        for(var i = 0; i < args.length; i++ ) nargs[i] = args[i];
-        for(var i = 0; i < arguments.length; i++ ) nargs[args.length+i] = arguments[i];
-        return caml_call_gen(f, nargs)
-      }
+    return function (){
+      var extra_args = (arguments.length == 0)?1:arguments.length;
+      var nargs = new Array(args.length+extra_args);
+      for(var i = 0; i < args.length; i++ ) nargs[i] = args[i];
+      for(var i = 0; i < arguments.length; i++ ) nargs[args.length+i] = arguments[i];
+      return caml_call_gen(f, nargs)
     }
   }
 }

--- a/runtime/stdlib.js
+++ b/runtime/stdlib.js
@@ -44,7 +44,6 @@ function raw_array_cons (a,x) {
 }
 
 //Provides: caml_call_gen (const, shallow)
-//Requires: raw_array_sub
 //Weakdef
 function caml_call_gen(f, args) {
   if(f.fun)

--- a/runtime/stdlib.js
+++ b/runtime/stdlib.js
@@ -1292,7 +1292,6 @@ function caml_sys_exit (code) {
 
 //Provides: caml_argv
 //Requires: caml_string_of_jsstring
-//Requires: raw_array_sub
 var caml_argv = ((function () {
   var g = joo_global_object;
   var main = "a.out";
@@ -1304,7 +1303,7 @@ var caml_argv = ((function () {
     var argv = g.process.argv
     //nodejs
     main = argv[1];
-    args = raw_array_sub(argv,2,argv.length - 2);
+    args = argv.slice(2);
   }
 
   var p = caml_string_of_jsstring(main);

--- a/runtime/stdlib.js
+++ b/runtime/stdlib.js
@@ -59,9 +59,11 @@ function raw_array_append_one(a,x) {
 function caml_call_gen(f, args) {
   if(f.fun)
     return caml_call_gen(f.fun, args);
-  var n = f.length;
-  var argsLen = args.length;
-  var d = n - argsLen;
+  //FIXME, can happen with too many arguments
+  if(typeof f !== "function") return f;
+  var n = f.length | 0;
+  var argsLen = args.length | 0;
+  var d = n - argsLen | 0;
   if (d == 0)
     return f.apply(null, args);
   else if (d < 0) {

--- a/runtime/stdlib.js
+++ b/runtime/stdlib.js
@@ -57,9 +57,7 @@ function caml_call_gen(f, args) {
   if (d == 0)
     return f.apply(null, args);
   else if (d < 0) {
-    return caml_call_gen(f.apply(null,
-                                 raw_array_sub(args,0,n)),
-                         raw_array_sub(args,n,argsLen - n));
+    return caml_call_gen(f.apply(null,args.slice(0,n)),args.slice(n));
   }
   else {
     return function (x){

--- a/runtime/stdlib.js
+++ b/runtime/stdlib.js
@@ -43,18 +43,8 @@ function raw_array_cons (a,x) {
   return b
 }
 
-//Provides: raw_array_append_one
-function raw_array_append_one(a,x) {
-  var l = a.length;
-  var b = new Array(l+1);
-  var i = 0;
-  for(; i < l; i++ ) b[i] = a[i];
-  b[i]=x;
-  return b
-}
-
 //Provides: caml_call_gen (const, shallow)
-//Requires: raw_array_sub, raw_array_append_one
+//Requires: raw_array_sub
 //Weakdef
 function caml_call_gen(f, args) {
   if(f.fun)
@@ -73,7 +63,17 @@ function caml_call_gen(f, args) {
   }
   else {
     return function (x){
-      return caml_call_gen(f, raw_array_append_one(args,x))
+      if(arguments.length <= 1) {
+        var nargs = new Array(args.length+1);
+        for(var i = 0; i < args.length; i++ ) nargs[i] = args[i];
+        nargs[args.length] = x;
+        return caml_call_gen(f, nargs)
+      } else {
+        var nargs = new Array(args.length+arguments.length);
+        for(var i = 0; i < args.length; i++ ) nargs[i] = args[i];
+        for(var i = 0; i < arguments.length; i++ ) nargs[args.length+i] = arguments[i];
+        return caml_call_gen(f, nargs)
+      }
     }
   }
 }

--- a/runtime/stdlib_modern.js
+++ b/runtime/stdlib_modern.js
@@ -16,6 +16,7 @@
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
+//TODO: fix the implementation below
 //Provides: caml_call_gen (const, shallow)
 function caml_call_gen(f, args) {
   var args_copied = false;
@@ -25,7 +26,8 @@ function caml_call_gen(f, args) {
       f = f.fun;
       continue;
     }
-
+    // TODO: This can happen with over-application. Should we fail here ?
+    if (typeof f !== "function") return f;
     var n = f.length | 0;
     var argsLen = args.length | 0;
     var d = (n - argsLen) | 0;
@@ -35,17 +37,18 @@ function caml_call_gen(f, args) {
     }
     else if (d < 0) {
       if (!args_copied) {
-        args = args.slice();
+        args = Array.prototype.slice.call(args);
         args_copied = true;
       }
 
       var before = args;
       var after = before.splice(n);
-
       f = f(...before);
       args = after;
     }
     else {
+      if(!args.concat)
+        args = Array.prototype.slice.call(args);
       switch (d) {
       case 1: return function (a1) {
         return f(...args, a1);

--- a/runtime/stdlib_modern.js
+++ b/runtime/stdlib_modern.js
@@ -24,13 +24,13 @@ function caml_call_gen(f, args) {
   //FIXME, can happen with too many arguments
   if(typeof f !== "function") return f;
   var n = f.length | 0;
-  if(n === 0) return f.apply(null,args);
+  if(n === 0) return f(...args);
   var argsLen = args.length | 0;
   var d = n - argsLen | 0;
   if (d == 0)
-    return f.apply(null, args);
+    return f(...args);
   else if (d < 0) {
-    return caml_call_gen(f.apply(null,args.slice(0,n)),args.slice(n));
+    return caml_call_gen(f(...args.slice(0,n)),args.slice(n));
   }
   else {
     return function (){

--- a/runtime/stdlib_modern.js
+++ b/runtime/stdlib_modern.js
@@ -19,63 +19,26 @@
 //TODO: fix the implementation below
 //Provides: caml_call_gen (const, shallow)
 function caml_call_gen(f, args) {
-  var args_copied = false;
-
-  while (true) {
-    if (f.fun) {
-      f = f.fun;
-      continue;
-    }
-    // TODO: This can happen with over-application. Should we fail here ?
-    if (typeof f !== "function") return f;
-    var n = f.length | 0;
-    var argsLen = args.length | 0;
-    var d = (n - argsLen) | 0;
-
-    if (d === 0) {
-      return f(...args);
-    }
-    else if (d < 0) {
-      if (!args_copied) {
-        args = Array.prototype.slice.call(args);
-        args_copied = true;
-      }
-
-      var before = args;
-      var after = before.splice(n);
-      f = f(...before);
-      args = after;
-    }
-    else {
-      if(!args.concat)
-        args = Array.prototype.slice.call(args);
-      switch (d) {
-      case 1: return function (a1) {
-        return f(...args, a1);
-      }
-      case 2: return function (a1, a2) {
-        return f(...args, a1, a2);
-      }
-      case 3: return function (a1, a2, a3) {
-        return f(...args, a1, a2, a3);
-      }
-      case 4: return function (a1, a2, a3, a4) {
-        return f(...args, a1, a2, a3, a4);
-      }
-      case 5: return function (a1, a2, a3, a4, a5) {
-        return f(...args, a1, a2, a3, a4, a5);
-      }
-      case 6: return function (a1, a2, a3, a4, a5, a6) {
-        return f(...args, a1, a2, a3, a4, a5, a6);
-      }
-      case 7: return function (a1, a2, a3, a4, a5, a6, a7) {
-        return f(...args, a1, a2, a3, a4, a5, a6, a7);
-      }
-      default:
-        return function (a1, a2, a3, a4, a5, a6, a7, a8) {
-          return caml_call_gen(f, args.concat([a1, a2, a3, a4, a5, a6, a7, a8]));
-        };
-      }
+  if(f.fun)
+    return caml_call_gen(f.fun, args);
+  //FIXME, can happen with too many arguments
+  if(typeof f !== "function") return f;
+  var n = f.length | 0;
+  if(n === 0) return f.apply(null,args);
+  var argsLen = args.length | 0;
+  var d = n - argsLen | 0;
+  if (d == 0)
+    return f.apply(null, args);
+  else if (d < 0) {
+    return caml_call_gen(f.apply(null,args.slice(0,n)),args.slice(n));
+  }
+  else {
+    return function (){
+      var extra_args = (arguments.length == 0)?1:arguments.length;
+      var nargs = new Array(args.length+extra_args);
+      for(var i = 0; i < args.length; i++ ) nargs[i] = args[i];
+      for(var i = 0; i < arguments.length; i++ ) nargs[args.length+i] = arguments[i];
+      return caml_call_gen(f, nargs)
     }
   }
 }

--- a/runtime/stdlib_modern.js
+++ b/runtime/stdlib_modern.js
@@ -16,7 +16,6 @@
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
-//TODO: fix the implementation below
 //Provides: caml_call_gen (const, shallow)
 function caml_call_gen(f, args) {
   if(f.fun)


### PR DESCRIPTION
Replacement for #993 and #994 
Commits should be read individually

The first commit revert the implement of caml_call_gen to the version before https://github.com/ocsigen/js_of_ocaml/commit/f8d2c7bf594271ede0066935d06f3865195f97e5
and adds many tests for functions wrapping callback and methods

Other commits fix or improve various stubs and update the newly added tests accordingly.
