### PR TITLE
fix: Allow reading nodejs stdin that does not close

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
 * Runtime: fix Out_channel.is_buffered, set_buffered
 * Runtime: fix format wrt alternative
 * Misc: fix installation with dune 3 without opam
+* Node: fix reading from stdin that doesn't close
 
 # 4.0.0 (2021-01-24) - Lille
 ## Features/Changes

--- a/runtime/io.js
+++ b/runtime/io.js
@@ -138,9 +138,8 @@ function caml_ml_open_descriptor_in (fd)  {
   var refill = null;
   if(fd == 0 && fs_node_supported()){
     var fs = require('fs');
-    var Buffer = require('buffer').Buffer;
     refill = function () {
-      var buf = Buffer.alloc(256);
+      var buf = globalThis.Buffer.alloc(256);
       // Ref https://gist.github.com/espadrine/172658142820a356e1e0
       var stdinFd;
       var needsClose = false;

--- a/runtime/io.js
+++ b/runtime/io.js
@@ -150,7 +150,7 @@ function caml_ml_open_descriptor_in (fd)  {
         // Opening /dev/stdin can fail (on Windows or in pkg)
         if (globalThis.process.platform === 'win32') {
           // On Windows, we need to use the stdin fd
-          stdinFd = process.stdin.fd;
+          stdinFd = globalThis.process.stdin.fd;
         } else {
           // On Linux, we just want to use fd 0
           // due to this nodejs bug: https://github.com/nodejs/node/issues/42826


### PR DESCRIPTION
When using `fs.readFileSync(0, 'utf8')` in nodejs, the stdin has to be closed before the function will return. However, in the Grain LSP, stdin is always open, and separate messages are sent.

This implementation supports reading synchronously from the stdin file descriptor, while refilling only what is available in the stream at the time.