### PR TITLE
Compiler: better handling of empty libs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# dev (2021-??-??) - ??
+
+## Bug fixes
+* Compiler: fix sourcemap warning for empty cma
+
 # 3.11.0 (2021-10-06) - Lille
 
 ## Features/Changes

--- a/compiler/bin-js_of_ocaml/compile.ml
+++ b/compiler/bin-js_of_ocaml/compile.ml
@@ -116,10 +116,11 @@ let run
   in
   if times () then Format.eprintf "Start parsing...@.";
   let need_debug = Option.is_some source_map || Config.Flag.debuginfo () in
-  let check_debug debug =
+  let check_debug (one : Parse_bytecode.one) =
     if (not runtime_only)
        && Option.is_some source_map
-       && Parse_bytecode.Debug.is_empty debug
+       && Parse_bytecode.Debug.is_empty one.debug
+       && not (Code.is_empty one.code)
     then
       warn
         "Warning: '--source-map' is enabled but the bytecode program was compiled with \
@@ -141,7 +142,7 @@ let run
         Code.(Let (Var.fresh (), Prim (Extern "caml_set_static_env", args))))
   in
   let output (one : Parse_bytecode.one) ~standalone output_file =
-    check_debug one.debug;
+    check_debug one;
     let init_pseudo_fs = fs_external && standalone in
     (match output_file with
     | `Stdout ->

--- a/compiler/lib/code.mli
+++ b/compiler/lib/code.mli
@@ -227,6 +227,8 @@ val prepend : program -> instr list -> program
 
 val empty : program
 
+val is_empty : program -> bool
+
 val eq : program -> program -> bool
 
 val invariant : program -> unit

--- a/compiler/tests-compiler/empty_cma.ml
+++ b/compiler/tests-compiler/empty_cma.ml
@@ -21,7 +21,7 @@ open Util
 
 let%expect_test _ =
   compile_lib [] "empty"
-  |> compile_cmo_to_javascript ~sourcemap:false
+  |> compile_cmo_to_javascript ~sourcemap:true
   |> Filetype.read_js
   |> Filetype.string_of_js_text
   |> print_endline;
@@ -29,7 +29,7 @@ let%expect_test _ =
   Sys.remove "empty.js";
   [%expect
     {|
-      (function(joo_global_object)
-         {"use strict";var runtime=joo_global_object.jsoo_runtime;return}
-        (function(){return this}()));
+      (function(joo_global_object){"use strict";return}(function(){return this}()));
+
+      //# sourceMappingURL=empty.map
     |}]


### PR DESCRIPTION
This PR removes the warning `Warning: '--source-map' is enabled but the bytecode program was compiled with` when compiling empty libraries. cc @abate