### PR TITLE
Introduce js_of_ocaml.runtime-lib to improve compatibility with gen_js_api and brr

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
 * Lib: add PerformanceObserver API (#1164)
 * Lib: add CSSStyleDeclaration.{setProperty, getPropertyValue, getPropertyPriority, removeProperty} (#1170)
 * Lib: make window.{inner,outer}{Width,Height} non-optional
+* Lib: Introduce js_of_ocaml.runtime-lib to improve compatibility with gen_js_api and brr
 * PPX: json can now be derived for mutable records (#1184)
 * Runtime: use crypto.getRandomValues when available (#1209)
 

--- a/compiler/bin-js_of_ocaml/dune
+++ b/compiler/bin-js_of_ocaml/dune
@@ -7,7 +7,7 @@
   js_of_ocaml-compiler
   cmdliner
   compiler-libs.common
-  js_of_ocaml-compiler.runtime
+  js_of_ocaml-compiler.builtin-runtime
   (select
    findlib_support.ml
    from

--- a/compiler/lib-runtime/dune
+++ b/compiler/lib-runtime/dune
@@ -1,7 +1,7 @@
 (library
  (name jsoo_runtime)
  (libraries js_of_ocaml-compiler)
- (public_name js_of_ocaml-compiler.runtime))
+ (public_name js_of_ocaml-compiler.builtin-runtime))
 
 (rule
  (target files.ml)

--- a/lib/js_of_ocaml-runtime/dune
+++ b/lib/js_of_ocaml-runtime/dune
@@ -1,6 +1,6 @@
 (library
  (name js_of_ocaml_runtime)
- (public_name js_of_ocaml.runtime-lib)
+ (public_name js_of_ocaml-compiler.runtime)
  (foreign_stubs
   (language c)
   (names js_of_ocaml_runtime_stubs)))

--- a/lib/js_of_ocaml-runtime/dune
+++ b/lib/js_of_ocaml-runtime/dune
@@ -1,4 +1,16 @@
 (library
-  (name js_of_ocaml_runtime)
-  (public_name js_of_ocaml.runtime-lib)
-)
+ (name js_of_ocaml_runtime)
+ (public_name js_of_ocaml.runtime-lib)
+ (foreign_stubs
+  (language c)
+  (names js_of_ocaml_runtime_stubs)))
+
+(rule
+ (targets js_of_ocaml_runtime_stubs.c)
+ (deps
+  (glob_files *.ml))
+ (mode promote)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ../gen_stubs/gen_stubs.exe %{deps}))))

--- a/lib/js_of_ocaml-runtime/dune
+++ b/lib/js_of_ocaml-runtime/dune
@@ -1,0 +1,4 @@
+(library
+  (name js_of_ocaml_runtime)
+  (public_name js_of_ocaml.runtime-lib)
+)

--- a/lib/js_of_ocaml-runtime/js_of_ocaml_runtime.ml
+++ b/lib/js_of_ocaml-runtime/js_of_ocaml_runtime.ml
@@ -1,0 +1,7 @@
+module Js_error = struct
+  type t
+
+  exception Exn of t
+
+  let () = Callback.register_exception "jsError" (Exn (Obj.magic [||]))
+end

--- a/lib/js_of_ocaml-runtime/js_of_ocaml_runtime.ml
+++ b/lib/js_of_ocaml-runtime/js_of_ocaml_runtime.ml
@@ -198,6 +198,117 @@ module Js = struct
 
   external to_string : js_string t -> string = "caml_string_of_jsstring"
 
+  external bytestring : string -> js_string t = "caml_jsbytes_of_string"
+
+  external to_bytestring : js_string t -> string = "caml_string_of_jsbytes"
+
+  external bool : bool -> bool t = "caml_js_from_bool"
+
+  external to_bool : bool t -> bool = "caml_js_to_bool"
+
+  external typeof : _ t -> js_string t = "caml_js_typeof"
+
+  external instanceof : _ t -> _ constr -> bool = "caml_js_instanceof"
+
+  class type number =
+    object
+      method toString : js_string t meth
+
+      method toString_radix : int -> js_string t meth
+
+      method toLocaleString : js_string t meth
+
+      method toFixed : int -> js_string t meth
+
+      method toExponential : js_string t meth
+
+      method toExponential_digits : int -> js_string t meth
+
+      method toPrecision : int -> js_string t meth
+    end
+
+  external number_of_float : float -> number t = "caml_js_from_float"
+
+  external float_of_number : number t -> float = "caml_js_to_float"
+
+  class type ['a] js_array =
+    object
+      method toString : js_string t meth
+
+      method toLocaleString : js_string t meth
+
+      method concat : 'a js_array t -> 'a js_array t meth
+
+      method join : js_string t -> js_string t meth
+
+      method pop : 'a optdef meth
+
+      method push : 'a -> int meth
+
+      method push_2 : 'a -> 'a -> int meth
+
+      method push_3 : 'a -> 'a -> 'a -> int meth
+
+      method push_4 : 'a -> 'a -> 'a -> 'a -> int meth
+
+      method reverse : 'a js_array t meth
+
+      method shift : 'a optdef meth
+
+      method slice : int -> int -> 'a js_array t meth
+
+      method slice_end : int -> 'a js_array t meth
+
+      method sort : ('a -> 'a -> float) callback -> 'a js_array t meth
+
+      method sort_asStrings : 'a js_array t meth
+
+      method splice : int -> int -> 'a js_array t meth
+
+      method splice_1 : int -> int -> 'a -> 'a js_array t meth
+
+      method splice_2 : int -> int -> 'a -> 'a -> 'a js_array t meth
+
+      method splice_3 : int -> int -> 'a -> 'a -> 'a -> 'a js_array t meth
+
+      method splice_4 : int -> int -> 'a -> 'a -> 'a -> 'a -> 'a js_array t meth
+
+      method unshift : 'a -> int meth
+
+      method unshift_2 : 'a -> 'a -> int meth
+
+      method unshift_3 : 'a -> 'a -> 'a -> int meth
+
+      method unshift_4 : 'a -> 'a -> 'a -> 'a -> int meth
+
+      method some : ('a -> int -> 'a js_array t -> bool t) callback -> bool t meth
+
+      method every : ('a -> int -> 'a js_array t -> bool t) callback -> bool t meth
+
+      method forEach : ('a -> int -> 'a js_array t -> unit) callback -> unit meth
+
+      method map : ('a -> int -> 'a js_array t -> 'b) callback -> 'b js_array t meth
+
+      method filter :
+        ('a -> int -> 'a js_array t -> bool t) callback -> 'a js_array t meth
+
+      method reduce_init :
+        ('b -> 'a -> int -> 'a js_array t -> 'b) callback -> 'b -> 'b meth
+
+      method reduce : ('a -> 'a -> int -> 'a js_array t -> 'a) callback -> 'a meth
+
+      method reduceRight_init :
+        ('b -> 'a -> int -> 'a js_array t -> 'b) callback -> 'b -> 'b meth
+
+      method reduceRight : ('a -> 'a -> int -> 'a js_array t -> 'a) callback -> 'a meth
+
+      method length : int prop
+    end
+
+  external array : 'a array -> 'a js_array t = "caml_js_from_array"
+
+  external to_array : 'a js_array t -> 'a array = "caml_js_to_array"
+
   class type error =
     object
       method name : js_string t prop
@@ -220,4 +331,45 @@ module Js_error = struct
   exception Exn of t
 
   let () = Callback.register_exception "jsError" (Exn (Obj.magic [||]))
+end
+
+module Sys = struct
+  external create_file : name:string -> content:string -> unit = "caml_create_file"
+
+  external read_file : name:string -> string = "caml_read_file_content"
+
+  external set_channel_output' :
+    out_channel -> (Js.js_string Js.t -> unit) Js.callback -> unit
+    = "caml_ml_set_channel_output"
+
+  external set_channel_input' : in_channel -> (unit -> string) Js.callback -> unit
+    = "caml_ml_set_channel_refill"
+
+  external mount_point : unit -> string list = "caml_list_mount_point"
+
+  external mount_autoload :
+    string -> (string -> string -> string option) Js.callback -> unit
+    = "caml_mount_autoload"
+
+  external unmount : string -> unit = "caml_unmount"
+end
+
+[@@@ocaml.warning "-32-60"]
+
+module For_compatibility_only : sig end = struct
+  (* Add primitives for compatibility reasons. Existing users might
+     depend on it (e.g. gen_js_api), we dont want the ocaml compiler
+     to complain about theses missing primitives. *)
+
+  external caml_js_from_string : string -> Js.js_string Js.t = "caml_js_from_string"
+
+  external caml_js_to_byte_string : Js.js_string Js.t -> string = "caml_js_to_byte_string"
+
+  external caml_js_to_string : Js.js_string Js.t -> string = "caml_js_to_string"
+
+  external caml_list_of_js_array : 'a Js.js_array Js.t -> 'a list
+    = "caml_list_of_js_array"
+
+  external caml_list_to_js_array : 'a list -> 'a Js.js_array Js.t
+    = "caml_list_to_js_array"
 end

--- a/lib/js_of_ocaml-runtime/js_of_ocaml_runtime.ml
+++ b/lib/js_of_ocaml-runtime/js_of_ocaml_runtime.ml
@@ -1,5 +1,221 @@
+(* This local module [Js] is needed so that the ppx_js extension work within that file. *)
+module Js = struct
+  type +'a t
+
+  type (-'a, +'b) meth_callback
+
+  module Unsafe = struct
+    type top
+
+    type any = top t
+
+    type any_js_array = any
+
+    external inject : 'a -> any = "%identity"
+
+    external coerce : _ t -> _ t = "%identity"
+
+    external get : 'a -> 'b -> 'c = "caml_js_get"
+
+    external set : 'a -> 'b -> 'c -> unit = "caml_js_set"
+
+    external delete : 'a -> 'b -> unit = "caml_js_delete"
+
+    external call : 'a -> 'b -> any array -> 'c = "caml_js_call"
+
+    external fun_call : 'a -> any array -> 'b = "caml_js_fun_call"
+
+    external meth_call : 'a -> string -> any array -> 'b = "caml_js_meth_call"
+
+    external new_obj : 'a -> any array -> 'b = "caml_js_new"
+
+    external new_obj_arr : 'a -> any_js_array -> 'b = "caml_ojs_new_arr"
+
+    external obj : (string * any) array -> 'a = "caml_js_object"
+
+    external equals : 'a -> 'b -> bool = "caml_js_equals"
+
+    external pure_expr : (unit -> 'a) -> 'a = "caml_js_pure_expr"
+
+    external eval_string : string -> 'a = "caml_js_eval_string"
+
+    external js_expr : string -> 'a = "caml_js_expr"
+
+    external pure_js_expr : string -> 'a = "caml_pure_js_expr"
+
+    external callback : ('a -> 'b) -> ('c, 'a -> 'b) meth_callback = "%identity"
+
+    external callback_with_arguments :
+      (any_js_array -> 'b) -> ('c, any_js_array -> 'b) meth_callback
+      = "caml_js_wrap_callback_arguments"
+
+    external callback_with_arity : int -> ('a -> 'b) -> ('c, 'a -> 'b) meth_callback
+      = "caml_js_wrap_callback_strict"
+
+    external meth_callback : ('b -> 'a) -> ('b, 'a) meth_callback
+      = "caml_js_wrap_meth_callback_unsafe"
+
+    external meth_callback_with_arity : int -> ('b -> 'a) -> ('b, 'a) meth_callback
+      = "caml_js_wrap_meth_callback_strict"
+
+    external meth_callback_with_arguments :
+      ('b -> any_js_array -> 'a) -> ('b, any_js_array -> 'a) meth_callback
+      = "caml_js_wrap_meth_callback_arguments"
+
+    (* DEPRECATED *)
+    external variable : string -> 'a = "caml_js_var"
+  end
+
+  external debugger : unit -> unit = "debugger"
+
+  (****)
+
+  type 'a opt = 'a
+
+  type 'a optdef = 'a
+
+  (****)
+
+  type +'a meth
+
+  type +'a gen_prop
+
+  type 'a readonly_prop = < get : 'a > gen_prop
+
+  type 'a writeonly_prop = < set : 'a -> unit > gen_prop
+
+  type 'a prop = < get : 'a ; set : 'a -> unit > gen_prop
+
+  type 'a optdef_prop = < get : 'a optdef ; set : 'a -> unit > gen_prop
+
+  type +'a constr
+
+  (****)
+
+  type 'a callback = (unit, 'a) meth_callback
+
+  external wrap_callback : ('a -> 'b) -> ('c, 'a -> 'b) meth_callback
+    = "caml_js_wrap_callback"
+
+  external wrap_meth_callback : ('a -> 'b) -> ('a, 'b) meth_callback
+    = "caml_js_wrap_meth_callback"
+
+  (****)
+
+  type match_result_handle
+
+  type string_array
+
+  class type js_string =
+    object
+      method toString : js_string t meth
+
+      method valueOf : js_string t meth
+
+      method charAt : int -> js_string t meth
+
+      method charCodeAt : int -> float meth
+
+      (* This may return NaN... *)
+      method concat : js_string t -> js_string t meth
+
+      method concat_2 : js_string t -> js_string t -> js_string t meth
+
+      method concat_3 : js_string t -> js_string t -> js_string t -> js_string t meth
+
+      method concat_4 :
+        js_string t -> js_string t -> js_string t -> js_string t -> js_string t meth
+
+      method indexOf : js_string t -> int meth
+
+      method indexOf_from : js_string t -> int -> int meth
+
+      method lastIndexOf : js_string t -> int meth
+
+      method lastIndexOf_from : js_string t -> int -> int meth
+
+      method localeCompare : js_string t -> float meth
+
+      method _match : regExp t -> match_result_handle t opt meth
+
+      method replace : regExp t -> js_string t -> js_string t meth
+
+      method replace_string : js_string t -> js_string t -> js_string t meth
+
+      method search : regExp t -> int meth
+
+      method slice : int -> int -> js_string t meth
+
+      method slice_end : int -> js_string t meth
+
+      method split : js_string t -> string_array t meth
+
+      method split_limited : js_string t -> int -> string_array t meth
+
+      method split_regExp : regExp t -> string_array t meth
+
+      method split_regExpLimited : regExp t -> int -> string_array t meth
+
+      method substring : int -> int -> js_string t meth
+
+      method substring_toEnd : int -> js_string t meth
+
+      method toLowerCase : js_string t meth
+
+      method toLocaleLowerCase : js_string t meth
+
+      method toUpperCase : js_string t meth
+
+      method toLocaleUpperCase : js_string t meth
+
+      method trim : js_string t meth
+
+      method length : int readonly_prop
+    end
+
+  and regExp =
+    object
+      method exec : js_string t -> match_result_handle t opt meth
+
+      method test : js_string t -> bool t meth
+
+      method toString : js_string t meth
+
+      method source : js_string t readonly_prop
+
+      method global : bool t readonly_prop
+
+      method ignoreCase : bool t readonly_prop
+
+      method multiline : bool t readonly_prop
+
+      method lastIndex : int prop
+    end
+
+  (* string is used by ppx_js, it needs to come before any use of the
+     new syntax in this file *)
+  external string : string -> js_string t = "caml_jsstring_of_string"
+
+  external to_string : js_string t -> string = "caml_string_of_jsstring"
+
+  class type error =
+    object
+      method name : js_string t prop
+
+      method message : js_string t prop
+
+      method stack : js_string t optdef prop
+
+      method toString : js_string t meth
+    end
+
+  external js_error_of_exn : exn -> error t opt = "caml_js_error_of_exception"
+
+  external exn_with_js_backtrace : exn -> force:bool -> exn = "caml_exn_with_js_backtrace"
+end
+
 module Js_error = struct
-  type t
+  type t = Js.error Js.t
 
   exception Exn of t
 

--- a/lib/js_of_ocaml-runtime/js_of_ocaml_runtime.ml
+++ b/lib/js_of_ocaml-runtime/js_of_ocaml_runtime.ml
@@ -390,12 +390,11 @@ module Typed_array = struct
     ('a, 'b) typedArray t -> ('a, 'b, Bigarray.c_layout) Bigarray.Genarray.t
     = "caml_ba_from_typed_array"
 
-  let set : ('a, 'b) typedArray t -> int -> 'a -> unit =
-   fun a i v -> Unsafe.set (Unsafe.coerce a) i v
+  external set : ('a, 'b) typedArray t -> int -> 'a -> unit = "caml_js_set"
 
-  let get : ('a, 'b) typedArray t -> int -> 'a optdef = fun a i -> Js.Unsafe.get a i
+  external get : ('a, 'b) typedArray t -> int -> 'a optdef = "caml_js_get"
 
-  let unsafe_get : ('a, 'b) typedArray t -> int -> 'a = fun a i -> Js.Unsafe.get a i
+  external unsafe_get : ('a, 'b) typedArray t -> int -> 'a = "caml_js_get"
 
   module Bigstring = struct
     type uint8Array = (int, Bigarray.int8_unsigned_elt) typedArray

--- a/lib/js_of_ocaml-runtime/js_of_ocaml_runtime_stubs.c
+++ b/lib/js_of_ocaml-runtime/js_of_ocaml_runtime_stubs.c
@@ -1,5 +1,33 @@
 #include <stdlib.h>
 #include <stdio.h>
+void bigstring_of_array_buffer () {
+  fprintf(stderr, "Unimplemented Javascript primitive bigstring_of_array_buffer!\n");
+  exit(1);
+}
+void bigstring_of_typed_array () {
+  fprintf(stderr, "Unimplemented Javascript primitive bigstring_of_typed_array!\n");
+  exit(1);
+}
+void bigstring_to_array_buffer () {
+  fprintf(stderr, "Unimplemented Javascript primitive bigstring_to_array_buffer!\n");
+  exit(1);
+}
+void bigstring_to_typed_array () {
+  fprintf(stderr, "Unimplemented Javascript primitive bigstring_to_typed_array!\n");
+  exit(1);
+}
+void caml_ba_from_typed_array () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_ba_from_typed_array!\n");
+  exit(1);
+}
+void caml_ba_kind_of_typed_array () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_ba_kind_of_typed_array!\n");
+  exit(1);
+}
+void caml_ba_to_typed_array () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_ba_to_typed_array!\n");
+  exit(1);
+}
 void caml_create_file () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_create_file!\n");
   exit(1);
@@ -178,6 +206,10 @@ void caml_pure_js_expr () {
 }
 void caml_read_file_content () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_read_file_content!\n");
+  exit(1);
+}
+void caml_string_of_array () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_string_of_array!\n");
   exit(1);
 }
 void caml_string_of_jsbytes () {

--- a/lib/js_of_ocaml-runtime/js_of_ocaml_runtime_stubs.c
+++ b/lib/js_of_ocaml-runtime/js_of_ocaml_runtime_stubs.c
@@ -1,0 +1,110 @@
+#include <stdlib.h>
+#include <stdio.h>
+void caml_exn_with_js_backtrace () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_exn_with_js_backtrace!\n");
+  exit(1);
+}
+void caml_js_call () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_js_call!\n");
+  exit(1);
+}
+void caml_js_delete () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_js_delete!\n");
+  exit(1);
+}
+void caml_js_equals () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_js_equals!\n");
+  exit(1);
+}
+void caml_js_error_of_exception () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_js_error_of_exception!\n");
+  exit(1);
+}
+void caml_js_eval_string () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_js_eval_string!\n");
+  exit(1);
+}
+void caml_js_expr () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_js_expr!\n");
+  exit(1);
+}
+void caml_js_fun_call () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_js_fun_call!\n");
+  exit(1);
+}
+void caml_js_get () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_js_get!\n");
+  exit(1);
+}
+void caml_js_meth_call () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_js_meth_call!\n");
+  exit(1);
+}
+void caml_js_new () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_js_new!\n");
+  exit(1);
+}
+void caml_js_object () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_js_object!\n");
+  exit(1);
+}
+void caml_js_pure_expr () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_js_pure_expr!\n");
+  exit(1);
+}
+void caml_js_set () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_js_set!\n");
+  exit(1);
+}
+void caml_js_var () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_js_var!\n");
+  exit(1);
+}
+void caml_js_wrap_callback () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_js_wrap_callback!\n");
+  exit(1);
+}
+void caml_js_wrap_callback_arguments () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_js_wrap_callback_arguments!\n");
+  exit(1);
+}
+void caml_js_wrap_callback_strict () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_js_wrap_callback_strict!\n");
+  exit(1);
+}
+void caml_js_wrap_meth_callback () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_js_wrap_meth_callback!\n");
+  exit(1);
+}
+void caml_js_wrap_meth_callback_arguments () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_js_wrap_meth_callback_arguments!\n");
+  exit(1);
+}
+void caml_js_wrap_meth_callback_strict () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_js_wrap_meth_callback_strict!\n");
+  exit(1);
+}
+void caml_js_wrap_meth_callback_unsafe () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_js_wrap_meth_callback_unsafe!\n");
+  exit(1);
+}
+void caml_jsstring_of_string () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_jsstring_of_string!\n");
+  exit(1);
+}
+void caml_ojs_new_arr () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_ojs_new_arr!\n");
+  exit(1);
+}
+void caml_pure_js_expr () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_pure_js_expr!\n");
+  exit(1);
+}
+void caml_string_of_jsstring () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_string_of_jsstring!\n");
+  exit(1);
+}
+void debugger () {
+  fprintf(stderr, "Unimplemented Javascript primitive debugger!\n");
+  exit(1);
+}

