### PR TITLE
caml_js_get and caml_js_delete (can) have side-effects

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,7 @@
 * Runtime: sync channel seek / pos with the native runtime
 * Misc: fix installation with dune 3 without opam
 * Node: Only write small chunks to stdout/stderr so they flush
+* Compiler: no dead code elimination for caml_js_get
 
 # 4.0.0 (2021-01-24) - Lille
 ## Features/Changes

--- a/compiler/lib/generate.ml
+++ b/compiler/lib/generate.ml
@@ -861,7 +861,7 @@ let _ =
 
   register_tern_prim "caml_js_set" (fun cx cy cz _ ->
       J.EBin (J.Eq, J.EAccess (cx, cy), cz));
-  register_bin_prim "caml_js_get" `Mutable (fun cx cy _ -> J.EAccess (cx, cy));
+  register_bin_prim "caml_js_get" `Mutator (fun cx cy _ -> J.EAccess (cx, cy));
   register_bin_prim "caml_js_delete" `Mutator (fun cx cy _ ->
       J.EUn (J.Delete, J.EAccess (cx, cy)));
   register_bin_prim "caml_js_equals" `Mutable (fun cx cy _ ->

--- a/runtime/jslib.js
+++ b/runtime/jslib.js
@@ -24,7 +24,7 @@ function caml_js_pure_expr (f) { return f(); }
 
 //Provides: caml_js_set (mutable, const, const)
 function caml_js_set(o,f,v) { o[f]=v;return 0}
-//Provides: caml_js_get mutable (const, const)
+//Provides: caml_js_get mutator (const, const)
 function caml_js_get(o,f) { return o[f]; }
 //Provides: caml_js_delete (mutable, const)
 function caml_js_delete(o,f) { delete o[f]; return 0}

--- a/runtime/jslib.js
+++ b/runtime/jslib.js
@@ -24,7 +24,7 @@ function caml_js_pure_expr (f) { return f(); }
 
 //Provides: caml_js_set (mutable, const, const)
 function caml_js_set(o,f,v) { o[f]=v;return 0}
-//Provides: caml_js_get mutator (const, const)
+//Provides: caml_js_get (const, const)
 function caml_js_get(o,f) { return o[f]; }
 //Provides: caml_js_delete (mutable, const)
 function caml_js_delete(o,f) { delete o[f]; return 0}


### PR DESCRIPTION
This is obvious for caml_js_delete, but also for caml_js_get which can trigger arbitrary code in the property getter.

Fix #1310