### PR TITLE
Compiler: get rid of block.handler

### DIFF
--- a/compiler/lib/code.ml
+++ b/compiler/lib/code.ml
@@ -329,7 +329,7 @@ type last =
   | Cond of Var.t * cont * cont
   | Switch of Var.t * cont array * cont array
   | Pushtrap of cont * Var.t * cont * Addr.Set.t
-  | Poptrap of cont * Addr.t
+  | Poptrap of cont
 
 type block =
   { params : Var.t list
@@ -483,7 +483,7 @@ module Print = struct
           cont
           cont2
           (String.concat ~sep:", " (List.map (Addr.Set.elements pcs) ~f:string_of_int))
-    | Poptrap (c, _) -> Format.fprintf f "poptrap %a" cont c
+    | Poptrap c -> Format.fprintf f "poptrap %a" cont c
 
   type xinstr =
     | Instr of instr
@@ -549,7 +549,7 @@ let fold_children blocks pc f accu =
   let block = Addr.Map.find pc blocks in
   match block.branch with
   | Return _ | Raise _ | Stop -> accu
-  | Branch (pc', _) | Poptrap ((pc', _), _) -> f pc' accu
+  | Branch (pc', _) | Poptrap (pc', _) -> f pc' accu
   | Pushtrap ((pc', _), _, (pc_h, _), _) ->
       let accu = f pc' accu in
       let accu = f pc_h accu in
@@ -653,7 +653,7 @@ let invariant { blocks; start; _ } =
       | Pushtrap (cont1, _x, cont2, _pcs) ->
           check_cont cont1;
           check_cont cont2
-      | Poptrap (cont, _) -> check_cont cont
+      | Poptrap cont -> check_cont cont
     in
     Addr.Map.iter
       (fun _pc block ->

--- a/compiler/lib/code.mli
+++ b/compiler/lib/code.mli
@@ -178,7 +178,7 @@ type last =
   | Cond of Var.t * cont * cont
   | Switch of Var.t * cont array * cont array
   | Pushtrap of cont * Var.t * cont * Addr.Set.t
-  | Poptrap of cont * Addr.t
+  | Poptrap of cont
 
 type block =
   { params : Var.t list

--- a/compiler/lib/code.mli
+++ b/compiler/lib/code.mli
@@ -182,7 +182,6 @@ type last =
 
 type block =
   { params : Var.t list
-  ; handler : (Var.t * cont) option
   ; body : instr list
   ; branch : last
   }

--- a/compiler/lib/deadcode.ml
+++ b/compiler/lib/deadcode.ml
@@ -89,7 +89,7 @@ and mark_reachable st pc =
     match block.branch with
     | Return x | Raise (x, _) -> mark_var st x
     | Stop -> ()
-    | Branch cont | Poptrap (cont, _) -> mark_cont_reachable st cont
+    | Branch cont | Poptrap cont -> mark_cont_reachable st cont
     | Cond (x, cont1, cont2) ->
         mark_var st x;
         mark_cont_reachable st cont1;
@@ -142,7 +142,7 @@ let filter_live_last blocks st l =
         , x
         , filter_cont blocks st cont2
         , Addr.Set.inter pcs st.reachable_blocks )
-  | Poptrap (cont, addr) -> Poptrap (filter_cont blocks st cont, addr)
+  | Poptrap cont -> Poptrap (filter_cont blocks st cont)
 
 (****)
 
@@ -205,7 +205,7 @@ let f ({ blocks; _ } as p : Code.program) =
       | Pushtrap (cont, _, cont_h, _) ->
           add_cont_dep blocks defs cont_h;
           add_cont_dep blocks defs cont
-      | Poptrap (cont, _) -> add_cont_dep blocks defs cont)
+      | Poptrap cont -> add_cont_dep blocks defs cont)
     blocks;
   let st = { live; defs; blocks; reachable_blocks = Addr.Set.empty; pure_funs } in
   mark_reachable st p.start;

--- a/compiler/lib/eval.ml
+++ b/compiler/lib/eval.ml
@@ -385,10 +385,7 @@ let drop_exception_handler blocks =
   Addr.Map.fold
     (fun pc _ blocks ->
       match Addr.Map.find pc blocks with
-      | { branch = Pushtrap (((addr, _) as cont1), _x, _cont2, addrset)
-        ; handler = parent_hander
-        ; _
-        } as b -> (
+      | { branch = Pushtrap (((addr, _) as cont1), _x, _cont2, addrset); _ } as b -> (
           try
             let visited = do_not_raise addr Addr.Set.empty blocks in
             let b = { b with branch = Branch cont1 } in
@@ -397,7 +394,6 @@ let drop_exception_handler blocks =
               Addr.Set.fold
                 (fun pc2 blocks ->
                   let b = Addr.Map.find pc2 blocks in
-                  assert (Poly.(b.handler <> parent_hander));
                   let branch =
                     match b.branch with
                     | Poptrap (((addr, _) as cont), _) ->
@@ -405,7 +401,7 @@ let drop_exception_handler blocks =
                         Branch cont
                     | x -> x
                   in
-                  let b = { b with branch; handler = parent_hander } in
+                  let b = { b with branch } in
                   Addr.Map.add pc2 b blocks)
                 visited
                 blocks

--- a/compiler/lib/eval.ml
+++ b/compiler/lib/eval.ml
@@ -396,7 +396,7 @@ let drop_exception_handler blocks =
                   let b = Addr.Map.find pc2 blocks in
                   let branch =
                     match b.branch with
-                    | Poptrap (((addr, _) as cont), _) ->
+                    | Poptrap ((addr, _) as cont) ->
                         assert (Addr.Set.mem addr addrset);
                         Branch cont
                     | x -> x

--- a/compiler/lib/flow.ml
+++ b/compiler/lib/flow.ml
@@ -112,7 +112,7 @@ let program_deps { blocks; _ } =
           | Set_field _ | Array_set _ | Offset_ref _ -> ());
       match block.branch with
       | Return _ | Raise _ | Stop -> ()
-      | Branch cont | Poptrap (cont, _) -> cont_deps blocks vars deps defs cont
+      | Branch cont | Poptrap cont -> cont_deps blocks vars deps defs cont
       | Cond (_, cont1, cont2) ->
           cont_deps blocks vars deps defs cont1;
           cont_deps blocks vars deps defs cont2

--- a/compiler/lib/flow.ml
+++ b/compiler/lib/flow.ml
@@ -110,9 +110,6 @@ let program_deps { blocks; _ } =
               add_expr_def defs x e;
               expr_deps blocks vars deps defs x e
           | Set_field _ | Array_set _ | Offset_ref _ -> ());
-      Option.iter block.handler ~f:(fun (x, cont) ->
-          add_param_def vars defs x;
-          cont_deps blocks vars deps defs cont);
       match block.branch with
       | Return _ | Raise _ | Stop -> ()
       | Branch cont | Poptrap (cont, _) -> cont_deps blocks vars deps defs cont
@@ -122,7 +119,10 @@ let program_deps { blocks; _ } =
       | Switch (_, a1, a2) ->
           Array.iter a1 ~f:(fun cont -> cont_deps blocks vars deps defs cont);
           Array.iter a2 ~f:(fun cont -> cont_deps blocks vars deps defs cont)
-      | Pushtrap (cont, _, _, _) -> cont_deps blocks vars deps defs cont)
+      | Pushtrap (cont, x, cont_h, _) ->
+          add_param_def vars defs x;
+          cont_deps blocks vars deps defs cont_h;
+          cont_deps blocks vars deps defs cont)
     blocks;
   vars, deps, defs
 

