### PR TITLE
Control flow analysis: fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
 ## Bug fixes
 - Effects: fix Js.export and Js.export_all to work with functions
 - Sourcemap: fix incorrect sourcemap with separate compilation
+- Compiler: fix control flow analysis; some annotions were wrong in the runtime
 
 # 5.0.1 (2022-12-20) - Lille
 ## Features/Changes

--- a/compiler/lib/flow.ml
+++ b/compiler/lib/flow.ml
@@ -193,6 +193,7 @@ let expr_escape st _x e =
   match e with
   | Constant _ | Closure _ | Block _ | Field _ -> ()
   | Apply { args; _ } -> List.iter args ~f:(fun x -> block_escape st x)
+  | Prim (Array_get, [ Pv x; _ ]) -> block_escape st x
   | Prim ((Vectlength | Array_get | Not | IsInt | Eq | Neq | Lt | Le | Ult), _) -> ()
   | Prim (Extern name, l) ->
       let ka =

--- a/compiler/tests-compiler/dune.inc
+++ b/compiler/tests-compiler/dune.inc
@@ -320,6 +320,22 @@
   (pps ppx_expect)))
 
 (library
+ ;; compiler/tests-compiler/gh1390.ml
+ (name gh1390_15)
+ (enabled_if true)
+ (modules gh1390)
+ (libraries js_of_ocaml_compiler unix str jsoo_compiler_expect_tests_helper)
+ (inline_tests
+  (enabled_if true)
+  (flags -allow-output-patterns)
+  (deps
+   (file %{project_root}/compiler/bin-js_of_ocaml/js_of_ocaml.exe)
+   (file %{project_root}/compiler/bin-jsoo_minify/jsoo_minify.exe)))
+ (flags (:standard -open Jsoo_compiler_expect_tests_helper))
+ (preprocess
+  (pps ppx_expect)))
+
+(library
  ;; compiler/tests-compiler/gl507.ml
  (name gl507_15)
  (enabled_if true)

--- a/compiler/tests-compiler/gh1390.ml
+++ b/compiler/tests-compiler/gh1390.ml
@@ -28,7 +28,7 @@ let%expect_test _ =
        x' := "OK";
        print_endline !x
     |};
-  [%expect {| BUG |}]
+  [%expect {| OK |}]
 
 let%expect_test _ =
   compile_and_run

--- a/compiler/tests-compiler/gh1390.ml
+++ b/compiler/tests-compiler/gh1390.ml
@@ -1,0 +1,65 @@
+(* Js_of_ocaml compiler
+ * http://www.ocsigen.org/js_of_ocaml/
+ * Copyright (C) 2019 Hugo Heuzard
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+
+open Util
+
+let%expect_test _ =
+  compile_and_run
+    {|
+       let x = ref "BUG" in
+       let y = [|x|]  in
+       let x' = Array.unsafe_get y 0 in
+       x' := "OK";
+       print_endline !x
+    |};
+  [%expect {| BUG |}]
+
+let%expect_test _ =
+  compile_and_run
+    {|
+       let x = ref "BUG" in
+       let y = [|x|]  in
+       let x' = y.(0) in
+       x' := "OK";
+       print_endline !x
+    |};
+  [%expect {| BUG |}]
+
+let%expect_test _ =
+  compile_and_run
+    {|
+       let x = ref "BUG" in
+       let y = Array.make 1 x  in
+       let x' = y.(0) in
+       x' := "OK";
+       print_endline !x
+    |};
+  [%expect {| BUG |}]
+
+let%expect_test _ =
+  compile_and_run
+    {|
+       let x = ref "BUG" in
+       let y = [|ref ""|] in
+       y.(0) <- x;
+       let x' = y.(0) in
+       x' := "OK";
+       print_endline !x
+    |};
+  [%expect {| BUG |}]

--- a/compiler/tests-compiler/gh1390.ml
+++ b/compiler/tests-compiler/gh1390.ml
@@ -39,7 +39,7 @@ let%expect_test _ =
        x' := "OK";
        print_endline !x
     |};
-  [%expect {| BUG |}]
+  [%expect {| OK |}]
 
 let%expect_test _ =
   compile_and_run
@@ -50,7 +50,7 @@ let%expect_test _ =
        x' := "OK";
        print_endline !x
     |};
-  [%expect {| BUG |}]
+  [%expect {| OK |}]
 
 let%expect_test _ =
   compile_and_run
@@ -62,4 +62,4 @@ let%expect_test _ =
        x' := "OK";
        print_endline !x
     |};
-  [%expect {| BUG |}]
+  [%expect {| OK |}]

--- a/runtime/array.js
+++ b/runtime/array.js
@@ -71,14 +71,14 @@ function caml_floatarray_blit(a1, i1, a2, i2, len) {
 }
 
 ///////////// Pervasive
-//Provides: caml_array_set (mutable, const, const)
+//Provides: caml_array_set (mutable, const, mutable)
 //Requires: caml_array_bound_error
 function caml_array_set (array, index, newval) {
   if ((index < 0) || (index >= array.length - 1)) caml_array_bound_error();
   array[index+1]=newval; return 0;
 }
 
