### PR TITLE
feat: Add more provided global values

### DIFF
--- a/compiler/lib/reserved.ml
+++ b/compiler/lib/reserved.ml
@@ -140,7 +140,24 @@ let provided =
     ; "isNaN"
     ; "parseFloat"
     ; "parseInt"
-    ; "module"
-    ; "require"
+    ; "module" (* only available in node *)
+    ; "require" (* only available in node *)
     ; "Symbol"
+    ; "ArrayBuffer"
+    ; "Float32Array"
+    ; "Float64Array"
+    ; "Int16Array"
+    ; "Int32Array"
+    ; "Int8Array"
+    ; "TextDecoder"
+    ; "Uint16Array"
+    ; "Uint32Array"
+    ; "Uint8Array"
+    ; "atob"
+    ; "clearInterval"
+    ; "console"
+    ; "global" (* only available in node *)
+    ; "importScripts" (* only available in WebWorker *)
+    ; "performance"
+    ; "setTimeout"
     ]

--- a/compiler/lib/reserved.ml
+++ b/compiler/lib/reserved.ml
@@ -154,6 +154,7 @@ let provided =
     ; "Uint32Array"
     ; "Uint8Array"
     ; "atob"
+    ; "btoa"
     ; "clearInterval"
     ; "console"
     ; "global" (* only available in node *)

--- a/compiler/lib/reserved.ml
+++ b/compiler/lib/reserved.ml
@@ -159,6 +159,6 @@ let provided =
     ; "console"
     ; "global" (* only available in node *)
     ; "importScripts" (* only available in WebWorker *)
-    ; "performance"
+    ; "performance" (* Not available in node until v16+ *)
     ; "setTimeout"
     ]


### PR DESCRIPTION
This adds a bunch of global values that are provided by the web platform. I annotated a couple with the platforms where they are available.

In the future, it'd be cool for these lists to be adjusted based on the `--target-env`