### PR TITLE
Lib: add missing Intl options

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 * Misc: remove uchar dep
 * Misc: use 4.14 in the CI
 * Lib: add missing options for Intl.DateTimeFormat
+* Lib: add missing options for Intl.NumberFormat
 
 ## Bug fixes
 * Compiler: fix rewriter bug in share_constant (fix #1247)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 * Misc: remove old binaries jsoo_link, jsoo_fs
 * Misc: remove uchar dep
 * Misc: use 4.14 in the CI
+* Lib: add missing options for Intl.DateTimeFormat
 
 ## Bug fixes
 * Compiler: fix rewriter bug in share_constant (fix #1247)

--- a/lib/js_of_ocaml/intl.ml
+++ b/lib/js_of_ocaml/intl.ml
@@ -149,6 +149,16 @@ module DateTimeFormat = struct
 
   class type options =
     object
+      method dateStyle : Js.js_string Js.t Js.optdef Js.prop
+
+      method timeStyle : Js.js_string Js.t Js.optdef Js.prop
+
+      method calendar : Js.js_string Js.t Js.optdef Js.prop
+
+      method dayPeriod : Js.js_string Js.t Js.optdef Js.prop
+
+      method numberingSystem : Js.js_string Js.t Js.optdef Js.prop
+
       method localeMatcher : Js.js_string Js.t Js.prop
 
       method timeZone : Js.js_string Js.t Js.optdef Js.prop
@@ -175,11 +185,23 @@ module DateTimeFormat = struct
 
       method second : Js.js_string Js.t Js.optdef Js.prop
 
+      method fractionalSecondDigits : int Js.optdef Js.prop
+
       method timeZoneName : Js.js_string Js.t Js.optdef Js.prop
     end
 
   let options () : options Js.t =
     object%js
+      val mutable dateStyle = Js.undefined
+
+      val mutable timeStyle = Js.undefined
+
+      val mutable calendar = Js.undefined
+
+      val mutable dayPeriod = Js.undefined
+
+      val mutable numberingSystem = Js.undefined
+
       val mutable localeMatcher = Js.string "best fit"
 
       val mutable timeZone = Js.undefined
@@ -205,6 +227,8 @@ module DateTimeFormat = struct
       val mutable minute = Js.undefined
 
       val mutable second = Js.undefined
+
+      val mutable fractionalSecondDigits = Js.undefined
 
       val mutable timeZoneName = Js.undefined
     end

--- a/lib/js_of_ocaml/intl.ml
+++ b/lib/js_of_ocaml/intl.ml
@@ -281,15 +281,37 @@ module NumberFormat = struct
 
   class type options =
     object
-      method localeMatcher : Js.js_string Js.t Js.prop
-
-      method style : Js.js_string Js.t Js.prop
+      method compactDisplay : Js.js_string Js.t Js.optdef Js.prop
 
       method currency : Js.js_string Js.t Js.optdef Js.prop
 
       method currencyDisplay : Js.js_string Js.t Js.optdef Js.prop
 
+      method currencySign : Js.js_string Js.t Js.optdef Js.prop
+
+      method localeMatcher : Js.js_string Js.t Js.prop
+
+      method notation : Js.js_string Js.t Js.optdef Js.prop
+
+      method numberingSystem : Js.js_string Js.t Js.optdef Js.prop
+
+      method signDisplay : Js.js_string Js.t Js.optdef Js.prop
+
+      method style : Js.js_string Js.t Js.prop
+
+      method unit : Js.js_string Js.t Js.optdef Js.prop
+
+      method unitDisplay : Js.js_string Js.t Js.optdef Js.prop
+
       method useGrouping : bool Js.t Js.prop
+
+      method roundingMode : Js.js_string Js.t Js.optdef Js.prop
+
+      method roundingPriority : Js.js_string Js.t Js.optdef Js.prop
+
+      method roundingIncrement : Js.js_string Js.t Js.optdef Js.prop
+
+      method trailingZeroDisplay : Js.js_string Js.t Js.optdef Js.prop
 
       method minimumIntegerDigits : int Js.optdef Js.prop
 
@@ -304,15 +326,37 @@ module NumberFormat = struct
 
   let options () : options Js.t =
     object%js
-      val mutable localeMatcher = Js.string "best fit"
-
-      val mutable style = Js.string "decimal"
+      val mutable compactDisplay = Js.undefined
 
       val mutable currency = Js.undefined
 
       val mutable currencyDisplay = Js.undefined
 
+      val mutable currencySign = Js.undefined
+
+      val mutable localeMatcher = Js.string "best fit"
+
+      val mutable notation = Js.undefined
+
+      val mutable numberingSystem = Js.undefined
+
+      val mutable signDisplay = Js.undefined
+
+      val mutable style = Js.string "decimal"
+
+      val mutable unit = Js.undefined
+
+      val mutable unitDisplay = Js.undefined
+
       val mutable useGrouping = Js._true
+
+      val mutable roundingMode = Js.undefined
+
+      val mutable roundingPriority = Js.undefined
+
+      val mutable roundingIncrement = Js.undefined
+
+      val mutable trailingZeroDisplay = Js.undefined
 
       val mutable minimumIntegerDigits = Js.undefined
 

--- a/lib/js_of_ocaml/intl.mli
+++ b/lib/js_of_ocaml/intl.mli
@@ -608,15 +608,37 @@ module NumberFormat : sig
 
   class type options =
     object
-      method localeMatcher : Js.js_string Js.t Js.prop
-
-      method style : Js.js_string Js.t Js.prop
+      method compactDisplay : Js.js_string Js.t Js.optdef Js.prop
 
       method currency : Js.js_string Js.t Js.optdef Js.prop
 
       method currencyDisplay : Js.js_string Js.t Js.optdef Js.prop
 
+      method currencySign : Js.js_string Js.t Js.optdef Js.prop
+
+      method localeMatcher : Js.js_string Js.t Js.prop
+
+      method notation : Js.js_string Js.t Js.optdef Js.prop
+
+      method numberingSystem : Js.js_string Js.t Js.optdef Js.prop
+
+      method signDisplay : Js.js_string Js.t Js.optdef Js.prop
+
+      method style : Js.js_string Js.t Js.prop
+
+      method unit : Js.js_string Js.t Js.optdef Js.prop
+
+      method unitDisplay : Js.js_string Js.t Js.optdef Js.prop
+
       method useGrouping : bool Js.t Js.prop
+
+      method roundingMode : Js.js_string Js.t Js.optdef Js.prop
+
+      method roundingPriority : Js.js_string Js.t Js.optdef Js.prop
+
+      method roundingIncrement : Js.js_string Js.t Js.optdef Js.prop
+
+      method trailingZeroDisplay : Js.js_string Js.t Js.optdef Js.prop
 
       method minimumIntegerDigits : int Js.optdef Js.prop
 

--- a/lib/js_of_ocaml/intl.mli
+++ b/lib/js_of_ocaml/intl.mli
@@ -517,6 +517,16 @@ module DateTimeFormat : sig
 
   class type options =
     object
+      method dateStyle : Js.js_string Js.t Js.optdef Js.prop
+
+      method timeStyle : Js.js_string Js.t Js.optdef Js.prop
+
+      method calendar : Js.js_string Js.t Js.optdef Js.prop
+
+      method dayPeriod : Js.js_string Js.t Js.optdef Js.prop
+
+      method numberingSystem : Js.js_string Js.t Js.optdef Js.prop
+
       method localeMatcher : Js.js_string Js.t Js.prop
 
       method timeZone : Js.js_string Js.t Js.optdef Js.prop
@@ -542,6 +552,8 @@ module DateTimeFormat : sig
       method minute : Js.js_string Js.t Js.optdef Js.prop
 
       method second : Js.js_string Js.t Js.optdef Js.prop
+
+      method fractionalSecondDigits : int Js.optdef Js.prop
 
       method timeZoneName : Js.js_string Js.t Js.optdef Js.prop
     end


### PR DESCRIPTION
Fixes #1251

There may be (probably is) more missing options in the other `Intl` APIs. These two were the only one's I checked. If you want to be thorough I can go through the rest of them later though.