### PR TITLE
Upgrade to ocamlformat 0.15.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -12,4 +12,4 @@ break-infix-before-func
 break-separators=before
 dock-collection-brackets=false
 margin=90
-version=0.14.3
+version=0.15.0

--- a/compiler/lib/parse_bytecode.ml
+++ b/compiler/lib/parse_bytecode.ml
@@ -158,11 +158,12 @@ end = struct
       let paths = read_paths ic @ includes in
       List.iter
         evl
-        ~f:(fun ({ ev_module
-                 ; ev_loc = { Location.loc_start = { Lexing.pos_fname; _ }; _ }
-                 ; _
-                 } as ev)
-                ->
+        ~f:(fun
+             ({ ev_module
+              ; ev_loc = { Location.loc_start = { Lexing.pos_fname; _ }; _ }
+              ; _
+              } as ev)
+           ->
           let unit =
             try Hashtbl.find units (ev_module, pos_fname)
             with Not_found ->


### PR DESCRIPTION
Hi, this is what the project would look like after being reformated with the current version (candidate) of ocamlformat 0.15.0.
**Please do not merge until ocamlformat.0.15.0 is available with opam.**

Please let me know if you see any regressions that I may have missed.