### PR TITLE
Avoid spurious `ocamlfind` warning when not generating Graphics lib

### DIFF
--- a/lib/lwt/graphics/dune
+++ b/lib/lwt/graphics/dune
@@ -3,7 +3,7 @@ open Jbuild_plugin.V1
 
 let graphics_exists =
   try
-    match run_and_read_lines "ocamlfind query -a-format -predicates byte graphics" with
+    match run_and_read_lines "ocamlfind query -a-format -predicates byte graphics -qe" with
     | path :: _ -> Sys.file_exists path
     | _ -> false
   with _ -> false


### PR DESCRIPTION
The `dune` file for the `js_of_ocaml` Graphics library is conditional on the availability of the `graphics` library, as determined by querying `ocamlfind`. This commit passes `-qe` to the OCamlfind query to avoid a redundant warning when `graphics` is not available:

```
$ dune build
       ocaml (internal)
ocamlfind: Package `graphics' not found
```

(This warning is visible to all packages that vendor `js_of_ocaml`.)