--- a/lib/js_of_ocaml-runtime/js_of_ocaml_runtime_stubs.c
+++ b/lib/js_of_ocaml-runtime/js_of_ocaml_runtime_stubs.c
@@ -1,5 +1,9 @@
 #include <stdlib.h>
 #include <stdio.h>
+void caml_create_file () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_create_file!\n");
+  exit(1);
+}
 void caml_exn_with_js_backtrace () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_exn_with_js_backtrace!\n");
   exit(1);
@@ -28,12 +32,32 @@ void caml_js_expr () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_expr!\n");
   exit(1);
 }
+void caml_js_from_array () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_js_from_array!\n");
+  exit(1);
+}
+void caml_js_from_bool () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_js_from_bool!\n");
+  exit(1);
+}
+void caml_js_from_float () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_js_from_float!\n");
+  exit(1);
+}
+void caml_js_from_string () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_js_from_string!\n");
+  exit(1);
+}
 void caml_js_fun_call () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_fun_call!\n");
   exit(1);
 }
 void caml_js_get () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_get!\n");
+  exit(1);
+}
+void caml_js_instanceof () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_js_instanceof!\n");
   exit(1);
 }
 void caml_js_meth_call () {
@@ -54,6 +78,30 @@ void caml_js_pure_expr () {
 }
 void caml_js_set () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_set!\n");
+  exit(1);
+}
+void caml_js_to_array () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_js_to_array!\n");
+  exit(1);
+}
+void caml_js_to_bool () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_js_to_bool!\n");
+  exit(1);
+}
+void caml_js_to_byte_string () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_js_to_byte_string!\n");
+  exit(1);
+}
+void caml_js_to_float () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_js_to_float!\n");
+  exit(1);
+}
+void caml_js_to_string () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_js_to_string!\n");
+  exit(1);
+}
+void caml_js_typeof () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_js_typeof!\n");
   exit(1);
 }
 void caml_js_var () {
@@ -88,8 +136,36 @@ void caml_js_wrap_meth_callback_unsafe () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_wrap_meth_callback_unsafe!\n");
   exit(1);
 }