--- a/compiler/lib/freevars.ml
+++ b/compiler/lib/freevars.ml
@@ -58,7 +58,7 @@ let iter_last_free_var f l =
   match l with
   | Return x | Raise (x, _) -> f x
   | Stop -> ()
-  | Branch cont | Poptrap (cont, _) -> iter_cont_free_vars f cont
+  | Branch cont | Poptrap cont -> iter_cont_free_vars f cont
   | Cond (x, cont1, cont2) ->
       f x;
       iter_cont_free_vars f cont1;

--- a/compiler/lib/generate.ml
+++ b/compiler/lib/generate.ml
@@ -621,7 +621,7 @@ let fold_children blocks pc f accu =
   let block = Addr.Map.find pc blocks in
   match block.branch with
   | Return _ | Raise _ | Stop -> accu
-  | Branch (pc', _) | Poptrap ((pc', _), _) -> f pc' accu
+  | Branch (pc', _) | Poptrap (pc', _) -> f pc' accu
   | Pushtrap ((pc1, _), _, (pc2, _), _) ->
       let accu = f pc1 accu in
       let accu = f pc2 accu in
@@ -1445,7 +1445,7 @@ and compile_block_no_loop st queue (pc : Addr.t) frontier interm =
         else
           match Addr.Map.find pc st.blocks with
           | { body = []; branch = Return _; _ } -> false
