### PR TITLE
Compiler: speedup emitting js files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,9 @@
 # dev (2021-??-??) - ??
 ## Features/Changes
 * Compiler: static evaluation of backend_type
+* Compiler: speedup emitting js files.
 * Lib: add messageEvent to Dom_html
 * Lib: add PerformanceObserver API
-
-## Features/Changes
 * Lib: add CSSStyleDeclaration.{setProperty, getPropertyValue, getPropertyPriority, removeProperty}
 
 ## Bug fixes


### PR DESCRIPTION
This reduces the time spent serializing of the js ast of `toplevel/examples/lwt_toplevel/toplevel.js` from 1.44 down to 0.62