### PR TITLE
Runtime: rely on crypto.getRandomValues when available

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 * Lib: add PerformanceObserver API (#1164)
 * Lib: add CSSStyleDeclaration.{setProperty, getPropertyValue, getPropertyPriority, removeProperty} (#1170)
 * PPX: json can now be derived for mutable records (#1184)
+* Runtime: use crypto.getRandomValues when available (#1209)
 
 ## Bug fixes
 * Compiler: fix sourcemap warning for empty cma (#1169)

--- a/runtime/sys.js
+++ b/runtime/sys.js
@@ -212,6 +212,19 @@ function caml_sys_time_include_children(b) {
 //Provides: caml_sys_random_seed mutable
 //The function needs to return an array since OCaml 4.0...
 function caml_sys_random_seed () {
+  if(globalThis.crypto) {
+    if(typeof globalThis.crypto.getRandomValues === 'function'){
+      // Webbrowsers
+      var a = new globalThis.Uint32Array(1);
+      globalThis.crypto.getRandomValues(a);
+      return [0,a[0]];
+    } else if(globalThis.crypto.randomBytes === 'function'){
+      // Nodejs
+      var buff = globalThis.crypto.randomBytes(4);
+      var a = new globalThis.Uint32Array(buff);
+      return [0,a[0]];
+    }
+  }
   var now = (new Date()).getTime();
   var x = now^0xffffffff*Math.random();
   return [0,x];


### PR DESCRIPTION
Fix #1081 