### PR TITLE
Implemement set_parser_trace

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@
 * Runtime: Implement buffer for in_channels
 * Runtime: add support for unix_opendir, unix_readdir, unix_closedir, win_findfirst, win_findnext, win_findclose
 * Runtime: Dont use require when target-env is browser
+* Runtime: Implements Parsing.set_trace (#1308)
 * Test: track external used in the stdlib and unix
 
 ## Bug fixes

--- a/compiler/tests-jsoo/gh_1307.ml
+++ b/compiler/tests-jsoo/gh_1307.ml
@@ -10,7 +10,8 @@ let test content =
       print_endline "failure"
 
 let%expect_test "parsing" =
-  let (_ : bool) = Parsing.set_trace false in
+  (* use [Parsing.set_trace true] once https://github.com/janestreet/ppx_expect/issues/43 is fixed *)
+  let (old : bool) = Parsing.set_trace false in
   test "a";
   [%expect {|
     input: "a"
@@ -25,4 +26,6 @@ let%expect_test "parsing" =
   [%expect {|
     input: "aaa"
     Stdlib.Parsing.Parse_error
-    failure |}]
+    failure |}];
+  let (_ : bool) = Parsing.set_trace old in
+  ()

--- a/compiler/tests-jsoo/test_parsing.ml
+++ b/compiler/tests-jsoo/test_parsing.ml
@@ -29,20 +29,93 @@ let parse s =
   with Calc_lexer.Eof -> print_endline "EOF"
 
 let%expect_test "parsing" =
-  let (old : bool) = Parsing.set_trace false in
-  parse "1+2*3";
-  [%expect {|
-    EOF |}];
-  parse "(1+2)*3";
-  [%expect {|
-    EOF |}];
-  parse "-10-1";
-  [%expect {|
-    EOF |}];
-  parse "63/2*-3";
-  [%expect {|
-    EOF |}];
-  let (_ : bool) = Parsing.set_trace old in
+  (* Uncomment once https://github.com/janestreet/ppx_expect/issues/43 is fixed.
+        {[
+     let (old : bool) = Parsing.set_trace true in
+     parse "1+2*3";
+     [%expect
+       {|
+       State 0: shift to state 1
+       State 1: read token INT(1)
+       State 1: shift to state 3
+       State 3: reduce by rule 2
+       State 7: read token PLUS
+       State 7: shift to state 10
+       State 10: read token INT(2)
+       State 10: shift to state 3
+       State 3: reduce by rule 2
+       State 16: read token TIMES
+       State 16: shift to state 12
+       State 12: read token INT(3)
+       State 12: shift to state 3
+       State 3: reduce by rule 2
+       State 18: reduce by rule 6
+       EOF |}];
+     parse "(1+2)*3";
+     [%expect
+       {|
+       State 0: shift to state 1
+       State 1: read token LPAREN
+       State 1: shift to state 5
+       State 5: read token INT(1)
+       State 5: shift to state 3
+       State 3: reduce by rule 2
+       State 9: read token PLUS
+       State 9: shift to state 10
+       State 10: read token INT(2)
+       State 10: shift to state 3
+       State 3: reduce by rule 2
+       State 16: read token RPAREN
+       State 16: reduce by rule 4
+       State 9: shift to state 15
+       State 15: reduce by rule 3
+       State 7: read token TIMES
+       State 7: shift to state 12
+       State 12: read token INT(3)
+       State 12: shift to state 3
+       State 3: reduce by rule 2
+       State 18: reduce by rule 6
+       EOF |}];
+     parse "-10-1";
+     [%expect
+       {|
+       State 0: shift to state 1
+       State 1: read token MINUS
+       State 1: shift to state 4
+       State 4: read token INT(10)
+       State 4: shift to state 3
+       State 3: reduce by rule 2
+       State 8: reduce by rule 8
+       State 7: read token MINUS
+       State 7: shift to state 11
+       State 11: read token INT(1)
+       State 11: shift to state 3
+       State 3: reduce by rule 2
+       EOF |}];
+     parse "63/2*-3";
+     [%expect
+       {|
+       State 0: shift to state 1
+       State 1: read token INT(63)
+       State 1: shift to state 3
+       State 3: reduce by rule 2
+       State 7: read token DIV
+       State 7: shift to state 13
+       State 13: read token INT(2)
+       State 13: shift to state 3
+       State 3: reduce by rule 2
+       State 19: reduce by rule 7
+       State 7: read token TIMES
+       State 7: shift to state 12
+       State 12: read token MINUS
+       State 12: shift to state 4
+       State 4: read token INT(3)
+       State 4: shift to state 3
+       State 3: reduce by rule 2
+       State 8: reduce by rule 8
+       State 18: reduce by rule 6
+       EOF |}];
+     let (_ : bool) = Parsing.set_trace old in ]} *)
   parse "1+2*3";
   [%expect {| EOF |}];
   parse "(1+2)*3";


### PR DESCRIPTION
# Description 

While investigating #1307, I made this to try to understand what was going on. 
It implements the tracer of the `Parsing` module using `console.log` with minor differences with the native counterpart (`console.log` is adding spaces around values as well as some colors when executed with node). 

Feel free to close if not interested. 