### PR TITLE
Runtime: specialize caml_call_gen

### DIFF
--- a/runtime/jslib_js_of_ocaml.js
+++ b/runtime/jslib_js_of_ocaml.js
@@ -131,32 +131,32 @@ function caml_ojs_new_arr(c, a) {
   return new F;
 }
 //Provides: caml_js_wrap_callback const (const)
-//Requires: caml_call_gen
+//Requires: caml_call_gen_cb
 function caml_js_wrap_callback(f) {
   return function () {
     var len = arguments.length;
     if(len > 0){
       var args = new Array(len);
       for (var i = 0; i < len; i++) args[i] = arguments[i];
-      return caml_call_gen(f, args);
+      return caml_call_gen_cb(f, args);
     } else {
-      return caml_call_gen(f, [undefined]);
+      return caml_call_gen_cb(f, [undefined]);
     }
   }
 }
 
 //Provides: caml_js_wrap_callback_arguments
-//Requires: caml_call_gen
+//Requires: caml_call_gen_cb
 function caml_js_wrap_callback_arguments(f) {
   return function() {
     var len = arguments.length;
     var args = new Array(len);
     for (var i = 0; i < len; i++) args[i] = arguments[i];
-    return caml_call_gen(f, [args]);
+    return caml_call_gen_cb(f, [args]);
   }
 }
 //Provides: caml_js_wrap_callback_strict const
-//Requires: caml_call_gen
+//Requires: caml_call_gen_cb
 function caml_js_wrap_callback_strict(arity, f) {
   return function () {
     var n = arguments.length;
@@ -164,43 +164,43 @@ function caml_js_wrap_callback_strict(arity, f) {
     var args = new Array(arity);
     var len = Math.min(arguments.length, arity)
     for (var i = 0; i < len; i++) args[i] = arguments[i];
-    return caml_call_gen(f, args);
+    return caml_call_gen_cb(f, args);
   };
 }
 //Provides: caml_js_wrap_meth_callback const (const)
-//Requires: caml_call_gen
+//Requires: caml_call_gen_cb
 function caml_js_wrap_meth_callback(f) {
   return function () {
     var len = arguments.length;
     var args = new Array(len + 1);
     args[0] = this;
     for (var i = 0; i < len; i++) args[i+1] = arguments[i];
-    return caml_call_gen(f,args);
+    return caml_call_gen_cb(f,args);
   }
 }
 //Provides: caml_js_wrap_meth_callback_arguments const (const)
-//Requires: caml_call_gen
+//Requires: caml_call_gen_cb
 function caml_js_wrap_meth_callback_arguments(f) {
   return function () {
     var len = arguments.length;
     var args = new Array(len);
     for (var i = 0; i < len; i++) args[i] = arguments[i];
-    return caml_call_gen(f,[this,args]);
+    return caml_call_gen_cb(f,[this,args]);
   }
 }
 //Provides: caml_js_wrap_meth_callback_strict const
-//Requires: caml_call_gen
+//Requires: caml_call_gen_cb
 function caml_js_wrap_meth_callback_strict(arity, f) {
   return function () {
     var args = new Array(arity + 1);
     var len = Math.min(arguments.length, arity)
     args[0] = this;
     for (var i = 0; i < len; i++) args[i+1] = arguments[i];
-    return caml_call_gen(f, args);
+    return caml_call_gen_cb(f, args);
   };
 }
 //Provides: caml_js_wrap_meth_callback_unsafe const (const)
-//Requires: caml_call_gen
+//Requires: caml_call_gen_cb
 function caml_js_wrap_meth_callback_unsafe(f) {
   return function () {
     var len = arguments.length;

--- a/runtime/stdlib.js
+++ b/runtime/stdlib.js
@@ -17,13 +17,39 @@
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
+//Provides: caml_call_gen_cb (const, shallow)
+function caml_call_gen_cb(f, args) {
+  if(f.fun) return caml_call_gen_cb(f.fun, args);
+  //This can happen with too many arguments
+  if(typeof f !== "function") return f;
+  var n = f.length | 0;
+  if(n === 0) return f.apply(null,args);
+  var argsLen = args.length | 0;
+  var d = n - argsLen | 0;
+  if (d == 0)
+    return f.apply(null, args);
+  else if (d < 0) {
+    return caml_call_gen_cb(f.apply(null,args.slice(0,n)),args.slice(n));
+  }
+  else {
+    return function (){
+      var extra_args = (arguments.length == 0)?1:arguments.length;
+      var nargs = new Array(args.length+extra_args);
+      for(var i = 0; i < args.length; i++ ) nargs[i] = args[i];
+      for(var i = 0; i < arguments.length; i++ ) nargs[args.length+i] = arguments[i];
+      return caml_call_gen_cb(f, nargs)
+    }
+  }
+}
+
 //Provides: caml_call_gen (const, shallow)
+//Requires: caml_invalid_argument
 //Weakdef
+// args is a non-empty array
 function caml_call_gen(f, args) {
   if(f.fun)
     return caml_call_gen(f.fun, args);
-  //FIXME, can happen with too many arguments
-  if(typeof f !== "function") return f;
+  if(typeof f !== "function") caml_invalid_argument("caml_call_gen: too many arguments");
   var n = f.length | 0;
   if(n === 0) return f.apply(null,args);
   var argsLen = args.length | 0;
@@ -34,12 +60,31 @@ function caml_call_gen(f, args) {
     return caml_call_gen(f.apply(null,args.slice(0,n)),args.slice(n));
   }
   else {
-    return function (){
-      var extra_args = (arguments.length == 0)?1:arguments.length;
-      var nargs = new Array(args.length+extra_args);
-      for(var i = 0; i < args.length; i++ ) nargs[i] = args[i];
-      for(var i = 0; i < arguments.length; i++ ) nargs[args.length+i] = arguments[i];
-      return caml_call_gen(f, nargs)
+    switch(d) {
+    case 1: return function (a1) {
+      return f.apply(null,args.concat([a1]))
+    }
+    case 2: return function (a1,a2) {
+      return f.apply(null,args.concat([a1,a2]))
+    }
+    case 3: return function (a1,a2,a3) {
+      return f.apply(null,args.concat([a1,a2,a3]))
+    }
+    case 4: return function (a1,a2,a3,a4) {
+      return f.apply(null,args.concat([a1,a2,a3,a4]))
+    }
+    case 5: return function (a1,a2,a3,a4,a5) {
+      return f.apply(null,args.concat([a1,a2,a3,a4,a5]))
+    }
+    case 6: return function (a1,a2,a3,a4,a5,a6) {
+      return f.apply(null,args.concat([a1,a2,a3,a4,a5,a6]))
+    }
+    case 7: return function (a1,a2,a3,a4,a5,a6,a7) {
+      return f.apply(null,args.concat([a1,a2,a3,a4,a5,a6,a7]))
+    }
+    default: return function (a1,a2,a3,a4,a5,a6,a7,a8) {
+      return caml_call_gen(f,args.concat([a1,a2,a3,a4,a5,a6,a7,a8]))
+    }
     }
   }
 }


### PR DESCRIPTION
Two implementations of caml_call_gen for two different use cases
- function calls generated by the compiler
- wrapping functions into javascript callbacks