### PR TITLE
Rename `msg` method to `message` in `Worker` module

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 * Compiler: fix code generation for recursive function under for-loops (#1009)
 * Compiler: the jsoo compiler compiled to javascript was not behaving correctly
             when parsing constant in the from the bytecode
+* Lib: Rename msg to message in Worker (#1037)
 
 # 3.6.0 (2020-04-26) - Lille
 ## Features/Changes

--- a/lib/js_of_ocaml/worker.ml
+++ b/lib/js_of_ocaml/worker.ml
@@ -38,7 +38,7 @@ and errorEvent =
   object
     inherit event
 
-    method msg : js_string t readonly_prop
+    method message : js_string t readonly_prop
 
     method filename : js_string t readonly_prop
 

--- a/lib/js_of_ocaml/worker.mli
+++ b/lib/js_of_ocaml/worker.mli
@@ -46,7 +46,7 @@ and errorEvent =
   object
     inherit event
 
-    method msg : js_string t readonly_prop
+    method message : js_string t readonly_prop
 
     method filename : js_string t readonly_prop
 


### PR DESCRIPTION
As it can be seen at https://developer.mozilla.org/en-US/docs/Web/API/ErrorEvent, the method of `ErrorMessage` to retrieve the message isn't called `msg` but `message`.