### PR TITLE
adds the intersection observer API

### DIFF
--- a/lib/js_of_ocaml/intersectionObserver.ml
+++ b/lib/js_of_ocaml/intersectionObserver.ml
@@ -43,19 +43,17 @@ class type intersectionObserver =
 
 let empty_intersection_observer_options () : intersectionObserverOptions Js.t =
   Js.Unsafe.obj [||]
-;;
 
 let intersectionObserver_unsafe = Js.Unsafe.global##._IntersectionObserver
+
 let is_supported () = Js.Optdef.test intersectionObserver_unsafe
 
-let intersectionObserver
-  : ((intersectionObserverEntry Js.t Js.js_array Js.t
-      -> intersectionObserver Js.t
-      -> unit)
-       Js.callback
+let intersectionObserver :
+    (   (   intersectionObserverEntry Js.t Js.js_array Js.t
+         -> intersectionObserver Js.t
+         -> unit)
+        Js.callback
      -> intersectionObserverOptions Js.t
      -> intersectionObserver Js.t)
-      Js.constr
-  =
+    Js.constr =
   intersectionObserver_unsafe
-;;

--- a/lib/js_of_ocaml/intersectionObserver.ml
+++ b/lib/js_of_ocaml/intersectionObserver.ml
@@ -1,0 +1,61 @@
+class type intersectionObserverEntry =
+  object
+    method target : Dom.node Js.t Js.readonly_prop
+
+    method boundingClientRect : Dom_html.clientRect Js.t Js.readonly_prop
+
+    method rootBounds : Dom_html.clientRect Js.t Js.readonly_prop
+
+    method intersectionRect : Dom_html.clientRect Js.t Js.readonly_prop
+
+    method intersectionRatio : float Js.t Js.readonly_prop
+
+    method isIntersecting : bool Js.t Js.readonly_prop
+    (* Missing Dom.highResTimeStamp
+       method time : Dom.highResTimeStamp Js.t Js.readonly_prop *)
+  end
+
+class type intersectionObserverOptions =
+  object
+    method root : Dom.node Js.t Js.writeonly_prop
+
+    method rootMargin : Js.js_string Js.t Js.writeonly_prop
+
+    method threshold : float Js.js_array Js.t Js.writeonly_prop
+  end
+
+class type intersectionObserver =
+  object
+    method root : Dom.node Js.t Js.readonly_prop
+
+    method rootMargin : Js.js_string Js.t Js.readonly_prop
+
+    method threshold : float Js.t Js.readonly_prop
+
+    method observe : #Dom.node Js.t -> unit Js.meth
+
+    method unobserve : #Dom.node Js.t -> unit Js.meth
+
+    method disconnect : unit Js.meth
+
+    method takeRecords : intersectionObserverEntry Js.t Js.js_array Js.meth
+  end
+
+let empty_intersection_observer_options () : intersectionObserverOptions Js.t =
+  Js.Unsafe.obj [||]
+;;
+
+let intersectionObserver_unsafe = Js.Unsafe.global##._IntersectionObserver
+let is_supported () = Js.Optdef.test intersectionObserver_unsafe
+
+let intersectionObserver
+  : ((intersectionObserverEntry Js.t Js.js_array Js.t
+      -> intersectionObserver Js.t
+      -> unit)
+       Js.callback
+     -> intersectionObserverOptions Js.t
+     -> intersectionObserver Js.t)
+      Js.constr
+  =
+  intersectionObserver_unsafe
+;;

--- a/lib/js_of_ocaml/intersectionObserver.mli
+++ b/lib/js_of_ocaml/intersectionObserver.mli
@@ -4,7 +4,6 @@
 
     https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API *)
 
-
 class type intersectionObserverEntry =
   object
     method target : Dom.node Js.t Js.readonly_prop
@@ -18,7 +17,6 @@ class type intersectionObserverEntry =
     method intersectionRatio : float Js.t Js.readonly_prop
 
     method isIntersecting : bool Js.t Js.readonly_prop
-
     (* Missing Dom.highResTimeStamp
        method time : Dom.highResTimeStamp Js.t Js.readonly_prop *)
   end
@@ -54,6 +52,10 @@ val empty_intersection_observer_options : unit -> intersectionObserverOptions Js
 val is_supported : unit -> bool
 
 val intersectionObserver :
-  ((intersectionObserverEntry Js.t Js.js_array Js.t -> intersectionObserver Js.t -> unit) Js.callback ->
-   intersectionObserverOptions Js.t -> intersectionObserver Js.t)
+  (   (   intersectionObserverEntry Js.t Js.js_array Js.t
+       -> intersectionObserver Js.t
+       -> unit)
+      Js.callback
+   -> intersectionObserverOptions Js.t
+   -> intersectionObserver Js.t)
   Js.constr

--- a/lib/js_of_ocaml/intersectionObserver.mli
+++ b/lib/js_of_ocaml/intersectionObserver.mli
@@ -1,0 +1,59 @@
+(** The Intersection Observer API provides a way to asynchronously observe
+    changes in the intersection of a target element with an ancestor element or
+    with a top-level document's viewport.
+
+    https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API *)
+
+
+class type intersectionObserverEntry =
+  object
+    method target : Dom.node Js.t Js.readonly_prop
+
+    method boundingClientRect : Dom_html.clientRect Js.t Js.readonly_prop
+
+    method rootBounds : Dom_html.clientRect Js.t Js.readonly_prop
+
+    method intersectionRect : Dom_html.clientRect Js.t Js.readonly_prop
+
+    method intersectionRatio : float Js.t Js.readonly_prop
+
+    method isIntersecting : bool Js.t Js.readonly_prop
+
+    (* Missing Dom.highResTimeStamp
+       method time : Dom.highResTimeStamp Js.t Js.readonly_prop *)
+  end
+
+class type intersectionObserverOptions =
+  object
+    method root : Dom.node Js.t Js.writeonly_prop
+
+    method rootMargin : Js.js_string Js.t Js.writeonly_prop
+
+    method threshold : float Js.js_array Js.t Js.writeonly_prop
+  end
+
+class type intersectionObserver =
+  object
+    method root : Dom.node Js.t Js.readonly_prop
+
+    method rootMargin : Js.js_string Js.t Js.readonly_prop
+
+    method threshold : float Js.t Js.readonly_prop
+
+    method observe : #Dom.node Js.t -> unit Js.meth
+
+    method unobserve : #Dom.node Js.t -> unit Js.meth
+
+    method disconnect : unit Js.meth
+
+    method takeRecords : intersectionObserverEntry Js.t Js.js_array Js.meth
+  end
+
+val empty_intersection_observer_options : unit -> intersectionObserverOptions Js.t
+
+val is_supported : unit -> bool
+
+val intersectionObserver :
+  ((intersectionObserverEntry Js.t Js.js_array Js.t -> intersectionObserver Js.t -> unit) Js.callback ->
+   intersectionObserverOptions Js.t -> intersectionObserver Js.t)
+  Js.constr


### PR DESCRIPTION
The Intersection Observer API provides a way to asynchronously observe
    changes in the intersection of a target element with an ancestor element or
    with a top-level document's viewport.
    https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API 
