### PR TITLE
add innerText to `Dom_html`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,6 @@
 # ??? (??) - ??
++## Features/Changes
++* Lib: add innerText property for Dom_html
 
 # 3.9.1 (2021-02-17) - Lille
 ## Features/Changes

--- a/lib/js_of_ocaml/dom_html.ml
+++ b/lib/js_of_ocaml/dom_html.ml
@@ -667,6 +667,8 @@ and element =
 
     method textContent : js_string t opt prop
 
+    method innerText : js_string t prop
+
     method clientLeft : int readonly_prop
 
     method clientTop : int readonly_prop

--- a/lib/js_of_ocaml/dom_html.mli
+++ b/lib/js_of_ocaml/dom_html.mli
@@ -682,6 +682,8 @@ and element =
 
     method textContent : js_string t opt prop
 
+    method innerText : js_string t prop
+
     method clientLeft : int readonly_prop
 
     method clientTop : int readonly_prop


### PR DESCRIPTION
This seems to be supported in all common browsers now [1], and also seems part of the current html living spec [2].

[1] https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/innerText
[2] https://html.spec.whatwg.org/multipage/dom.html#the-innertext-idl-attribute