### PR TITLE
Fix `Error: Unbound module Js` when compiling math.ml

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 # ??? (??) - ??
-+## Features/Changes
-+* Lib: add innerText property for Dom_html
+## Features/Changes
+* Lib: add innerText property for Dom_html
+
+## Misc
+* manual/rev_bindings.wiki: fix compilation error
 
 # 3.9.1 (2021-02-17) - Lille
 ## Features/Changes

--- a/manual/rev-bindings.wiki
+++ b/manual/rev-bindings.wiki
@@ -5,6 +5,8 @@ create a JavaScript object containing all values to export
 and to make the object reachable.
 
 <<code language="ocaml"|
+open Js_of_ocaml
+
 let _ =
   Js.export "myMathLib"
     (object%js
@@ -23,6 +25,8 @@ myMathLib.add(3,4)
 
 {{{
 # cat math.ml
+open Js_of_ocaml
+
 let _ =
   Js.export_all
     (object%js


### PR DESCRIPTION
I got this error while looking for the "hello world" here: https://ocsigen.org/js_of_ocaml/latest/manual/rev-bindings
```
$ cat math.ml
let _ =
  Js.export_all
    (object%js
      method add x y = x +. y
      method abs x = abs_float x
      val zero = 0.
     end)
$ ocamlfind ocamlc -verbose \
  -package js_of_ocaml -package js_of_ocaml-ppx \
  -linkpkg math.ml -o math.byte
Effective set of compiler predicates: pkg_bytes,pkg_uchar,pkg_js_of_ocaml,pkg_js_of_ocaml-ppx,autolink,byte
+ ocamlc.opt -verbose -o math.byte -I /home/g/.opam/default/lib/bytes -I /home/g/.opam/default/lib/uchar -I /home/g/.opam/default/lib/js_of_ocaml -I /home/g/.opam/default/lib/js_of_ocaml-ppx -ppx "/home/g/.opam/default/lib/js_of_ocaml-ppx/./ppx.exe --as-ppx" /home/g/.opam/default/lib/js_of_ocaml/js_of_ocaml.cma math.ml
+ /home/g/.opam/default/lib/js_of_ocaml-ppx/./ppx.exe --as-ppx '/tmp/camlppx16679a' '/tmp/camlppx8a9bc9'
File "math.ml", line 2, characters 2-15:
2 |   Js.export_all
      ^^^^^^^^^^^^^
Error: Unbound module Js
ocamlc.opt returned with exit code 2
$ ocaml -version
The OCaml toplevel, version 4.11.1
$ opam --version
2.0.8
$ ocamlc -version
4.11.1
$ uname -a
Linux manjaro 5.9.16-1-MANJARO #1 SMP PREEMPT Mon Dec 21 22:00:46 UTC 2020 x86_64 GNU/Linux
```