### PR TITLE
Compiler: some small size-optimisation 

### DIFF
--- a/compiler/lib/generate.ml
+++ b/compiler/lib/generate.ml
@@ -1372,6 +1372,14 @@ and compile_block st queue (pc : Addr.t) frontier interm =
         in
         st.loop_stack <- (pc, (lab, ref false)) :: st.loop_stack;
         let body = compile_block_no_loop st queue pc frontier interm in
+        let body =
+          let rec remove_tailing_continue acc = function
+            | [] -> body
+            | [ (J.Continue_statement None, _) ] -> List.rev acc
+            | x :: xs -> remove_tailing_continue (x :: acc) xs
+          in
+          remove_tailing_continue [] body
+        in
         let for_loop =
           ( J.For_statement
               ( J.Left None

--- a/compiler/lib/generate.ml
+++ b/compiler/lib/generate.ml
@@ -1445,7 +1445,6 @@ and compile_block_no_loop st queue (pc : Addr.t) frontier interm =
         else
           match Addr.Map.find pc st.blocks with
           | { body = []; branch = Return _; _ } -> false
-          | { body = []; branch = Poptrap (pc', _); _ }
           | { body = []; branch = Branch (pc', _); _ } -> limit pc'
           | _ -> true
       in

--- a/compiler/lib/generate.ml
+++ b/compiler/lib/generate.ml
@@ -1260,11 +1260,11 @@ let rec translate_expr ctx queue loc _x e level : _ * J.statement_list =
         | Lt, [ x; y ] ->
             let (px, cx), queue = access_queue' ~ctx queue x in
             let (py, cy), queue = access_queue' ~ctx queue y in
-            bool (J.EBin (J.Lt, cx, cy)), or_p px py, queue
+            bool (J.EBin (J.LtInt, cx, cy)), or_p px py, queue
         | Le, [ x; y ] ->
             let (px, cx), queue = access_queue' ~ctx queue x in
             let (py, cy), queue = access_queue' ~ctx queue y in
-            bool (J.EBin (J.Le, cx, cy)), or_p px py, queue
+            bool (J.EBin (J.LeInt, cx, cy)), or_p px py, queue
         | Eq, [ x; y ] ->
             let (px, cx), queue = access_queue' ~ctx queue x in
             let (py, cy), queue = access_queue' ~ctx queue y in
@@ -1279,7 +1279,7 @@ let rec translate_expr ctx queue loc _x e level : _ * J.statement_list =
         | Ult, [ x; y ] ->
             let (px, cx), queue = access_queue' ~ctx queue x in
             let (py, cy), queue = access_queue' ~ctx queue y in
-            bool (J.EBin (J.Lt, unsigned cx, unsigned cy)), or_p px py, queue
+            bool (J.EBin (J.LtInt, unsigned cx, unsigned cy)), or_p px py, queue
         | (Vectlength | Array_get | Not | IsInt | Eq | Neq | Lt | Le | Ult), _ ->
             assert false
       in
@@ -1621,8 +1621,8 @@ and compile_decision_tree st _queue backs frontier interm succs loc cx dtree =
           match cond with
           | IsTrue -> cx
           | CEq n -> J.EBin (J.EqEqEq, int32 n, cx)
-          | CLt n -> J.EBin (J.Lt, int32 n, cx)
-          | CLe n -> J.EBin (J.Le, int32 n, cx)
+          | CLt n -> J.EBin (J.LtInt, int32 n, cx)
+          | CLe n -> J.EBin (J.LeInt, int32 n, cx)
         in
         ( never1 && never2
         , Js_simpl.if_statement

--- a/compiler/lib/javascript.ml
+++ b/compiler/lib/javascript.ml
@@ -167,6 +167,10 @@ and binop =
   | Le
   | Gt
   | Ge
+  | LtInt
+  | LeInt
+  | GtInt
+  | GeInt
   | InstanceOf
   | In
   | Lsl

--- a/compiler/lib/javascript.mli
+++ b/compiler/lib/javascript.mli
@@ -112,6 +112,10 @@ and binop =
   | Le
   | Gt
   | Ge
+  | LtInt
+  | LeInt
+  | GtInt
+  | GeInt
   | InstanceOf
   | In
   | Lsl

--- a/compiler/lib/js_output.ml
+++ b/compiler/lib/js_output.ml
@@ -218,7 +218,7 @@ struct
     | Bxor -> 6, 6, 6
     | Band -> 7, 7, 7
     | EqEq | NotEq | EqEqEq | NotEqEq -> 8, 8, 9
-    | Gt | Ge | Lt | Le | InstanceOf | In -> 9, 9, 10
+    | Gt | GtInt | Ge | GeInt | Lt | LtInt | Le | LeInt | InstanceOf | In -> 9, 9, 10
     | Lsl | Lsr | Asr -> 10, 10, 11
     | Plus | Minus -> 11, 11, 12
     | Mul | Div | Mod -> 12, 12, 13
@@ -246,10 +246,10 @@ struct
     | BandEq -> "&="
     | BxorEq -> "^="
     | BorEq -> "|="
-    | Lt -> "<"
-    | Le -> "<="
-    | Gt -> ">"
-    | Ge -> ">="
+    | Lt | LtInt -> "<"
+    | Le | LeInt -> "<="
+    | Gt | GtInt -> ">"
+    | Ge | GeInt -> ">="
     | Lsl -> "<<"
     | Lsr -> ">>>"
     | Asr -> ">>"

--- a/compiler/lib/js_simpl.ml
+++ b/compiler/lib/js_simpl.ml
@@ -44,6 +44,16 @@ let rec enot_rec e =
         | J.NotEq -> J.EBin (J.EqEq, e1, e2), 0
         | J.EqEqEq -> J.EBin (J.NotEqEq, e1, e2), 0
         | J.NotEqEq -> J.EBin (J.EqEqEq, e1, e2), 0
+        | J.LtInt ->
+            (* not (a < b) *)
+            (* a >= b *)
+            J.EBin (J.GeInt, e1, e2), 0
+        | J.GtInt ->
+            (* not (a > b) *)
+            (* a <= b *)
+            J.EBin (J.LeInt, e1, e2), 0
+        | J.LeInt -> J.EBin (J.GtInt, e1, e2), 0
+        | J.GeInt -> J.EBin (J.LtInt, e1, e2), 0
         (* Disabled: this is not correct!
            {[ !(x < 0) ]} and {[ x >= 0 ]} give different result when x = nan
            {[

--- a/compiler/tests-compiler/array_access.ml
+++ b/compiler/tests-compiler/array_access.ml
@@ -33,7 +33,8 @@ let%expect_test "array_set" =
   print_fun_decl program (Some "some_name");
   [%expect
     {|
-    function some_name(a,n){runtime.caml_check_bound(a,n)[1 + n] = n;return 1} |}]
+    function some_name(a,n){runtime.caml_check_bound(a,n)[1 + n] = n;return 1}
+    //end |}]
 
 let%expect_test "array_set" =
   compile_and_run array_set;

--- a/compiler/tests-compiler/call_gen.ml
+++ b/compiler/tests-compiler/call_gen.ml
@@ -61,23 +61,32 @@ module M1 = struct
     [%expect
       {|
     function f(g){return caml_call2(f_prime(g),3,4)}
+    //end
     function f_prime(g){return caml_call2(g,1,2)}
+    //end
     function g(param)
      {return f
               (function(a,b,c,d)
                 {return caml_call1(Stdlib[44],((a + b | 0) + c | 0) + d | 0)})}
+    //end
     function h(param)
      {return f
               (function(a,b,c,d)
                 {return caml_call1(Stdlib[44],((a + b | 0) + c | 0) + d | 0)})}
+    //end
     function k(a,b,c,d)
      {return caml_call1(Stdlib[44],((a + b | 0) + c | 0) + d | 0)}
+    //end
     function l(_g_,_h_){return k(_b_,_a_,_g_,_h_)}
+    //end
     function m(_e_,_f_){return k(_d_,_c_,_e_,_f_)}
+    //end
     function caml_call1(f,a0)
      {return f.length == 1?f(a0):runtime.caml_call_gen(f,[a0])}
+    //end
     function caml_call2(f,a0,a1)
      {return f.length == 2?f(a0,a1):runtime.caml_call_gen(f,[a0,a1])}
+    //end
     |}]
 end
 
@@ -107,9 +116,13 @@ module M2 = struct
       function f(param,a,b,c,d,e,f)
        {caml_call1(Stdlib[44],(((a + b | 0) + c | 0) + d | 0) + e | 0);
         return caml_call1(Stdlib[47],0)}
+      //end
       function f_prime(f){return caml_call1(f,1)}
+      //end
       function f_prime_prime(f){return caml_call1(f,0)}
-      function g(a,b,c,d,e,f){return caml_call1(Stdlib[2],cst_printed_g)} |}]
+      //end
+      function g(a,b,c,d,e,f){return caml_call1(Stdlib[2],cst_printed_g)}
+      //end |}]
 
   let%expect_test _ =
     compile_and_run code;

--- a/compiler/tests-compiler/cond.ml
+++ b/compiler/tests-compiler/cond.ml
@@ -63,4 +63,5 @@ let%expect_test "conditional" =
           else
            if(f){var x=6;switch$0 = 1}else{var x=100;switch$0 = 1}
       if(! switch$0)var x=- 1;
-      return x + 2 | 0} |}]
+      return x + 2 | 0}
+    //end |}]

--- a/compiler/tests-compiler/eliminate_exception_handler.ml
+++ b/compiler/tests-compiler/eliminate_exception_handler.ml
@@ -49,4 +49,7 @@ try raise Not_found with
                    |}
   in
   print_fun_decl program (Some "some_name");
-  [%expect {| function some_name(param){try {throw Stdlib[8]}catch(_a_){return 0}} |}]
+  [%expect
+    {|
+    function some_name(param){try {throw Stdlib[8]}catch(_a_){return 0}}
+    //end |}]

--- a/compiler/tests-compiler/exceptions.ml
+++ b/compiler/tests-compiler/exceptions.ml
@@ -36,7 +36,8 @@ let prevent_inline = some_name
      {try
        {try {throw Stdlib[8]}catch(x){x = caml_wrap_exception(x);var i=x}}
       catch(i$0){i$0 = caml_wrap_exception(i$0);var i=i$0}
-      throw i} |}];
+      throw i}
+    //end |}];
   print_fun_decl (program ~debug:false) None;
   [%expect
     {|
@@ -44,4 +45,5 @@ let prevent_inline = some_name
      {try
        {try {throw Stdlib[8]}catch(_e_){var _c_=caml_wrap_exception(_e_)}}
       catch(_d_){_d_ = caml_wrap_exception(_d_);throw _d_}
-      throw _c_} |}]
+      throw _c_}
+    //end |}]

--- a/compiler/tests-compiler/exports.ml
+++ b/compiler/tests-compiler/exports.ml
@@ -57,7 +57,8 @@ let%expect_test "static eval of string get" =
     {|
     function Loader(globalThis)
      {var jsoo_exports={};jsoo_exports["x"] = 3;return jsoo_exports}
-    if(typeof module === "object" && module.exports)module["exports"] = Loader; |}];
+    if(typeof module === "object" && module.exports)module["exports"] = Loader;
+    //end |}];
   let program =
     compile_and_parse_whole_program
       ~flags:[ "--wrap-with-fun"; "Loader"; "--target-env"; "browser"; "--no-extern-fs" ]
