### PR TITLE
Make tests clean up files they create

### DIFF
--- a/compiler/tests-compiler/empty_cma.ml
+++ b/compiler/tests-compiler/empty_cma.ml
@@ -27,4 +27,5 @@ let%expect_test _ =
   |> print_endline;
   Sys.remove "empty.cma";
   Sys.remove "empty.js";
+  Sys.remove "empty.map";
   [%expect {| //# sourceMappingURL=empty.map |}]

--- a/compiler/tests-jsoo/test_io.ml
+++ b/compiler/tests-jsoo/test_io.ml
@@ -99,4 +99,5 @@ let%expect_test _ =
   close_out oc;
   print_endline (file_contents fname);
   [%expect {| this is a test |}];
+  Sys.remove "file2.txt";
   ()


### PR DESCRIPTION
This PR upstreams some diffs we maintain internally to satisfy our build system. While these extra files don't bother dune, it seems better to me for tests to leave the filesystem the way they found it.