### PR TITLE
Dialog element support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Features/Changes
 * Compiler: only flush the necessary env for closures (#1568)
+* Library: dialog element support
 
 ## Bug fixes
 * Compiler: fix --enable=vardecl

--- a/dune-project
+++ b/dune-project
@@ -111,7 +111,7 @@
   (js_of_ocaml-ppx (= :version))
   (react (>= 1.2.1))
   (reactiveData (>= 0.2))
-  (tyxml (>= 4.3))
+  (tyxml (>= 4.6))
   (num :with-test)
   (ppx_expect (and (>= v0.14.2) :with-test))
   (ppxlib (and (>= 0.22.0) :with-test))

--- a/js_of_ocaml-tyxml.opam
+++ b/js_of_ocaml-tyxml.opam
@@ -18,7 +18,7 @@ depends: [
   "js_of_ocaml-ppx" {= version}
   "react" {>= "1.2.1"}
   "reactiveData" {>= "0.2"}
-  "tyxml" {>= "4.3"}
+  "tyxml" {>= "4.6"}
   "num" {with-test}
   "ppx_expect" {>= "v0.14.2" & with-test}
   "ppxlib" {>= "0.22.0" & with-test}

--- a/lib/js_of_ocaml/dom_html.ml
+++ b/lib/js_of_ocaml/dom_html.ml
@@ -770,7 +770,11 @@ let invoke_handler = Dom.invoke_handler
 module Event = struct
   type 'a typ = 'a Dom.Event.typ
 
+  let cancel = Dom.Event.make "cancel"
+
   let click = Dom.Event.make "click"
+
+  let close = Dom.Event.make "close"
 
   let copy = Dom.Event.make "copy"
 
@@ -1304,6 +1308,10 @@ class type dialogElement =
     method show : unit meth
 
     method showModal : unit meth
+
+    method oncancel : ('self t, event t) event_listener prop
+
+    method onclose : ('self t, event t) event_listener prop
   end
 
 class type divElement = element

--- a/lib/js_of_ocaml/dom_html.ml
+++ b/lib/js_of_ocaml/dom_html.ml
@@ -1289,6 +1289,23 @@ class type dListElement = element
 
 class type liElement = element
 
+class type dialogElement =
+  object
+    inherit element
+
+    method close : unit meth
+
+    method close_returnValue : js_string t -> unit meth
+
+    method open_ : bool t prop
+
+    method returnValue : js_string t prop
+
+    method show : unit meth
+
+    method showModal : unit meth
+  end
+
 class type divElement = element
 
 class type paragraphElement = element
@@ -2537,6 +2554,8 @@ let createDl doc : dListElement t = unsafeCreateElement doc "dl"
 
 let createLi doc : liElement t = unsafeCreateElement doc "li"
 
+let createDialog doc : dialogElement t = unsafeCreateElement doc "dialog"
+
 let createDiv doc : divElement t = unsafeCreateElement doc "div"
 
 let createEmbed doc : embedElement t = unsafeCreateElement doc "embed"
@@ -3360,6 +3379,7 @@ type taggedElement =
   | Col of tableColElement t
   | Colgroup of tableColElement t
   | Del of modElement t
+  | Dialog of dialogElement t
   | Div of divElement t
   | Dl of dListElement t
   | Embed of embedElement t

--- a/lib/js_of_ocaml/dom_html.ml
+++ b/lib/js_of_ocaml/dom_html.ml
@@ -1293,26 +1293,25 @@ class type dListElement = element
 
 class type liElement = element
 
-class type dialogElement =
-  object
-    inherit element
+class type dialogElement = object
+  inherit element
 
-    method close : unit meth
+  method close : unit meth
 
-    method close_returnValue : js_string t -> unit meth
+  method close_returnValue : js_string t -> unit meth
 
-    method open_ : bool t prop
+  method open_ : bool t prop
 
-    method returnValue : js_string t prop
+  method returnValue : js_string t prop
 
-    method show : unit meth
+  method show : unit meth
 
-    method showModal : unit meth
+  method showModal : unit meth
 
-    method oncancel : ('self t, event t) event_listener prop
+  method oncancel : ('self t, event t) event_listener prop
 
-    method onclose : ('self t, event t) event_listener prop
-  end
+  method onclose : ('self t, event t) event_listener prop
+end
 
 class type divElement = element
 

--- a/lib/js_of_ocaml/dom_html.mli
+++ b/lib/js_of_ocaml/dom_html.mli
@@ -1114,26 +1114,25 @@ class type dListElement = element
 
 class type liElement = element
 
-class type dialogElement =
-  object
-    inherit element
+class type dialogElement = object
+  inherit element
 
-    method close : unit meth
+  method close : unit meth
 
-    method close_returnValue : js_string t -> unit meth
+  method close_returnValue : js_string t -> unit meth
 
-    method open_ : bool t prop
+  method open_ : bool t prop
 
-    method returnValue : js_string t prop
+  method returnValue : js_string t prop
 
-    method show : unit meth
+  method show : unit meth
 
-    method showModal : unit meth
+  method showModal : unit meth
 
-    method oncancel : ('self t, event t) event_listener prop
+  method oncancel : ('self t, event t) event_listener prop
 
-    method onclose : ('self t, event t) event_listener prop
-  end
+  method onclose : ('self t, event t) event_listener prop
+end
 
 class type divElement = element
 

--- a/lib/js_of_ocaml/dom_html.mli
+++ b/lib/js_of_ocaml/dom_html.mli
@@ -1129,6 +1129,10 @@ class type dialogElement =
     method show : unit meth
 
     method showModal : unit meth
+
+    method oncancel : ('self t, event t) event_listener prop
+
+    method onclose : ('self t, event t) event_listener prop
   end
 
 class type divElement = element
@@ -2314,7 +2318,11 @@ val eventRelatedTarget : #mouseEvent t -> element t opt
 module Event : sig
   type 'a typ = 'a Dom.Event.typ
 
+  val cancel : event t typ
+
   val click : mouseEvent t typ
+
+  val close : event t typ
 
   val copy : clipboardEvent t typ
 

--- a/lib/js_of_ocaml/dom_html.mli
+++ b/lib/js_of_ocaml/dom_html.mli
@@ -1114,6 +1114,23 @@ class type dListElement = element
 
 class type liElement = element
 
+class type dialogElement =
+  object
+    inherit element
+
+    method close : unit meth
+
+    method close_returnValue : js_string t -> unit meth
+
+    method open_ : bool t prop
+
+    method returnValue : js_string t prop
+
+    method show : unit meth
+
+    method showModal : unit meth
+  end
+
 class type divElement = element
 
 class type paragraphElement = element
@@ -2773,6 +2790,8 @@ val createDl : document t -> dListElement t
 
 val createLi : document t -> liElement t
 
+val createDialog : document t -> dialogElement t
+
 val createDiv : document t -> divElement t
 
 val createEmbed : document t -> embedElement t
@@ -2919,6 +2938,7 @@ type taggedElement =
   | Col of tableColElement t
   | Colgroup of tableColElement t
   | Del of modElement t
+  | Dialog of dialogElement t
   | Div of divElement t
   | Dl of dListElement t
   | Embed of embedElement t

--- a/lib/tyxml/tyxml_cast.ml
+++ b/lib/tyxml/tyxml_cast.ml
@@ -79,6 +79,8 @@ end) : Tyxml_cast_sigs.TO with type 'a elt = 'a C.elt = struct
 
   let of_li elt = rebuild_node "of_li" elt
 
+  let of_dialog elt = rebuild_node "of_dialog" elt
+
   let of_div elt = rebuild_node "of_div" elt
 
   let of_p elt = rebuild_node "of_p" elt
@@ -308,6 +310,8 @@ end) : Tyxml_cast_sigs.OF with type 'a elt = 'a C.elt = struct
   let of_dList elt = rebuild_node "of_dList" elt
 
   let of_li elt = rebuild_node "of_li" elt
+
+  let of_dialog elt = rebuild_node "of_dialog" elt
 
   let of_div elt = rebuild_node "of_div" elt
 

--- a/lib/tyxml/tyxml_cast_sigs.ml
+++ b/lib/tyxml/tyxml_cast_sigs.ml
@@ -71,6 +71,8 @@ module type OF = sig
 
   val of_li : Dom_html.liElement Js.t -> [> Html_types.li ] elt
 
+  val of_dialog : Dom_html.dialogElement Js.t -> [> Html_types.dialog ] elt
+
   val of_div : Dom_html.divElement Js.t -> [> Html_types.div ] elt
 
   val of_paragraph : Dom_html.paragraphElement Js.t -> [> Html_types.p ] elt
@@ -179,6 +181,8 @@ module type TO = sig
   val of_dl : [< Html_types.dl ] elt -> Dom_html.dListElement Js.t
 
   val of_li : [< Html_types.li ] elt -> Dom_html.liElement Js.t
+
+  val of_dialog : [< Html_types.dialog ] elt -> Dom_html.dialogElement Js.t
 
   val of_div : [< Html_types.div ] elt -> Dom_html.divElement Js.t
 

--- a/lib/tyxml/tyxml_cast_sigs.mli
+++ b/lib/tyxml/tyxml_cast_sigs.mli
@@ -70,6 +70,8 @@ module type OF = sig
 
   val of_li : Dom_html.liElement Js.t -> [> Html_types.li ] elt
 
+  val of_dialog : Dom_html.dialogElement Js.t -> [> Html_types.dialog ] elt
+
   val of_div : Dom_html.divElement Js.t -> [> Html_types.div ] elt
 
   val of_paragraph : Dom_html.paragraphElement Js.t -> [> Html_types.p ] elt
@@ -178,6 +180,8 @@ module type TO = sig
   val of_dl : [< Html_types.dl ] elt -> Dom_html.dListElement Js.t
 
   val of_li : [< Html_types.li ] elt -> Dom_html.liElement Js.t
+
+  val of_dialog : [< Html_types.dialog ] elt -> Dom_html.dialogElement Js.t
 
   val of_div : [< Html_types.div ] elt -> Dom_html.divElement Js.t
 


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog
and
https://html.spec.whatwg.org/multipage/interactive-elements.html#the-dialog-element

I think that I remember that `cancel` and `close` events are not well supported, but they are part of the spec.

~THIS PR DEPENDS ON CURRENT TYXML MASTER, which is unreleased right now. Would a new tyxml release be good enough for this to be merged?~