### PR TITLE
PPX: removing the error concerning mutable fields

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 * Lib: add messageEvent to Dom_html (#1164)
 * Lib: add PerformanceObserver API (#1164)
 * Lib: add CSSStyleDeclaration.{setProperty, getPropertyValue, getPropertyPriority, removeProperty} (#1170)
+* PPX: json can now be derived for mutable records (#1184)
 
 ## Bug fixes
 * Compiler: fix sourcemap warning for empty cma (#1169)

--- a/ppx/ppx_deriving_json/lib/ppx_deriving_json.ml
+++ b/ppx/ppx_deriving_json/lib/ppx_deriving_json.ml
@@ -245,8 +245,6 @@ let seqlist = function
 
 let check_record_fields =
   List.iter ~f:(function
-      | { Parsetree.pld_mutable = Mutable; _ } ->
-          Location.raise_errorf "%s cannot be derived for mutable records" deriver
       | { pld_type = { ptyp_desc = Ptyp_poly _; _ }; _ } ->
           Location.raise_errorf "%s cannot be derived for polymorphic records" deriver
       | _ -> ())

--- a/ppx/ppx_deriving_json/tests/ppx.mlt
+++ b/ppx/ppx_deriving_json/tests/ppx.mlt
@@ -369,3 +369,16 @@ let () = test' inline_record_json "inline_record 2" (J {empty = ()})
 [%%expect {|
 inline_record 2 = [1,0]
 |}]
+
+type mutable_record =
+  { mutable i : int }
+[@@deriving json]
+
+[%%expect
+{|
+type mutable_record = { mutable i : int; }
+val mutable_record_of_json : Deriving_Json_lexer.lexbuf -> mutable_record =
+  <fun>
+val mutable_record_to_json : Buffer.t -> mutable_record -> unit = <fun>
+val mutable_record_json : mutable_record Deriving_Json.t = <abstr>
+|}]


### PR DESCRIPTION
I discussed with @vouillon and he doesn't see why there should be this error. 
fix https://github.com/ocsigen/js_of_ocaml/issues/1184