+void caml_jsbytes_of_string () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_jsbytes_of_string!\n");
+  exit(1);
+}
 void caml_jsstring_of_string () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_jsstring_of_string!\n");
+  exit(1);
+}
+void caml_list_mount_point () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_list_mount_point!\n");
+  exit(1);
+}
+void caml_list_of_js_array () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_list_of_js_array!\n");
+  exit(1);
+}
+void caml_list_to_js_array () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_list_to_js_array!\n");
+  exit(1);
+}
+void caml_ml_set_channel_output () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_ml_set_channel_output!\n");
+  exit(1);
+}
+void caml_ml_set_channel_refill () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_ml_set_channel_refill!\n");
+  exit(1);
+}
+void caml_mount_autoload () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_mount_autoload!\n");
   exit(1);
 }
 void caml_ojs_new_arr () {
@@ -100,8 +176,20 @@ void caml_pure_js_expr () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_pure_js_expr!\n");
   exit(1);
 }
+void caml_read_file_content () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_read_file_content!\n");
+  exit(1);
+}
+void caml_string_of_jsbytes () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_string_of_jsbytes!\n");
+  exit(1);
+}
 void caml_string_of_jsstring () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_string_of_jsstring!\n");
+  exit(1);
+}
+void caml_unmount () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_unmount!\n");
   exit(1);
 }
 void debugger () {

--- a/lib/js_of_ocaml/dune
+++ b/lib/js_of_ocaml/dune
@@ -1,7 +1,7 @@
 (library
  (name js_of_ocaml)
  (public_name js_of_ocaml)
- (libraries uchar bytes)
+ (libraries uchar bytes js_of_ocaml_runtime)
  (foreign_stubs
   (language c)
   (names js_of_ocaml_stubs))

--- a/lib/js_of_ocaml/dune
+++ b/lib/js_of_ocaml/dune
@@ -1,7 +1,7 @@
 (library
  (name js_of_ocaml)
  (public_name js_of_ocaml)
- (libraries uchar bytes js_of_ocaml_runtime)
+ (libraries uchar bytes js_of_ocaml-compiler.runtime)
  (foreign_stubs
   (language c)
   (names js_of_ocaml_stubs))

--- a/lib/js_of_ocaml/dune
+++ b/lib/js_of_ocaml/dune
@@ -16,7 +16,15 @@
  (action
   (with-stdout-to
    %{targets}
-   (run ../gen_stubs/gen_stubs.exe %{deps}))))
+   (run
+    ../gen_stubs/gen_stubs.exe
+    --ignore
+    caml_js_get
+    --ignore
+    caml_js_set
+    --ignore
+    caml_js_equals
+    %{deps}))))
 
 (rule
  (targets lib_version.ml)

--- a/lib/js_of_ocaml/dune
+++ b/lib/js_of_ocaml/dune
@@ -22,8 +22,6 @@
     caml_js_get
     --ignore
     caml_js_set
-    --ignore
-    caml_js_equals
     %{deps}))))
 
 (rule

--- a/lib/js_of_ocaml/js.ml
+++ b/lib/js_of_ocaml/js.ml
@@ -21,304 +21,117 @@ open! Import
 
 (* This local module [Js] is needed so that the ppx_js extension work within that file. *)
 module Js = struct
-  type +'a t
-
-  type (-'a, +'b) meth_callback
-
   module Unsafe = struct
-    type top
-
-    type any = top t
-
-    type any_js_array = any
-
-    external inject : 'a -> any = "%identity"
-
-    external coerce : _ t -> _ t = "%identity"
-
-    external get : 'a -> 'b -> 'c = "caml_js_get"
-
-    external set : 'a -> 'b -> 'c -> unit = "caml_js_set"
-
-    external delete : 'a -> 'b -> unit = "caml_js_delete"
-
-    external call : 'a -> 'b -> any array -> 'c = "caml_js_call"
-
-    external fun_call : 'a -> any array -> 'b = "caml_js_fun_call"
-
-    external meth_call : 'a -> string -> any array -> 'b = "caml_js_meth_call"
-
-    external new_obj : 'a -> any array -> 'b = "caml_js_new"
-
-    external new_obj_arr : 'a -> any_js_array -> 'b = "caml_ojs_new_arr"
-
-    external obj : (string * any) array -> 'a = "caml_js_object"
-
-    external equals : 'a -> 'b -> bool = "caml_js_equals"
-
-    external pure_expr : (unit -> 'a) -> 'a = "caml_js_pure_expr"
-
-    external eval_string : string -> 'a = "caml_js_eval_string"
-
-    external js_expr : string -> 'a = "caml_js_expr"
-
-    external pure_js_expr : string -> 'a = "caml_pure_js_expr"
+    include Js_of_ocaml_runtime.Js.Unsafe
 
     let global = pure_js_expr "globalThis"
-
-    external callback : ('a -> 'b) -> ('c, 'a -> 'b) meth_callback = "%identity"
-
-    external callback_with_arguments :
-      (any_js_array -> 'b) -> ('c, any_js_array -> 'b) meth_callback
-      = "caml_js_wrap_callback_arguments"
-
-    external callback_with_arity : int -> ('a -> 'b) -> ('c, 'a -> 'b) meth_callback
-      = "caml_js_wrap_callback_strict"
-
-    external meth_callback : ('b -> 'a) -> ('b, 'a) meth_callback
-      = "caml_js_wrap_meth_callback_unsafe"
-
-    external meth_callback_with_arity : int -> ('b -> 'a) -> ('b, 'a) meth_callback
-      = "caml_js_wrap_meth_callback_strict"
-
-    external meth_callback_with_arguments :
-      ('b -> any_js_array -> 'a) -> ('b, any_js_array -> 'a) meth_callback
-      = "caml_js_wrap_meth_callback_arguments"
-
-    (* DEPRECATED *)
-    external variable : string -> 'a = "caml_js_var"
   end
 
-  (****)
-
-  type 'a opt = 'a
-
-  type 'a optdef = 'a
-
-  external debugger : unit -> unit = "debugger"
-
-  let null : 'a opt = Unsafe.pure_js_expr "null"
-
-  external some : 'a -> 'a opt = "%identity"
-
-  let undefined : 'a optdef = Unsafe.pure_js_expr "undefined"
-
-  external def : 'a -> 'a optdef = "%identity"
-
-  module type OPT = sig
-    type 'a t
-
-    val empty : 'a t
-
-    val return : 'a -> 'a t
-
-    val map : 'a t -> ('a -> 'b) -> 'b t
-
-    val bind : 'a t -> ('a -> 'b t) -> 'b t
-
-    val test : 'a t -> bool
-
-    val iter : 'a t -> ('a -> unit) -> unit
-
-    val case : 'a t -> (unit -> 'b) -> ('a -> 'b) -> 'b
-
-    val get : 'a t -> (unit -> 'a) -> 'a
-
-    val option : 'a option -> 'a t
-
-    val to_option : 'a t -> 'a option
-  end
-
-  module Opt : OPT with type 'a t = 'a opt = struct
-    type 'a t = 'a opt
-
-    let empty = null
-
-    let return = some
-
-    let map x f = if Unsafe.equals x null then null else return (f x)
-
-    let bind x f = if Unsafe.equals x null then null else f x
-
-    let test x = not (Unsafe.equals x null)
-
-    let iter x f = if not (Unsafe.equals x null) then f x
-
-    let case x f g = if Unsafe.equals x null then f () else g x
-
-    let get x f = if Unsafe.equals x null then f () else x
-
-    let option x =
-      match x with
-      | None -> empty
-      | Some x -> return x
-
-    let to_option x = case x (fun () -> None) (fun x -> Some x)
-  end
-
-  module Optdef : OPT with type 'a t = 'a optdef = struct
-    type 'a t = 'a optdef
-
-    let empty = undefined
-
-    let return = def
-
-    let map x f = if x == undefined then undefined else return (f x)
-
-    let bind x f = if x == undefined then undefined else f x
-
-    let test x = x != undefined
-
-    let iter x f = if x != undefined then f x
-
-    let case x f g = if x == undefined then f () else g x
-
-    let get x f = if x == undefined then f () else x
-
-    let option x =
-      match x with
-      | None -> empty
-      | Some x -> return x
-
-    let to_option x = case x (fun () -> None) (fun x -> Some x)
-  end
-
-  (****)
-
-  let coerce x f g = Opt.get (f x) (fun () -> g x)
-
-  let coerce_opt x f g = Opt.get (Opt.bind x f) (fun () -> g x)
-
-  (****)
-
-  type +'a meth
-
-  type +'a gen_prop
-
-  type 'a readonly_prop = < get : 'a > gen_prop
-
-  type 'a writeonly_prop = < set : 'a -> unit > gen_prop
-
-  type 'a prop = < get : 'a ; set : 'a -> unit > gen_prop
-
-  type 'a optdef_prop = < get : 'a optdef ; set : 'a -> unit > gen_prop
-
-  type +'a constr
-
-  (****)
-
-  type 'a callback = (unit, 'a) meth_callback
-
-  external wrap_callback : ('a -> 'b) -> ('c, 'a -> 'b) meth_callback
-    = "caml_js_wrap_callback"
-
-  external wrap_meth_callback : ('a -> 'b) -> ('a, 'b) meth_callback
-    = "caml_js_wrap_meth_callback"
-
-  (****)
-
-  let _true = Unsafe.pure_js_expr "true"
-
-  let _false = Unsafe.pure_js_expr "false"
-
-  type match_result_handle
-
-  type string_array
-
-  class type js_string =
-    object
-      method toString : js_string t meth
-
-      method valueOf : js_string t meth
-
-      method charAt : int -> js_string t meth
-
-      method charCodeAt : int -> float meth
-
-      (* This may return NaN... *)
-      method concat : js_string t -> js_string t meth
-
-      method concat_2 : js_string t -> js_string t -> js_string t meth
-
-      method concat_3 : js_string t -> js_string t -> js_string t -> js_string t meth
-
-      method concat_4 :
-        js_string t -> js_string t -> js_string t -> js_string t -> js_string t meth
-
-      method indexOf : js_string t -> int meth
-
-      method indexOf_from : js_string t -> int -> int meth
-
-      method lastIndexOf : js_string t -> int meth
-
-      method lastIndexOf_from : js_string t -> int -> int meth
-
-      method localeCompare : js_string t -> float meth
-
-      method _match : regExp t -> match_result_handle t opt meth
-
-      method replace : regExp t -> js_string t -> js_string t meth
-
-      method replace_string : js_string t -> js_string t -> js_string t meth
-
-      method search : regExp t -> int meth
-
-      method slice : int -> int -> js_string t meth
-
-      method slice_end : int -> js_string t meth
-
-      method split : js_string t -> string_array t meth
-
-      method split_limited : js_string t -> int -> string_array t meth
-
-      method split_regExp : regExp t -> string_array t meth
-
-      method split_regExpLimited : regExp t -> int -> string_array t meth
-
-      method substring : int -> int -> js_string t meth
-
-      method substring_toEnd : int -> js_string t meth
-
-      method toLowerCase : js_string t meth
-
-      method toLocaleLowerCase : js_string t meth
-
-      method toUpperCase : js_string t meth
-
-      method toLocaleUpperCase : js_string t meth
-
-      method trim : js_string t meth
-
-      method length : int readonly_prop
-    end
-
-  and regExp =
-    object
-      method exec : js_string t -> match_result_handle t opt meth
-
-      method test : js_string t -> bool t meth
-
-      method toString : js_string t meth
-
-      method source : js_string t readonly_prop
-
-      method global : bool t readonly_prop
-
-      method ignoreCase : bool t readonly_prop
-
-      method multiline : bool t readonly_prop
-
-      method lastIndex : int prop
-    end
-
-  (* string is used by ppx_js, it needs to come before any use of the
-     new syntax in this file *)
-  external string : string -> js_string t = "caml_jsstring_of_string"
-
-  external to_string : js_string t -> string = "caml_string_of_jsstring"
+  include (
+    Js_of_ocaml_runtime.Js :
+      module type of struct
+        include Js_of_ocaml_runtime.Js
+      end
+      with module Unsafe := Js_of_ocaml_runtime.Js.Unsafe)
 end
 
 include Js
+
+let null : 'a opt = Unsafe.pure_js_expr "null"
+
+let undefined : 'a optdef = Unsafe.pure_js_expr "undefined"
+
+let _true = Unsafe.pure_js_expr "true"
+
+let _false = Unsafe.pure_js_expr "false"
+
+external some : 'a -> 'a opt = "%identity"
+
+external def : 'a -> 'a optdef = "%identity"
+
+module type OPT = sig
+  type 'a t
+
+  val empty : 'a t
+
+  val return : 'a -> 'a t
+
+  val map : 'a t -> ('a -> 'b) -> 'b t
+
+  val bind : 'a t -> ('a -> 'b t) -> 'b t
+
+  val test : 'a t -> bool
+
+  val iter : 'a t -> ('a -> unit) -> unit
+
+  val case : 'a t -> (unit -> 'b) -> ('a -> 'b) -> 'b
+
+  val get : 'a t -> (unit -> 'a) -> 'a
+
+  val option : 'a option -> 'a t
+
+  val to_option : 'a t -> 'a option
+end
+
+module Opt : OPT with type 'a t = 'a opt = struct
+  type 'a t = 'a opt
+
+  let empty = null
+
+  let return = some
+
+  let map x f = if Unsafe.equals x null then null else return (f x)
+
+  let bind x f = if Unsafe.equals x null then null else f x
+
+  let test x = not (Unsafe.equals x null)
+
+  let iter x f = if not (Unsafe.equals x null) then f x
+
+  let case x f g = if Unsafe.equals x null then f () else g x
+
+  let get x f = if Unsafe.equals x null then f () else x
+
+  let option x =
+    match x with
+    | None -> empty
+    | Some x -> return x
+
+  let to_option x = case x (fun () -> None) (fun x -> Some x)
+end
+
+module Optdef : OPT with type 'a t = 'a optdef = struct
+  type 'a t = 'a optdef
+
+  let empty = undefined
+
+  let return = def
+
+  let map x f = if x == undefined then undefined else return (f x)
+
+  let bind x f = if x == undefined then undefined else f x
+
+  let test x = x != undefined
+
+  let iter x f = if x != undefined then f x
+
+  let case x f g = if x == undefined then f () else g x
+
+  let get x f = if x == undefined then f () else x
+
+  let option x =
+    match x with
+    | None -> empty
+    | Some x -> return x
+
+  let to_option x = case x (fun () -> None) (fun x -> Some x)
+end
+
+(****)
+
+let coerce x f g = Opt.get (f x) (fun () -> g x)
+
+let coerce_opt x f g = Opt.get (Opt.bind x f) (fun () -> g x)
 
 class type string_constr =
   object
