### PR TITLE
Lib: add message event types and PerformanceObserver

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # dev (2021-??-??) - ??
 ## Features/Changes
 * Compiler: static evaluation of backend_type
+* Lib: add messageEvent to Dom_html
+* Lib: add PerformanceObserver API
 
 ## Bug fixes
 * Compiler: fix sourcemap warning for empty cma

--- a/lib/js_of_ocaml/dom_html.mli
+++ b/lib/js_of_ocaml/dom_html.mli
@@ -631,6 +631,15 @@ and mediaEvent =
     inherit event
   end
 
+and messageEvent =
+  object
+    inherit event
+
+    method data : Unsafe.any opt readonly_prop
+
+    method source : Unsafe.any opt readonly_prop
+  end
+
 (** {2 HTML elements} *)
 
 and nodeSelector =
@@ -2439,6 +2448,8 @@ module Event : sig
 
   val lostpointercapture : pointerEvent t typ
 
+  val message : messageEvent t typ
+
   val pause : mediaEvent t typ
 
   val play : mediaEvent t typ
@@ -2972,6 +2983,7 @@ val opt_tagged : #element t opt -> taggedElement option
 type taggedEvent =
   | MouseEvent of mouseEvent t
   | KeyboardEvent of keyboardEvent t
+  | MessageEvent of messageEvent t
   | MousewheelEvent of mousewheelEvent t
   | MouseScrollEvent of mouseScrollEvent t
   | PopStateEvent of popStateEvent t
@@ -3123,6 +3135,8 @@ module CoerceTo : sig
   val mouseScrollEvent : #event t -> mouseScrollEvent t opt
 
   val popStateEvent : #event t -> popStateEvent t opt
+
+  val messageEvent : #event t -> messageEvent t opt
 end
 
 type timeout_id_safe

--- a/lib/js_of_ocaml/js_of_ocaml.ml
+++ b/lib/js_of_ocaml/js_of_ocaml.ml
@@ -33,6 +33,7 @@ module Js = Js
 module Json = Json
 module Jstable = Jstable
 module MutationObserver = MutationObserver
+module PerformanceObserver = PerformanceObserver
 module ResizeObserver = ResizeObserver
 module Regexp = Regexp
 module Sys_js = Sys_js

--- a/lib/js_of_ocaml/performanceObserver.ml
+++ b/lib/js_of_ocaml/performanceObserver.ml
@@ -1,0 +1,49 @@
+open! Import
+
+class type performanceObserverInit =
+  object
+    method entryTypes : Js.js_string Js.t Js.js_array Js.t Js.writeonly_prop
+  end
+
+class type performanceEntry =
+  object
+    method name : Js.js_string Js.t Js.readonly_prop
+
+    method entryType : Js.js_string Js.t Js.readonly_prop
+
+    method startTime : float Js.readonly_prop
+
+    method duration : float Js.readonly_prop
+  end
+
+class type performanceObserverEntryList =
+  object
+    method getEntries : performanceEntry Js.t Js.js_array Js.t Js.meth
+  end
+
+class type performanceObserver =
+  object
+    method observe : performanceObserverInit Js.t -> unit Js.meth
+
+    method disconnect : unit Js.meth
+
+    method takeRecords : performanceEntry Js.t Js.js_array Js.t Js.meth
+  end
+
+let performanceObserver = Js.Unsafe.global##._PerformanceObserver
+
+let is_supported () = Js.Optdef.test performanceObserver
+
+let performanceObserver :
+    (   (performanceObserverEntryList Js.t -> performanceObserver Js.t -> unit) Js.callback
+     -> performanceObserver Js.t)
+    Js.constr =
+  performanceObserver
+
+let observe ~entry_types ~f =
+  let entry_types = entry_types |> List.map Js.string |> Array.of_list |> Js.array in
+  let performance_observer_init : performanceObserverInit Js.t = Js.Unsafe.obj [||] in
+  let () = performance_observer_init##.entryTypes := entry_types in
+  let obs = new%js performanceObserver (Js.wrap_callback f) in
+  let () = obs##observe performance_observer_init in
+  obs

--- a/lib/js_of_ocaml/performanceObserver.mli
+++ b/lib/js_of_ocaml/performanceObserver.mli
@@ -1,0 +1,59 @@
+(** PerformanceObserver API
+
+    A code example:
+    {[
+      if (PerformanceObserver.is_supported()) then
+        let entry_types = [ "measure" ] in
+        let f entries observer =
+          let entries = entries##getEntries in
+          Firebug.console##debug entries ;
+          Firebug.console##debug observer
+        in
+        PerformanceObserver.observe ~entry_types ~f
+        ()
+   ]}
+
+   @see <https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserver> for API documentation.
+*)
+
+class type performanceObserverInit =
+  object
+    method entryTypes : Js.js_string Js.t Js.js_array Js.t Js.writeonly_prop
+  end
+
+class type performanceEntry =
+  object
+    method name : Js.js_string Js.t Js.readonly_prop
+
+    method entryType : Js.js_string Js.t Js.readonly_prop
+
+    method startTime : float Js.readonly_prop
+
+    method duration : float Js.readonly_prop
+  end
+
+class type performanceObserverEntryList =
+  object
+    method getEntries : performanceEntry Js.t Js.js_array Js.t Js.meth
+  end
+
+class type performanceObserver =
+  object
+    method observe : performanceObserverInit Js.t -> unit Js.meth
+
+    method disconnect : unit Js.meth
+
+    method takeRecords : performanceEntry Js.t Js.js_array Js.t Js.meth
+  end
+
+val performanceObserver :
+  (   (performanceObserverEntryList Js.t -> performanceObserver Js.t -> unit) Js.callback
+   -> performanceObserver Js.t)
+  Js.constr
+
+val is_supported : unit -> bool
+
+val observe :
+     entry_types:string list
+  -> f:(performanceObserverEntryList Js.t -> performanceObserver Js.t -> unit)
+  -> performanceObserver Js.t


### PR DESCRIPTION
This is re-opened version of https://github.com/ocsigen/js_of_ocaml/pull/1123 to fix the bad state that I got the repo into. Sorry for the extra noise.