### PR TITLE
Eliminate allocation of dummy function  

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -12,4 +12,4 @@ break-infix-before-func
 break-separators=before
 dock-collection-brackets=false
 margin=90
-version=0.14.2
+version=0.14.3

--- a/compiler/tests-compiler/recfun.ml
+++ b/compiler/tests-compiler/recfun.ml
@@ -95,18 +95,20 @@ let myfun x =
   end
   in
   M.hash_fold_t (create ()) (List [ Atom "asd"]),
-  M.hash (List [ Atom "asd"])
+  M.hash (List [ Atom "asd"]),
+  M.hash (List [ ])
 
   |}
   in
   print_fun_decl program (Some "myfun");
   [%expect
     {|
-    function myfun(x$0)
+    function myfun(x)
      {function hash_fold_t(hsv,arg)
        {if(0 === arg[0])
          {var a0=arg[1],hsv$0=hsv | 0;return hash_fold_string(hsv$0,a0)}
         var a0$0=arg[1],hsv$1=hsv + 1 | 0;
         return hash_fold_list(hash_fold_t,hsv$1,a0$0)}
-      var _b_=hash_fold_t(42,x);
-      return [0,hash_fold_t(42,_a_),_b_]} |}]
+      function hash(x){return hash_fold_t(42,x)}
+      var _d_=hash(_a_),_e_=hash(_b_);
+      return [0,hash_fold_t(42,_c_),_e_,_d_]} |}]

--- a/compiler/tests-compiler/recfun.ml
+++ b/compiler/tests-compiler/recfun.ml
@@ -1,0 +1,117 @@
+(* Js_of_ocaml compiler
+ * http://www.ocsigen.org/js_of_ocaml/
+ * Copyright (C) 2020 Hugo Heuzard
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+
+open Util
+
+module M = struct
+  type state = int
+
+  type hash_value = int
+
+  let get_hash_value x = x
+
+  let create () = 42
+
+  let fold_int state i = state + i
+
+  let hash_fold_string state s = state + String.length s
+
+  let hash_fold_list fold state l = List.fold_left fold state l
+
+  type t =
+    | Atom of string
+    | List of t list
+
+  let rec (hash_fold_t : state -> t -> state) =
+    (fun hsv arg ->
+       match arg with
+       | Atom _a0 ->
+           let hsv = fold_int hsv 0 in
+           let hsv = hsv in
+           hash_fold_string hsv _a0
+       | List _a0 ->
+           let hsv = fold_int hsv 1 in
+           let hsv = hsv in
+           hash_fold_list hash_fold_t hsv _a0
+      : state -> t -> state)
+
+  and (hash : t -> hash_value) =
+    let func arg =
+      get_hash_value
+        (let hsv = create () in
+         hash_fold_t hsv arg)
+    in
+    fun x -> func x
+end
+
+let%expect_test _ =
+  let program =
+    compile_and_parse
+      {|
+type state = int
+type hash_value = int
+let get_hash_value x = x
+let create () = 42
+let fold_int state i = state + i
+let hash_fold_string state s = state + String.length s
+let hash_fold_list fold state l = List.fold_left fold state l
+
+let myfun x =
+  let module M = struct
+    type t =
+      | Atom of string
+      | List of t list
+
+    let rec (hash_fold_t : state -> t -> state) =
+      (fun hsv ->
+         fun arg ->
+           match arg with
+           | Atom _a0 ->
+             let hsv = fold_int hsv 0 in
+             let hsv = hsv in hash_fold_string hsv _a0
+           | List _a0 ->
+             let hsv = fold_int hsv 1 in
+             let hsv = hsv in hash_fold_list hash_fold_t hsv _a0 : state -> t -> state)
+    and (hash : t -> hash_value) =
+      let func arg = get_hash_value
+          (let hsv = create () in hash_fold_t hsv arg) in
+      fun x -> func x
+  end
+  in
+
+  M.hash (List [ Atom "asd"])
+
+  |}
+  in
+  print_fun_decl program (Some "myfun");
+  [%expect
+    {|
+    function myfun(x)
+     {var
+       hash_fold_t=function _f_(_d_,_e_){return _f_.fun(_d_,_e_)},
+       hash=function _c_(_b_){return _c_.fun(_b_)};
+      caml_update_dummy
+       (hash_fold_t,
+        function(hsv,arg)
+         {if(0 === arg[0])
+           {var a0=arg[1],hsv$0=hsv | 0;return hash_fold_string(hsv$0,a0)}
+          var a0$0=arg[1],hsv$1=hsv + 1 | 0;
+          return hash_fold_list(hash_fold_t,hsv$1,a0$0)});
+      caml_update_dummy(hash,function(x){return caml_call2(hash_fold_t,42,x)});
+      return caml_call1(hash,_a_)} |}]

--- a/compiler/tests-compiler/recfun.ml
+++ b/compiler/tests-compiler/recfun.ml
@@ -94,17 +94,19 @@ let myfun x =
       fun x -> func x
   end
   in
-
+  M.hash_fold_t (create ()) (List [ Atom "asd"]),
   M.hash (List [ Atom "asd"])
 
   |}
   in
   print_fun_decl program (Some "myfun");