@@ -660,28 +473,11 @@ class type math =
 
 let math = Unsafe.global##._Math
 
-class type error =
-  object
-    method name : js_string t prop
-
-    method message : js_string t prop
-
-    method stack : js_string t optdef prop
-
-    method toString : js_string t meth
-  end
-
 exception Error = Js_of_ocaml_runtime.Js_error.Exn
 
 let error_constr = Unsafe.global##._Error
 
 let raise_js_error : error t -> 'a = Unsafe.js_expr "(function (exn) { throw exn })"
-
-external exn_with_js_backtrace : exn -> force:bool -> exn = "caml_exn_with_js_backtrace"
-
-external js_error_of_exn : exn -> error t opt = "caml_js_error_of_exception"
-
-external js_error : Js_of_ocaml_runtime.Js_error.t -> error t = "%identity"
 
 class type json =
   object
@@ -739,9 +535,7 @@ let parseFloat (s : js_string t) : float =
 
 let _ =
   Printexc.register_printer (function
-      | Error e ->
-          let e = js_error e in
-          Some (to_string e##toString)
+      | Error e -> Some (to_string e##toString)
       | _ -> None)
 
 let _ =

--- a/lib/js_of_ocaml/js.ml
+++ b/lib/js_of_ocaml/js.ml
@@ -146,79 +146,6 @@ let regExp_copy = regExp
 
 let regExp_withFlags = regExp
 
-class type ['a] js_array =
-  object
-    method toString : js_string t meth
-
-    method toLocaleString : js_string t meth
-
-    method concat : 'a js_array t -> 'a js_array t meth
-
-    method join : js_string t -> js_string t meth
-
-    method pop : 'a optdef meth
-
-    method push : 'a -> int meth
-
-    method push_2 : 'a -> 'a -> int meth
-
-    method push_3 : 'a -> 'a -> 'a -> int meth
-
-    method push_4 : 'a -> 'a -> 'a -> 'a -> int meth
-
-    method reverse : 'a js_array t meth
-
-    method shift : 'a optdef meth
-
-    method slice : int -> int -> 'a js_array t meth
-
-    method slice_end : int -> 'a js_array t meth
-
-    method sort : ('a -> 'a -> float) callback -> 'a js_array t meth
-
-    method sort_asStrings : 'a js_array t meth
-
-    method splice : int -> int -> 'a js_array t meth
-
-    method splice_1 : int -> int -> 'a -> 'a js_array t meth
-
-    method splice_2 : int -> int -> 'a -> 'a -> 'a js_array t meth
-
-    method splice_3 : int -> int -> 'a -> 'a -> 'a -> 'a js_array t meth
-
-    method splice_4 : int -> int -> 'a -> 'a -> 'a -> 'a -> 'a js_array t meth
-
-    method unshift : 'a -> int meth
-
-    method unshift_2 : 'a -> 'a -> int meth
-
-    method unshift_3 : 'a -> 'a -> 'a -> int meth
-
-    method unshift_4 : 'a -> 'a -> 'a -> 'a -> int meth
-
-    method some : ('a -> int -> 'a js_array t -> bool t) callback -> bool t meth
-
-    method every : ('a -> int -> 'a js_array t -> bool t) callback -> bool t meth
-
-    method forEach : ('a -> int -> 'a js_array t -> unit) callback -> unit meth
-
-    method map : ('a -> int -> 'a js_array t -> 'b) callback -> 'b js_array t meth
-
-    method filter : ('a -> int -> 'a js_array t -> bool t) callback -> 'a js_array t meth
-
-    method reduce_init :
-      ('b -> 'a -> int -> 'a js_array t -> 'b) callback -> 'b -> 'b meth
-
-    method reduce : ('a -> 'a -> int -> 'a js_array t -> 'a) callback -> 'a meth
-
-    method reduceRight_init :
-      ('b -> 'a -> int -> 'a js_array t -> 'b) callback -> 'b -> 'b meth
-
-    method reduceRight : ('a -> 'a -> int -> 'a js_array t -> 'a) callback -> 'a meth
-
-    method length : int prop
-  end
-
 let object_constructor = Unsafe.global##._Object
 
 let object_keys o : js_string t js_array t = object_constructor##keys o
@@ -253,27 +180,6 @@ class type match_result =
 let str_array : string_array t -> js_string t js_array t = Unsafe.coerce
 
 let match_result : match_result_handle t -> match_result t = Unsafe.coerce
-
-class type number =
-  object
-    method toString : js_string t meth
-
-    method toString_radix : int -> js_string t meth
-
-    method toLocaleString : js_string t meth
-
-    method toFixed : int -> js_string t meth
-
-    method toExponential : js_string t meth
-
-    method toExponential_digits : int -> js_string t meth
-
-    method toPrecision : int -> js_string t meth
-  end
-
-external number_of_float : float -> number t = "caml_js_from_float"
-
-external float_of_number : number t -> float = "caml_js_to_float"
 
 class type date =
   object
@@ -506,22 +412,6 @@ let escape (s : js_string t) : js_string t =
 let unescape (s : js_string t) : js_string t =
   Unsafe.fun_call Unsafe.global##.unescape [| Unsafe.inject s |]
 
-external bool : bool -> bool t = "caml_js_from_bool"
-
-external to_bool : bool t -> bool = "caml_js_to_bool"
-
-external array : 'a array -> 'a js_array t = "caml_js_from_array"
-
-external to_array : 'a js_array t -> 'a array = "caml_js_to_array"
-
-external bytestring : string -> js_string t = "caml_jsbytes_of_string"
-
-external to_bytestring : js_string t -> string = "caml_string_of_jsbytes"
-
-external typeof : _ t -> js_string t = "caml_js_typeof"
-
-external instanceof : _ t -> _ constr -> bool = "caml_js_instanceof"
-
 let isNaN (i : 'a) : bool =
   to_bool (Unsafe.fun_call Unsafe.global##.isNaN [| Unsafe.inject i |])
 
@@ -564,21 +454,3 @@ type float_prop = float prop
 external float : float -> float = "%identity"
 
 external to_float : float -> float = "%identity"
-
-[@@@ocaml.warning "-32-60"]
-
-module For_compatibility_only = struct
-  (* Add primitives for compatibility reasons. Existing users might
-     depend on it (e.g. gen_js_api), we dont want the ocaml compiler
-     to complain about theses missing primitives. *)
-
-  external caml_js_from_string : string -> js_string t = "caml_js_from_string"
-
-  external caml_js_to_byte_string : js_string t -> string = "caml_js_to_byte_string"
-
-  external caml_js_to_string : js_string t -> string = "caml_js_to_string"
-
-  external caml_list_of_js_array : 'a js_array t -> 'a list = "caml_list_of_js_array"
-
-  external caml_list_to_js_array : 'a list -> 'a js_array t = "caml_list_to_js_array"
-end

--- a/lib/js_of_ocaml/js.ml
+++ b/lib/js_of_ocaml/js.ml
@@ -671,17 +671,17 @@ class type error =
     method toString : js_string t meth
   end
 
-exception Error of error t
+exception Error = Js_of_ocaml_runtime.Js_error.Exn
 
 let error_constr = Unsafe.global##._Error
-
-let _ = Callback.register_exception "jsError" (Error (Unsafe.obj [||]))
 
 let raise_js_error : error t -> 'a = Unsafe.js_expr "(function (exn) { throw exn })"
 
 external exn_with_js_backtrace : exn -> force:bool -> exn = "caml_exn_with_js_backtrace"
 
 external js_error_of_exn : exn -> error t opt = "caml_js_error_of_exception"
+
+external js_error : Js_of_ocaml_runtime.Js_error.t -> error t = "%identity"
 
 class type json =
   object
@@ -739,7 +739,9 @@ let parseFloat (s : js_string t) : float =
 
 let _ =
   Printexc.register_printer (function
-      | Error e -> Some (to_string e##toString)
+      | Error e ->
+          let e = js_error e in
+          Some (to_string e##toString)
       | _ -> None)
 
 let _ =

--- a/lib/js_of_ocaml/js.mli
+++ b/lib/js_of_ocaml/js.mli
@@ -698,7 +698,9 @@ val js_error_of_exn : exn -> error t opt
 (** Extract a JavaScript error attached to an OCaml exception, if any.  This is useful to
     inspect an eventual stack strace, especially when sourcemap is enabled. *)
 
-exception Error of error t
+external js_error : Js_of_ocaml_runtime.Js_error.t -> error t = "%identity"
+
+exception Error of Js_of_ocaml_runtime.Js_error.t
 (** The [Error] exception wrap javascript exceptions when caught by OCaml code.
       In case the javascript exception is not an instance of javascript [Error],
       it will be serialized and wrapped into a [Failure] exception.

--- a/lib/js_of_ocaml/js.mli
+++ b/lib/js_of_ocaml/js.mli
@@ -698,9 +698,7 @@ val js_error_of_exn : exn -> error t opt
 (** Extract a JavaScript error attached to an OCaml exception, if any.  This is useful to
     inspect an eventual stack strace, especially when sourcemap is enabled. *)
 
-external js_error : Js_of_ocaml_runtime.Js_error.t -> error t = "%identity"
-
-exception Error of Js_of_ocaml_runtime.Js_error.t
+exception Error of error t
 (** The [Error] exception wrap javascript exceptions when caught by OCaml code.
       In case the javascript exception is not an instance of javascript [Error],
       it will be serialized and wrapped into a [Failure] exception.

--- a/lib/js_of_ocaml/js.mli
+++ b/lib/js_of_ocaml/js.mli
@@ -27,10 +27,10 @@
 
 (** {2 Dealing with [null] and [undefined] values.} *)
 
-type +'a opt
+type +'a opt = 'a Js_of_ocaml_runtime.Js.opt
 (** Type of possibly null values. *)
 
-type +'a optdef
+type +'a optdef = 'a Js_of_ocaml_runtime.Js.optdef
 (** Type of possibly undefined values. *)
 
 val null : 'a opt
@@ -91,18 +91,18 @@ module Optdef : OPT with type 'a t = 'a optdef
 
 (** {2 Types for specifying method and properties of Javascript objects} *)
 
-type +'a t
+type +'a t = 'a Js_of_ocaml_runtime.Js.t
 (** Type of Javascript objects.  The type parameter is used to
       specify more precisely an object.  *)
 
-type +'a meth
+type +'a meth = 'a Js_of_ocaml_runtime.Js.meth
 (** Type used to specify method types:
       a Javascript object
         [<m : t1 -> t2 -> ... -> tn -> t Js.meth> Js.t]
       has a Javascript method [m] expecting {i n} arguments
       of types [t1] to [tn] and returns a value of type [t]. *)
 
-type +'a gen_prop
+type +'a gen_prop = 'a Js_of_ocaml_runtime.Js.gen_prop
 (** Type used to specify the properties of Javascript
       objects.  In practice you should rarely need this type directly,
       but should rather use the type abbreviations below instead. *)
@@ -133,7 +133,7 @@ type 'a optdef_prop = < get : 'a optdef ; set : 'a -> unit > gen_prop
 
 (** {2 Object constructors} *)
 
-type +'a constr
+type +'a constr = 'a Js_of_ocaml_runtime.Js.constr
 (** A value of type [(t1 -> ... -> tn -> t Js.t) Js.constr] is a
       Javascript constructor expecting {i n} arguments of types [t1]
       to [tn] and returning a Javascript object of type [t Js.t].  Use
@@ -142,7 +142,7 @@ type +'a constr
 
 (** {2 Callbacks to OCaml} *)
 
-type (-'a, +'b) meth_callback
+type (-'a, +'b) meth_callback = ('a, 'b) Js_of_ocaml_runtime.Js.meth_callback
 (** Type of callback functions.  A function of type
        [(u, t1 -> ... -> tn -> t) meth_callback] can be called
        from Javascript with [this] bound to a value of type [u]
@@ -176,13 +176,13 @@ val _true : bool t
 val _false : bool t
 (** Javascript [false] boolean. *)
 
-type match_result_handle
+type match_result_handle = Js_of_ocaml_runtime.Js.match_result_handle
 (** A handle to a match result.  Use function [Js.match_result]
       to get the corresponding [MatchResult] object.
       (This type is used to resolved the mutual dependency between
        string and array type definitions.) *)
 
-type string_array
+type string_array = Js_of_ocaml_runtime.Js.string_array
 (** Opaque type for string arrays.  You can get the actual [Array]
       object using function [Js.str_array].
       (This type is used to resolved the mutual dependency between
@@ -834,7 +834,7 @@ export_all
 
 (** Unsafe Javascript operations *)
 module Unsafe : sig
-  type top
+  type top = Js_of_ocaml_runtime.Js.Unsafe.top
 
   type any = top t
   (** Top type.  Used for putting values of different types

--- a/lib/js_of_ocaml/js_of_ocaml_stubs.c
+++ b/lib/js_of_ocaml/js_of_ocaml_stubs.c
@@ -1,33 +1,5 @@
 #include <stdlib.h>
 #include <stdio.h>
-void bigstring_of_array_buffer () {
-  fprintf(stderr, "Unimplemented Javascript primitive bigstring_of_array_buffer!\n");
-  exit(1);
-}
-void bigstring_of_typed_array () {
-  fprintf(stderr, "Unimplemented Javascript primitive bigstring_of_typed_array!\n");
-  exit(1);
-}
-void bigstring_to_array_buffer () {
-  fprintf(stderr, "Unimplemented Javascript primitive bigstring_to_array_buffer!\n");
-  exit(1);
-}
-void bigstring_to_typed_array () {
-  fprintf(stderr, "Unimplemented Javascript primitive bigstring_to_typed_array!\n");
-  exit(1);
-}
-void caml_ba_from_typed_array () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_ba_from_typed_array!\n");
-  exit(1);
-}
-void caml_ba_kind_of_typed_array () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_ba_kind_of_typed_array!\n");
-  exit(1);
-}
-void caml_ba_to_typed_array () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_ba_to_typed_array!\n");
-  exit(1);
-}
 void caml_int64_create_lo_mi_hi () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_int64_create_lo_mi_hi!\n");
   exit(1);
@@ -46,10 +18,6 @@ void caml_js_html_escape () {
 }
 void caml_js_on_ie () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_on_ie!\n");
-  exit(1);
-}
-void caml_string_of_array () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_string_of_array!\n");
   exit(1);
 }
 void caml_xmlhttprequest_create () {

--- a/lib/js_of_ocaml/js_of_ocaml_stubs.c
+++ b/lib/js_of_ocaml/js_of_ocaml_stubs.c
@@ -32,36 +32,8 @@ void caml_create_file () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_create_file!\n");
   exit(1);
 }
-void caml_exn_with_js_backtrace () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_exn_with_js_backtrace!\n");
-  exit(1);
-}
 void caml_int64_create_lo_mi_hi () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_int64_create_lo_mi_hi!\n");
-  exit(1);
-}
-void caml_js_call () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_js_call!\n");
-  exit(1);
-}
-void caml_js_delete () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_js_delete!\n");
-  exit(1);
-}
-void caml_js_equals () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_js_equals!\n");
-  exit(1);
-}
-void caml_js_error_of_exception () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_js_error_of_exception!\n");
-  exit(1);
-}
-void caml_js_eval_string () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_js_eval_string!\n");
-  exit(1);
-}
-void caml_js_expr () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_js_expr!\n");
   exit(1);
 }
 void caml_js_from_array () {
@@ -80,14 +52,6 @@ void caml_js_from_string () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_from_string!\n");
   exit(1);
 }
-void caml_js_fun_call () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_js_fun_call!\n");
-  exit(1);
-}
-void caml_js_get () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_js_get!\n");
-  exit(1);
-}
 void caml_js_get_console () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_get_console!\n");
   exit(1);
