### PR TITLE
Fix resize-observer

### DIFF
--- a/lib/js_of_ocaml/resizeObserver.ml
+++ b/lib/js_of_ocaml/resizeObserver.ml
@@ -31,9 +31,9 @@ class type resizeObserverEntry =
 
     method contentRect : Dom_html.clientRect Js.t Js.readonly_prop
 
-    method borderBoxSize : resizeObserverSize Js.t Js.readonly_prop
+    method borderBoxSize : resizeObserverSize Js.t Js.js_array Js.t Js.readonly_prop
 
-    method contentBoxSize : resizeObserverSize Js.t Js.readonly_prop
+    method contentBoxSize : resizeObserverSize Js.t Js.js_array Js.t Js.readonly_prop
   end
 
 class type resizeObserverOptions =

--- a/lib/js_of_ocaml/resizeObserver.mli
+++ b/lib/js_of_ocaml/resizeObserver.mli
@@ -54,9 +54,9 @@ class type resizeObserverEntry =
 
     method contentRect : Dom_html.clientRect Js.t Js.readonly_prop
 
-    method borderBoxSize : resizeObserverSize Js.t Js.readonly_prop
+    method borderBoxSize : resizeObserverSize Js.t Js.js_array Js.t Js.readonly_prop
 
-    method contentBoxSize : resizeObserverSize Js.t Js.readonly_prop
+    method contentBoxSize : resizeObserverSize Js.t Js.js_array Js.t Js.readonly_prop
   end
 
 class type resizeObserverOptions =


### PR DESCRIPTION
borderBoxSize and contentBoxSize are actually arrays

https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserverEntry/borderBoxSize
