### PR TITLE
Add Style Declaration Property Accessors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # dev (2021-??-??) - ??
 
+## Features/Changes
+* Lib: add CSSStyleDeclaration.{setProperty, getPropertyValue, getPropertyPriority, removeProperty}
+
 ## Bug fixes
 * Compiler: fix sourcemap warning for empty cma
 

--- a/lib/js_of_ocaml/dom_html.ml
+++ b/lib/js_of_ocaml/dom_html.ml
@@ -39,7 +39,7 @@ class type cssStyleDeclaration =
     method getPropertyPriority : js_string t -> js_string t meth
 
     method removeProperty : js_string t -> js_string t meth
-    
+
     method animation : js_string t prop
 
     method animationDelay : js_string t prop

--- a/lib/js_of_ocaml/dom_html.ml
+++ b/lib/js_of_ocaml/dom_html.ml
@@ -31,13 +31,14 @@ external decode_html_entities : js_string t -> js_string t = "caml_js_html_entit
 
 class type cssStyleDeclaration =
   object
-    method setProperty : js_string t -> js_string t -> js_string t optdef -> js_string t meth
+    method setProperty :
+      js_string t -> js_string t -> js_string t optdef -> js_string t meth
 
-    method getPropertyValue : js_string t ->  js_string t meth
+    method getPropertyValue : js_string t -> js_string t meth
     
-    method getPropertyPriority : js_string t ->  js_string t meth
+    method getPropertyPriority : js_string t -> js_string t meth
 
-    method removeProperty : js_string t ->  js_string t meth
+    method removeProperty : js_string t -> js_string t meth
   
     method animation : js_string t prop
 

--- a/lib/js_of_ocaml/dom_html.ml
+++ b/lib/js_of_ocaml/dom_html.ml
@@ -35,11 +35,11 @@ class type cssStyleDeclaration =
       js_string t -> js_string t -> js_string t optdef -> js_string t meth
 
     method getPropertyValue : js_string t -> js_string t meth
-    
+
     method getPropertyPriority : js_string t -> js_string t meth
 
     method removeProperty : js_string t -> js_string t meth
-  
+    
     method animation : js_string t prop
 
     method animationDelay : js_string t prop

--- a/lib/js_of_ocaml/dom_html.ml
+++ b/lib/js_of_ocaml/dom_html.ml
@@ -31,6 +31,14 @@ external decode_html_entities : js_string t -> js_string t = "caml_js_html_entit
 
 class type cssStyleDeclaration =
   object
+    method setProperty : js_string t -> js_string t -> js_string t optdef -> js_string t meth
+
+    method getPropertyValue : js_string t ->  js_string t meth
+    
+    method getPropertyPriority : js_string t ->  js_string t meth
+
+    method removeProperty : js_string t ->  js_string t meth
+  
     method animation : js_string t prop
 
     method animationDelay : js_string t prop

--- a/lib/js_of_ocaml/dom_html.mli
+++ b/lib/js_of_ocaml/dom_html.mli
@@ -29,13 +29,14 @@ open Js
 
 class type cssStyleDeclaration =
   object
-    method setProperty : js_string t -> js_string t -> js_string t optdef -> js_string t meth
+    method setProperty :
+      js_string t -> js_string t -> js_string t optdef -> js_string t meth
 
-    method getPropertyValue : js_string t ->  js_string t meth
+    method getPropertyValue : js_string t -> js_string t meth
 
-    method getPropertyPriority : js_string t ->  js_string t meth
+    method getPropertyPriority : js_string t -> js_string t meth
 
-    method removeProperty : js_string t ->  js_string t meth
+    method removeProperty : js_string t -> js_string t meth
 
     method animation : js_string t prop
 

--- a/lib/js_of_ocaml/dom_html.mli
+++ b/lib/js_of_ocaml/dom_html.mli
@@ -29,6 +29,14 @@ open Js
 
 class type cssStyleDeclaration =
   object
+    method setProperty : js_string t -> js_string t -> js_string t optdef -> js_string t meth
+
+    method getPropertyValue : js_string t ->  js_string t meth
+
+    method getPropertyPriority : js_string t ->  js_string t meth
+
+    method removeProperty : js_string t ->  js_string t meth
+
     method animation : js_string t prop
 
     method animationDelay : js_string t prop


### PR DESCRIPTION
These APIs allow direct access to the declarations programatically.  They are especially useful for setting [css custom properties](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties).

- [CSSStyleDeclaration.setProperty](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleDeclaration/setProperty)
- [CSSStyleDeclaration.getPropertyValue](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleDeclaration/getPropertyValue)
- [CSSStyleDeclaration.getPropertyPriority](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleDeclaration/getPropertyPriority)
- [CSSStyleDeclaration.removeProperty](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleDeclaration/removeProperty)
