### PR TITLE
Cache function length correctly in stdlib_modern.js

### DIFF
--- a/compiler/tests-compiler/gh1051.ml
+++ b/compiler/tests-compiler/gh1051.ml
@@ -26,6 +26,7 @@ let%expect_test _ =
   [%expect
     {|
 Warning: integer overflow: integer 0xffffffff (4294967295) truncated to 0xffffffff (-1); the generated code might be incorrect.
+Warning: integer overflow: integer 0xffffffff (4294967295) truncated to 0xffffffff (-1); the generated code might be incorrect.
 ffffffff |}];
   ()
 

--- a/compiler/tests-compiler/unix_fs.ml
+++ b/compiler/tests-compiler/unix_fs.ml
@@ -320,7 +320,10 @@ let f () =
     read dh;
     Unix.closedir dh;
     fail Unix.rewinddir dh;
-    fail Unix.readdir dh
+    fail Unix.readdir dh;
+    Sys.remove "aaa/bbb";
+    Sys.remove "aaa/ccc";
+    Sys.rmdir "aaa"
   with e -> print_endline  (Printexc.to_string (norm e))
 let () = f (); Sys.chdir "/static"; f () |};
   [%expect
@@ -404,7 +407,11 @@ let f () =
     read dh;
     Unix.closedir dh;
     fail Unix.rewinddir dh;
-    fail Unix.readdir dh
+    fail Unix.readdir dh;
+    Sys.remove "bbb";
+    Sys.remove "ccc";
+    Sys.chdir "..";
+    Sys.rmdir "aaa"
   with e -> print_endline  (Printexc.to_string (norm e))
 let () = f (); Sys.chdir "/static"; f () |};
   [%expect

--- a/runtime/stdlib_modern.js
+++ b/runtime/stdlib_modern.js
@@ -62,7 +62,7 @@ function caml_call_gen(f, args) {
         return caml_call_gen(f, nargs)
       };
     }}
-    g.l = d + 1;
+    g.l = d;
     return g;
   }
 }


### PR DESCRIPTION
This fixes a bug in `stdlib_modern.js` that slipped in via https://github.com/ocsigen/js_of_ocaml/commit/23f4f71a9bdf77e4b2adac1ddee7d23471e7cbb4. Perhaps this repository should run the tests under both `stdlib.js` and `stdlib_modern.js`, so that bugs like this get caught earlier.