### PR TITLE
More efficient implementation of Js_traverse.rename_variable + fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 * Compiler: bump magic number to match the 5.0.0~alpha0 release (#1288)
 * Compiler: complain when runtime and compiler built-in primitives disagree (#1312)
 * Compiler: more efficient implementation of Js_traverse.freevar
+* Compiler: more efficient implementation of Js_traverse.rename_variable
 * Misc: switch to cmdliner.1.1.0
 * Misc: remove old binaries jsoo_link, jsoo_fs
 * Misc: remove uchar dep
@@ -24,6 +25,7 @@
 ## Bug fixes
 * Compiler: fix rewriter bug in share_constant (fix #1247)
 * Compiler: fix miscompilation of mutually recursive functions in loop (#1321)
+* Compiler: fix bug while minifying/renaming try-catch blocks
 * Runtime: fix ocamlyacc parse engine (#1307)
 * Runtime: fix Out_channel.is_buffered, set_buffered
 * Runtime: fix format wrt alternative

--- a/compiler/bin-jsoo_minify/jsoo_minify.ml
+++ b/compiler/bin-jsoo_minify/jsoo_minify.ml
@@ -74,9 +74,7 @@ let f { Cmd_arg.common; output_file; use_stdin; files } =
     let true_ () = true in
     let open Config in
     let passes : ((unit -> bool) * (unit -> Js_traverse.mapper)) list =
-      [ ( Flag.shortvar
-        , fun () -> (new Js_traverse.rename_variable toplevel_def :> Js_traverse.mapper)
-        )
+      [ (Flag.shortvar, fun () -> (new Js_traverse.rename_variable :> Js_traverse.mapper))
       ; (true_, fun () -> new Js_traverse.simpl)
       ; (true_, fun () -> new Js_traverse.clean)
       ]

--- a/compiler/bin-jsoo_minify/jsoo_minify.ml
+++ b/compiler/bin-jsoo_minify/jsoo_minify.ml
@@ -74,7 +74,7 @@ let f { Cmd_arg.common; output_file; use_stdin; files } =
     let true_ () = true in
     let open Config in
     let passes : ((unit -> bool) * (unit -> Js_traverse.mapper)) list =
-      [ (Flag.shortvar, fun () -> (new Js_traverse.rename_variable :> Js_traverse.mapper))
+      [ (Flag.shortvar, fun () -> new Js_traverse.rename_variable)
       ; (true_, fun () -> new Js_traverse.simpl)
       ; (true_, fun () -> new Js_traverse.clean)
       ]

--- a/compiler/lib/driver.ml
+++ b/compiler/lib/driver.ml
@@ -474,8 +474,7 @@ if (typeof module === 'object' && module.exports) {
     if Config.Flag.shortvar ()
     then (
       let t5 = Timer.make () in
-      let keep = StringSet.empty in
-      let js = (new Js_traverse.rename_variable keep)#program js in
+      let js = (new Js_traverse.rename_variable)#program js in
       if times () then Format.eprintf "    shortten vars: %a@." Timer.print t5;
       js)
     else js

--- a/compiler/lib/js_traverse.ml
+++ b/compiler/lib/js_traverse.ml
@@ -430,17 +430,17 @@ class free =
             | None -> None
             | Some (id, block) ->
                 let block = tbody#statements block in
-                let () = tbody#def_var id in
                 tbody#block ~catch:true [ id ];
                 (* special merge here *)
                 (* we need to propagate both def and use .. *)
-                (* .. except 'id' because its scope is limited to 'block' *)
+                (* .. except the use of 'id' since its scope is limited
+                   to 'block' *)
                 let clean set sets =
                   match id with
                   | S { name; _ } -> set, StringSet.remove name sets
                   | V i -> S.remove i set, sets
                 in
-                let def, def_name = clean tbody#state.def tbody#state.def_name in
+                let def, def_name = tbody#state.def, tbody#state.def_name in
                 let use, use_name = clean tbody#state.use tbody#state.use_name in
                 state_ <-
                   { use = S.union state_.use use

--- a/compiler/lib/js_traverse.mli
+++ b/compiler/lib/js_traverse.mli
@@ -96,7 +96,7 @@ class type freevar =
 
 class free : freevar
 
-class rename_variable : freevar
+class rename_variable : mapper
 
 class share_constant : mapper
 

--- a/compiler/lib/js_traverse.mli
+++ b/compiler/lib/js_traverse.mli
@@ -96,7 +96,7 @@ class type freevar =
 
 class free : freevar
 
-class rename_variable : StringSet.t -> freevar
+class rename_variable : freevar
 
 class share_constant : mapper
 

--- a/compiler/tests-compiler/dune.inc
+++ b/compiler/tests-compiler/dune.inc
@@ -260,6 +260,19 @@
   (pps ppx_expect)))
 
 (library
+ (name jsooexp_minify)
+ (modules minify)
+ (libraries js_of_ocaml_compiler unix str jsoo_compiler_expect_tests_helper)
+ (inline_tests
+  (flags -allow-output-patterns)
+  (deps
+   (file ../../compiler/bin-js_of_ocaml/js_of_ocaml.exe)
+   (file ../../compiler/bin-jsoo_minify/jsoo_minify.exe)))
+ (flags (:standard -open Jsoo_compiler_expect_tests_helper))
+ (preprocess
+  (pps ppx_expect)))
+
+(library
  (name jsooexp_mutable_closure)
  (modules mutable_closure)
  (libraries js_of_ocaml_compiler unix str jsoo_compiler_expect_tests_helper)

--- a/compiler/tests-compiler/minify.ml
+++ b/compiler/tests-compiler/minify.ml
@@ -1,0 +1,106 @@
+(* Js_of_ocaml compiler
+ * http://www.ocsigen.org/js_of_ocaml/
+ * Copyright (C) 2022 Hugo Heuzard
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+
+open Util
+
+let%expect_test _ =
+  with_temp_dir ~f:(fun () ->
+      let js_prog =
+        {|
+var xx = 1;
+
+function f () {
+    xx = 2;
+    try {
+        throw 1
+    } catch (xx) {
+        var xx = 3
+    };
+    return xx;
+}
+
+function g () {
+    var xx = 2;
+    return xx;
+}
+console.log("xx =", xx);
+console.log("f() =", f());
+console.log("xx =", xx);
+console.log("g() =", g());
+console.log("xx =", xx);
+|}
+      in
+      let js_file =
+        js_prog |> Filetype.js_text_of_string |> Filetype.write_js ~name:"test.js"
+      in
+      let js_min_file =
+        js_file
+        |> jsoo_minify
+             ~flags:[ "--enable"; "stable_var"; "--enable"; "shortvar" ]
+             ~pretty:false
+      in
+      print_file (Filetype.path_of_js_file js_file);
+      run_javascript js_file |> print_endline;
+      [%expect
+        {|
+        $ cat "test.js"
+          1:
+          2: var xx = 1;
+          3:
+          4: function f () {
+          5:     xx = 2;
+          6:     try {
+          7:         throw 1
+          8:     } catch (xx) {
+          9:         var xx = 3
+         10:     };
+         11:     return xx;
+         12: }
+         13:
+         14: function g () {
+         15:     var xx = 2;
+         16:     return xx;
+         17: }
+         18: console.log("xx =", xx);
+         19: console.log("f() =", f());
+         20: console.log("xx =", xx);
+         21: console.log("g() =", g());
+         22: console.log("xx =", xx);
+        xx = 1
+        f() = 2
+        xx = 1
+        g() = 2
+        xx = 1 |}];
+      print_file (Filetype.path_of_js_file js_min_file);
+      run_javascript js_min_file |> print_endline;
+      [%expect
+        {|
+    $ cat "test.min.js"
+      1: var
+      2: xx=1;function
+      3: f(){xx=2;try{throw 1}catch(a){var
+      4: a=3}return xx}function
+      5: g(){var
+      6: xx=2;return xx}console.log("xx =",xx);console.log("f() =",f());console.log("xx =",xx);console.log("g() =",g());console.log("xx =",xx);
+    xx = 1
+    f() = 2
+    xx = 2
+    g() = 2
+    xx = 2
+ |}])

--- a/compiler/tests-compiler/minify.ml
+++ b/compiler/tests-compiler/minify.ml
@@ -104,3 +104,28 @@ console.log("xx =", xx);
     g() = 2
     xx = 1
  |}])
+
+let%expect_test _ =
+  with_temp_dir ~f:(fun () ->
+      let js_prog = {|
+var a = "toto";
+function f (e){ return a; }
+|} in
+      let js_file =
+        js_prog |> Filetype.js_text_of_string |> Filetype.write_js ~name:"test.js"
+      in
+      let js_min_file =
+        js_file |> jsoo_minify ~flags:[ "--enable"; "shortvar" ] ~pretty:false
+      in
+      print_file (Filetype.path_of_js_file js_file);
+      print_file (Filetype.path_of_js_file js_min_file);
+      [%expect
+        {|
+        $ cat "test.js"
+          1:
+          2: var a = "toto";
+          3: function f (e){ return a; }
+        $ cat "test.min.js"
+          1: var
+          2: a="toto";function
+          3: f(b){return a} |}])

--- a/compiler/tests-compiler/minify.ml
+++ b/compiler/tests-compiler/minify.ml
@@ -94,13 +94,13 @@ console.log("xx =", xx);
     $ cat "test.min.js"
       1: var
       2: xx=1;function
-      3: f(){xx=2;try{throw 1}catch(a){var
-      4: a=3}return xx}function
+      3: f(){a=2;try{throw 1}catch(a){var
+      4: a=3}return a}function
       5: g(){var
-      6: xx=2;return xx}console.log("xx =",xx);console.log("f() =",f());console.log("xx =",xx);console.log("g() =",g());console.log("xx =",xx);
+      6: a=2;return a}console.log("xx =",xx);console.log("f() =",f());console.log("xx =",xx);console.log("g() =",g());console.log("xx =",xx);
     xx = 1
     f() = 2
-    xx = 2
+    xx = 1
     g() = 2
-    xx = 2
+    xx = 1
  |}])


### PR DESCRIPTION
It was inefficient for deeply nested functions since we were performing variable substitution repeatedly.

Also,
```javascript
var xx = 1;

function f () {
    xx = 2; 
    try {
        throw 1
    } catch (xx) { 
        var xx = 3 
    }; 
    return xx;
}

function g () {
    var xx = 2; 
    return xx; 
}
```
was minified into
```javascript
var
xx=1;function
f(){xx=2;try{throw 1}catch(a){var
a=3}return xx}function
g(){var
xx=2;return xx}
```
which is wrong for `f` since `xx` is no longer declared locally.

And, we rename variables with the same name as a topelevel variable as in function `g`. I think the fix for #331 was overly conservative.