### PR TITLE
Compiler: static-eval caml_sys_const_naked_pointers_checked

### DIFF
--- a/compiler/lib/eval.ml
+++ b/compiler/lib/eval.ml
@@ -144,6 +144,7 @@ let eval_prim x =
       | "caml_sys_const_word_size", [ _ ] -> Some (Int 32l)
       | "caml_sys_const_int_size", [ _ ] -> Some (Int 32l)
       | "caml_sys_const_big_endian", [ _ ] -> Some (Int 0l)
+      | "caml_sys_const_naked_pointers_checked", [ _ ] -> Some (Int 0l)
       | _ -> None)
   | _ -> None
 


### PR DESCRIPTION
It allows to remove the following deadcode from stdlib.ml

```
external major : unit -> unit = "caml_gc_major"
external naked_pointers_checked : unit -> bool
  = "caml_sys_const_naked_pointers_checked"
let () = if naked_pointers_checked () then at_exit major
```