### PR TITLE
feat: Implement unix_opendir and windows variants

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 * Runtime: Implement buffer for in_channels
 * Lib: wheel event binding
 * Test: track external used in the stdlib and unix
+* Runtime: add support for unix_opendir, unix_readdir, unix_closedir, win_findfirst, win_findnext, win_findclose
 
 ## Bug fixes
 * Compiler: fix rewriter bug in share_constant (fix #1247)

--- a/compiler/tests-check-prim/main.output
+++ b/compiler/tests-check-prim/main.output
@@ -208,6 +208,7 @@ caml_spacetime_only_works_for_native_code
 unix_inet_addr_of_string
 
 From +unix.js:
+unix_closedir
 unix_getpwuid
 unix_gettimeofday
 unix_getuid
@@ -219,7 +220,10 @@ unix_lstat
 unix_lstat_64
 unix_mkdir
 unix_mktime
+unix_opendir
+unix_readdir
 unix_readlink
+unix_rewinddir
 unix_rmdir
 unix_stat
 unix_stat_64
@@ -227,6 +231,9 @@ unix_symlink
 unix_time
 unix_unlink
 win_cleanup
+win_findclose
+win_findfirst
+win_findnext
 win_handle_fd
 win_startup
 

--- a/compiler/tests-check-prim/unix-unix.output
+++ b/compiler/tests-check-prim/unix-unix.output
@@ -42,7 +42,6 @@ unix_chroot
 unix_clear_close_on_exec
 unix_clear_nonblock
 unix_close
-unix_closedir
 unix_connect
 unix_dup
 unix_dup2
@@ -97,17 +96,14 @@ unix_lseek_64
 unix_mkfifo
 unix_nice
 unix_open
-unix_opendir
 unix_outchannel_of_filedescr
 unix_pipe
 unix_putenv
 unix_read
-unix_readdir
 unix_realpath
 unix_recv
 unix_recvfrom
 unix_rename
-unix_rewinddir
 unix_select
 unix_send
 unix_sendto
@@ -321,6 +317,9 @@ caml_spacetime_only_works_for_native_code
 
 From +unix.js:
 win_cleanup
+win_findclose
+win_findfirst
+win_findnext
 win_handle_fd
 win_startup
 

--- a/compiler/tests-check-prim/unix-win32.output
+++ b/compiler/tests-check-prim/unix-win32.output
@@ -98,9 +98,6 @@ unix_utimes
 unix_write
 win_clear_close_on_exec
 win_create_process
-win_findclose
-win_findfirst
-win_findnext
 win_inchannel_of_filedescr
 win_outchannel_of_filedescr
 win_set_close_on_exec
@@ -285,4 +282,5 @@ caml_spacetime_only_works_for_native_code
 From +unix.js:
 unix_getpwuid
 unix_getuid
+unix_rewinddir
 

--- a/runtime/fs_node.js
+++ b/runtime/fs_node.js
@@ -154,6 +154,13 @@ MlNodeDevice.prototype.readlink = function(name, raise_unix) {
     this.raise_nodejs_error(err, raise_unix);
   }
 }
