### PR TITLE
Runtime: make stdin work on nodejs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,8 @@
 * Lib: add hidden, onfullscreenchange and onwebkitfullscreenchange to document
 * Runtime: Fix for Windows, tests pass
 * Runtime: add support for Sys.mkdir and Sys.rmdir
-
+* Runtime: make stdin work on nodejs
+ 
 ## Bug fixes
 * Compiler: fix toplevel generation (#1129, #1130, #1131)
 

--- a/compiler/tests-io/cat.ml
+++ b/compiler/tests-io/cat.ml
@@ -1,3 +1,1 @@
-let () =
-  input_line stdin
-  |> output_string stdout
+let () = input_line stdin |> output_string stdout

--- a/compiler/tests-io/cat.ml
+++ b/compiler/tests-io/cat.ml
@@ -1,0 +1,3 @@
+let () =
+  input_line stdin
+  |> output_string stdout

--- a/compiler/tests-io/dune
+++ b/compiler/tests-io/dune
@@ -1,0 +1,15 @@
+(executable
+  (name cat)
+  (modes native js))
+
+(rule
+  (target native.stdout)
+  (action (with-stdout-to native.stdout (pipe-stdout (run printf "echo \xE2\x98\xA0") (run %{dep:./cat.exe})))))
+
+(rule
+  (target js.stdout)
+  (action (with-stdout-to js.stdout (pipe-stdout (run printf "echo \xE2\x98\xA0") (run node %{dep:./cat.bc.js})))))
+
+(rule
+  (alias runtest)
+  (action (diff js.stdout native.stdout)))

--- a/runtime/io.js
+++ b/runtime/io.js
@@ -129,17 +129,23 @@ function caml_ml_open_descriptor_out (fd) {
 
 //Provides: caml_ml_open_descriptor_in
 //Requires: caml_global_data,caml_sys_open,caml_raise_sys_error, caml_ml_channels
+//Requires: fs_node_supported, caml_string_of_jsstring
 function caml_ml_open_descriptor_in (fd)  {
   var data = caml_global_data.fds[fd];
   if(data.flags.wronly) caml_raise_sys_error("fd "+ fd + " is writeonly");
-
+  var refill = null;
+  if(fd == 0 && fs_node_supported()){
+    var fs = require('fs');
+    refill = function () {
+      return caml_string_of_jsstring(fs.readFileSync(0, 'utf8'))};
+  }
   var channel = {
     file:data.file,
     offset:data.offset,
     fd:fd,
     opened:true,
     out: false,
-    refill:null
+    refill:refill
   };
   caml_ml_channels[channel.fd]=channel;
   return channel.fd;


### PR DESCRIPTION
Fix https://github.com/ocsigen/js_of_ocaml/issues/397
Makes https://github.com/grain-lang/grain/blob/main/compiler/grainc/jsoo_header.re obsolete (cc @phated) 