### PR TITLE
DRAFT:  flush output_channel if length over max length

### DIFF
--- a/runtime/io.js
+++ b/runtime/io.js
@@ -366,6 +366,7 @@ function caml_ml_flush (chanid) {
 //Requires: caml_ml_flush,caml_ml_bytes_length
 //Requires: caml_create_bytes, caml_blit_bytes, caml_raise_sys_error, caml_ml_channels, caml_string_of_bytes
 //Requires: caml_jsbytes_of_string
+var MAX_LENGTH = 65536;
 function caml_ml_output_bytes(chanid,buffer,offset,len) {
   var chan = caml_ml_channels[chanid];
   if(! chan.opened) caml_raise_sys_error("Cannot output to a closed channel");
@@ -380,16 +381,15 @@ function caml_ml_output_bytes(chanid,buffer,offset,len) {
   var jsstring = caml_jsbytes_of_string(string);
   var id = jsstring.lastIndexOf("\n");
   var total_length = jsstring.length + chan.buffer.length;
-  if(id < 0) {
+  if (total_length > MAX_LENGTH) {
     chan.buffer+=jsstring;
-    if (total_length > 65536) {
-      caml_ml_flush (chanid);
-    }
-  }
-  else {
+    caml_ml_flush (chanid);
+  } else if(id >= 0) {
     chan.buffer+=jsstring.substr(0,id+1);
     caml_ml_flush (chanid);
     chan.buffer += jsstring.substr(id+1);
+  } else {
+    chan.buffer+=jsstring;
   }
   return 0;
 }

--- a/runtime/io.js
+++ b/runtime/io.js
@@ -379,8 +379,13 @@ function caml_ml_output_bytes(chanid,buffer,offset,len) {
   var string = caml_string_of_bytes(bytes);
   var jsstring = caml_jsbytes_of_string(string);
   var id = jsstring.lastIndexOf("\n");
-  if(id < 0)
+  var total_length = jsstring.length + chan.buffer.length;
+  if(id < 0) {
     chan.buffer+=jsstring;
+    if (total_length > 65536) {
+      caml_ml_flush (chanid);
+    }
+  }
   else {
     chan.buffer+=jsstring.substr(0,id+1);
     caml_ml_flush (chanid);


### PR DESCRIPTION
The code is not ready yet, but I wanted to open the PR already because I have some questions. This PR fixes #1238 

### What should the actual logic be?

* The current implementation is a lot slower if you add small strings with line breaks vs small string without line breaks (4-5 times slower in some quick tests).
* What if we have a string that is `n * max_length`? Do we...
  * add the whole string and flush after that
  * flush `n` times, every time after `max_length`
* If we want to keep the current behavior and flush after line breaks, and we have a string that looks like: `foo\n very long .... string after line break"`, what do we want to do?
  * only flush after `\n` and add the long string without flushing
  * flush both after `\n` and do the same as a string with `n * max_length`
  * ignore the `\n` and do the same as a string with `n * max_length`

My proposal would be to do the simplest thing:

```
  if total_length > max_length : add full string and flush (* even if there are linebreaks in the string *)
  else if we have a line break: flush after the line break
  else just add the string
```

What do you think?

### Should I write a test for this? And how and where should I do it?

I could write some js unit tests, but I don't see any in the code so far, so I'm not sure what to do, just let me know