### PR TITLE
Compiler: add a warning when we redefine the purity of a primitive

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 ## Features/Changes
 * Compiler: initial support for OCaml 5 (#1265,#1303)
 * Compiler: bump magic number to match the 5.0.0~alpha0 release (#1288)
+* Compiler: complain when runtime and compiler built-in primitives disagree (#1312)
 * Misc: switch to cmdliner.1.1.0
 * Misc: remove old binaries jsoo_link, jsoo_fs
 * Misc: remove uchar dep

--- a/compiler/lib/generate.mli
+++ b/compiler/lib/generate.mli
@@ -25,3 +25,5 @@ val f :
   -> should_export:bool
   -> Parse_bytecode.Debug.t
   -> Javascript.program
+
+val init : unit -> unit

--- a/compiler/lib/linker.ml
+++ b/compiler/lib/linker.ml
@@ -379,7 +379,9 @@ let reset () =
   always_included := [];
   Hashtbl.clear provided;
   Hashtbl.clear provided_rev;
-  Hashtbl.clear code_pieces
+  Hashtbl.clear code_pieces;
+  Primitive.reset ();
+  Generate.init ()
 
 let load_fragment ~target_env ~filename (f : Fragment.t) =
   match f with

--- a/compiler/lib/primitive.mli
+++ b/compiler/lib/primitive.mli
@@ -67,10 +67,10 @@ val resolve : string -> string
 
 val add_external : string -> unit
 
-val is_external : string -> bool
-
 val get_external : unit -> StringSet.t
 
 val need_named_value : string -> bool
 
 val register_named_value : string -> unit
+
+val reset : unit -> unit


### PR DESCRIPTION
and synchronize the information present in `generate.ml` and in the runtime.

The PR doesn't change the semantic. See #1311 for fixes.   