-          | { body = []; branch = Poptrap ((pc', _), _); _ }
+          | { body = []; branch = Poptrap (pc', _); _ }
           | { body = []; branch = Branch (pc', _); _ } -> limit pc'
           | _ -> true
       in
@@ -1694,8 +1694,7 @@ and compile_conditional st queue pc last backs frontier interm succs =
         flush_all queue [ J.Return_statement e_opt, loc ]
     | Branch cont -> compile_branch st queue cont backs frontier interm
     | Pushtrap _ -> assert false
-    | Poptrap (cont, _) ->
-        flush_all queue (compile_branch st [] cont backs frontier interm)
+    | Poptrap cont -> flush_all queue (compile_branch st [] cont backs frontier interm)
     | Cond (x, c1, c2) ->
         let (_px, cx), queue = access_queue queue x in
         let b =

--- a/compiler/lib/generate_closure.ml
+++ b/compiler/lib/generate_closure.ml
@@ -92,19 +92,17 @@ let group_closures ~tc_only closures_map =
   SCC.connected_components_sorted_from_roots_to_leaf graph
 
 module Trampoline = struct
-  let direct_call_block block ~counter ~x ~f ~args =
+  let direct_call_block ~counter ~x ~f ~args =
     let return = Code.Var.fork x in
     match counter with
     | None ->
-        { block with
-          params = []
+        { params = []
         ; body = [ Let (return, Apply (f, args, true)) ]
         ; branch = Return return
         }
     | Some counter ->
         let counter_plus_1 = Code.Var.fork counter in
-        { block with
-          params = []
+        { params = []
         ; body =
             [ Let (counter_plus_1, Prim (Extern "%int_add", [ Pv counter; Pc (Int 1l) ]))
             ; Let (return, Apply (f, counter_plus_1 :: args, true))
@@ -112,11 +110,10 @@ module Trampoline = struct
         ; branch = Return return
         }
 
-  let bounce_call_block block ~x ~f ~args =
+  let bounce_call_block ~x ~f ~args =
     let return = Code.Var.fork x in
     let new_args = Code.Var.fresh () in
-    { block with
-      params = []
+    { params = []
     ; body =
         [ Let
             ( new_args
@@ -132,7 +129,6 @@ module Trampoline = struct
     let result2 = Code.Var.fresh () in
     let block =
       { params = []
-      ; handler = None
       ; body =
           (match counter with
           | None ->
@@ -217,13 +213,13 @@ module Trampoline = struct
                         let blocks =
                           Addr.Map.add
                             direct_call_pc
-                            (direct_call_block block ~counter ~x ~f:new_f ~args)
+                            (direct_call_block ~counter ~x ~f:new_f ~args)
                             blocks
                         in
                         let blocks =
                           Addr.Map.add
                             bounce_call_pc
-                            (bounce_call_block block ~x ~f:new_f ~args)
+                            (bounce_call_block ~x ~f:new_f ~args)
                             blocks
                         in
                         let block =
@@ -317,7 +313,6 @@ let rewrite_mutable
         rewrite_list := (mapping, pc) :: !rewrite_list;
         let new_block =
           { params = []
-          ; handler = None
           ; body = [ Let (new_x, Closure (params, (pc, List.map pc_args ~f:mapping))) ]
           ; branch = Return new_x
           }
@@ -360,7 +355,6 @@ let rewrite_mutable
                 | _ -> assert false)
           in
           { params = []
-          ; handler = None
           ; body =
               closures_intern
               @ proj

--- a/compiler/lib/inline.ml
+++ b/compiler/lib/inline.ml
@@ -113,7 +113,7 @@ let fold_children blocks pc f accu =
   let block = Addr.Map.find pc blocks in
   match block.branch with
   | Return _ | Raise _ | Stop -> accu
-  | Branch (pc', _) | Poptrap ((pc', _), _) -> f pc' accu
+  | Branch (pc', _) | Poptrap (pc', _) -> f pc' accu
   | Pushtrap (_, _, (pc1, _), pcs) -> f pc1 (Addr.Set.fold f pcs accu)
   | Cond (_, (pc1, _), (pc2, _)) ->
       let accu = f pc1 accu in

--- a/compiler/lib/parse_bytecode.ml
+++ b/compiler/lib/parse_bytecode.ml
@@ -545,6 +545,7 @@ module State = struct
     ; stack_len : int
     ; block_pc : Addr.t
     }
+  [@@warning "-69"]
 
   type t =
     { accu : elt
@@ -649,18 +650,6 @@ module State = struct
     match state.handlers with
     | [] -> assert false
     | x :: _ -> x.block_pc
-
-  let current_handler state =
-    match state.handlers with
-    | [] -> None
-    | { var; addr; stack_len; _ } :: _ ->
-        let state =
-          { state with
-            accu = Var var
-          ; stack = st_pop (List.length state.stack - stack_len) state.stack
-          }
-        in
-        Some (var, (addr, stack_vars state))
 
   let initial g =
     { accu = Dummy
@@ -2211,11 +2200,7 @@ let parse_bytecode code globals debug_data =
       let blocks =
         Addr.Map.mapi
           (fun _ (state, instr, last) ->
-            { params = State.stack_vars state
-            ; handler = State.current_handler state
-            ; body = instr
-            ; branch = last
-            })
+            { params = State.stack_vars state; body = instr; branch = last })
           !compiled_blocks
       in
       let blocks = match_exn_traps blocks in
@@ -2788,5 +2773,5 @@ let predefined_exceptions () =
         ])
     |> List.concat
   in
-  let block = { params = []; handler = None; body; branch = Stop } in
+  let block = { params = []; body; branch = Stop } in
   { start = 0; blocks = Addr.Map.singleton 0 block; free_pc = 1 }

--- a/compiler/lib/parse_bytecode.ml
+++ b/compiler/lib/parse_bytecode.ml
@@ -539,13 +539,7 @@ module State = struct
     | Var x -> Format.fprintf f "%a" Var.print x
     | Dummy -> Format.fprintf f "???"
 
-  type handler =
-    { var : Var.t
-    ; addr : Addr.t
-    ; stack_len : int
-    ; block_pc : Addr.t
-    }
-  [@@warning "-69"]
+  type handler = { block_pc : Addr.t }
 
   type t =
     { accu : elt
@@ -633,16 +627,8 @@ module State = struct
         Var.propagate_name x y;
         state
 
-  let push_handler state x addr =
-    { state with
-      handlers =
-        { block_pc = state.current_pc
-        ; var = x
-        ; addr
-        ; stack_len = List.length state.stack
-        }
-        :: state.handlers
-    }
+  let push_handler state =
+    { state with handlers = { block_pc = state.current_pc } :: state.handlers }
 
   let pop_handler state = { state with handlers = List.tl state.handlers }
 
@@ -1505,7 +1491,7 @@ and compile infos pc state instrs =
           infos.debug
           code
           (pc + 2)
-          { (State.push_handler state x addr) with
+          { (State.push_handler state) with
             State.stack =
               (* See interp.c *)
               State.Dummy

--- a/compiler/lib/phisimpl.ml
+++ b/compiler/lib/phisimpl.ml
@@ -68,7 +68,6 @@ let program_deps { blocks; _ } =
               add_var vars x;
               expr_deps blocks vars deps defs x e
           | Set_field _ | Array_set _ | Offset_ref _ -> ());
-      Option.iter block.handler ~f:(fun (_, cont) -> cont_deps blocks vars deps defs cont);
       match block.branch with
       | Return _ | Raise _ | Stop -> ()
       | Branch cont -> cont_deps blocks vars deps defs cont
@@ -78,7 +77,9 @@ let program_deps { blocks; _ } =
       | Switch (_, a1, a2) ->
           Array.iter a1 ~f:(fun cont -> cont_deps blocks vars deps defs cont);
           Array.iter a2 ~f:(fun cont -> cont_deps blocks vars deps defs cont)
-      | Pushtrap (cont, _, _, _) -> cont_deps blocks vars deps defs cont
+      | Pushtrap (cont, _, cont_h, _) ->
+          cont_deps blocks vars deps defs cont_h;
+          cont_deps blocks vars deps defs cont
       | Poptrap (cont, _) -> cont_deps blocks vars deps defs cont)
     blocks;
   vars, deps, defs

--- a/compiler/lib/phisimpl.ml
+++ b/compiler/lib/phisimpl.ml
@@ -80,7 +80,7 @@ let program_deps { blocks; _ } =
       | Pushtrap (cont, _, cont_h, _) ->
           cont_deps blocks vars deps defs cont_h;
           cont_deps blocks vars deps defs cont
-      | Poptrap (cont, _) -> cont_deps blocks vars deps defs cont)
+      | Poptrap cont -> cont_deps blocks vars deps defs cont)
     blocks;
   vars, deps, defs
 

--- a/compiler/lib/specialize.ml
+++ b/compiler/lib/specialize.ml
@@ -69,7 +69,6 @@ let specialize_instr info (acc, free_pc, extra) i =
             { params = params'
             ; body = [ Let (return', Apply (f, l @ params', true)) ]
             ; branch = Return return'
-            ; handler = None
             }
           in
           ( Let (x, Closure (missing, (free_pc, missing))) :: acc

--- a/compiler/lib/subst.ml
+++ b/compiler/lib/subst.ml
@@ -64,11 +64,7 @@ let last s l =
   | Poptrap (cont, addr) -> Poptrap (subst_cont s cont, addr)
 
 let block s block =
-  { params = block.params
-  ; handler = Option.map block.handler ~f:(fun (x, cont) -> x, subst_cont s cont)
-  ; body = instrs s block.body
-  ; branch = last s block.branch
-  }
+  { params = block.params; body = instrs s block.body; branch = last s block.branch }
 
 let program s p =
   let blocks = Addr.Map.map (fun b -> block s b) p.blocks in

--- a/compiler/lib/subst.ml
+++ b/compiler/lib/subst.ml
@@ -61,7 +61,7 @@ let last s l =
         ( s x
         , Array.map a1 ~f:(fun cont -> subst_cont s cont)
         , Array.map a2 ~f:(fun cont -> subst_cont s cont) )
-  | Poptrap (cont, addr) -> Poptrap (subst_cont s cont, addr)
+  | Poptrap cont -> Poptrap (subst_cont s cont)
 
 let block s block =
   { params = block.params; body = instrs s block.body; branch = last s block.branch }

--- a/compiler/lib/tailcall.ml
+++ b/compiler/lib/tailcall.ml
@@ -62,7 +62,7 @@ let fold_children blocks pc f accu =
   let block = Addr.Map.find pc blocks in
   match block.branch with
   | Return _ | Raise _ | Stop -> accu
-  | Branch (pc', _) | Poptrap ((pc', _), _) -> f pc' accu
+  | Branch (pc', _) | Poptrap (pc', _) -> f pc' accu
   | Pushtrap (_, _, (pc1, _), pcs) -> f pc1 (Addr.Set.fold f pcs accu)
   | Cond (_, (pc1, _), (pc2, _)) ->
       let accu = f pc1 accu in

--- a/compiler/lib/tailcall.ml
+++ b/compiler/lib/tailcall.ml
@@ -50,7 +50,6 @@ let rewrite_block (f, f_params, f_pc, args) pc blocks =
           Addr.Map.add
             pc
             { params = block.params
-            ; handler = block.handler
             ; body = remove_last block.body
             ; branch = Branch (f_pc, List.map args ~f:(fun x -> Var.Map.find x m))
             }


### PR DESCRIPTION
The `handler` of a block doesn't seem to be useful. There was some renaming logic in `generate.ml` based on `handler` but I don't it ever triggers. Remove it allows to simplify the code a bit.

The PR also removes the second argument of the Poptrap constructor which was only used in parse_bytecode.