### PR TITLE
OCaml 4.11 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ jobs:
       name: "4.10 all targets"
     - os: osx
       env: OCAML_VERSION=4.10 MODE=opam
+    - os: linux
+      env: OCAML_VERSION=4.11.0+trunk OCAML_BETA=enable MODE=opam
 
   allow_failures:
     - os: osx


### PR DESCRIPTION
As none of the alpha/beta of 4.11.0 have yet been release I'll put that as a draft, but as it currently stands, this should fix js_of_ocaml-compiler with OCaml 4.11