### PR TITLE
Clean-up caml_call_gen

### DIFF
--- a/runtime/stdlib.js
+++ b/runtime/stdlib.js
@@ -21,18 +21,15 @@
 //If: !effects
 //Weakdef
 function caml_call_gen(f, args) {
-  if(f.fun)
-    return caml_call_gen(f.fun, args);
-  //FIXME, can happen with too many arguments
-  if(typeof f !== "function") return f;
   var n = (f.l >= 0)?f.l:(f.l = f.length);
-  if(n === 0) return f.apply(null,args);
-  var argsLen = args.length | 0;
-  var d = n - argsLen | 0;
+  var argsLen = args.length;
+  var d = n - argsLen;
   if (d == 0)
     return f.apply(null, args);
   else if (d < 0) {
-    return caml_call_gen(f.apply(null,args.slice(0,n)),args.slice(n));
+    var g = f.apply(null,args.slice(0,n));
+    if(typeof g !== "function") return g;
+    return caml_call_gen(g,args.slice(n));
   }
   else {
     switch (d) {
@@ -73,13 +70,9 @@ function caml_call_gen(f, args) {
 //If: effects
 //Weakdef
 function caml_call_gen(f, args) {
-  if (f.fun)
-    return caml_call_gen(f.fun, args);
-  if (typeof f !== "function") return args[args.length-1](f);
   var n = (f.l >= 0)?f.l:(f.l = f.length);
-  if (n === 0) return f.apply(null, args);
-  var argsLen = args.length | 0;
-  var d = n - argsLen | 0;
+  var argsLen = args.length;
+  var d = n - argsLen;
   if (d == 0) {
     return f.apply(null, args);
   } else if (d < 0) {
@@ -87,6 +80,7 @@ function caml_call_gen(f, args) {
     var k = args [argsLen - 1];
     args = args.slice(0, n);
     args[n - 1] = function (g) {
+      if (typeof g !== "function") return k(g);
       var args = rest.slice();
       args[args.length - 1] = k;
       return caml_call_gen(g, args); };

--- a/runtime/stdlib_modern.js
+++ b/runtime/stdlib_modern.js
@@ -19,18 +19,15 @@
 //Provides: caml_call_gen (const, shallow)
 //If: !effects
 function caml_call_gen(f, args) {
-  if(f.fun)
-    return caml_call_gen(f.fun, args);
-  //FIXME, can happen with too many arguments
-  if(typeof f !== "function") return f;
   var n = (f.l >= 0)?f.l:(f.l = f.length);
-  if(n === 0) return f(...args);
-  var argsLen = args.length | 0;
-  var d = n - argsLen | 0;
+  var argsLen = args.length;
+  var d = n - argsLen;
   if (d == 0)
     return f(...args);
   else if (d < 0) {
-    return caml_call_gen(f(...args.slice(0,n)),args.slice(n));
+    var g = f(...args.slice(0,n));
+    if(typeof g !== "function") return g;
+    return caml_call_gen(g,args.slice(n));
   }
   else {
     switch (d) {
@@ -70,14 +67,9 @@ function caml_call_gen(f, args) {
 //Provides: caml_call_gen (const, shallow)
 //If: effects
 function caml_call_gen(f, args) {
-  if(f.fun)
-    return caml_call_gen(f.fun, args);
-  //FIXME, can happen with too many arguments
-  if(typeof f !== "function") return args[args.length-1](f);
   var n = (f.l >= 0)?f.l:(f.l = f.length);
-  if(n === 0) return f(...args);
-  var argsLen = args.length | 0;
-  var d = n - argsLen | 0;
+  var argsLen = args.length;
+  var d = n - argsLen;
   if (d == 0)
     return f(...args);
   else if (d < 0) {
@@ -85,6 +77,7 @@ function caml_call_gen(f, args) {
     var k = args [argsLen - 1];
     args = args.slice(0, n);
     args[n - 1] = function (g) {
+      if(typeof g !== "function") return k(g);
       var args = rest.slice();
       args[args.length - 1] = k;
       return caml_call_gen(g, args); };


### PR DESCRIPTION
- We don't need to check for `f.fun` since, when it is set, function `f` is a wrapper that calls `f.fun`.
- We only need to check whether we still have a function in the over application case (`d < 0').
- We don't need a special case for `n === 0` since we now explictly set `f.l` for under-applied functions