### PR TITLE
Return from caml_sys_exit when quit/exit called

### DIFF
--- a/runtime/sys.js
+++ b/runtime/sys.js
@@ -27,10 +27,10 @@ function caml_raise_sys_error (msg) {
 //Requires: caml_invalid_argument
 function caml_sys_exit (code) {
   var g = globalThis;
-  if(g.quit) g.quit(code);
+  if(g.quit) return g.quit(code);
   //nodejs
   if(g.process && g.process.exit)
-    g.process.exit(code);
+    return g.process.exit(code);
   caml_invalid_argument("Function 'exit' not implemented");
 }
 


### PR DESCRIPTION
This is a pretty obscure issue, but I'm trying to mock out the node process object in a WebWorker (so we can run the Grain compiler in it).

I can provide `process.exit()`, but I can't close the Worker synchronously. This would be fine if exit was only called on an error because I can throw; however, it is also called with the `0` code upon a successful execution.

By returning after calling `quit` or `exit`, you are leaving it up to the implementer to handle the closing (and it can do async cleanup, etc).