@@ -71,7 +72,8 @@ let%expect_test "static eval of string get" =
   [%expect
     {|
     function Loader(globalThis){var jsoo_exports={};return jsoo_exports}
-    if(typeof module === "object" && module.exports)module["exports"] = Loader; |}];
+    if(typeof module === "object" && module.exports)module["exports"] = Loader;
+    //end |}];
   let program =
     compile_and_parse_whole_program
       ~flags:[ "--target-env"; "browser"; "--no-extern-fs" ]
@@ -90,7 +92,8 @@ let%expect_test "static eval of string get" =
          jsoo_exports=
           typeof module === "object" && module.exports || globalThis;
         jsoo_exports["x"] = 3}
-      (globalThis)); |}];
+      (globalThis));
+    //end |}];
   let program =
     compile_and_parse_whole_program
       ~flags:[ "--target-env"; "browser"; "--no-extern-fs" ]
@@ -101,5 +104,7 @@ let%expect_test "static eval of string get" =
       let () = if false then set (pure_js_expr "jsoo_exports") (pure_js_expr "'x'") x  |}
   in
   print_program (clean program);
-  [%expect {|
-    (function(Object){}(Object));(function(globalThis){}(globalThis)); |}]
+  [%expect
+    {|
+    (function(Object){}(Object));(function(globalThis){}(globalThis));
+    //end |}]

--- a/compiler/tests-compiler/gh1007.ml
+++ b/compiler/tests-compiler/gh1007.ml
@@ -158,139 +158,138 @@ let ()  = M.myfun M.x
      {var x$0=x;
       a:
       for(;;)
-       {if(x$0)
-         {var
-           next=x$0[1],
-           rev_sort=
-            function(n,l)
-             {if(2 === n)
-               {if(l)
-                 {var _e_=l[2];
-                  if(_e_)
-                   {var
-                     tl=_e_[2],
-                     x2=_e_[1],
-                     x1=l[1],
-                     s=0 < caml_int_compare(x1,x2)?[0,x1,[0,x2,0]]:[0,x2,[0,x1,0]];
-                    return [0,s,tl]}}}
-              else
-               if(3 === n && l)
-                {var _g_=l[2];
-                 if(_g_)
-                  {var _h_=_g_[2];
-                   if(_h_)
-                    {var
-                      tl$1=_h_[2],
-                      x3=_h_[1],
-                      x2$0=_g_[1],
-                      x1$0=l[1],
-                      s$0=
-                       0 < caml_int_compare(x1$0,x2$0)
-                        ?0 < caml_int_compare(x2$0,x3)
-                          ?[0,x1$0,[0,x2$0,[0,x3,0]]]
-                          :0 < caml_int_compare(x1$0,x3)
-                            ?[0,x1$0,[0,x3,[0,x2$0,0]]]
-                            :[0,x3,[0,x1$0,[0,x2$0,0]]]
+       {if(! x$0)return 0;
+        var
+         next=x$0[1],
+         rev_sort=
+          function(n,l)
+           {if(2 === n)
+             {if(l)
+               {var _e_=l[2];
+                if(_e_)
+                 {var
+                   tl=_e_[2],
+                   x2=_e_[1],
+                   x1=l[1],
+                   s=0 < caml_int_compare(x1,x2)?[0,x1,[0,x2,0]]:[0,x2,[0,x1,0]];
+                  return [0,s,tl]}}}
+            else
+             if(3 === n && l)
+              {var _g_=l[2];
+               if(_g_)
+                {var _h_=_g_[2];
+                 if(_h_)
+                  {var
+                    tl$1=_h_[2],
+                    x3=_h_[1],
+                    x2$0=_g_[1],
+                    x1$0=l[1],
+                    s$0=
+                     0 < caml_int_compare(x1$0,x2$0)
+                      ?0 < caml_int_compare(x2$0,x3)
+                        ?[0,x1$0,[0,x2$0,[0,x3,0]]]
                         :0 < caml_int_compare(x1$0,x3)
-                          ?[0,x2$0,[0,x1$0,[0,x3,0]]]
-                          :0 < caml_int_compare(x2$0,x3)
-                            ?[0,x2$0,[0,x3,[0,x1$0,0]]]
-                            :[0,x3,[0,x2$0,[0,x1$0,0]]];
-                     return [0,s$0,tl$1]}}}
-              var
-               n1=n >> 1,
-               n2=n - n1 | 0,
-               match=sort(n1,l),
-               l2$0=match[2],
-               s1=match[1],
-               match$0=sort(n2,l2$0),
-               tl$0=match$0[2],
-               s2=match$0[1],
-               l1=s1,
-               l2=s2,
-               accu=0;
-              for(;;)
-               {if(l1)
-                 {if(l2)
-                   {var t2=l2[2],h2=l2[1],t1=l1[2],h1=l1[1];
-                    if(0 < caml_int_compare(h1,h2))
-                     {var accu$0=[0,h2,accu],l2=t2,accu=accu$0;continue}
-                    var accu$1=[0,h1,accu],l1=t1,accu=accu$1;
-                    continue}
-                  var _f_=rev_append(l1,accu)}
-                else
-                 var _f_=rev_append(l2,accu);
-                return [0,_f_,tl$0]}},
-           sort=
-            function(n,l)
-             {if(2 === n)
-               {if(l)
-                 {var _a_=l[2];
-                  if(_a_)
-                   {var
-                     tl=_a_[2],
-                     x2=_a_[1],
-                     x1=l[1],
-                     s=0 < caml_int_compare(x1,x2)?[0,x2,[0,x1,0]]:[0,x1,[0,x2,0]];
-                    return [0,s,tl]}}}
-              else
-               if(3 === n && l)
-                {var _c_=l[2];
-                 if(_c_)
-                  {var _d_=_c_[2];
-                   if(_d_)
-                    {var
-                      tl$1=_d_[2],
-                      x3=_d_[1],
-                      x2$0=_c_[1],
-                      x1$0=l[1],
-                      s$0=
-                       0 < caml_int_compare(x1$0,x2$0)
-                        ?0 < caml_int_compare(x1$0,x3)
-                          ?0 < caml_int_compare(x2$0,x3)
-                            ?[0,x3,[0,x2$0,[0,x1$0,0]]]
-                            :[0,x2$0,[0,x3,[0,x1$0,0]]]
-                          :[0,x2$0,[0,x1$0,[0,x3,0]]]
+                          ?[0,x1$0,[0,x3,[0,x2$0,0]]]
+                          :[0,x3,[0,x1$0,[0,x2$0,0]]]
+                      :0 < caml_int_compare(x1$0,x3)
+                        ?[0,x2$0,[0,x1$0,[0,x3,0]]]
                         :0 < caml_int_compare(x2$0,x3)
-                          ?0 < caml_int_compare(x1$0,x3)
-                            ?[0,x3,[0,x1$0,[0,x2$0,0]]]
-                            :[0,x1$0,[0,x3,[0,x2$0,0]]]
-                          :[0,x1$0,[0,x2$0,[0,x3,0]]];
-                     return [0,s$0,tl$1]}}}
-              var
-               n1=n >> 1,
-               n2=n - n1 | 0,
-               match=rev_sort(n1,l),
-               l2$0=match[2],
-               s1=match[1],
-               match$0=rev_sort(n2,l2$0),
-               tl$0=match$0[2],
-               s2=match$0[1],
-               l1=s1,
-               l2=s2,
-               accu=0;
-              for(;;)
-               {if(l1)
-                 {if(l2)
-                   {var t2=l2[2],h2=l2[1],t1=l1[2],h1=l1[1];
-                    if(0 < caml_int_compare(h1,h2))
-                     {var accu$0=[0,h1,accu],l1=t1,accu=accu$0;continue}
-                    var accu$1=[0,h2,accu],l2=t2,accu=accu$1;
-                    continue}
-                  var _b_=rev_append(l1,accu)}
-                else
-                 var _b_=rev_append(l2,accu);
-                return [0,_b_,tl$0]}},
-           len=0,
-           param=l;
-          for(;;)
-           {if(param)
-             {var param$0=param[2],len$0=len + 1 | 0,len=len$0,param=param$0;
-              continue}
-            if(2 <= len)sort(len,l);
-            var x$0=next;
-            continue a}}
-        return 0}}
+                          ?[0,x2$0,[0,x3,[0,x1$0,0]]]
+                          :[0,x3,[0,x2$0,[0,x1$0,0]]];
+                   return [0,s$0,tl$1]}}}
+            var
+             n1=n >> 1,
+             n2=n - n1 | 0,
+             match=sort(n1,l),
+             l2$0=match[2],
+             s1=match[1],
+             match$0=sort(n2,l2$0),
+             tl$0=match$0[2],
+             s2=match$0[1],
+             l1=s1,
+             l2=s2,
+             accu=0;
+            for(;;)
+             {if(l1)
+               {if(l2)
+                 {var t2=l2[2],h2=l2[1],t1=l1[2],h1=l1[1];
+                  if(0 < caml_int_compare(h1,h2))
+                   {var accu$0=[0,h2,accu],l2=t2,accu=accu$0;continue}
+                  var accu$1=[0,h1,accu],l1=t1,accu=accu$1;
+                  continue}
+                var _f_=rev_append(l1,accu)}
+              else
+               var _f_=rev_append(l2,accu);
+              return [0,_f_,tl$0]}},
+         sort=
+          function(n,l)
+           {if(2 === n)
+             {if(l)
+               {var _a_=l[2];
+                if(_a_)
+                 {var
+                   tl=_a_[2],
+                   x2=_a_[1],
+                   x1=l[1],
+                   s=0 < caml_int_compare(x1,x2)?[0,x2,[0,x1,0]]:[0,x1,[0,x2,0]];
+                  return [0,s,tl]}}}
+            else
+             if(3 === n && l)
+              {var _c_=l[2];
+               if(_c_)
+                {var _d_=_c_[2];
+                 if(_d_)
+                  {var
+                    tl$1=_d_[2],
+                    x3=_d_[1],
+                    x2$0=_c_[1],
+                    x1$0=l[1],
+                    s$0=
+                     0 < caml_int_compare(x1$0,x2$0)
+                      ?0 < caml_int_compare(x1$0,x3)
+                        ?0 < caml_int_compare(x2$0,x3)
+                          ?[0,x3,[0,x2$0,[0,x1$0,0]]]
+                          :[0,x2$0,[0,x3,[0,x1$0,0]]]
+                        :[0,x2$0,[0,x1$0,[0,x3,0]]]
+                      :0 < caml_int_compare(x2$0,x3)
+                        ?0 < caml_int_compare(x1$0,x3)
+                          ?[0,x3,[0,x1$0,[0,x2$0,0]]]
+                          :[0,x1$0,[0,x3,[0,x2$0,0]]]
+                        :[0,x1$0,[0,x2$0,[0,x3,0]]];
+                   return [0,s$0,tl$1]}}}
+            var
+             n1=n >> 1,
+             n2=n - n1 | 0,
+             match=rev_sort(n1,l),
+             l2$0=match[2],
+             s1=match[1],
+             match$0=rev_sort(n2,l2$0),
+             tl$0=match$0[2],
+             s2=match$0[1],
+             l1=s1,
+             l2=s2,
+             accu=0;
+            for(;;)
+             {if(l1)
+               {if(l2)
+                 {var t2=l2[2],h2=l2[1],t1=l1[2],h1=l1[1];
+                  if(0 < caml_int_compare(h1,h2))
+                   {var accu$0=[0,h1,accu],l1=t1,accu=accu$0;continue}
+                  var accu$1=[0,h2,accu],l2=t2,accu=accu$1;
+                  continue}
+                var _b_=rev_append(l1,accu)}
+              else
+               var _b_=rev_append(l2,accu);
+              return [0,_b_,tl$0]}},
+         len=0,
+         param=l;
+        for(;;)
+         {if(param)
+           {var param$0=param[2],len$0=len + 1 | 0,len=len$0,param=param$0;
+            continue}
+          if(2 <= len)sort(len,l);
+          var x$0=next;
+          continue a}}}
     //end |}]
 
 let%expect_test _ =
@@ -347,8 +346,8 @@ let ()  = M.run ()
               default:return 1 - (1 - even(1))}};
         even(i);
         var _a_=i + 1 | 0;
