### PR TITLE
Lazy files

### DIFF
--- a/lib/js_of_ocaml/js_of_ocaml_stubs.c
+++ b/lib/js_of_ocaml/js_of_ocaml_stubs.c
@@ -232,6 +232,10 @@ void caml_read_file_content () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_read_file_content!\n");
   exit(1);
 }
+void caml_register_lazy () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_register_lazy!\n");
+  exit(1);
+}
 void caml_string_of_array () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_string_of_array!\n");
   exit(1);

--- a/lib/js_of_ocaml/sys_js.ml
+++ b/lib/js_of_ocaml/sys_js.ml
@@ -61,3 +61,5 @@ let js_of_ocaml_version =
   if String.equal Lib_version.git_version ""
   then Lib_version.s
   else Lib_version.s ^ "+" ^ Lib_version.git_version
+
+external register_lazy : string -> unit = "caml_register_lazy"

--- a/lib/js_of_ocaml/sys_js.mli
+++ b/lib/js_of_ocaml/sys_js.mli
@@ -56,6 +56,12 @@ val create_file : name:string -> content:string -> unit
       [create_file ~name ~content] register the file [name] with content [content]
       so it can be be opened with [open_in name] *)
 
+val register_lazy : string -> unit
+(** Register a lazy file to a Pseudo Filesystem.
+    [register_lazy name] causes an entry to be made in the filesystem such that it
+    will be present in a directory list, but the callback will be called when the
+    file is opened. *)
+
 val update_file : name:string -> content:string -> unit
 (** Update a file in the Pseudo Filesystem.
       [update_file ~name ~content] update the file [name] with content [content] *)

--- a/runtime/fs.js
+++ b/runtime/fs.js
@@ -314,7 +314,6 @@ function caml_create_file(name,content) {
   return 0;
 }
 
-
 //Provides: jsoo_create_file
 //Requires: caml_create_file, caml_string_of_jsbytes
 function jsoo_create_file(name,content) {
@@ -323,6 +322,16 @@ function jsoo_create_file(name,content) {
   return caml_create_file(name, content);
 }
 
+
+//Provides: caml_register_lazy
+//Requires: caml_failwith, resolve_fs_device, caml_string_of_jsbytes
+function caml_register_lazy(name) {
+  var name = (typeof name == "string")?caml_string_of_jsbytes(name):name;
+  var root = resolve_fs_device(name);
+  if(! root.device.register_lazy) caml_failwith("cannot register lazy file");
+  root.device.register_lazy(root.rest);
+  return 0;
+}
 
 //Provides: caml_read_file_content
 //Requires: resolve_fs_device, caml_raise_no_such_file, caml_create_bytes, caml_string_of_bytes


### PR DESCRIPTION
The idea of this PR is to be able to register files in the fake filesystem but without loading their contents until actually accessed. This means that a directory list will show the file as present, but on actually opening the file the usual callback is called.

The motivation behind this is to reduce the size of toplevels - so rather than compiling in all of the cmi files as is currently done we just register the files lazily. The compiler is pretty good at not actually opening the files until they're needed so this seems to end up reducing the amount of data transferred quite a bit.

The end goal is to produce a javascript toplevel for each and every library in opam to be hosted on v3.ocaml.org, so keeping the size down is an important part of this.

Does this approach make sense?