### PR TITLE
Change the semantic of MlBytes.toString

### DIFF
--- a/lib/tests/test_unsafe_set_get.ml
+++ b/lib/tests/test_unsafe_set_get.ml
@@ -1,0 +1,61 @@
+(* Js_of_ocaml tests
+ * http://www.ocsigen.org/js_of_ocaml/
+ * Copyright (C) 2020 Hugo Heuzard
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+
+open Js_of_ocaml
+
+let s x =
+  let to_string : _ -> _ =
+    Js.Unsafe.eval_string
+      {|
+(function(x){
+    if(x === null)
+      return "null"
+    if(x === undefined)
+      return "undefined"
+    if(typeof x === "function")
+      return "function#" + x.length
+    if(x.toString() == "[object Arguments]")
+      return "(Arguments: " + Array.prototype.slice.call(x).toString() + ")";
+    if(typeof x === "object")
+      return "(Object: " + Object.keys(x).toString() + ")";
+    return x.toString()
+})
+|}
+  in
+  Js.to_string (to_string x)
+
+let%expect_test _ =
+  let o = object%js end in
+  Js.Unsafe.set o "ascii1" 1;
+  Js.Unsafe.set o (Js.string "ascii2") 2;
+  print_endline (s o);
+  [%expect {| (Object: ascii1,ascii2) |}];
+  let o = object%js end in
+  Js.Unsafe.set o "a•›" 1;
+  Js.Unsafe.set o (Js.string "b•›") 2;
+  print_endline (s o);
+  [%expect {| (Object: a•›,b•›) |}];
+  let o = object%js end in
+  let prefix = "prefix:" in
+  let f s g t = Js.Unsafe.set o (g (prefix ^ s)) t in
+  f "a•›" (fun s -> s) 1;
+  f "b•›" Js.string 2;
+  f "c•›" Js.bytestring 2;
+  print_endline (s o);
+  [%expect {| (Object: prefix:a•›,prefix:b•›,prefix:câ¢âº) |}]

--- a/lib/tests/test_unsafe_set_get.ml
+++ b/lib/tests/test_unsafe_set_get.ml
@@ -50,7 +50,7 @@ let%expect_test _ =
   Js.Unsafe.set o "a•›" 1;
   Js.Unsafe.set o (Js.string "b•›") 2;
   print_endline (s o);
-  [%expect {| (Object: a•›,b•›) |}];
+  [%expect {| (Object: aâ¢âº,b•›) |}];
   let o = object%js end in
   let prefix = "prefix:" in
   let f s g t = Js.Unsafe.set o (g (prefix ^ s)) t in
@@ -58,4 +58,4 @@ let%expect_test _ =
   f "b•›" Js.string 2;
   f "c•›" Js.bytestring 2;
   print_endline (s o);
-  [%expect {| (Object: prefix:a•›,prefix:b•›,prefix:câ¢âº) |}]
+  [%expect {| (Object: prefix:aâ¢âº,prefix:b•›,prefix:câ¢âº) |}]

--- a/runtime/mlBytes.js
+++ b/runtime/mlBytes.js
@@ -425,9 +425,14 @@ MlBytes.prototype.toString = function(){
     }
     this.t = 8; /*BYTES | NOT_ASCII*/
   case 8: /*BYTES | NOT_ASCII*/
-    return caml_utf16_of_utf8(this.c);
+    return this.c;
   }
 };
+MlBytes.prototype.toUtf16 = function (){
+  var r = this.toString();
+  if(this.t == 9) return r
+  return caml_utf16_of_utf8(r);
+}
 MlBytes.prototype.slice = function (){
   var content = this.t == 4 ? this.c.slice() : this.c;
   return new MlBytes(this.t,content,this.l);
@@ -807,7 +812,7 @@ function caml_jsbytes_of_string(s) {
 //Provides: caml_jsstring_of_string mutable (const)
 //If: !js-string
 function caml_jsstring_of_string(s){
-  return s.toString()
+  return s.toUtf16()
 }
 
 //Provides: caml_string_of_jsstring


### PR DESCRIPTION
Until now, `MlBytes.toString()` would return a utf16 javascript string.

This is becoming problematic now that we want to change the representation of ocaml string to use JavaScript strings.
The reason is that JavaScript VMs will transparently rely on the toString method when converting a value to a primitive type. For example, the following snippet will behave differently depending on how we represent strings. 
```ocaml
let get o (name : string) = Js.Unsafe.get o name
```
```js
function get(o, name) { return o[name] }
```
- If implemented like ocaml bytes, a conversion from utf8 to utf16 will happen (the vm will call toString)
- If implemented like a javascript string, no conversion will happen

This PR propose to change the semantic of `MlBytes.toString()` to not apply the conversion to utf16 and return the raw sequence of bytes.