-        if(4 !== i){var i=_a_;continue}
-        return 0}}
+        if(4 === i)return 0;
+        var i=_a_}}
     //end |}]
 
 let%expect_test _ =
@@ -548,12 +547,12 @@ let ()  = M.run ()
          param=even(i),
          param$1=param;
         for(;;)
-         {if(759635106 <= param$1[1])
-           {var _g_=i + 1 | 0;
-            if(4 !== i){var i=_g_;continue a}
-            var
-             _e_=caml_call1(Stdlib_List[9],delayed[1]),
-             _f_=function(f){return caml_call1(f,0)};
-            return caml_call2(Stdlib_List[17],_f_,_e_)}
-          var f=param$1[2],param$2=caml_call1(f,0),param$1=param$2}}}
+         {if(759635106 > param$1[1])
+           {var f=param$1[2],param$2=caml_call1(f,0),param$1=param$2;continue}
+          var _g_=i + 1 | 0;
+          if(4 !== i){var i=_g_;continue a}
+          var
+           _e_=caml_call1(Stdlib_List[9],delayed[1]),
+           _f_=function(f){return caml_call1(f,0)};
+          return caml_call2(Stdlib_List[17],_f_,_e_)}}}
     //end |}]

--- a/compiler/tests-compiler/gh1007.ml
+++ b/compiler/tests-compiler/gh1007.ml
@@ -290,7 +290,8 @@ let ()  = M.myfun M.x
             if(2 <= len)sort(len,l);
             var x$0=next;
             continue a}}
