### PR TITLE
Compiler: fix stack overflow when linking against many files

### DIFF
--- a/compiler/lib/source_map.ml
+++ b/compiler/lib/source_map.ml
@@ -218,10 +218,11 @@ let merge = function
               ; sources_content =
                   merge_sources_content acc.sources_content sm.sources_content
               ; mappings =
-                  acc.mappings
-                  @ List.map
-                      ~f:(maps ~gen_line_offset ~sources_offset ~names_offset)
-                      sm.mappings
+                  List.rev_append
+                    (List.rev acc.mappings)
+                    (List.map
+                       ~f:(maps ~gen_line_offset ~sources_offset ~names_offset)
+                       sm.mappings)
               }
             in
             loop


### PR DESCRIPTION
Fix https://github.com/ocsigen/js_of_ocaml/issues/1104.

This is the simplest possible fix for #1104. There may be other uses of `( @ )` worth replacing in the code-base, but I'll leave this for someone more experienced with Jsoo to determine.