@@ -104,28 +68,8 @@ void caml_js_instanceof () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_instanceof!\n");
   exit(1);
 }
-void caml_js_meth_call () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_js_meth_call!\n");
-  exit(1);
-}
-void caml_js_new () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_js_new!\n");
-  exit(1);
-}
-void caml_js_object () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_js_object!\n");
-  exit(1);
-}
 void caml_js_on_ie () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_on_ie!\n");
-  exit(1);
-}
-void caml_js_pure_expr () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_js_pure_expr!\n");
-  exit(1);
-}
-void caml_js_set () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_js_set!\n");
   exit(1);
 }
 void caml_js_to_array () {
@@ -152,44 +96,8 @@ void caml_js_typeof () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_typeof!\n");
   exit(1);
 }
-void caml_js_var () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_js_var!\n");
-  exit(1);
-}
-void caml_js_wrap_callback () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_js_wrap_callback!\n");
-  exit(1);
-}
-void caml_js_wrap_callback_arguments () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_js_wrap_callback_arguments!\n");
-  exit(1);
-}
-void caml_js_wrap_callback_strict () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_js_wrap_callback_strict!\n");
-  exit(1);
-}
-void caml_js_wrap_meth_callback () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_js_wrap_meth_callback!\n");
-  exit(1);
-}
-void caml_js_wrap_meth_callback_arguments () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_js_wrap_meth_callback_arguments!\n");
-  exit(1);
-}
-void caml_js_wrap_meth_callback_strict () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_js_wrap_meth_callback_strict!\n");
-  exit(1);
-}
-void caml_js_wrap_meth_callback_unsafe () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_js_wrap_meth_callback_unsafe!\n");
-  exit(1);
-}
 void caml_jsbytes_of_string () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_jsbytes_of_string!\n");