-        return 0}} |}]
+        return 0}}
+    //end |}]
 
 let%expect_test _ =
   let prog =
@@ -347,7 +348,8 @@ let ()  = M.run ()
         even(i);
         var _a_=i + 1 | 0;
         if(4 !== i){var i=_a_;continue}
-        return 0}} |}]
+        return 0}}
+    //end |}]
 
 let%expect_test _ =
   let prog =
@@ -440,7 +442,8 @@ let ()  = M.run ()
         var
          _c_=caml_call1(Stdlib_List[9],delayed[1]),
          _d_=function(f){return caml_call1(f,0)};
-        return caml_call2(Stdlib_List[17],_d_,_c_)}} |}]
+        return caml_call2(Stdlib_List[17],_d_,_c_)}}
+    //end |}]
 
 let%expect_test _ =
   let prog =
@@ -553,4 +556,5 @@ let ()  = M.run ()
              _f_=function(f){return caml_call1(f,0)};
             return caml_call2(Stdlib_List[17],_f_,_e_)}
           var f=param$1[2],param$2=caml_call1(f,0),param$1=param$2;
-          continue}}} |}]
+          continue}}}
+    //end |}]

--- a/compiler/tests-compiler/gh1007.ml
+++ b/compiler/tests-compiler/gh1007.ml
@@ -555,6 +555,5 @@ let ()  = M.run ()
              _e_=caml_call1(Stdlib_List[9],delayed[1]),
              _f_=function(f){return caml_call1(f,0)};
             return caml_call2(Stdlib_List[17],_f_,_e_)}
-          var f=param$1[2],param$2=caml_call1(f,0),param$1=param$2;
-          continue}}}
+          var f=param$1[2],param$2=caml_call1(f,0),param$1=param$2}}}
     //end |}]

--- a/compiler/tests-compiler/gh1051.ml
+++ b/compiler/tests-compiler/gh1051.ml
@@ -35,5 +35,6 @@ let%expect_test _ =
     {|
     Warning: integer overflow: integer 0xffffffff (4294967295) truncated to 0xffffffff (-1); the generated code might be incorrect.
     function caml_call2(f,a0,a1)
-     {return f.length == 2?f(a0,a1):runtime.caml_call_gen(f,[a0,a1])} |}];
+     {return f.length == 2?f(a0,a1):runtime.caml_call_gen(f,[a0,a1])}
+    //end |}];
   ()

--- a/compiler/tests-compiler/gh1320.ml
+++ b/compiler/tests-compiler/gh1320.ml
@@ -58,6 +58,6 @@ let () = myfun ()
          _b_=g(i);
         caml_call2(Stdlib_Format[131],_a_,_b_);
         var _c_=i + 1 | 0;
-        if(4 !== i){var i=_c_;continue}
-        return 0}}
+        if(4 === i)return 0;
+        var i=_c_}}
     //end |}]

--- a/compiler/tests-compiler/gh1320.ml
+++ b/compiler/tests-compiler/gh1320.ml
@@ -59,4 +59,5 @@ let () = myfun ()
         caml_call2(Stdlib_Format[131],_a_,_b_);
         var _c_=i + 1 | 0;
         if(4 !== i){var i=_c_;continue}
-        return 0}} |}]
+        return 0}}
+    //end |}]

--- a/compiler/tests-compiler/inlining.ml
+++ b/compiler/tests-compiler/inlining.ml
@@ -28,7 +28,7 @@ let%expect_test "inline recursive function" =
   print_fun_decl program (Some "g");
   [%expect
     {|
-    function f(param){for(;;)continue}
+    function f(param){for(;;);}
     //end
     function g(param){return f(0)}
     //end |}]

--- a/compiler/tests-compiler/inlining.ml
+++ b/compiler/tests-compiler/inlining.ml
@@ -29,4 +29,6 @@ let%expect_test "inline recursive function" =
   [%expect
     {|
     function f(param){for(;;)continue}
-    function g(param){return f(0)} |}]
+    //end
+    function g(param){return f(0)}
+    //end |}]

--- a/compiler/tests-compiler/lazy.ml
+++ b/compiler/tests-compiler/lazy.ml
@@ -39,4 +39,5 @@ let%expect_test "static eval of string get" =
        _b_=do_the_lazy_rec(n - 1 | 0),
        _c_=runtime.caml_obj_tag(lz),
        _d_=250 === _c_?lz[1]:246 === _c_?caml_call1(CamlinternalLazy[2],lz):lz;
-      return [0,_d_,_b_]} |}]
+      return [0,_d_,_b_]}
+    //end |}]

