### PR TITLE
Compiler: attempt to optimize computation of dominance frontier 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@
 * Test: track external used in the stdlib and unix
 
 ## Bug fixes
+* Compiler: fix quadratic behavior of dominance frontier (fix #1300)
 * Compiler: fix rewriter bug in share_constant (fix #1247)
 * Compiler: fix miscompilation of mutually recursive functions in loop (#1321)
 * Runtime: fix ocamlyacc parse engine (#1307)


### PR DESCRIPTION
Cache computation of dominance frontier to avoid the quadratic behavior when dealing with long chains of simple branches.

- Add debug for dominance frontier timings.
- keeps the old implementation next to the new one, allowing to check that the two implementations give the same result.  
- the cache is invalidated every time we update the graph (when collapsing frontier / processing interm nodes).

Fixes #1300.
With the following exemple, dominance frontier timing goes from 14.43 s to 0.01 s.
 
 ```
ocaml <(echo "for i = 0 to 10000  do print_endline \"print_char '.';\"; done") > a.ml && ocamlc -g a.ml -o a.byte && _build/default/compiler/bin-js_of_ocaml/js_of_ocaml.exe --debuginfo --debug times  --pretty a.byte
```