### PR TITLE
fix: Only write small chunks to stdout/stderr in node

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
 * Runtime: fix Out_channel.is_buffered, set_buffered
 * Runtime: fix format wrt alternative
 * Misc: fix installation with dune 3 without opam
+* Node: Only write small chunks to stdout/stderr so they flush
 
 # 4.0.0 (2021-01-24) - Lille
 ## Features/Changes

--- a/runtime/jslib.js
+++ b/runtime/jslib.js
@@ -80,7 +80,7 @@ function js_print_stdout(s) {
 function js_print_stderr(s) {
   var s = caml_utf16_of_utf8(s);
   var process = globalThis.process;
-  if (process && process.stdout && process.stdout.write) {
+  if (process && process.stderr && process.stderr.write) {
     process.stderr.write(s)
   } else {
     // Do not output the last \n if present

--- a/runtime/jslib.js
+++ b/runtime/jslib.js
@@ -81,7 +81,16 @@ function js_print_stderr(s) {
   var s = caml_utf16_of_utf8(s);
   var process = globalThis.process;
   if (process && process.stderr && process.stderr.write) {
-    process.stderr.write(s)
+    // Writing too much data at once causes node's stderr socket to choke
+    // so we write it using 8-length chunks (which seem to flush quickly)
+    var written = 0;
+    var chunk_len = 8;
+    while (written <= s.length) {
+      var chunk = s.slice(written, written + chunk_len);
+      // TODO: Do we need to handle the `drained` flag returned? Throw when not drained?
+      process.stderr.write(chunk);
+      written += chunk_len;
+    }
   } else {
     // Do not output the last \n if present
     // as console logging display a newline at the end

--- a/runtime/jslib.js
+++ b/runtime/jslib.js
@@ -50,22 +50,28 @@ function caml_trampoline_return(f,args) {
   return {joo_tramp:f,joo_args:args};
 }
 
+//Provides: nodejs_print (const)
+function nodejs_print(stream, s) {
+  // Writing too much data at once causes node's stdout socket to choke
+  // so we write it using 8-length chunks (which seem to flush quickly)
+  var written = 0;
+  var chunk_len = 8;
+  while (written <= s.length) {
+    var chunk = s.slice(written, written + chunk_len);
+    // TODO: Do we need to handle the `drained` flag returned? Throw when not drained?
+    stream.write(chunk);
+    written += chunk_len;
+  }
+}
+
 //Provides: js_print_stdout (const)
 //Requires: caml_utf16_of_utf8
+//Requires: nodejs_print
 function js_print_stdout(s) {
   var s = caml_utf16_of_utf8(s);
   var process = globalThis.process;
   if (process && process.stdout && process.stdout.write) {
-    // Writing too much data at once causes node's stdout socket to choke
-    // so we write it using 8-length chunks (which seem to flush quickly)
-    var written = 0;
-    var chunk_len = 8;
-    while (written <= s.length) {
-      var chunk = s.slice(written, written + chunk_len);
-      // TODO: Do we need to handle the `drained` flag returned? Throw when not drained?
-      process.stdout.write(chunk);
-      written += chunk_len;
-    }
+    nodejs_print(process.stdout, s);
   } else {
     // Do not output the last \n if present
     // as console logging display a newline at the end
@@ -77,20 +83,12 @@ function js_print_stdout(s) {
 }
 //Provides: js_print_stderr (const)
 //Requires: caml_utf16_of_utf8
+//Requires: nodejs_print
 function js_print_stderr(s) {
   var s = caml_utf16_of_utf8(s);
   var process = globalThis.process;
   if (process && process.stderr && process.stderr.write) {
-    // Writing too much data at once causes node's stderr socket to choke
-    // so we write it using 8-length chunks (which seem to flush quickly)
-    var written = 0;
-    var chunk_len = 8;
-    while (written <= s.length) {
-      var chunk = s.slice(written, written + chunk_len);
-      // TODO: Do we need to handle the `drained` flag returned? Throw when not drained?
-      process.stderr.write(chunk);
-      written += chunk_len;
-    }
+    nodejs_print(process.stderr, s);
   } else {
     // Do not output the last \n if present
     // as console logging display a newline at the end


### PR DESCRIPTION
We encountered a problem in the Grain LSP when compiled to JS. We were attempting to write a string that was >8096 bytes but  only 8096 bytes were being written. We dug into the nodejs source code and found that node only keeps a buffer with size 8096 around when you try to write on stdout or stderr.

The `process.stdout.write()` and `process.stderr.write()` functions that return a flag on whether the data was flushed, and any large content will result it in returning `false`. We dropped the chunk size down to 8 characters and it seems to flush instantly in a loop.

I left the `// TODO` comments in the code in case @hhugo thinks we should handle the `flushed` return value in some way.