+MlNodeDevice.prototype.opendir = function(name, raise_unix) {
+  try {
+    return this.fs.opendirSync(this.nm(name));
+  } catch (err) {
+    this.raise_nodejs_error(err, raise_unix);
+  }
+}
 MlNodeDevice.prototype.raise_nodejs_error = function(err, raise_unix) {
   var unix_error = caml_named_value("Unix.Unix_error");
   if (raise_unix && unix_error) {

--- a/runtime/unix.js
+++ b/runtime/unix.js
@@ -205,130 +205,78 @@ function unix_has_symlink(unit) {
 }
 
 //Provides: unix_opendir
-//Requires: caml_jsstring_of_string
-//Requires: make_unix_err_args, caml_raise_with_args, caml_named_value
-//Requires: fs_node_supported, caml_failwith
+//Requires: resolve_fs_device, caml_failwith
 function unix_opendir(path) {
-  if (!fs_node_supported()) {
+  var root = resolve_fs_device(path);
+  if (!root.device.opendir) {
     caml_failwith("unix_opendir: not implemented");
   }
-  var fs = require('fs');
-  var p = caml_jsstring_of_string(path);
-  try {
-    return fs.opendirSync(p);
-  } catch (err) {
-    var unix_error = caml_named_value('Unix.Unix_error');
-    caml_raise_with_args(unix_error, make_unix_err_args(err.code, err.syscall, err.path, err.errno));
-  }
+  var dir_handle = root.device.opendir(root.rest, /* raise Unix_error */ true);
+  return { pointer : dir_handle, path: path }
 }
 
 //Provides: unix_readdir
 //Requires: caml_raise_end_of_file
 //Requires: caml_string_of_jsstring
 //Requires: make_unix_err_args, caml_raise_with_args, caml_named_value
-//Requires: fs_node_supported, caml_failwith
 function unix_readdir(dir_handle) {
-  if (!fs_node_supported()) {
-    caml_failwith("unix_readdir: not implemented");
-  }
-  var dir;
+  var entry;
   try {
-      dir = dir_handle.readSync();
+      entry = dir_handle.pointer.readSync();
   } catch (e) {
       var unix_error = caml_named_value('Unix.Unix_error');
       caml_raise_with_args(unix_error, make_unix_err_args("EBADF", "readdir", dir_handle.path));
   }
-  if (dir === null) {
+  if (entry === null) {
       caml_raise_end_of_file();
   } else {
-      return caml_string_of_jsstring(dir.name);
+      return caml_string_of_jsstring(entry.name);
   }
 }
 
 //Provides: unix_closedir
 //Requires: make_unix_err_args, caml_raise_with_args, caml_named_value
-//Requires: fs_node_supported, caml_failwith
 function unix_closedir(dir_handle) {
-  if (!fs_node_supported()) {
-    caml_failwith("unix_closedir: not implemented");
-  }
   try {
-      dir_handle.closeSync();
+      dir_handle.pointer.closeSync();
   } catch (e) {
       var unix_error = caml_named_value('Unix.Unix_error');
       caml_raise_with_args(unix_error, make_unix_err_args("EBADF", "closedir", dir_handle.path));
   }
+}
+
+//Provides: unix_rewinddir
+//Requires: unix_closedir, unix_opendir
+function unix_rewinddir(dir_handle) {
+  unix_closedir(dir_handle);
+  var new_dir_handle = unix_opendir(dir_handle.path);
+  dir_handle.pointer = new_dir_handle.pointer;
+  return 0;
 }
 
 //Provides: win_findfirst
 //Requires: caml_jsstring_of_string, caml_string_of_jsstring
-//Requires: make_unix_err_args, caml_raise_with_args, caml_named_value
-//Requires: caml_raise_end_of_file
-//Requires: fs_node_supported, caml_failwith
+//Requires: unix_opendir, unix_readdir
 function win_findfirst(path) {
-  if (!fs_node_supported()) {
-    caml_failwith("win_findfirst: not implemented");
-  }
-  var fs = require('fs');
   // The Windows code adds this glob to the path, so we need to remove it
-  var p = caml_jsstring_of_string(path).replace("*.*", "");
-  var dir_handle;
-  try {
-      dir_handle = fs.opendirSync(p);
-  } catch (err) {
-      var unix_error = caml_named_value('Unix.Unix_error');
-      caml_raise_with_args(unix_error, make_unix_err_args(err.code, err.syscall, err.path, err.errno));
-  }
-  var dir;
-  try {
-      dir = dir_handle.readSync();
-  } catch (e) {
-      var unix_error = caml_named_value('Unix.Unix_error');
-      caml_raise_with_args(unix_error, make_unix_err_args("EBADF", "readdir", dir_handle.path));
-  }
-  if (dir === null) {
-      caml_raise_end_of_file();
-  } else {
-      var first_entry = caml_string_of_jsstring(dir.name);
-      // The Windows bindings type dir_handle as an `int` but it's not in JS
-      return [0, first_entry, dir_handle];
-  }
+  var path_js = caml_jsstring_of_string(path);
+  path_js = path_js.replace(/(^|[\\\/])\*\.\*$/, "");
+  path = caml_string_of_jsstring(path_js);
+  // *.* is now stripped
+  var dir_handle = unix_opendir(path);
+  var first_entry = unix_readdir(dir_handle);
+  // The Windows bindings type dir_handle as an `int` but it's not in JS
+  return [0, first_entry, dir_handle];
 }
 
 //Provides: win_findnext
-//Requires: caml_raise_end_of_file
-//Requires: caml_string_of_jsstring
-//Requires: make_unix_err_args, caml_raise_with_args, caml_named_value
-//Requires: fs_node_supported, caml_failwith
+//Requires: unix_readdir
 function win_findnext(dir_handle) {
-  if (!fs_node_supported()) {
-    caml_failwith("win_findnext: not implemented");
-  }
-  var dir;
-  try {
-      dir = dir_handle.readSync();
-  } catch (e) {
-      var unix_error = caml_named_value('Unix.Unix_error');
-      caml_raise_with_args(unix_error, make_unix_err_args("EBADF", "readdir", dir_handle.path));
-  }
-  if (dir === null) {
-      caml_raise_end_of_file();
-  } else {
-      return caml_string_of_jsstring(dir.name);
-  }
+  return unix_readdir(dir_handle);
 }
 
 //Provides: win_findclose
-//Requires: make_unix_err_args, caml_raise_with_args, caml_named_value
-//Requires: fs_node_supported, caml_failwith
+//Requires: unix_closedir
 function win_findclose(dir_handle) {
-  if (!fs_node_supported()) {
-    caml_failwith("win_findnext: not implemented");
-  }
-  try {
-      dir_handle.closeSync();
-  } catch (e) {
-      var unix_error = caml_named_value('Unix.Unix_error');
-      caml_raise_with_args(unix_error, make_unix_err_args("EBADF", "closedir", dir_handle.path));
-  }
+  return unix_closedir(dir_handle);
 }


### PR DESCRIPTION
We needed these in Grain to provided externals needed by [reason-native `fs`](https://github.com/reasonml/reason-native/tree/master/src/fs) so I implemented in nodejs.

We're using these in our published binaries, but let me know if you'd like any changes.