-  exit(1);
-}
-void caml_jsstring_of_string () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_jsstring_of_string!\n");
   exit(1);
 }
 void caml_list_mount_point () {
@@ -216,14 +124,6 @@ void caml_mount_autoload () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_mount_autoload!\n");
   exit(1);
 }
-void caml_ojs_new_arr () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_ojs_new_arr!\n");
-  exit(1);
-}
-void caml_pure_js_expr () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_pure_js_expr!\n");
-  exit(1);
-}
 void caml_read_file_content () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_read_file_content!\n");
   exit(1);
@@ -236,19 +136,11 @@ void caml_string_of_jsbytes () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_string_of_jsbytes!\n");
   exit(1);
 }
-void caml_string_of_jsstring () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_string_of_jsstring!\n");
-  exit(1);
-}
 void caml_unmount () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_unmount!\n");
   exit(1);
 }
 void caml_xmlhttprequest_create () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_xmlhttprequest_create!\n");
-  exit(1);
-}
-void debugger () {
-  fprintf(stderr, "Unimplemented Javascript primitive debugger!\n");
   exit(1);
 }

--- a/lib/js_of_ocaml/js_of_ocaml_stubs.c
+++ b/lib/js_of_ocaml/js_of_ocaml_stubs.c
@@ -28,28 +28,8 @@ void caml_ba_to_typed_array () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_ba_to_typed_array!\n");
   exit(1);
 }