-  [%expect{|
+  [%expect
+    {|
     function myfun(x$0)
      {function hash_fold_t(hsv,arg)
        {if(0 === arg[0])
          {var a0=arg[1],hsv$0=hsv | 0;return hash_fold_string(hsv$0,a0)}
         var a0$0=arg[1],hsv$1=hsv + 1 | 0;
         return hash_fold_list(hash_fold_t,hsv$1,a0$0)}
-      return hash_fold_t(42,x)} |}]
+      var _b_=hash_fold_t(42,x);
+      return [0,hash_fold_t(42,_a_),_b_]} |}]

--- a/compiler/tests-compiler/recfun.ml
+++ b/compiler/tests-compiler/recfun.ml
@@ -100,18 +100,11 @@ let myfun x =
   |}
   in
   print_fun_decl program (Some "myfun");
-  [%expect
-    {|
-    function myfun(x)
-     {var
-       hash_fold_t=function _f_(_d_,_e_){return _f_.fun(_d_,_e_)},
-       hash=function _c_(_b_){return _c_.fun(_b_)};
-      caml_update_dummy
-       (hash_fold_t,
-        function(hsv,arg)
-         {if(0 === arg[0])
-           {var a0=arg[1],hsv$0=hsv | 0;return hash_fold_string(hsv$0,a0)}
-          var a0$0=arg[1],hsv$1=hsv + 1 | 0;
-          return hash_fold_list(hash_fold_t,hsv$1,a0$0)});
-      caml_update_dummy(hash,function(x){return caml_call2(hash_fold_t,42,x)});
-      return caml_call1(hash,_a_)} |}]
+  [%expect{|
+    function myfun(x$0)
+     {function hash_fold_t(hsv,arg)
+       {if(0 === arg[0])
+         {var a0=arg[1],hsv$0=hsv | 0;return hash_fold_string(hsv$0,a0)}
+        var a0$0=arg[1],hsv$1=hsv + 1 | 0;
+        return hash_fold_list(hash_fold_t,hsv$1,a0$0)}
+      return hash_fold_t(42,x)} |}]

--- a/runtime/internalMod.js
+++ b/runtime/internalMod.js
@@ -27,7 +27,7 @@ function caml_CamlinternalMod_init_mod(loc,shape) {
     if(typeof shape === "number")
       switch(shape){
       case 0://function
-        struct[idx]={fun:undef_module};
+        struct[idx]=undef_module;
         break;
       case 1://lazy
         struct[idx]=[246, undef_module];
@@ -53,22 +53,27 @@ function caml_CamlinternalMod_init_mod(loc,shape) {
 //Provides: caml_CamlinternalMod_update_mod
 //Requires: caml_update_dummy
 function caml_CamlinternalMod_update_mod(shape,real,x) {
-  if(typeof shape === "number")
-    switch(shape){
-    case 0://function
-    case 1://lazy
-    case 2://class
-    default:
-      caml_update_dummy(real,x);
-    }
-  else
-    switch(shape[0]){
-    case 0://module
-      for(var i=1;i<shape[1].length;i++)
-        caml_CamlinternalMod_update_mod(shape[1][i],real[i],x[i]);
-      break;
-      //case 1://Value
-    default:
-    };
-  return 0
+  function loop (shape,real,x,parent,i) {
+    if(typeof shape === "number")
+      switch(shape){
+      case 0://function
+        parent[i]=x;
+        break
+      case 1://lazy
+      case 2://class
+      default:
+        caml_update_dummy(real,x);
+      }
+    else
+      switch(shape[0]){
+      case 0://module
+        for(var i=1;i<shape[1].length;i++)
+          loop(shape[1][i],real[i],x[i],real,i);
+        break;
+        //case 1://Value
+      default:
+      };
+  }
+  loop(shape,real,x,undefined,undefined);
+  return 0;
 }


### PR DESCRIPTION
The PR: 
- updates internalMod to not use the `.fun` property proxy for functions.
- adds an optimization to eliminate allocation of dummy function (`caml_alloc_dummy_function`). The dummy allocation is not necessary in JavaScript due to the weird non-lexical scoping.

Assuming the optimization properly eliminate all occurrences of `caml_alloc_dummy_function`,  we should be able to remove `.fun` property handling from the runtime.   

Note that `caml_alloc_dummy_function` was introduced in OCaml `4.02.3`, we would need to bump the lower bound from `4.02.0` to `4.02.3` which is fine.  