### PR TITLE
Removes bytes from dune files.

### DIFF
--- a/compiler/lib/dune
+++ b/compiler/lib/dune
@@ -5,7 +5,6 @@
  (libraries
   compiler-libs.common
   compiler-libs.bytecomp
-  bytes
   menhirLib
   (select
    source_map_io.ml

--- a/lib/deriving_json/dune
+++ b/lib/deriving_json/dune
@@ -2,7 +2,6 @@
  (name js_of_ocaml_deriving)
  (public_name js_of_ocaml.deriving)
  (synopsis "Runtime library for the class Json.")
- (libraries bytes)
  (wrapped false))
 
 (ocamllex deriving_Json_lexer)

--- a/lib/js_of_ocaml/dune
+++ b/lib/js_of_ocaml/dune
@@ -1,7 +1,7 @@
 (library
  (name js_of_ocaml)
  (public_name js_of_ocaml)
- (libraries bytes js_of_ocaml-compiler.runtime)
+ (libraries js_of_ocaml-compiler.runtime)
  (foreign_stubs
   (language c)
   (names js_of_ocaml_stubs))

--- a/toplevel/bin/dune
+++ b/toplevel/bin/dune
@@ -3,7 +3,6 @@
  (public_names jsoo_mkcmis jsoo_mktop jsoo_listunits)
  (package js_of_ocaml-toplevel)
  (libraries
-  bytes
   js_of_ocaml-compiler
   js_of_ocaml-compiler.findlib-support
   js_of_ocaml-compiler.runtime-files))

--- a/toplevel/examples/server/dune
+++ b/toplevel/examples/server/dune
@@ -1,3 +1,3 @@
 (executables
  (names server)
- (libraries bytes findlib cohttp-lwt-unix))
+ (libraries findlib cohttp-lwt-unix))

--- a/toplevel/lib/dune
+++ b/toplevel/lib/dune
@@ -5,7 +5,6 @@
  (libraries
   js_of_ocaml-compiler
   js_of_ocaml
-  bytes
   compiler-libs.bytecomp
   compiler-libs.toplevel)
  (preprocess


### PR DESCRIPTION
Hello, I came across [this build](http://check.ocamllabs.io/log/1658671506-f1eef1a5b413443a841a24a1c7f655ef64772692/5.0+alpha-repo/bad/js_of_ocaml-compiler.4.0.0.1~alpha-repo) of your branch on `check.ocamllabs.io` and thought I would contribute what I hope to be a fix.

I'm quoting a colleague here at Tarides:

> 5.0.0~alpha1 corrects a mistake since the very beginning of jbuilder where packages insisted on adding the bytes package to libraries stanzas, even though there was no version of OCaml you could be using which didn't have the Bytes module

Thus my suggested fix is to remove `bytes` from any dune file that currently has it.