--- a/compiler/tests-compiler/loops.ml
+++ b/compiler/tests-compiler/loops.ml
@@ -45,7 +45,8 @@ let%expect_test "rec-fun" =
         var
          _a_=caml_call1(Stdlib_List[9],acc$0),
          _b_=caml_call1(Stdlib_List[9],_a_);
-        return caml_call1(Stdlib_List[9],_b_)}} |}]
+        return caml_call1(Stdlib_List[9],_b_)}}
+    //end |}]
 
 let%expect_test "rec-fun-2" =
   let program =
@@ -94,6 +95,7 @@ let rec fun_with_loop acc = function
          _d_=caml_call1(Stdlib_List[9],acc$0),
          _e_=caml_call1(Stdlib_List[9],_d_);
         return caml_call1(Stdlib_List[9],_e_)}}
+    //end
  |}]
 
 let%expect_test "for-for-while" =
@@ -129,7 +131,8 @@ let for_for_while () =
              if(10 !== k){var k=_a_;continue a}
              return 0}
            id[1]++;
-           continue}}} |}]
+           continue}}}
+    //end |}]
 
 let%expect_test "for-for-while-try" =
   let program =
@@ -166,7 +169,8 @@ let for_for_while () =
              return 0}
            try {caml_div(k,j)}catch(_c_){throw Stdlib[8]}
            id[1]++;
-           continue}}} |}]
+           continue}}}
+    //end |}]
 
 let%expect_test "loop seq.ml" =
   let program =
@@ -202,7 +206,8 @@ let rec equal eq xs ys =
            {var ys$1=match$0[2],xs$1=match[2],xs$0=xs$1,ys$0=ys$1;continue}}
         else
          if(! match$0)return 1;
-        return 0}} |}]
+        return 0}}
+    //end |}]
 
 let%expect_test "try-catch inside loop" =
   let program =
@@ -255,7 +260,8 @@ let f t x =
               if(switch$1)var _b_=0}
             return _b_?1:2}}
         return - 2}
-      return other(t,x)} |}]
+      return other(t,x)}
+    //end |}]
 
 let%expect_test "loop-and-switch" =
   let program =
@@ -299,7 +305,8 @@ in loop x
             if(switch$0)var _a_=2;
             return _a_ + 2 | 0}}
         var x$3=x$2 + 1 | 0,x$2=x$3;
-        continue}} |}]
+        continue}}
+    //end |}]
 
 let%expect_test "buffer.add_substitute" =
   let program =
@@ -462,4 +469,5 @@ let add_substitute =
           var i$11=i$7 + 1 | 0,previous=current,i$7=i$11;
           continue}
         var _c_=92 === previous?1:0;
-        return _c_?caml_call2(add_char,b,previous):_c_}} |}]
+        return _c_?caml_call2(add_char,b,previous):_c_}}
+    //end |}]

--- a/compiler/tests-compiler/loops.ml
+++ b/compiler/tests-compiler/loops.ml
@@ -75,26 +75,26 @@ let rec fun_with_loop acc = function
      {var acc$0=acc,param$0=param;
       a:
       for(;;)
-       {if(param$0)
-         {var _a_=param$0[1];
-          if(1 === _a_ && ! param$0[2])
-           {var a$0=[0,acc$0],i$0=0;
-            for(;;)
-             {a$0[1] = [0,1,a$0[1]];
-              var _c_=i$0 + 1 | 0;
-              if(10 !== i$0){var i$0=_c_;continue}
-              return a$0[1]}}
-          var xs=param$0[2],a=[0,acc$0],i=0;
+       {if(! param$0)
+         {var
+           _d_=caml_call1(Stdlib_List[9],acc$0),
+           _e_=caml_call1(Stdlib_List[9],_d_);
+          return caml_call1(Stdlib_List[9],_e_)}
+        var _a_=param$0[1];
+        if(1 === _a_ && ! param$0[2])
+         {var a$0=[0,acc$0],i$0=0;
           for(;;)
-           {a[1] = [0,1,a[1]];
-            var _b_=i + 1 | 0;
-            if(10 !== i){var i=_b_;continue}
-            var acc$1=[0,_a_,a[1]],acc$0=acc$1,param$0=xs;
-            continue a}}
-        var
-         _d_=caml_call1(Stdlib_List[9],acc$0),
-         _e_=caml_call1(Stdlib_List[9],_d_);
-        return caml_call1(Stdlib_List[9],_e_)}}
+           {a$0[1] = [0,1,a$0[1]];
+            var _c_=i$0 + 1 | 0;
+            if(10 === i$0)return a$0[1];
+            var i$0=_c_}}
+        var xs=param$0[2],a=[0,acc$0],i=0;
+        for(;;)
+         {a[1] = [0,1,a[1]];
+          var _b_=i + 1 | 0;
+          if(10 !== i){var i=_b_;continue}
+          var acc$1=[0,_a_,a[1]],acc$0=acc$1,param$0=xs;
+          continue a}}}
     //end
  |}]
 
@@ -124,13 +124,13 @@ let for_for_while () =
         b:
         for(;;)
          for(;;)
-          {if(10 <= runtime.caml_mul(k,j))
-            {var _b_=j + 1 | 0;
-             if(10 !== j){var j=_b_;continue b}
-             var _a_=k + 1 | 0;
-             if(10 !== k){var k=_a_;continue a}
-             return 0}
-           id[1]++}}}
+          {if(10 > runtime.caml_mul(k,j)){id[1]++;continue}
+           var _b_=j + 1 | 0;
+           if(10 !== j){var j=_b_;continue b}
+           var _a_=k + 1 | 0;
+           if(10 === k)return 0;
+           var k=_a_;
+           continue a}}}
     //end |}]
 
 let%expect_test "for-for-while-try" =
@@ -160,14 +160,14 @@ let for_for_while () =
         b:
         for(;;)
          for(;;)
-          {if(10 <= caml_div(k,j))
-            {var _b_=j + 1 | 0;
-             if(10 !== j){var j=_b_;continue b}
-             var _a_=k + 1 | 0;
-             if(10 !== k){var k=_a_;continue a}
-             return 0}
-           try {caml_div(k,j)}catch(_c_){throw Stdlib[8]}
-           id[1]++}}}
+          {if(10 > caml_div(k,j))
+            {try {caml_div(k,j)}catch(_c_){throw Stdlib[8]}id[1]++;continue}
+           var _b_=j + 1 | 0;
+           if(10 !== j){var j=_b_;continue b}
+           var _a_=k + 1 | 0;
+           if(10 === k)return 0;
+           var k=_a_;
+           continue a}}}
     //end |}]
 
 let%expect_test "loop seq.ml" =
@@ -288,21 +288,20 @@ in loop x
      {var x$2=x;
       for(;;)
        {if(0 === x$2)return 1;
-        if(1 === x$2)
-         {var x$0=2;
-          for(;;)
-           {var switch$0=0;
-            if(3 < x$0 >>> 0)
-             switch$0 = 1;
-            else
-             switch(x$0)
-              {case 0:var _a_=1;break;
-               case 2:var n=caml_call1(Stdlib_Random[5],2),_a_=n + n | 0;break;
-               case 3:var x$1=caml_call1(Stdlib_Random[5],2),x$0=x$1;continue;
-               default:switch$0 = 1}
-            if(switch$0)var _a_=2;
-            return _a_ + 2 | 0}}
-        var x$3=x$2 + 1 | 0,x$2=x$3}}
+        if(1 !== x$2){var x$3=x$2 + 1 | 0,x$2=x$3;continue}
+        var x$0=2;
+        for(;;)
+         {var switch$0=0;
+          if(3 < x$0 >>> 0)
+           switch$0 = 1;
+          else
+           switch(x$0)
+            {case 0:var _a_=1;break;
+             case 2:var n=caml_call1(Stdlib_Random[5],2),_a_=n + n | 0;break;
+             case 3:var x$1=caml_call1(Stdlib_Random[5],2),x$0=x$1;continue;
+             default:switch$0 = 1}
+          if(switch$0)var _a_=2;
+          return _a_ + 2 | 0}}}
     //end |}]
 
 let%expect_test "buffer.add_substitute" =
