### PR TITLE
Always try to run git log but catch exception

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 ## Bug fixes
 * Compiler: fix toplevel generation (#1129, #1130, #1131)
 * Runtime: fix error handling of Sys.readdir
+* Dune: make git version lookup more resilient
 
 # 3.10.0 (2021-08-30) - Lille
 ## Features/Changes

--- a/dune
+++ b/dune
@@ -14,12 +14,10 @@ let split_on_char ~sep s =
   String.sub s ~pos:0 ~len:!j :: !r
 
 let git_version =
-  if not (try Sys.is_directory ".git" with _ -> false)
-  then ""
-  else
-    match run_and_read_lines "git log -n1 --pretty=format:%h" with
-    | version :: _ -> version
-    | [] -> ""
+  match run_and_read_lines "git log -n1 --pretty=format:%h" with
+  | exception _ -> ""
+  | version :: _ -> version
+  | [] -> ""
 
 let version =
   let ic = open_in "VERSION" in


### PR DESCRIPTION
Closes #1139 

I believe catching any exception that occurs while running `git log` will be more resilient than checking the `.git/` directory exists. I tested this with an esy resolution in Grain and it no longer crashes.