-void caml_create_file () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_create_file!\n");
-  exit(1);
-}
 void caml_int64_create_lo_mi_hi () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_int64_create_lo_mi_hi!\n");
-  exit(1);
-}
-void caml_js_from_array () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_js_from_array!\n");
-  exit(1);
-}
-void caml_js_from_bool () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_js_from_bool!\n");
-  exit(1);
-}
-void caml_js_from_float () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_js_from_float!\n");
-  exit(1);
-}
-void caml_js_from_string () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_js_from_string!\n");
   exit(1);
 }
 void caml_js_get_console () {
@@ -64,80 +44,12 @@ void caml_js_html_escape () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_html_escape!\n");
   exit(1);
 }
-void caml_js_instanceof () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_js_instanceof!\n");
-  exit(1);
-}
 void caml_js_on_ie () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_on_ie!\n");
   exit(1);
 }
-void caml_js_to_array () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_js_to_array!\n");
-  exit(1);
-}
-void caml_js_to_bool () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_js_to_bool!\n");
-  exit(1);
-}
-void caml_js_to_byte_string () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_js_to_byte_string!\n");
-  exit(1);
-}
-void caml_js_to_float () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_js_to_float!\n");
-  exit(1);
-}
-void caml_js_to_string () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_js_to_string!\n");
-  exit(1);
-}
-void caml_js_typeof () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_js_typeof!\n");
-  exit(1);
-}
-void caml_jsbytes_of_string () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_jsbytes_of_string!\n");
-  exit(1);
-}
-void caml_list_mount_point () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_list_mount_point!\n");
-  exit(1);
-}
-void caml_list_of_js_array () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_list_of_js_array!\n");
-  exit(1);
-}
-void caml_list_to_js_array () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_list_to_js_array!\n");
-  exit(1);
-}
-void caml_ml_set_channel_output () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_ml_set_channel_output!\n");
-  exit(1);
-}
-void caml_ml_set_channel_refill () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_ml_set_channel_refill!\n");
-  exit(1);
-}
-void caml_mount_autoload () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_mount_autoload!\n");
-  exit(1);
-}
-void caml_read_file_content () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_read_file_content!\n");
-  exit(1);
-}
 void caml_string_of_array () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_string_of_array!\n");