-//Provides: caml_array_get mutable (const, const)
+//Provides: caml_array_get mutable (mutable, const)
 //Requires: caml_array_bound_error
 function caml_array_get (array, index) {
   if ((index < 0) || (index >= array.length - 1)) caml_array_bound_error();
@@ -93,14 +93,14 @@ function caml_array_fill(array, ofs, len, v){
   return 0;
 }
 
-//Provides: caml_check_bound (const, const)
+//Provides: caml_check_bound (mutable, const)
 //Requires: caml_array_bound_error
 function caml_check_bound (array, index) {
   if (index >>> 0 >= array.length - 1) caml_array_bound_error();
   return array;
 }
 
-//Provides: caml_make_vect const (const, const)
+//Provides: caml_make_vect const (const, mutable)
 //Requires: caml_array_bound_error
 function caml_make_vect (len, init) {
   if (len < 0) caml_array_bound_error();

--- a/runtime/fail.js
+++ b/runtime/fail.js
@@ -23,10 +23,10 @@ function caml_raise_constant (tag) { throw tag; }
 //Provides: caml_return_exn_constant (const)
 function caml_return_exn_constant (tag) { return tag; }
 
-//Provides: caml_raise_with_arg (const, const)
+//Provides: caml_raise_with_arg (const, mutable)
 function caml_raise_with_arg (tag, arg) { throw [0, tag, arg]; }
 
-//Provides: caml_raise_with_args (const, const)
+//Provides: caml_raise_with_args (const, mutable)
 function caml_raise_with_args (tag, args) { throw [0, tag].concat(args); }
 
 //Provides: caml_raise_with_string (const, const)

--- a/runtime/jslib.js
+++ b/runtime/jslib.js
@@ -23,9 +23,9 @@
 //Requires: caml_callback
 function caml_js_pure_expr (f) { return caml_callback(f, [0]); }
 
-//Provides: caml_js_set (mutable, const, const)
+//Provides: caml_js_set (mutable, const, mutable)
 function caml_js_set(o,f,v) { o[f]=v;return 0}
-//Provides: caml_js_get (const, const)
+//Provides: caml_js_get (mutable, const)
 function caml_js_get(o,f) { return o[f]; }
 //Provides: caml_js_delete (mutable, const)
 function caml_js_delete(o,f) { delete o[f]; return 0}
@@ -127,7 +127,7 @@ function caml_jsoo_flags_effects(unit){
   return FLAG("effects")
 }
 
-//Provides: caml_wrap_exception const (const)
+//Provides: caml_wrap_exception const (mutable)
 //Requires: caml_global_data,caml_string_of_jsstring,caml_named_value
 //Requires: caml_return_exn_constant
 function caml_wrap_exception(e) {
@@ -194,7 +194,7 @@ function caml_js_to_array(a) {
   return b;
 }
 
-//Provides: caml_list_of_js_array const (const)
+//Provides: caml_list_of_js_array const (mutable)
 function caml_list_of_js_array(a){
   var l = 0;
   for(var i=a.length - 1; i>=0; i--){
@@ -204,7 +204,7 @@ function caml_list_of_js_array(a){
   return l
 }
 
-//Provides: caml_list_to_js_array const (const)
+//Provides: caml_list_to_js_array const (mutable)
 function caml_list_to_js_array(l){
   var a = [];
   for(; l !== 0; l = l[2]) {
@@ -213,7 +213,7 @@ function caml_list_to_js_array(l){
   return a;
 }
 
-//Provides: caml_js_var mutable (const)
+//Provides: caml_js_var mutable
 //Requires: caml_jsstring_of_string
 function caml_js_var(x) {
   var x = caml_jsstring_of_string(x);

--- a/runtime/obj.js
+++ b/runtime/obj.js
@@ -62,7 +62,7 @@ function caml_obj_with_tag(tag,x) {
   return a;
 }
 
-//Provides: caml_obj_dup mutable (const)
+//Provides: caml_obj_dup mutable (mutable)
 function caml_obj_dup (x) {
   var l = x.length;
   var a = new Array(l);
@@ -100,7 +100,7 @@ function caml_obj_is_shared(x){
   return 1
 }
 
-//Provides: caml_lazy_make_forward const (const)
+//Provides: caml_lazy_make_forward const (mutable)
 function caml_lazy_make_forward (v) { return [250, v]; }
 
 ///////////// CamlinternalOO

--- a/runtime/stdlib.js
+++ b/runtime/stdlib.js
@@ -134,7 +134,7 @@ function caml_call_gen(f, args) {
 //Provides: caml_named_values
 var caml_named_values = {};
 
-//Provides: caml_register_named_value (const,const)
+//Provides: caml_register_named_value (const,mutable)
 //Requires: caml_named_values, caml_jsbytes_of_string
 function caml_register_named_value(nm,v) {
   caml_named_values[caml_jsbytes_of_string(nm)] = v;


### PR DESCRIPTION
We were not handling `Array.unsafe_get` correctly, and some annotations in the runtime were wrong.