@@ -398,64 +397,12 @@ let add_substitute =
     function add_substitute(b,f,s)
      {var lim$1=caml_ml_string_length(s),previous=32,i$7=0;
       for(;;)
-       {if(i$7 < lim$1)
-         {var current=caml_string_get(s,i$7);
-          if(36 === current)
-           {if(92 === previous)
-             {caml_call2(add_char,b,current);
-              var i$8=i$7 + 1 | 0,previous=32,i$7=i$8;
-              continue}
-            var start=i$7 + 1 | 0;
-            if(lim$1 <= start)throw Stdlib[8];
-            var opening=caml_string_get(s,start),switch$0=0;
-            if(40 !== opening && 123 !== opening)
-             {var i$6=start + 1 | 0,lim$0=caml_ml_string_length(s),i$3=i$6;
-              for(;;)
-               {if(lim$0 <= i$3)
-                 var stop=lim$0;
-                else
-                 {var match=caml_string_get(s,i$3),switch$1=0;
-                  if(91 <= match)
-                   {if(97 <= match)
-                     {if(123 > match)switch$1 = 1}
-                    else
-                     if(95 === match)switch$1 = 1}
-                  else
-                   if(58 <= match)
-                    {if(65 <= match)switch$1 = 1}
-                   else
-                    if(48 <= match)switch$1 = 1;
-                  if(switch$1){var i$4=i$3 + 1 | 0,i$3=i$4;continue}
-                  var stop=i$3}
-                var
-                 match$0=
-                  [0,caml_call3(Stdlib_String[15],s,start,stop - start | 0),stop];
-                switch$0 = 1;
-                break}}
-            if(! switch$0)
-             {var i$5=start + 1 | 0,k$2=0;
-              if(40 === opening)
-               var _b_=41;
-              else
-               {if(123 !== opening)throw [0,Assert_failure,_a_];var _b_=125}
-              var lim=caml_ml_string_length(s),k=k$2,i=i$5;
-              for(;;)
-               {if(lim <= i)throw Stdlib[8];
-                if(caml_string_get(s,i) === opening)
-                 {var i$0=i + 1 | 0,k$0=k + 1 | 0,k=k$0,i=i$0;continue}
-                if(caml_string_get(s,i) !== _b_){var i$2=i + 1 | 0,i=i$2;continue}
-                if(0 !== k){var i$1=i + 1 | 0,k$1=k - 1 | 0,k=k$1,i=i$1;continue}
-                var
-                 match$0=
-                  [0,
-                   caml_call3(Stdlib_String[15],s,i$5,(i - start | 0) - 1 | 0),
-                   i + 1 | 0];
-                break}}
-            var next_i=match$0[2],ident=match$0[1];
-            caml_call2(add_string,b,caml_call1(f,ident));
-            var previous=32,i$7=next_i;
-            continue}
-          if(92 === previous)
+       {if(i$7 >= lim$1)
+         {var _c_=92 === previous?1:0;
+          return _c_?caml_call2(add_char,b,previous):_c_}
+        var current=caml_string_get(s,i$7);
+        if(36 !== current)
+         {if(92 === previous)
            {caml_call2(add_char,b,92);
             caml_call2(add_char,b,current);
             var i$9=i$7 + 1 | 0,previous=32,i$7=i$9;
@@ -465,6 +412,57 @@ let add_substitute =
           caml_call2(add_char,b,current);
           var i$11=i$7 + 1 | 0,previous=current,i$7=i$11;
           continue}
-        var _c_=92 === previous?1:0;
-        return _c_?caml_call2(add_char,b,previous):_c_}}
+        if(92 === previous)
+         {caml_call2(add_char,b,current);
+          var i$8=i$7 + 1 | 0,previous=32,i$7=i$8;
+          continue}
+        var start=i$7 + 1 | 0;
+        if(lim$1 <= start)throw Stdlib[8];
+        var opening=caml_string_get(s,start),switch$0=0;
+        if(40 !== opening && 123 !== opening)
+         {var i$6=start + 1 | 0,lim$0=caml_ml_string_length(s),i$3=i$6;
+          for(;;)
+           {if(lim$0 <= i$3)
+             var stop=lim$0;
+            else
+             {var match=caml_string_get(s,i$3),switch$1=0;
+              if(91 <= match)
+               {if(97 <= match)
+                 {if(123 > match)switch$1 = 1}
+                else
+                 if(95 === match)switch$1 = 1}
+              else
+               if(58 <= match)
+                {if(65 <= match)switch$1 = 1}
+               else
+                if(48 <= match)switch$1 = 1;
+              if(switch$1){var i$4=i$3 + 1 | 0,i$3=i$4;continue}
+              var stop=i$3}
+            var
+             match$0=
+              [0,caml_call3(Stdlib_String[15],s,start,stop - start | 0),stop];
+            switch$0 = 1;
+            break}}
+        if(! switch$0)
+         {var i$5=start + 1 | 0,k$2=0;
+          if(40 === opening)
+           var _b_=41;
+          else
+           {if(123 !== opening)throw [0,Assert_failure,_a_];var _b_=125}
+          var lim=caml_ml_string_length(s),k=k$2,i=i$5;
+          for(;;)
+           {if(lim <= i)throw Stdlib[8];
+            if(caml_string_get(s,i) === opening)
+             {var i$0=i + 1 | 0,k$0=k + 1 | 0,k=k$0,i=i$0;continue}
+            if(caml_string_get(s,i) !== _b_){var i$2=i + 1 | 0,i=i$2;continue}
+            if(0 !== k){var i$1=i + 1 | 0,k$1=k - 1 | 0,k=k$1,i=i$1;continue}
+            var
+             match$0=
+              [0,
+               caml_call3(Stdlib_String[15],s,i$5,(i - start | 0) - 1 | 0),
+               i + 1 | 0];
+            break}}
+        var next_i=match$0[2],ident=match$0[1];
+        caml_call2(add_string,b,caml_call1(f,ident));
+        var previous=32,i$7=next_i}}
     //end |}]

--- a/compiler/tests-compiler/loops.ml
+++ b/compiler/tests-compiler/loops.ml
@@ -130,8 +130,7 @@ let for_for_while () =
              var _a_=k + 1 | 0;
              if(10 !== k){var k=_a_;continue a}
              return 0}
-           id[1]++;
-           continue}}}
+           id[1]++}}}
     //end |}]
 
 let%expect_test "for-for-while-try" =
@@ -168,8 +167,7 @@ let for_for_while () =
              if(10 !== k){var k=_a_;continue a}
              return 0}
            try {caml_div(k,j)}catch(_c_){throw Stdlib[8]}
-           id[1]++;
-           continue}}}
+           id[1]++}}}
     //end |}]
 
 let%expect_test "loop seq.ml" =
@@ -304,8 +302,7 @@ in loop x
                default:switch$0 = 1}
             if(switch$0)var _a_=2;
             return _a_ + 2 | 0}}