-  exit(1);
-}
-void caml_string_of_jsbytes () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_string_of_jsbytes!\n");
-  exit(1);
-}
-void caml_unmount () {
-  fprintf(stderr, "Unimplemented Javascript primitive caml_unmount!\n");
   exit(1);
 }
 void caml_xmlhttprequest_create () {

--- a/lib/js_of_ocaml/sys_js.ml
+++ b/lib/js_of_ocaml/sys_js.ml
@@ -17,22 +17,12 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *)
 open! Import
-
-external create_file : name:string -> content:string -> unit = "caml_create_file"
-
-external read_file : name:string -> string = "caml_read_file_content"
+include Js_of_ocaml_runtime.Sys
 
 let update_file ~name ~content =
   let oc = open_out name in
   output_string oc content;
   close_out oc
-
-external set_channel_output' :
-  out_channel -> (Js.js_string Js.t -> unit) Js.callback -> unit
-  = "caml_ml_set_channel_output"
-
-external set_channel_input' : in_channel -> (unit -> string) Js.callback -> unit
-  = "caml_ml_set_channel_refill"
 
 let set_channel_flusher (out_channel : out_channel) (f : string -> unit) =
   let f' : (Js.js_string Js.t -> unit) Js.callback =
@@ -43,14 +33,6 @@ let set_channel_flusher (out_channel : out_channel) (f : string -> unit) =
 let set_channel_filler (in_channel : in_channel) (f : unit -> string) =
   let f' : (unit -> string) Js.callback = Js.wrap_callback f in
   set_channel_input' in_channel f'
-
-external mount_point : unit -> string list = "caml_list_mount_point"
-
-external mount_autoload :
-  string -> (string -> string -> string option) Js.callback -> unit
-  = "caml_mount_autoload"
-
-external unmount : string -> unit = "caml_unmount"
 
 let mount ~path f =
   mount_autoload path (Js.wrap_callback (fun prefix path -> f ~prefix ~path))

--- a/lib/js_of_ocaml/typed_array.mli
+++ b/lib/js_of_ocaml/typed_array.mli
@@ -168,11 +168,11 @@ val float64Array_fromBuffer : (arrayBuffer t -> float64Array t) constr
 
 val float64Array_inBuffer : (arrayBuffer t -> int -> int -> float64Array t) constr
 
-val set : ('a, 'b) typedArray t -> int -> 'a -> unit
+external set : ('a, 'b) typedArray t -> int -> 'a -> unit = "caml_js_set"
 
-val get : ('a, 'b) typedArray t -> int -> 'a optdef
+external get : ('a, 'b) typedArray t -> int -> 'a optdef = "caml_js_get"
 
-val unsafe_get : ('a, 'b) typedArray t -> int -> 'a
+external unsafe_get : ('a, 'b) typedArray t -> int -> 'a = "caml_js_get"
 
 class type dataView =
   object

--- a/toplevel/bin/dune
+++ b/toplevel/bin/dune
@@ -6,4 +6,4 @@
   bytes
   js_of_ocaml-compiler
   js_of_ocaml-compiler.findlib-support
-  js_of_ocaml-compiler.runtime))
+  js_of_ocaml-compiler.builtin-runtime))

--- a/toplevel/examples/lwt_toplevel/toplevel.ml
+++ b/toplevel/examples/lwt_toplevel/toplevel.ml
@@ -442,9 +442,7 @@ let run _ =
      fun exc ->
        Format.eprintf "exc during Lwt.async: %s@." (Printexc.to_string exc);
        match exc with
-       | Js.Error e ->
-           let e = Js.js_error e in
-           Firebug.console##log e##.stack
+       | Js.Error e -> Firebug.console##log e##.stack
        | _ -> ());
   Lwt.async (fun () ->
       resize ~container ~textbox ()

--- a/toplevel/examples/lwt_toplevel/toplevel.ml
+++ b/toplevel/examples/lwt_toplevel/toplevel.ml
@@ -442,7 +442,9 @@ let run _ =
      fun exc ->
        Format.eprintf "exc during Lwt.async: %s@." (Printexc.to_string exc);
        match exc with
-       | Js.Error e -> Firebug.console##log e##.stack
+       | Js.Error e ->
+           let e = Js.js_error e in
+           Firebug.console##log e##.stack
        | _ -> ());
   Lwt.async (fun () ->
       resize ~container ~textbox ()


### PR DESCRIPTION
Fix #1146 

The first commit implement the solution suggested by @dbuenzli  in #1146
The next two commits restore the previous api but keep the extra library `js_of_ocaml.runtime-lib`.

I believe that `js_of_ocaml.runtime-lib` could be used by both brr and gen_js_api.
```ocaml
module Error : sig
  type t

  exception Exn of t
end = struct
  type nonrec t = Js_of_ocaml_runtime.Js.error Js_of_ocaml_runtime.Js.t

  exception Exn = Js_of_ocaml_runtime.Js.Exn
end
```

@dbuenzli, what do you think ?