### PR TITLE
Runtime: fix #707

### DIFF
--- a/lib/js_of_ocaml/js_of_ocaml_stubs.c
+++ b/lib/js_of_ocaml/js_of_ocaml_stubs.c
@@ -232,6 +232,10 @@ void caml_unmount () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_unmount!\n");
   exit(1);
 }
+void caml_xmlhttprequest_create () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_xmlhttprequest_create!\n");
+  exit(1);
+}
 void debugger () {
   fprintf(stderr, "Unimplemented Javascript primitive debugger!\n");
   exit(1);

--- a/lib/js_of_ocaml/xmlHttpRequest.ml
+++ b/lib/js_of_ocaml/xmlHttpRequest.ml
@@ -117,13 +117,4 @@ module Event = struct
   let loadend = Dom.Event.make "loadend"
 end
 
-let create () : xmlHttpRequest Js.t =
-  let xmlHttpRequest = Js.Unsafe.global##._XMLHttpRequest in
-  let activeXObject = Js.Unsafe.global##.activeXObject in
-  try new%js xmlHttpRequest
-  with _ -> (
-    try new%js activeXObject (Js.string "Msxml2.XMLHTTP")
-    with _ -> (
-      try new%js activeXObject (Js.string "Msxml3.XMLHTTP")
-      with _ -> (
-        try new%js activeXObject (Js.string "Microsoft.XMLHTTP") with _ -> assert false)))
+external create : unit -> xmlHttpRequest Js.t = "caml_xmlhttprequest_create"

--- a/runtime/jslib_js_of_ocaml.js
+++ b/runtime/jslib_js_of_ocaml.js
@@ -249,3 +249,20 @@ function caml_js_export_var (){
   else
     return joo_global_object;
 }
+
+
+//Provides: caml_xmlhttprequest_create
+//Requires: caml_failwith
+//Weakdef
+function caml_xmlhttprequest_create(unit){
+  var g = joo_global_object;
+  if(typeof g.XMLHttpRequest !== 'undefined') {
+    try { return new g.XMLHttpRequest } catch (e) { };
+  }
+  if(typeof g.activeXObject !== 'undefined') {
+    try { return new g.activeXObject("Msxml2.XMLHTTP") } catch(e){ };
+    try { return new g.activeXObject("Msxml3.XMLHTTP") } catch(e){ };
+    try { return new g.activeXObject("Microsoft.XMLHTTP") } catch(e){ };
+  }
+  caml_failwith("Cannot create a XMLHttpRequest");
+}


### PR DESCRIPTION
fix #707 

One should be able to override the javascript function `caml_xmlhttprequest_create`