-        var x$3=x$2 + 1 | 0,x$2=x$3;
-        continue}}
+        var x$3=x$2 + 1 | 0,x$2=x$3}}
     //end |}]
 
 let%expect_test "buffer.add_substitute" =

--- a/compiler/tests-compiler/loops.ml
+++ b/compiler/tests-compiler/loops.ml
@@ -420,7 +420,7 @@ let add_substitute =
                  {var match=caml_string_get(s,i$3),switch$1=0;
                   if(91 <= match)
                    {if(97 <= match)
-                     {if(! (123 <= match))switch$1 = 1}
+                     {if(123 > match)switch$1 = 1}
                     else
                      if(95 === match)switch$1 = 1}
                   else

--- a/compiler/tests-compiler/match_with_exn.ml
+++ b/compiler/tests-compiler/match_with_exn.ml
@@ -83,6 +83,7 @@ let fun2 () =
         var i=_c_}
       if(switch$0){if(0 !== i$0)return i$0 + 1 | 0;var i=i$0}
       return i}
+    //end
     function fun2(param)
      {try
        {var switch$0=0,i$0=caml_call1(Stdlib_Random[5],2);switch$0 = 1}
@@ -92,4 +93,5 @@ let fun2 () =
         if(_b_[1] === A){var _a_=_b_[2];if(2 === _a_){var i=_a_;switch$1 = 1}}
         if(! switch$1)throw _b_}
       if(switch$0){if(0 !== i$0)return i$0 + 1 | 0;var i=i$0}
-      return i} |}]
+      return i}
+    //end |}]

--- a/compiler/tests-compiler/mutable_closure.ml
+++ b/compiler/tests-compiler/mutable_closure.ml
@@ -122,25 +122,25 @@ let%expect_test _ =
            {function f(counter,n)
              {if(- 1 === n)
                {var _j_=- 2;
-                if(counter < 50)
-                 {var counter$1=counter + 1 | 0;return g(counter$1,_j_)}
-                return caml_trampoline_return(g,[0,_j_])}
+                if(counter >= 50)return caml_trampoline_return(g,[0,_j_]);
+                var counter$1=counter + 1 | 0;
+                return g(counter$1,_j_)}
               if(0 === n)return i;
               var _k_=n - 1 | 0;
-              if(counter < 50)
-               {var counter$0=counter + 1 | 0;return g(counter$0,_k_)}
-              return caml_trampoline_return(g,[0,_k_])}
+              if(counter >= 50)return caml_trampoline_return(g,[0,_k_]);
+              var counter$0=counter + 1 | 0;
+              return g(counter$0,_k_)}
             function g(counter,n)
              {if(- 1 === n)
                {var _h_=- 2;
-                if(counter < 50)
-                 {var counter$1=counter + 1 | 0;return f(counter$1,_h_)}
-                return caml_trampoline_return(f,[0,_h_])}
+                if(counter >= 50)return caml_trampoline_return(f,[0,_h_]);
+                var counter$1=counter + 1 | 0;
+                return f(counter$1,_h_)}
               if(0 === n)return i;
               var _i_=n - 1 | 0;
-              if(counter < 50)
-               {var counter$0=counter + 1 | 0;return f(counter$0,_i_)}
-              return caml_trampoline_return(f,[0,_i_])}
+              if(counter >= 50)return caml_trampoline_return(f,[0,_i_]);
+              var counter$0=counter + 1 | 0;
+              return f(counter$0,_i_)}
             function f$0(n){return caml_trampoline(f(0,n))}
             function g$0(n){return caml_trampoline(g(0,n))}
             var block=[0,f$0,g$0];

--- a/compiler/tests-compiler/mutable_closure.ml
+++ b/compiler/tests-compiler/mutable_closure.ml
@@ -161,4 +161,5 @@ let%expect_test _ =
          indirect$0=caml_call2(Stdlib_List[19],_d_,_c_),
          direct$0=direct[1];
         if(runtime.caml_equal(indirect$0,direct$0))return 0;
-        throw [0,Assert_failure,_b_]}}|}]
+        throw [0,Assert_failure,_b_]}}
+    //end|}]

--- a/compiler/tests-compiler/obj.ml
+++ b/compiler/tests-compiler/obj.ml
@@ -49,12 +49,22 @@ let%expect_test "static eval of string get" =
   [%expect
     {|
     function my_is_block(x){return caml_call1(Stdlib_Obj[1],x)}
+    //end
     function my_is_int(x){return typeof x === "number"?1:0}
+    //end
     function my_tag(x){return runtime.caml_obj_tag([0,x,0])}
+    //end
     function my_size(x){return x.length - 1}
+    //end
     function my_field(x,i){return x[1 + i]}
+    //end
     function my_set_field(x,i,o){x[1 + i] = o;return 0}
+    //end
     function my_set_tag(x,t){return runtime.caml_obj_set_tag([0,x,0],t)}
+    //end
     function my_new_block(x,l){return runtime.caml_obj_block(x + 1 | 0,3)}
+    //end
     function my_dup(t){return [0,t,0].slice()}
-    function my_truncate(t,i){return runtime.caml_obj_truncate([0,t,0],i)} |}]
+    //end
+    function my_truncate(t,i){return runtime.caml_obj_truncate([0,t,0],i)}
+    //end |}]

--- a/compiler/tests-compiler/static_eval.ml
+++ b/compiler/tests-compiler/static_eval.ml
@@ -137,24 +137,21 @@ let%expect_test "static eval of string get" =
   [%expect
     {|
     function copy_bucketlist(param)
-     {if(param)
-       {var
-         key=param[1],
-         data=param[2],
-         next=param[3],
-         prec$0=[0,key,data,next],
-         prec=prec$0,
-         param$0=next;
-        for(;;)
-         {if(param$0)
-           {var
-             key$0=param$0[1],
-             data$0=param$0[2],
-             next$0=param$0[3],
-             r=[0,key$0,data$0,next$0];
-            prec[3] = r;
-            var prec=r,param$0=next$0;
-            continue}
-          return prec$0}}
-      return 0}
+     {if(! param)return 0;
+      var
+       key=param[1],
+       data=param[2],
+       next=param[3],
+       prec$0=[0,key,data,next],
+       prec=prec$0,
+       param$0=next;
+      for(;;)
+       {if(! param$0)return prec$0;
+        var
+         key$0=param$0[1],
+         data$0=param$0[2],
+         next$0=param$0[3],
+         r=[0,key$0,data$0,next$0];
+        prec[3] = r;
+        var prec=r,param$0=next$0}}
     //end |}]

--- a/compiler/tests-compiler/static_eval.ml
+++ b/compiler/tests-compiler/static_eval.ml
@@ -45,8 +45,11 @@ let%expect_test "static eval of string get" =
   [%expect
     {|
     var ex = call_with_char(caml_string_get(cst_abcdefghijklmnopqrstuvwxyz,- 10));
+    //end
     var ax = call_with_char(103);
-    var bx = call_with_char(caml_string_get(cst_abcdefghijklmnopqrstuvwxyz,30)); |}]
+    //end
+    var bx = call_with_char(caml_string_get(cst_abcdefghijklmnopqrstuvwxyz,30));
+    //end |}]
 
 let%expect_test "static eval of string get" =
   let program =
@@ -74,8 +77,11 @@ let%expect_test "static eval of string get" =
   [%expect
     {|
     var ex = call_with_char(caml_string_get(constant,- 10));
+    //end
     var ax = call_with_char(103);
-    var bx = call_with_char(caml_string_get(constant,30)); |}]
+    //end
+    var bx = call_with_char(caml_string_get(constant,30));
+    //end |}]
 
 let%expect_test "static eval of Sys.backend_type" =
   let program =
@@ -95,7 +101,8 @@ let%expect_test "static eval of Sys.backend_type" =
   in
   print_fun_decl program (Some "myfun");
   [%expect {|
-    function myfun(param){return 42} |}]
+    function myfun(param){return 42}
+    //end |}]
 
 let%expect_test "static eval of string get" =
   let program =
@@ -149,4 +156,5 @@ let%expect_test "static eval of string get" =
             var prec=r,param$0=next$0;
             continue}
           return prec$0}}
