### PR TITLE
Bugfix in ocamlyacc runtime code 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@
 
 ## Bug fixes
 * Compiler: fix rewriter bug in share_constant (fix #1247)
+* Runtime: fix ocamlyacc parse engine (#1307)
 * Runtime: fix Out_channel.is_buffered, set_buffered
 * Runtime: fix format wrt alternative
 * Runtime: fix Digest.channel

--- a/runtime/parsing.js
+++ b/runtime/parsing.js
@@ -96,7 +96,7 @@ function caml_parse_engine(tables, env, cmd, arg)
   var errflag = env[env_errflag];
 
   exit:for (;;) {
-    switch(cmd) {
+    next:switch(cmd) {
     case 0://START:
       state = 0;
       errflag = 0;
@@ -149,7 +149,7 @@ function caml_parse_engine(tables, env, cmd, arg)
           n2 = n1 + ERRCODE;
           if (n1 != 0 && n2 >= 0 && n2 <= tables[tbl_tablesize] &&
               tables.check[n2] == ERRCODE) {
-            cmd = shift_recover; break;
+            cmd = shift_recover; break next;
           } else {
             if (sp <= env[env_stackbase]) return RAISE_PARSE_ERROR;
             /* The ML code raises Parse_error */


### PR DESCRIPTION
# Description 

The parsing module runtime has a bug in `parsing.js`. 

In happened in the "ERROR_DETECTED" case. 
There's a break instruction that is breaking a for loop instead of breaking a switch. 
Which makes the "flow" fall through the "SHIFT" case instead of the "SHIFT_RECOVER" case. 

This PR adds a label to fix this. 

Here is a reproduction case, https://github.com/mlasson/js-yacc-bug