### PR TITLE
Apply functions: optimizations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
   Feature is disabled by default while dune rules are being fixed. Enable with --enable=auto-link.
 * Compiler: specialize string to js-string conversion for all valid utf8 strings (previously just ascii)
 * Compiler: use identifier for object literals when possible
+* Compiler: Cache function arity (the length prop of a function is slow with v8)
 
 ## Bug fixes
 - Effects: fix Js.export and Js.export_all to work with functions

--- a/compiler/lib/generate.ml
+++ b/compiler/lib/generate.ml
@@ -981,8 +981,17 @@ let apply_fun_raw ctx f params exact cps =
     if exact
     then apply_directly
     else
+      let l = Utf8_string.of_string_exn "l" in
       J.ECond
-        ( J.EBin (J.EqEq, J.EDot (f, Utf8_string.of_string_exn "length"), int n)
+        ( J.EBin
+            ( J.EqEq
+            , J.EBin
+                ( J.Or
+                , J.EDot (f, l)
+                , J.EBin
+                    (J.Eq, J.EDot (f, l), J.EDot (f, Utf8_string.of_string_exn "length"))
+                )
+            , int n )
         , apply_directly
         , ecall
             (runtime_fun ctx "caml_call_gen")

--- a/compiler/lib/generate.ml
+++ b/compiler/lib/generate.ml
@@ -985,8 +985,8 @@ let apply_fun_raw ctx f params exact cps =
       J.ECond
         ( J.EBin
             ( J.EqEq
-            , J.EBin
-                ( J.Or
+            , J.ECond
+                ( J.EBin (J.Ge, J.EDot (f, l), int 0)
                 , J.EDot (f, l)
                 , J.EBin
                     (J.Eq, J.EDot (f, l), J.EDot (f, Utf8_string.of_string_exn "length"))

--- a/compiler/tests-compiler/call_gen.ml
+++ b/compiler/tests-compiler/call_gen.ml
@@ -82,10 +82,14 @@ module M1 = struct
     function m(_e_,_f_){return k(_d_,_c_,_e_,_f_)}
     //end
     function caml_call1(f,a0)
-     {return f.length == 1?f(a0):runtime.caml_call_gen(f,[a0])}
+     {return (f.l >= 0?f.l:f.l = f.length) == 1
+              ?f(a0)
+              :runtime.caml_call_gen(f,[a0])}
     //end
     function caml_call2(f,a0,a1)
-     {return f.length == 2?f(a0,a1):runtime.caml_call_gen(f,[a0,a1])}
+     {return (f.l >= 0?f.l:f.l = f.length) == 2
+              ?f(a0,a1)
+              :runtime.caml_call_gen(f,[a0,a1])}
     //end
     |}]
 end

--- a/compiler/tests-compiler/effects_toplevel.ml
+++ b/compiler/tests-compiler/effects_toplevel.ml
@@ -47,7 +47,9 @@ let%expect_test "test-compiler/lib-effects/test1.ml" =
                   :runtime.caml_trampoline_return(f,[a0])}
         function caml_cps_call2(f,a0,a1)
          {return runtime.caml_stack_check_depth()
-                  ?f.length == 2?f(a0,a1):runtime.caml_call_gen(f,[a0,a1])
+                  ?(f.l >= 0?f.l:f.l = f.length) == 2
+                    ?f(a0,a1)
+                    :runtime.caml_call_gen(f,[a0,a1])
                   :runtime.caml_trampoline_return(f,[a0,a1])}
         function caml_cps_exact_call2(f,a0,a1)
          {return runtime.caml_stack_check_depth()

--- a/compiler/tests-compiler/gh1051.ml
+++ b/compiler/tests-compiler/gh1051.ml
@@ -35,6 +35,8 @@ let%expect_test _ =
     {|
     Warning: integer overflow: integer 0xffffffff (4294967295) truncated to 0xffffffff (-1); the generated code might be incorrect.
     function caml_call2(f,a0,a1)
-     {return f.length == 2?f(a0,a1):runtime.caml_call_gen(f,[a0,a1])}
+     {return (f.l >= 0?f.l:f.l = f.length) == 2
+              ?f(a0,a1)
+              :runtime.caml_call_gen(f,[a0,a1])}
     //end |}];
   ()

--- a/compiler/tests-compiler/gh1354.ml
+++ b/compiler/tests-compiler/gh1354.ml
@@ -50,7 +50,9 @@ with Exit ->
          runtime=globalThis.jsoo_runtime,
          caml_wrap_exception=runtime.caml_wrap_exception;
         function caml_call2(f,a0,a1)
-         {return f.length == 2?f(a0,a1):runtime.caml_call_gen(f,[a0,a1])}
+         {return (f.l >= 0?f.l:f.l = f.length) == 2
+                  ?f(a0,a1)
+                  :runtime.caml_call_gen(f,[a0,a1])}
         var
          global_data=runtime.caml_get_global_data(),
          Stdlib=global_data.Stdlib,
@@ -108,7 +110,9 @@ with Exit ->
          caml_string_of_jsbytes=runtime.caml_string_of_jsbytes,
          caml_wrap_exception=runtime.caml_wrap_exception;
         function caml_call3(f,a0,a1,a2)
-         {return f.length == 3?f(a0,a1,a2):runtime.caml_call_gen(f,[a0,a1,a2])}
+         {return (f.l >= 0?f.l:f.l = f.length) == 3
+                  ?f(a0,a1,a2)
+                  :runtime.caml_call_gen(f,[a0,a1,a2])}
         var
          global_data=runtime.caml_get_global_data(),
          Stdlib=global_data.Stdlib,
@@ -179,7 +183,9 @@ with Exit ->
          caml_string_of_jsbytes=runtime.caml_string_of_jsbytes,
          caml_wrap_exception=runtime.caml_wrap_exception;
         function caml_call2(f,a0,a1)
-         {return f.length == 2?f(a0,a1):runtime.caml_call_gen(f,[a0,a1])}
+         {return (f.l >= 0?f.l:f.l = f.length) == 2
+                  ?f(a0,a1)
+                  :runtime.caml_call_gen(f,[a0,a1])}
         var
          global_data=runtime.caml_get_global_data(),
          Stdlib=global_data.Stdlib,

--- a/lib/tests/dune.inc
+++ b/lib/tests/dune.inc
@@ -32,7 +32,7 @@
 (library
  ;; lib/tests/test_fun_call.ml
  (name test_fun_call_75)
- (enabled_if true)
+ (enabled_if (<> %{profile} using-effects))
  (modules test_fun_call)
  (libraries js_of_ocaml unix)
  (inline_tests (modes js))

--- a/lib/tests/gen-rules/gen.ml
+++ b/lib/tests/gen-rules/gen.ml
@@ -47,10 +47,12 @@ let prefix : string =
 
 type enabled_if =
   | GE5
+  | No_effects
   | Any
 
 let enabled_if = function
   | "test_sys" -> GE5
+  | "test_fun_call" -> No_effects
   | _ -> Any
 
 let () =
@@ -77,5 +79,6 @@ let () =
            (Hashtbl.hash prefix mod 100)
            (match enabled_if basename with
            | Any -> "true"
-           | GE5 -> "(>= %{ocaml_version} 5)")
+           | GE5 -> "(>= %{ocaml_version} 5)"
+           | No_effects -> "(<> %{profile} using-effects)")
            basename)

--- a/lib/tests/test_fun_call.ml
+++ b/lib/tests/test_fun_call.ml
@@ -28,7 +28,7 @@ let s x =
     if(x === undefined)
       return "undefined"
     if(typeof x === "function")
-      return "function#" + x.length
+      return "function#" + x.length + "#" + x.l
     if(x.toString() == "[object Arguments]")
       return "(Arguments: " + Array.prototype.slice.call(x).toString() + ")";
     return x.toString()
@@ -96,7 +96,7 @@ let%expect_test "partial application, 0 argument call is treated like 1 argument
 let%expect_test _ =
   let plus = Js.wrap_callback (fun a b -> a + b) in
   call_and_log plus {| (function(f){ return f(1) }) |};
-  [%expect {| Result: function#0 |}];
+  [%expect {| Result: function#0#undefined |}];
   call_and_log plus {| (function(f){ return f(1)(2) }) |};
   [%expect {| Result: 3 |}];
   call_and_log plus {| (function(f){ return f(1,2) }) |};
@@ -147,7 +147,7 @@ let%expect_test "wrap_callback_strict" =
     (Js.Unsafe.callback_with_arity 2 cb3)
     {| (function(f){ return f(1,2,3) }) |};
   [%expect {|
-    Result: function#0 |}];
+    Result: function#1#1 |}];
   call_and_log
     (Js.Unsafe.callback_with_arity 2 cb3)
     ~cont:(fun g -> g 4)
@@ -164,7 +164,7 @@ let%expect_test "wrap_callback_strict" =
     Result: 0 |}];
   call_and_log (Js.Unsafe.callback_with_arity 2 cb3) {| (function(f){ return f(1,2) }) |};
   [%expect {|
-    Result: function#0 |}]
+    Result: function#1#1 |}]
 
 let%expect_test "wrap_callback_strict" =
   call_and_log
@@ -238,7 +238,7 @@ let%expect_test "partial application, 0 argument call is treated 1 argument (und
 let%expect_test _ =
   let plus = Js.wrap_meth_callback (fun _ a b -> a + b) in
   call_and_log plus {| (function(f){ return f(1) }) |};
-  [%expect {| Result: function#0 |}];
+  [%expect {| Result: function#0#undefined |}];
   call_and_log plus {| (function(f){ return f(1)(2) }) |};
   [%expect {| Result: 3 |}];
   call_and_log plus {| (function(f){ return f(1,2) }) |};
@@ -291,7 +291,7 @@ let%expect_test "wrap_meth_callback_strict" =
     (Js.Unsafe.meth_callback_with_arity 2 cb4)
     {| (function(f){ return f.apply("this",[1,2,3]) }) |};
   [%expect {|
-    Result: function#0 |}];
+    Result: function#1#1 |}];
   call_and_log
     (Js.Unsafe.meth_callback_with_arity 2 cb4)
     ~cont:(fun g -> g 4)
@@ -309,7 +309,7 @@ let%expect_test "wrap_meth_callback_strict" =
   call_and_log
     (Js.Unsafe.meth_callback_with_arity 2 cb4)
     {| (function(f){ return f.apply("this",[1,2]) }) |};
-  [%expect {| Result: function#0 |}]
+  [%expect {| Result: function#1#1 |}]
 
 let%expect_test "wrap_meth_callback_strict" =
   call_and_log
@@ -354,7 +354,7 @@ let%expect_test "partial application, extra arguments set to undefined" =
 let%expect_test _ =
   call_and_log cb3 ~cont:(fun g -> g 1) {| (function(f){ return f }) |};
   [%expect {|
-    Result: function#0 |}]
+    Result: function#2#2 |}]
 
 let%expect_test _ =
   call_and_log cb3 ~cont:(fun g -> g 1 2 3 4) {| (function(f){ return f }) |};
@@ -369,7 +369,7 @@ let%expect_test _ =
     | _ -> Printf.printf "Error: unknown"
   in
   f cb5;
-  [%expect {| Result: function#0 |}];
+  [%expect {| Result: function#1#1 |}];
   f cb4;
   [%expect {|
     got 1, 1, 2, 3, done
@@ -399,7 +399,7 @@ let%expect_test _ =
     Result: 0 |}];
   f (Obj.magic cb4);
   [%expect {|
-    Result: function#0 |}];
+    Result: function#1#1 |}];
   f (Obj.magic cb5);
   [%expect {|
-    Result: function#0 |}]
+    Result: function#2#2 |}]

--- a/runtime/jslib.js
+++ b/runtime/jslib.js
@@ -375,7 +375,7 @@ function caml_js_wrap_meth_callback_unsafe(f) {
 //Provides: caml_js_function_arity
 //If: !effects
 function caml_js_function_arity(f) {
-  return f.length
+  return (f.l >= 0)?f.l:(f.l = f.length)
 }
 
 //Provides: caml_js_function_arity
@@ -383,7 +383,7 @@ function caml_js_function_arity(f) {
 function caml_js_function_arity(f) {
   // Functions have an additional continuation parameter. This should
   // not be visible when calling them from JavaScript
-  return f.length - 1
+  return ((f.l >= 0)?f.l:(f.l = f.length)) - 1
 }
 
 //Provides: caml_js_equals mutable (const, const)

--- a/runtime/stdlib.js
+++ b/runtime/stdlib.js
@@ -25,7 +25,7 @@ function caml_call_gen(f, args) {
     return caml_call_gen(f.fun, args);
   //FIXME, can happen with too many arguments
   if(typeof f !== "function") return f;
-  var n = f.length | 0;
+  var n = (f.l >= 0)?f.l:(f.l = f.length);
   if(n === 0) return f.apply(null,args);
   var argsLen = args.length | 0;
   var d = n - argsLen | 0;
@@ -76,7 +76,7 @@ function caml_call_gen(f, args) {
   if (f.fun)
     return caml_call_gen(f.fun, args);
   if (typeof f !== "function") return args[args.length-1](f);
-  var n = f.length | 0;
+  var n = (f.l >= 0)?f.l:(f.l = f.length);
   if (n === 0) return f.apply(null, args);
   var argsLen = args.length | 0;
   var d = n - argsLen | 0;

--- a/runtime/stdlib.js
+++ b/runtime/stdlib.js
@@ -35,13 +35,35 @@ function caml_call_gen(f, args) {
     return caml_call_gen(f.apply(null,args.slice(0,n)),args.slice(n));
   }
   else {
-    var g = function (){
-      var extra_args = (arguments.length == 0)?1:arguments.length;
-      var nargs = new Array(args.length+extra_args);
-      for(var i = 0; i < args.length; i++ ) nargs[i] = args[i];
-      for(var i = 0; i < arguments.length; i++ ) nargs[args.length+i] = arguments[i];
-      return caml_call_gen(f, nargs)
-    };
+    switch (d) {
+    case 1: {
+      var g = function (x){
+        var nargs = new Array(argsLen + 1);
+        for(var i = 0; i < argsLen; i++ ) nargs[i] = args[i];
+        nargs[argsLen] = x;
+        return f.apply(null, nargs)
+      };
+      break;
+    }
+    case 2: {
+      var g = function (x, y){
+        var nargs = new Array(argsLen + 2);
+        for(var i = 0; i < argsLen; i++ ) nargs[i] = args[i];
+        nargs[argsLen] = x;
+        nargs[argsLen + 1] = y;
+        return f.apply(null, nargs)
+      };
+      break;
+    }
+    default: {
+      var g = function (){
+        var extra_args = (arguments.length == 0)?1:arguments.length;
+        var nargs = new Array(args.length+extra_args);
+        for(var i = 0; i < args.length; i++ ) nargs[i] = args[i];
+        for(var i = 0; i < arguments.length; i++ ) nargs[args.length+i] = arguments[i];
+        return caml_call_gen(f, nargs)
+      };
+    }}
     g.l = d;
     return g;
   }
@@ -72,15 +94,39 @@ function caml_call_gen(f, args) {
   } else {
     argsLen--;
     var k = args [argsLen];
-    var g = function (){
-      var extra_args = (arguments.length == 0)?1:arguments.length;
-      var nargs = new Array(argsLen + extra_args);
-      for(var i = 0; i < argsLen; i++ ) nargs[i] = args[i];
-      for(var i = 0; i < arguments.length; i++ )
-        nargs[argsLen + i] = arguments[i];
-      return caml_call_gen(f, nargs)
-    };
-    g.l = d;
+    switch (d) {
+    case 1: {
+      var g = function (x, y){
+        var nargs = new Array(argsLen + 2);
+        for(var i = 0; i < argsLen; i++ ) nargs[i] = args[i];
+        nargs[argsLen] = x;
+        nargs[argsLen + 1] = y;
+        return f.apply(null, nargs)
+      };
+      break;
+    }
+    case 2: {
+      var g = function (x, y, z){
+        var nargs = new Array(argsLen + 3);
+        for(var i = 0; i < argsLen; i++ ) nargs[i] = args[i];
+        nargs[argsLen] = x;
+        nargs[argsLen + 1] = y;
+        nargs[argsLen + 2] = z;
+        return f.apply(null, nargs)
+      };
+      break;
+    }
+    default: {
+      var g = function (){
+        var extra_args = (arguments.length == 0)?1:arguments.length;
+        var nargs = new Array(argsLen + extra_args);
+        for(var i = 0; i < argsLen; i++ ) nargs[i] = args[i];
+        for(var i = 0; i < arguments.length; i++ )
+          nargs[argsLen + i] = arguments[i];
+        return caml_call_gen(f, nargs)
+      };
+    }}
+    g.l = d + 1;
     return k(g);
   }
 }

--- a/runtime/stdlib.js
+++ b/runtime/stdlib.js
@@ -35,13 +35,15 @@ function caml_call_gen(f, args) {
     return caml_call_gen(f.apply(null,args.slice(0,n)),args.slice(n));
   }
   else {
-    return function (){
+    var g = function (){
       var extra_args = (arguments.length == 0)?1:arguments.length;
       var nargs = new Array(args.length+extra_args);
       for(var i = 0; i < args.length; i++ ) nargs[i] = args[i];
       for(var i = 0; i < arguments.length; i++ ) nargs[args.length+i] = arguments[i];
       return caml_call_gen(f, nargs)
-    }
+    };
+    g.l = d;
+    return g;
   }
 }
 
@@ -70,14 +72,16 @@ function caml_call_gen(f, args) {
   } else {
     argsLen--;
     var k = args [argsLen];
-    return k (function () {
+    var g = function (){
       var extra_args = (arguments.length == 0)?1:arguments.length;
       var nargs = new Array(argsLen + extra_args);
       for(var i = 0; i < argsLen; i++ ) nargs[i] = args[i];
       for(var i = 0; i < arguments.length; i++ )
         nargs[argsLen + i] = arguments[i];
       return caml_call_gen(f, nargs)
-    });
+    };
+    g.l = d;
+    return k(g);
   }
 }
 

--- a/runtime/stdlib_modern.js
+++ b/runtime/stdlib_modern.js
@@ -33,13 +33,15 @@ function caml_call_gen(f, args) {
     return caml_call_gen(f(...args.slice(0,n)),args.slice(n));
   }
   else {
-    return function (){
+    var g = function (){
       var extra_args = (arguments.length == 0)?1:arguments.length;
       var nargs = new Array(args.length+extra_args);
       for(var i = 0; i < args.length; i++ ) nargs[i] = args[i];
       for(var i = 0; i < arguments.length; i++ ) nargs[args.length+i] = arguments[i];
       return caml_call_gen(f, nargs)
-    }
+    };
+    g.l = d;
+    return g;
   }
 }
 
@@ -68,13 +70,15 @@ function caml_call_gen(f, args) {
   } else {
     argsLen--;
     var k = args [argsLen];
-    return k (function () {
+    var g = function (){
       var extra_args = (arguments.length == 0)?1:arguments.length;
       var nargs = new Array(argsLen + extra_args);
       for(var i = 0; i < argsLen; i++ ) nargs[i] = args[i];
       for(var i = 0; i < arguments.length; i++ )
         nargs[argsLen + i] = arguments[i];
       return caml_call_gen(f, nargs)
-    });
+    };
+    g.l = d;
+    return k(g);
   }
 }

--- a/runtime/stdlib_modern.js
+++ b/runtime/stdlib_modern.js
@@ -33,14 +33,36 @@ function caml_call_gen(f, args) {
     return caml_call_gen(f(...args.slice(0,n)),args.slice(n));
   }
   else {
-    var g = function (){
-      var extra_args = (arguments.length == 0)?1:arguments.length;
-      var nargs = new Array(args.length+extra_args);
-      for(var i = 0; i < args.length; i++ ) nargs[i] = args[i];
-      for(var i = 0; i < arguments.length; i++ ) nargs[args.length+i] = arguments[i];
-      return caml_call_gen(f, nargs)
-    };
-    g.l = d;
+    switch (d) {
+    case 1: {
+      var g = function (x){
+        var nargs = new Array(argsLen + 1);
+        for(var i = 0; i < argsLen; i++ ) nargs[i] = args[i];
+        nargs[argsLen] = x;
+        return f.apply(null, nargs)
+      };
+      break;
+    }
+    case 2: {
+      var g = function (x, y){
+        var nargs = new Array(argsLen + 2);
+        for(var i = 0; i < argsLen; i++ ) nargs[i] = args[i];
+        nargs[argsLen] = x;
+        nargs[argsLen + 1] = y;
+        return f.apply(null, nargs)
+      };
+      break;
+    }
+    default: {
+      var g = function (){
+        var extra_args = (arguments.length == 0)?1:arguments.length;
+        var nargs = new Array(args.length+extra_args);
+        for(var i = 0; i < args.length; i++ ) nargs[i] = args[i];
+        for(var i = 0; i < arguments.length; i++ ) nargs[args.length+i] = arguments[i];
+        return caml_call_gen(f, nargs)
+      };
+    }}
+    g.l = d + 1;
     return g;
   }
 }
@@ -70,15 +92,39 @@ function caml_call_gen(f, args) {
   } else {
     argsLen--;
     var k = args [argsLen];
-    var g = function (){
-      var extra_args = (arguments.length == 0)?1:arguments.length;
-      var nargs = new Array(argsLen + extra_args);
-      for(var i = 0; i < argsLen; i++ ) nargs[i] = args[i];
-      for(var i = 0; i < arguments.length; i++ )
-        nargs[argsLen + i] = arguments[i];
-      return caml_call_gen(f, nargs)
-    };
-    g.l = d;
+    switch (d) {
+    case 1: {
+      var g = function (x, y){
+        var nargs = new Array(argsLen + 2);
+        for(var i = 0; i < argsLen; i++ ) nargs[i] = args[i];
+        nargs[argsLen] = x;
+        nargs[argsLen + 1] = y;
+        return f.apply(null, nargs)
+      };
+      break;
+    }
+    case 2: {
+      var g = function (x, y, z){
+        var nargs = new Array(argsLen + 3);
+        for(var i = 0; i < argsLen; i++ ) nargs[i] = args[i];
+        nargs[argsLen] = x;
+        nargs[argsLen + 1] = y;
+        nargs[argsLen + 2] = z;
+        return f.apply(null, nargs)
+      };
+      break;
+    }
+    default: {
+      var g = function (){
+        var extra_args = (arguments.length == 0)?1:arguments.length;
+        var nargs = new Array(argsLen + extra_args);
+        for(var i = 0; i < argsLen; i++ ) nargs[i] = args[i];
+        for(var i = 0; i < arguments.length; i++ )
+          nargs[argsLen + i] = arguments[i];
+        return caml_call_gen(f, nargs)
+      };
+    }}
+    g.l = d + 1;
     return k(g);
   }
 }

--- a/runtime/stdlib_modern.js
+++ b/runtime/stdlib_modern.js
@@ -23,7 +23,7 @@ function caml_call_gen(f, args) {
     return caml_call_gen(f.fun, args);
   //FIXME, can happen with too many arguments
   if(typeof f !== "function") return f;
-  var n = f.length | 0;
+  var n = (f.l >= 0)?f.l:(f.l = f.length);
   if(n === 0) return f(...args);
   var argsLen = args.length | 0;
   var d = n - argsLen | 0;
@@ -74,7 +74,7 @@ function caml_call_gen(f, args) {
     return caml_call_gen(f.fun, args);
   //FIXME, can happen with too many arguments
   if(typeof f !== "function") return args[args.length-1](f);
-  var n = f.length | 0;
+  var n = (f.l >= 0)?f.l:(f.l = f.length);
   if(n === 0) return f(...args);
   var argsLen = args.length | 0;
   var d = n - argsLen | 0;


### PR DESCRIPTION
Getting the arity of a function is slow with `v8`. On Chrome, function `p` is about ten times slower than function `q`:
```javascript
function f (x) {}
f.l = 1;
var s = 0;
function p() {for (i = 0; i < 100000000; i++) { ((f.length)==1?s+=1:0)} }
function q(){for (i = 0; i < 100000000; i++) { ((f.l)==1?s+=1:0)}}
p(); q()
```
![image](https://user-images.githubusercontent.com/2060632/208249167-8455b907-4fd7-4418-a18c-ac588b49c89a.png)

`node` takes 3.1s to execute this piece of code without this optimization and 1.3s with it (and 0,8s when manually removing the call to `caml_call1`).
```ocaml
let l = List.of_seq (Seq.init 10000 (fun i -> i))
let s = ref 0
let f x = s := !s + x
let iter f  = for i = 1 to 10000 do List.iter f l; s := 0; List.iter f l done
let () = iter f
```

I have known about this issue for a long time. I was considering wrapping functions inside an object: `{arity:2,fun:function(...){..}}`, with some optimization for when the function is statically known. But that would had been a large change with some impact on the generated code size and of lot of added complexity in the `Js_of_ocaml` compiler. This change seems to address the issue at a very low cost.

Related issue:  #1246