-      return 0} |}]
+      return 0}
+    //end |}]

--- a/compiler/tests-compiler/tailcall.ml
+++ b/compiler/tests-compiler/tailcall.ml
@@ -64,7 +64,8 @@ let%expect_test _ =
        try
         {odd(5000);var _d_=log_success(0);return _d_}
        catch(_e_){return caml_call1(log_failure,cst_too_much_recursion)}
-      throw [0,Assert_failure,_b_]} |}]
+      throw [0,Assert_failure,_b_]}
+    //end |}]
 
 let%expect_test _ =
   let prog =
@@ -102,4 +103,5 @@ let%expect_test _ =
        try
         {odd(5000);var _d_=log_success(0);return _d_}
        catch(_e_){return caml_call1(log_failure,cst_too_much_recursion)}
-      throw [0,Assert_failure,_b_]} |}]
+      throw [0,Assert_failure,_b_]}
+    //end |}]

--- a/compiler/tests-compiler/tailcall.ml
+++ b/compiler/tests-compiler/tailcall.ml
@@ -48,23 +48,22 @@ let%expect_test _ =
      {function odd$0(counter,x)
        {if(0 === x)return 0;
         var _g_=x - 1 | 0;
-        if(counter < 50)
-         {var counter$0=counter + 1 | 0;return even$0(counter$0,_g_)}
-        return caml_trampoline_return(even$0,[0,_g_])}
+        if(counter >= 50)return caml_trampoline_return(even$0,[0,_g_]);
+        var counter$0=counter + 1 | 0;
+        return even$0(counter$0,_g_)}
       function even$0(counter,x)
        {if(0 === x)return 1;
         var _f_=x - 1 | 0;
-        if(counter < 50)
-         {var counter$0=counter + 1 | 0;return odd$0(counter$0,_f_)}
-        return caml_trampoline_return(odd$0,[0,_f_])}
+        if(counter >= 50)return caml_trampoline_return(odd$0,[0,_f_]);
+        var counter$0=counter + 1 | 0;
+        return odd$0(counter$0,_f_)}
       function odd(x){return caml_trampoline(odd$0(0,x))}
       function even(x){return caml_trampoline(even$0(0,x))}
       var _c_=even(1);
-      if(odd(1) !== _c_)
-       try
-        {odd(5000);var _d_=log_success(0);return _d_}
-       catch(_e_){return caml_call1(log_failure,cst_too_much_recursion)}
-      throw [0,Assert_failure,_b_]}
+      if(odd(1) === _c_)throw [0,Assert_failure,_b_];
+      try
+       {odd(5000);var _d_=log_success(0);return _d_}
+      catch(_e_){return caml_call1(log_failure,cst_too_much_recursion)}}
     //end |}]
 
 let%expect_test _ =
@@ -99,9 +98,8 @@ let%expect_test _ =
       function odd(x){return caml_trampoline(odd$0(x))}
       function even(x){return caml_trampoline(even$0(x))}
       var _c_=even(1);
-      if(odd(1) !== _c_)
-       try
-        {odd(5000);var _d_=log_success(0);return _d_}
-       catch(_e_){return caml_call1(log_failure,cst_too_much_recursion)}
-      throw [0,Assert_failure,_b_]}
+      if(odd(1) === _c_)throw [0,Assert_failure,_b_];
+      try
+       {odd(5000);var _d_=log_success(0);return _d_}
+      catch(_e_){return caml_call1(log_failure,cst_too_much_recursion)}}
     //end |}]

--- a/compiler/tests-compiler/util/util.ml
+++ b/compiler/tests-compiler/util/util.ml
@@ -360,6 +360,9 @@ let program_to_string ?(compact = false) p =
   let pp = Jsoo.Pretty_print.to_buffer buffer in
   Jsoo.Pretty_print.set_compact pp compact;
   Jsoo.Js_output.program pp p;
+  (* This final comment should help to keep merge-confict inside
+     {| .. |}, allowing to resolve confict with [dune promote]. *)
+  Buffer.add_string buffer "//end\n";
   Buffer.contents buffer
 
 let expression_to_string ?(compact = false) e =

--- a/compiler/tests-compiler/variable_declaration_output.ml
+++ b/compiler/tests-compiler/variable_declaration_output.ml
@@ -48,14 +48,20 @@ let%expect_test _ =
   [%expect
     {|
     var ex = [0,5,"hello","the \xe2\x80\xa2 and \xe2\x80\xba characters"];
+    //end
     var sx = [0,
      "hello2",
      runtime.caml_jsstring_of_string
       ("the \xe2\x80\xa2 and \xe2\x80\xba characters (2)")];
+    //end
     var ax = [0,1,2,3,4];
+    //end
     var bx = [254,1.,2.,3.,4.];
+    //end
     var cx = [254,NaN,NaN,Infinity,- Infinity,0.,- 0.];
-    var symbol_op = [0,symbol_bind,symbol_map,symbol]; |}]
+    //end
+    var symbol_op = [0,symbol_bind,symbol_map,symbol];
+    //end |}]
 
 let%expect_test _ =
   let program =
@@ -88,11 +94,17 @@ let%expect_test _ =
      5,
      caml_string_of_jsbytes("hello"),
      caml_string_of_jsbytes("the \xe2\x80\xa2 and \xe2\x80\xba characters")];
+    //end
     var sx = [0,cst_hello2,runtime.caml_jsstring_of_string(cst_the_and_characters_2)];
+    //end
     var ax = [0,1,2,3,4];
+    //end
     var bx = [254,1.,2.,3.,4.];
+    //end
     var cx = [254,NaN,NaN,Infinity,- Infinity,0.,- 0.];
-    var symbol_op = [0,symbol_bind,symbol_map,symbol]; |}]
+    //end
+    var symbol_op = [0,symbol_bind,symbol_map,symbol];
+    //end |}]
 
 let%expect_test _ =
   let compile ~enable s =
@@ -132,7 +144,8 @@ let%expect_test _ =
           switch$1 = 0;
           if(! _c_ || _c_[1])switch$1 = 1;
           if(switch$1)return 4}}
-      return 1} |}];
+      return 1}
+    //end |}];
   with_temp_dir ~f:(fun () -> print_fun_decl (program ~enable:false) (Some "match_expr"));
   [%expect
     {|
@@ -151,4 +164,5 @@ let%expect_test _ =
          {var _c_=param[2],switch$1=0;
           if(! _c_ || _c_[1])switch$1 = 1;
           if(switch$1)return 4}}
-      return 1} |}]
+      return 1}
+    //end |}]


### PR DESCRIPTION
- rewrite `! (a > b)` into `(a<=b)` when applied to integers  (for other comparison ops)
- remove trailing `continue` statement in for-loops
- improve `Js_simpl.if_statement` to decrease nesting.