### PR TITLE
Compiler: modernize js parser

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 * Compiler: Cache function arity (the length prop of a function is slow with v8)
 * Compiler: The js lexer is now utf8 aware, recognize and emit utf8 ident
 * Compiler: Update the js lexer with new number literal syntax
+* Compiler: update js parser to support most es6 feature (#1391)
 
 ## Bug fixes
 - Effects: fix Js.export and Js.export_all to work with functions

--- a/compiler/bin-jsoo_minify/jsoo_minify.ml
+++ b/compiler/bin-jsoo_minify/jsoo_minify.ml
@@ -70,10 +70,13 @@ let f { Cmd_arg.common; output_file; use_stdin; files } =
     let free = new Js_traverse.free in
     let (_ : Javascript.program) = free#program p in
     let toplevel_def_and_use =
-      Utf8_string_set.union free#get_def_name free#get_use_name
+      let state = free#state in
+      Javascript.IdentSet.union state.def_var state.use
     in
-    Utf8_string_set.iter
-      (fun (Utf8_string.Utf8 x) -> Var_printer.add_reserved x)
+    Javascript.IdentSet.iter
+      (function
+        | V _ -> ()
+        | S { name = Utf8_string.Utf8 x; _ } -> Var_printer.add_reserved x)
       toplevel_def_and_use;
     let true_ () = true in
     let open Config in

--- a/compiler/lib/dune
+++ b/compiler/lib/dune
@@ -35,9 +35,7 @@
   --unused-token
   T_AT
   --unused-token
-  T_POUND
-  --unused-token
-  T_TEMPLATE_PART))
+  T_POUND))
 
 (menhir
  (modules annot_parser)

--- a/compiler/lib/dune
+++ b/compiler/lib/dune
@@ -37,24 +37,6 @@
   --unused-token
   T_POUND
   --unused-token
-  T_PLING_PERIOD
-  --unused-token
-  T_PLING_PLING
-  --unused-token
-  T_OR_ASSIGN
-  --unused-token
-  T_AND_ASSIGN
-  --unused-token
-  T_NULLISH_ASSIGN
-  --unused-token
-  T_EXP
-  --unused-token
-  T_EXP_ASSIGN
-  --unused-token
-  T_ARROW
-  --unused-token
-  T_BIGINT
-  --unused-token
   T_TEMPLATE_PART))
 
 (menhir

--- a/compiler/lib/dune
+++ b/compiler/lib/dune
@@ -33,9 +33,7 @@
   --unused-token
   T_ERROR
   --unused-token
-  T_AT
-  --unused-token
-  T_POUND))
+  T_AT))
 
 (menhir
  (modules annot_parser)

--- a/compiler/lib/flow_lexer.mli
+++ b/compiler/lib/flow_lexer.mli
@@ -5,6 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  *)
 
+module Lex_mode : sig
+  type t =
+    | NORMAL
+    | BACKQUOTE
+    | REGEXP
+end
+
 module Parse_error : sig
   type t
 
@@ -40,5 +47,7 @@ val drop_line : Lex_env.t -> unit
 val regexp : Lex_env.t -> Lex_env.t * Lex_result.t
 
 val token : Lex_env.t -> Lex_env.t * Lex_result.t
+
+val lex : Lex_env.t -> Lex_env.t * Lex_result.t
 
 val is_valid_identifier_name : string -> bool

--- a/compiler/lib/flow_lexer.mli
+++ b/compiler/lib/flow_lexer.mli
@@ -12,15 +12,10 @@ module Parse_error : sig
 end
 
 module Loc : sig
-  type position =
-    { line : int
-    ; column : int
-    }
-
   type t =
     { source : string option
-    ; start : position
-    ; _end : position
+    ; start : Lexing.position
+    ; _end : Lexing.position
     }
 end
 

--- a/compiler/lib/javascript.ml
+++ b/compiler/lib/javascript.ml
@@ -222,11 +222,14 @@ and property_list = property list
 
 and property =
   | Property of property_name * expression
-  | PropertyGet of property_name * function_declaration
-  | PropertySet of property_name * function_declaration
-  | PropertyMethod of property_name * function_declaration
   | PropertySpread of expression
+  | PropertyMethod of property_name * method_
   | CoverInitializedName of early_error * ident * initialiser
+
+and method_ =
+  | MethodGet of function_declaration
+  | MethodSet of function_declaration
+  | Method of function_declaration
 
 and property_name =
   | PNI of identifier
@@ -247,6 +250,7 @@ and expression =
   | ENew of expression * arguments option
   | EVar of ident
   | EFun of ident option * function_declaration
+  | EClass of ident option * class_declaration
   | EArrow of function_declaration
   | EStr of Utf8_string.t
   | ETemplate of template
@@ -276,6 +280,7 @@ and statement =
   | Block of block
   | Variable_statement of variable_declaration_kind * variable_declaration list
   | Function_declaration of ident * function_declaration
+  | Class_declaration of ident * class_declaration
   | Empty_statement
   | Expression_statement of expression
   | If_statement of expression * (statement * location) * (statement * location) option
@@ -334,6 +339,20 @@ and function_kind =
   { async : bool
   ; generator : bool
   }
+
+and class_declaration =
+  { extends : expression option
+  ; body : class_element list
+  }
+
+and class_element =
+  | CEMethod of bool * class_element_name * method_
+  | CEField of bool * class_element_name * initialiser option
+  | CEStaticBLock of statement_list
+
+and class_element_name =
+  | PropName of property_name
+  | PrivName of ident
 
 and ('a, 'b) list_with_rest =
   { list : 'a list

--- a/compiler/lib/javascript.mli
+++ b/compiler/lib/javascript.mli
@@ -169,11 +169,14 @@ and property_list = property list
 
 and property =
   | Property of property_name * expression
-  | PropertyGet of property_name * function_declaration
-  | PropertySet of property_name * function_declaration
-  | PropertyMethod of property_name * function_declaration
   | PropertySpread of expression
+  | PropertyMethod of property_name * method_
   | CoverInitializedName of early_error * ident * initialiser
+
+and method_ =
+  | MethodGet of function_declaration
+  | MethodSet of function_declaration
+  | Method of function_declaration
 
 and property_name =
   | PNI of identifier
@@ -198,6 +201,7 @@ and expression =
   | ENew of expression * arguments option
   | EVar of ident
   | EFun of ident option * function_declaration
+  | EClass of ident option * class_declaration
   | EArrow of function_declaration
   | EStr of Utf8_string.t
   (* A UTF-8 encoded string that may contain escape sequences. *)
@@ -228,6 +232,7 @@ and statement =
   | Block of block
   | Variable_statement of variable_declaration_kind * variable_declaration list
   | Function_declaration of ident * function_declaration
+  | Class_declaration of ident * class_declaration
   | Empty_statement
   | Expression_statement of expression
   | If_statement of expression * (statement * location) * (statement * location) option
@@ -288,6 +293,20 @@ and function_kind =
   { async : bool
   ; generator : bool
   }
+
+and class_declaration =
+  { extends : expression option
+  ; body : class_element list
+  }
+
+and class_element =
+  | CEMethod of bool (* static *) * class_element_name * method_
+  | CEField of bool (* static *) * class_element_name * initialiser option
+  | CEStaticBLock of statement_list
+
+and class_element_name =
+  | PropName of property_name
+  | PrivName of ident
 
 and ('a, 'b) list_with_rest =
   { list : 'a list

--- a/compiler/lib/javascript.mli
+++ b/compiler/lib/javascript.mli
@@ -86,7 +86,12 @@ type ident =
 
 and array_litteral = element_list
 
-and element_list = expression option list
+and element_list = element list
+
+and element =
+  | ElementHole
+  | Element of expression
+  | ElementSpread of expression
 
 and binop =
   | Eq
@@ -102,7 +107,9 @@ and binop =
   | BxorEq
   | BorEq
   | Or
+  | OrEq
   | And
+  | AndEq
   | Bor
   | Bxor
   | Band
@@ -128,6 +135,10 @@ and binop =
   | Mul
   | Div
   | Mod
+  | Exp
+  | ExpEq
+  | Coalesce
+  | CoalesceEq
 
 and unop =
   | Not
@@ -141,15 +152,23 @@ and unop =
   | DecrA
   | IncrB
   | DecrB
+  | Await
 
-and spread =
-  [ `Spread
-  | `Not_spread
-  ]
+and arguments = argument list
 
-and arguments = (expression * spread) list
+and argument =
+  | Arg of expression
+  | ArgSpread of expression
 
-and property_name_and_value_list = (property_name * expression) list
+and property_list = property list
+
+and property =
+  | PropertySpread of expression
+  | PropertyGet of identifier * formal_parameter_list * function_body
+  | PropertySet of identifier * formal_parameter_list * function_body
+  | PropertyMethod of identifier * function_expression
+  | Property of property_name * expression
+  | PropertyComputed of expression * expression
 
 and property_name =
   | PNI of identifier
@@ -161,38 +180,51 @@ and expression =
   | ECond of expression * expression * expression
   | EBin of binop * expression * expression
   | EUn of unop * expression
-  | ECall of expression * arguments * location
-  | EAccess of expression * expression
-  | EDot of expression * identifier
+  | ECall of expression * access_kind * arguments * location
+  | EAccess of expression * access_kind * expression
+  | EDot of expression * access_kind * identifier
   | ENew of expression * arguments option
   | EVar of ident
   | EFun of function_expression
+  | EArrow of arrow_expression
   | EStr of Utf8_string.t
   (* A UTF-8 encoded string that may contain escape sequences. *)
   | EArr of array_litteral
   | EBool of bool
   | ENum of Num.t
-  | EObj of property_name_and_value_list
+  | EObj of property_list
   | ERegexp of string * string option
+  | EYield of expression option
+
+and access_kind =
+  | ANormal
+  | ANullish
 
 (****)
 
 (* A.4 Statements *)
 and statement =
   | Block of block
-  | Variable_statement of variable_declaration list
+  | Variable_statement of variable_declaration_kind * variable_declaration list
+  | Function_declaration of function_declaration
   | Empty_statement
   | Expression_statement of expression
   | If_statement of expression * (statement * location) * (statement * location) option
   | Do_while_statement of (statement * location) * expression
   | While_statement of expression * (statement * location)
   | For_statement of
-      (expression option, variable_declaration list) either
+      (expression option, variable_declaration_kind * variable_declaration list) either
       * expression option
       * expression option
       * (statement * location)
   | ForIn_statement of
-      (expression, variable_declaration) either * expression * (statement * location)
+      (expression, variable_declaration_kind * for_binding) either
+      * expression
+      * (statement * location)
+  | ForOf_statement of
+      (expression, variable_declaration_kind * for_binding) either
+      * expression
+      * (statement * location)
   | Continue_statement of Label.t option
   | Break_statement of Label.t option
   | Return_statement of expression option
@@ -203,7 +235,7 @@ and statement =
   | Switch_statement of
       expression * case_clause list * statement_list option * case_clause list
   | Throw_statement of expression
-  | Try_statement of block * (ident * block) option * block option
+  | Try_statement of block * (formal_parameter option * block) option * block option
   | Debugger_statement
 
 and ('left, 'right) either =
@@ -214,7 +246,14 @@ and block = statement_list
 
 and statement_list = (statement * location) list
 
-and variable_declaration = ident * initialiser option
+and variable_declaration =
+  | DIdent of ident * initialiser option
+  | DPattern of binding_pattern * initialiser
+
+and variable_declaration_kind =
+  | Var
+  | Let
+  | Const
 
 and case_clause = expression * statement_list
 
@@ -223,24 +262,52 @@ and initialiser = expression * location
 (****)
 
 (* A.5 Functions and programs *)
-and function_declaration = ident * formal_parameter_list * function_body * location
+and function_declaration =
+  ident * function_kind * formal_parameter_list * function_body * location
 
-and function_expression = ident option * formal_parameter_list * function_body * location
+and function_expression =
+  ident option * function_kind * formal_parameter_list * function_body * location
 
-and formal_parameter_list = ident list
+and arrow_expression = function_kind * formal_parameter_list * function_body * location
 
-and function_body = source_elements
+and formal_parameter_list = formal_parameter list
 
-and program = source_elements
+and function_kind =
+  { async : bool
+  ; generator : bool
+  }
 
-and source_elements = (source_element * location) list
+and formal_parameter =
+  | PPattern of binding_pattern * (expression * location) option
+  | PIdent of
+      { id : ident
+      ; default : (expression * location) option
+      }
+  | PIdentSpread of ident
 
-and program_with_annots =
-  ((source_element * location) * (Js_token.Annot.t * Parse_info.t) list) list
+and for_binding =
+  | ForBindIdent of ident
+  | ForBindPattern of binding_pattern
 
-and source_element =
-  | Statement of statement
-  | Function_declaration of function_declaration
+and binding_pattern =
+  | Object_binding of binding_property list
+  | Array_binding of binding_array_elt list
+  | Id of ident
+
+and binding_property =
+  | Prop_binding of property_name * binding_pattern * (expression * location) option
+  | Prop_rest of ident
+
+and binding_array_elt =
+  | Elt_binding of binding_pattern * (expression * location) option
+  | Elt_hole
+  | Elt_rest of ident
+
+and function_body = statement_list
+
+and program = statement_list
+
+and program_with_annots = (statement_list * (Js_token.Annot.t * Parse_info.t) list) list
 
 val compare_ident : ident -> ident -> int
 
@@ -250,8 +317,28 @@ val is_ident' : Utf8_string.t -> bool
 
 val ident : ?loc:location -> ?var:Code.Var.t -> identifier -> ident
 
+val param : ?loc:location -> ?var:Code.Var.t -> identifier -> formal_parameter
+
+val param' : ident -> formal_parameter
+
 val ident_unsafe : ?loc:location -> ?var:Code.Var.t -> identifier -> ident
+
+val bound_idents_of_params : formal_parameter list -> ident list
+
+val bound_idents_of_param : formal_parameter -> ident list
+
+val bound_idents_of_variable_declaration : variable_declaration -> ident list
+
+val bound_idents_of_pattern : binding_pattern -> ident list
 
 module IdentSet : Set.S with type elt = ident
 
 module IdentMap : Map.S with type key = ident
+
+val dot : expression -> identifier -> expression
+
+val array : expression list -> expression
+
+val call : expression -> expression list -> location -> expression
+
+val variable_declaration : (ident * initialiser) list -> statement

--- a/compiler/lib/js_assign.ml
+++ b/compiler/lib/js_assign.ml
@@ -322,9 +322,9 @@ class traverse record_block =
   object (m)
     inherit Js_traverse.free as super
 
-    method! block b =
+    method! record_block b =
       record_block m#state b;
-      super#block b
+      super#record_block b
   end
 
 let program' (module Strategy : Strategy) p =
@@ -332,7 +332,7 @@ let program' (module Strategy : Strategy) p =
   let state = Strategy.create nv in
   let mapper = new traverse (Strategy.record_block state) in
   let p = mapper#program p in
-  mapper#block Normal;
+  mapper#record_block Normal;
   let free =
     IdentSet.filter
       (function

--- a/compiler/lib/js_parser.mly
+++ b/compiler/lib/js_parser.mly
@@ -1,34 +1,59 @@
 (* Js_of_ocaml compiler *)
 (* Copyright (C) 2013 Hugo Heuzard *)
 
-(* Yoann Padioleau *)
-
-(* Copyright (C) 2010 Facebook *)
-
-(* This library is free software; you can redistribute it and/or *)
-(* modify it under the terms of the GNU Lesser General Public License *)
-(* version 2.1 as published by the Free Software Foundation, with the *)
-(* special exception on linking described in file license.txt. *)
-
-(* This library is distributed in the hope that it will be useful, but *)
-(* WITHOUT ANY WARRANTY; without even the implied warranty of *)
-(* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file *)
-(* license.txt for more details. *)
-
 %{
-(*
- * src: ocamlyaccified from Marcel Laverdet 'fbjs2' via emacs macros, itself
- * extracted from the official ECMAscript specification at:
- *  http://www.ecma-international.org/publications/standards/ecma-262.htm
+
+(* Yoann Padioleau
  *
- * see also http://en.wikipedia.org/wiki/ECMAScript_syntax
+ * Copyright (C) 2010-2014 Facebook
+ * Copyright (C) 2019-2022 r2c
  *
- * related work:
- *  - http://marijnhaverbeke.nl/parse-js/, js parser in common lisp
- *    (which has been since ported to javascript by nodejs people)
- *  - jslint
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation, with the
+ * special exception on linking described in file license.txt.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
+ * license.txt for more details.
  *)
 
+(*************************************************************************)
+(* Prelude *)
+(*************************************************************************)
+(* This file contains a grammar for Javascript (ES6 and more), as well
+ * as partial support for Typescript.
+ *
+ * reference:
+ *  - https://en.wikipedia.org/wiki/JavaScript_syntax
+ *  - http://www.ecma-international.org/publications/standards/Ecma-262.htm
+ *  - https://github.com/Microsoft/TypeScript/blob/master/doc/spec.md#A
+ *
+ * src: originally ocamlyacc-ified from Marcel Laverdet 'fbjs2' via Emacs
+ * macros, itself extracted from the official ECMAscript specification at:
+ * http://www.ecma-international.org/publications/standards/ecma-262.htm
+ * back in the day (probably ES4 or ES3).
+ *
+ * I have heavily extended the grammar to provide the first parser for Flow.
+ * I have extended it also to deal with many new Javascript features
+ * (see cst_js.ml top comment).
+ *
+ * The grammar is close to the ECMA grammar but I've simplified a few things
+ * when I could:
+ *  - less intermediate grammar rules for advanced features
+ *    (they are inlined in the original grammar rule)
+ *  - by using my retagging-tokens technique (see parsing_hacks_js.ml)
+ *    I could also get rid of some of the ugliness in the ECMA grammar
+ *    that has to deal with ambiguous constructs
+ *    (they conflate together expressions and arrow parameters, object
+ *    values and object matching, etc.).
+ *    Instead, in this grammar things are clearly separated.
+ *  - I've used some macros to factorize rules, including some tricky
+ *    macros to factorize expression rules.
+ *)
+
+open Js_token
 open Javascript
 
 let var pi name = ident_unsafe ~loc:(pi) name
@@ -42,707 +67,672 @@ let utf8_s = Stdlib.Utf8_string.of_string_exn
 %}
 
 (*************************************************************************)
-(* 1 Tokens                                                              *)
+(* Tokens                                                              *)
 (*************************************************************************)
 
+%token <string> T_ERROR
+%token T_EOF
+
 (*-----------------------------------------*)
-(* 2 the normal tokens                     *)
+(* The space/comment tokens *)
 (*-----------------------------------------*)
 
-(* Tokens with a value *)
+%token <Js_token.Annot.t> TAnnot
+%token <string> TComment
+%token <string> TCommentLineDirective
+
+(*-----------------------------------------*)
+(* normal tokens                           *)
+(*-----------------------------------------*)
+
+(* tokens with a value *)
 %token<Js_token.number_type * string> T_NUMBER
 %token<Js_token.bigint_type * string> T_BIGINT
 %token<Stdlib.Utf8_string.t * string> T_IDENTIFIER
 %token<Stdlib.Utf8_string.t * int> T_STRING
 %token<Stdlib.Utf8_string.t * string> T_REGEXP
 %token<Stdlib.Utf8_string.t> T_TEMPLATE_PART
-(* Keywords tokens *)
+
+(*-----------------------------------------*)
+(* Keyword tokens *)
+(*-----------------------------------------*)
+(* coupling: if you add an element here, expand also ident_keyword_bis
+ * and also maybe the special hack for regexp in lexer_js.mll *)
 %token
-T_FUNCTION T_IF T_RETURN T_SWITCH T_THIS T_THROW T_TRY
-T_VAR T_WHILE T_WITH T_NULL T_FALSE T_TRUE
-T_BREAK T_CASE T_CATCH T_CONTINUE T_DEFAULT T_DO T_FINALLY T_FOR
-T_DEBUGGER
-T_ASYNC
-T_AWAIT
-T_YIELD
-T_LET
-T_CONST
-T_CLASS
-T_SUPER
-T_EXPORT
-T_PACKAGE
-T_INTERFACE
-T_IMPLEMENTS
-T_DECLARE
-T_TYPE
-T_PUBLIC
-T_PRIVATE
-T_OPAQUE
-T_PROTECTED
-T_EXTENDS
-T_STATIC
+T_FUNCTION T_CONST T_VAR T_LET
+T_IF T_ELSE
+T_WHILE T_FOR T_DO T_CONTINUE T_BREAK
+T_SWITCH T_CASE T_DEFAULT
+T_RETURN
+T_THROW T_TRY T_CATCH T_FINALLY
+T_YIELD T_ASYNC T_AWAIT
+T_NEW T_IN T_OF T_THIS T_SUPER T_WITH
+T_NULL T_FALSE T_TRUE
+T_CLASS T_INTERFACE T_EXTENDS T_IMPLEMENTS T_STATIC
+T_IMPORT T_EXPORT
+T_INSTANCEOF T_TYPEOF
+T_DELETE T_VOID
 T_ENUM
-T_IMPORT
-T_OF
-
-%token T_ELSE
-
-%token T_NEW
+T_PUBLIC T_PRIVATE T_PROTECTED
+T_PACKAGE
+T_DEBUGGER
+T_GET T_SET
+T_FROM
+T_TARGET
+T_META
+(*-----------------------------------------*)
+(* Punctuation tokens *)
+(*-----------------------------------------*)
 
 (* Syntax *)
-%token 
-T_LCURLY T_RCURLY
-T_LPAREN T_RPAREN
-T_LBRACKET T_RBRACKET
-T_SEMICOLON
-T_COMMA
-T_ELLIPSIS
-T_PERIOD
+%token
+T_LCURLY "{" T_RCURLY "}"
+T_LPAREN "(" T_RPAREN ")"
+T_LBRACKET "[" T_RBRACKET "]"
+T_SEMICOLON ";" T_COMMA "," T_PERIOD "." T_COLON ":"
+T_PLING_PERIOD
+T_PLING "?"
+T_ARROW
+T_AT
+T_ELLIPSIS "..."
+T_POUND
+T_PLING_PLING
 
 (* Operators *)
-%token 
-T_RSHIFT3_ASSIGN T_RSHIFT_ASSIGN T_LSHIFT_ASSIGN
-T_BIT_XOR_ASSIGN T_BIT_OR_ASSIGN T_BIT_AND_ASSIGN T_MOD_ASSIGN T_DIV_ASSIGN
-T_MULT_ASSIGN T_MINUS_ASSIGN T_PLUS_ASSIGN T_ASSIGN
-T_OR_ASSIGN T_AND_ASSIGN T_EXP_ASSIGN
-T_EXP T_NULLISH_ASSIGN T_PLING_PERIOD T_PLING_PLING T_AT T_POUND
-
-%token 
-T_PLING T_COLON
-T_OR
-T_AND
-T_BIT_OR
-T_BIT_XOR
-T_BIT_AND
-T_EQUAL T_NOT_EQUAL T_STRICT_EQUAL T_STRICT_NOT_EQUAL
-T_LESS_THAN_EQUAL T_GREATER_THAN_EQUAL T_LESS_THAN T_GREATER_THAN
-T_IN T_INSTANCEOF
-T_LSHIFT T_RSHIFT T_RSHIFT3
-T_PLUS T_MINUS
-T_DIV T_MULT T_MOD
-T_NOT T_BIT_NOT T_INCR T_DECR T_INCR_NB T_DECR_NB T_DELETE T_TYPEOF T_VOID
-T_ARROW
+%token
+ T_OR T_AND
+ T_BIT_OR T_BIT_XOR T_BIT_AND
+ T_PLUS T_MINUS
+ T_DIV T_MULT "*" T_MOD
+ T_NOT T_BIT_NOT
+ T_RSHIFT3_ASSIGN T_RSHIFT_ASSIGN T_LSHIFT_ASSIGN
+ T_BIT_XOR_ASSIGN T_BIT_OR_ASSIGN T_BIT_AND_ASSIGN T_MOD_ASSIGN T_DIV_ASSIGN
+ T_MULT_ASSIGN T_MINUS_ASSIGN T_PLUS_ASSIGN
+ T_ASSIGN "="
+ T_EQUAL T_NOT_EQUAL T_STRICT_EQUAL T_STRICT_NOT_EQUAL
+ T_LESS_THAN_EQUAL T_GREATER_THAN_EQUAL T_LESS_THAN T_GREATER_THAN
+ T_LSHIFT T_RSHIFT T_RSHIFT3
+ T_INCR T_DECR
+ T_EXP
+ T_OR_ASSIGN T_AND_ASSIGN
+ T_NULLISH_ASSIGN
+ T_EXP_ASSIGN
 (*-----------------------------------------*)
-(* 2 extra tokens:                         *)
+(* Extra tokens: *)
 (*-----------------------------------------*)
 
 %token T_VIRTUAL_SEMICOLON
-%token <Js_token.Annot.t> TAnnot
-%token <string> T_ERROR
-%token <string> TComment
-%token <string> TCommentLineDirective
-
-
-(* classic *)
-%token T_EOF
+%token T_LPAREN_ARROW
+%token T_INCR_NB T_DECR_NB
 
 (*-----------------------------------------*)
-(* 2 priorities                            *)
+(* Priorities                              *)
 (*-----------------------------------------*)
+
+(* must be at the top so that it has the lowest priority *)
+(* %nonassoc LOW_PRIORITY_RULE *)
 
 (* Special if / else associativity*)
 %nonassoc p_IF
 %nonassoc T_ELSE
 
-%left T_OR
+(* unused according to menhir:
+%nonassoc p_POSTFIX
+%right
+ T_RSHIFT3_ASSIGN T_RSHIFT_ASSIGN T_LSHIFT_ASSIGN
+ T_BIT_XOR_ASSIGN T_BIT_OR_ASSIGN T_BIT_AND_ASSIGN T_MOD_ASSIGN T_DIV_ASSIGN
+ T_MULT_ASSIGN T_MINUS_ASSIGN T_PLUS_ASSIGN "="
+*)
+
+%left T_OR T_PLING_PLING
 %left T_AND
 %left T_BIT_OR
 %left T_BIT_XOR
 %left T_BIT_AND
 %left T_EQUAL T_NOT_EQUAL T_STRICT_EQUAL T_STRICT_NOT_EQUAL
-%left
-T_LESS_THAN_EQUAL T_GREATER_THAN_EQUAL T_LESS_THAN T_GREATER_THAN
-T_IN T_INSTANCEOF
+%left T_LESS_THAN_EQUAL T_GREATER_THAN_EQUAL T_LESS_THAN T_GREATER_THAN
+      T_IN T_INSTANCEOF
 %left T_LSHIFT T_RSHIFT T_RSHIFT3
 %left T_PLUS T_MINUS
 %left T_DIV T_MULT T_MOD
-%right T_NOT T_BIT_NOT T_INCR T_DECR T_INCR_NB T_DECR_NB T_DELETE T_TYPEOF T_VOID
+
+%right T_EXP
+
+%right T_NOT T_BIT_NOT T_INCR T_DECR T_INCR_NB T_DECR_NB T_DELETE T_TYPEOF T_VOID T_AWAIT
 
 (*************************************************************************)
-(* 1 Rules type declaration                                              *)
+(* Rules type decl                                                       *)
 (*************************************************************************)
 
-%start <Javascript.program_with_annots> program
+%start <[ `Annot of Js_token.Annot.t * Parse_info.t | `Item of Javascript.statement * Javascript.location] list > program
 %start <Javascript.expression> standalone_expression
 
 %%
 
 (*************************************************************************)
-(* 1 Toplevel                                                            *)
+(* Macros *)
 (*************************************************************************)
 
-program:
- | l=source_element_with_annot* T_EOF { l }
+listc(X):
+ | X              { [$1] }
+ | listc(X) "," X { $1 @ [$3] }
+
+optl(X):
+ | (* empty *) { [] }
+ | X           { $1 }
+
+(*************************************************************************)
+(* Toplevel                                                            *)
+(*************************************************************************)
 
 standalone_expression:
- | e=expression T_EOF { e }
+ | e=expr T_EOF { e }
+
+program:
+ | l=module_item* T_EOF { l }
 
 annot:
   | a=TAnnot { a, pi $symbolstartpos }
 
-source_element_with_annot:
- | annots=annot* s=source_element {s,annots}
-
-source_element:
- | statement
-   { let statement,pos = $1 in Statement statement, pos }
- | function_declaration
-   { let declaration = $1 in Function_declaration declaration, p $symbolstartpos }
+module_item:
+  | item { `Item $1 }
+  | annot { `Annot $1 }
 
 (*************************************************************************)
-(* 1 statement                                                           *)
+(* statement                                                           *)
 (*************************************************************************)
 
-statement_no_semi:
- | block=curly_block(statement*)
-   { let statements,_ = block in
-     Block statements }
- | s=if_statement
- | s=while_statement
- | s=for_statement
- | s=for_in_statement
- | s=with_statement
- | s=switch_statement
- | s=try_statement
- | s=labeled_statement
- | s=empty_statement { s }
+item:
+ | stmt { $1 }
+ | decl { $1 }
 
-statement_need_semi:
- | s=variable_statement
- | s=expression_statement
- | s=do_while_statement
- | s=continue_statement
- | s=break_statement
- | s=return_statement
- | s=throw_statement
- | s=debugger_statement { s }
+decl:
+ | function_decl
+   { Function_declaration $1, p $symbolstartpos }
+ | generator_decl
+   { Function_declaration $1, p $symbolstartpos }
+ | async_decl
+   { Function_declaration $1, p $symbolstartpos }
+ | lexical_decl    { $1, p $symbolstartpos }
 
-statement:
- | s=statement_no_semi { (s : statement), p $symbolstartpos }
- | s=statement_need_semi either(T_SEMICOLON, T_VIRTUAL_SEMICOLON) { (s : statement), p $symbolstartpos }
+(*************************************************************************)
+(* Variable decl *)
+(*************************************************************************)
 
-labeled_statement:
-| l=label T_COLON s=statement { Labelled_statement (l, s)}
+(* part of 'stmt' *)
 
-block:
- | block=curly_block(statement*)
-   { let statements,_ = block in statements }
+variable_stmt:
+ | T_VAR l=listc(variable_decl) sc { Variable_statement (Var, l) }
 
-variable_statement:
- | T_VAR list=separated_nonempty_list(T_COMMA, pair(variable, initializer_?))
-   { Variable_statement list }
+(* part of 'decl' *)
+lexical_decl:
+ (* es6: *)
+ | T_CONST l=listc(variable_decl) sc { Variable_statement (Const, l)}
+ | T_LET l=listc(variable_decl) sc { Variable_statement (Let, l)}
+
+variable_decl:
+ | i=ident e=initializer_?               { DIdent (i,e) }
+ | p=binding_pattern e=initializer_   { DPattern (p, e) }
 
 initializer_:
- | T_ASSIGN e=assignment_expression { e, p $symbolstartpos }
+ | "=" e=assignment_expr { e, p $symbolstartpos }
 
-empty_statement:
- | T_SEMICOLON { Empty_statement }
+for_variable_decl:
+ | T_VAR l=listc(variable_decl_no_in)   { Var, l }
+ (* es6: *)
+ | T_CONST l=listc(variable_decl_no_in) { Const, l }
+ | T_LET l=listc(variable_decl_no_in)   { Let, l }
 
-debugger_statement:
- | T_DEBUGGER { Debugger_statement }
+variable_decl_no_in:
+ | i=ident e=initializer_no_in              { DIdent (i,Some e) }
+ | i=ident                                  { DIdent (i, None) }
+ | p=binding_pattern e=initializer_no_in { DPattern (p, e) }
 
-expression_statement:
- | expression_no_statement { Expression_statement $1 }
+(* 'for ... in' and 'for ... of' declare only one variable *)
+for_single_variable_decl:
+ | T_VAR b=for_binding   { Var, b }
+ (* es6: *)
+ | T_CONST b=for_binding { Const, b }
+ | T_LET  b=for_binding  { Let, b }
 
-if_statement:
- | T_IF condition=parenthesised(expression) t=statement T_ELSE e=statement
-     { If_statement (condition, t, Some e) }
- | T_IF condition=parenthesised(expression) t=statement %prec p_IF
-     { If_statement (condition, t, None) }
-
-do_while_statement:
-  | T_DO body=statement T_WHILE condition=parenthesised(expression)
-    { Do_while_statement (body, condition) }
-
-while_statement:
- | T_WHILE condition=parenthesised(expression) body=statement
-     { While_statement (condition, body) }
-
-for_statement:
- | T_FOR T_LPAREN initial=expression_no_in?
-   T_SEMICOLON condition=expression? T_SEMICOLON increment=expression?
-   T_RPAREN statement=statement
-   { For_statement (Left initial, condition, increment, statement) }
- | T_FOR T_LPAREN T_VAR
-   initial=separated_nonempty_list(T_COMMA, pair(variable, initializer_no_in?))
-   T_SEMICOLON condition=expression?  T_SEMICOLON increment=expression?
-   T_RPAREN statement=statement
-   { For_statement (Right initial, condition, increment, statement) }
-
-for_in_statement:
- | T_FOR T_LPAREN left=left_hand_side_expression
-   T_IN right=expression T_RPAREN body=statement
-   { ForIn_statement (Left left, right, body) }
- | T_FOR T_LPAREN T_VAR left=pair(variable, initializer_no_in?)
-   T_IN right=expression T_RPAREN body=statement
-   { ForIn_statement (Right left, right, body) }
-
-initializer_no_in:
- | T_ASSIGN e=assignment_expression_no_in { e, p $symbolstartpos }
-
-continue_statement:
- | T_CONTINUE l=label? { (Continue_statement (l)) }
-
-break_statement:
- | T_BREAK l=label? { (Break_statement (l)) }
-
-return_statement:
- | T_RETURN e=expression? { (Return_statement e) }
-
-with_statement:
- | T_WITH parenthesised(expression) statement { assert false }
-
-switch_statement:
- | T_SWITCH subject=parenthesised(expression)
-   T_LCURLY pair=pair(case_clause*, pair(default_clause, case_clause*)?) T_RCURLY
-   { let switch = match pair with
-       | cases, None ->
-         Switch_statement (subject, cases, None, [])
-       | cases, Some (default, more_cases) ->
-         Switch_statement (subject, cases, Some default, more_cases)
-      in switch }
-
-throw_statement:
- | T_THROW e=expression { (Throw_statement e) }
-
-try_statement:
- | T_TRY b=block c=catch f=finally? { (Try_statement (b, Some c, f)) }
- | T_TRY b=block       f=finally { (Try_statement (b, None, Some f)) }
-
-catch:
- | T_CATCH pair=pair(parenthesised(variable), block) { pair }
-
-finally:
- | T_FINALLY b=block { b }
+for_binding:
+ | i=ident               { ForBindIdent (i) }
+ | p=binding_pattern     { ForBindPattern (p) }
 
 (*----------------------------*)
-(* 2 auxiliary statements     *)
+(* pattern *)
 (*----------------------------*)
 
-case_clause:
- | T_CASE pair=separated_pair(expression, T_COLON, statement*) { pair }
+binding_pattern:
+ | object_binding_pattern { $1 }
+ | array_binding_pattern  { $1 }
 
-default_clause:
- | T_DEFAULT T_COLON list=statement* { list }
+object_binding_pattern:
+ | "{" "}"                               { Object_binding [] }
+ | "{" l=listc(binding_property) ","?  "}" { Object_binding l }
+
+binding_property:
+  | i=ident e=initializer_? { let id = match i with
+                                   | S { name; _ } -> name
+                                   | _ -> assert false in
+                           Prop_binding (PNI id, Id i, e) }
+ | pn=property_name ":" e=binding_element { Prop_binding (pn, fst e, snd e) }
+ (* can appear only at the end of a binding_property_list in ECMA *)
+ | "..." id=ident      { Prop_rest id }
+
+(* in theory used also for formal parameter as is *)
+binding_element:
+ | i=ident         e=initializer_? { Id i, e }
+ | p=binding_pattern    e=initializer_? { p, e }
+
+(* array destructuring *)
+
+(* TODO use elision below.
+ * invent a new Hole category or maybe an array_argument special
+ * type like for the (call)argument type.
+ *)
+array_binding_pattern:
+ | "[" "]"                      { Array_binding [] }
+ | "[" l=binding_element_list "]" { Array_binding l }
+
+binding_start_element:
+ | ","                  { [Elt_hole] }
+ | b=binding_element ","  { [Elt_binding (fst b, snd b)] }
+
+binding_start_list:
+(* always ends in a "," *)
+ | binding_start_element                     { $1 }
+ | binding_start_list binding_start_element  { $1 @ $2 }
+
+(* can't use listc() here, it's $1 not [$1] below *)
+binding_element_list:
+ | binding_start_list                         { $1 }
+ | binding_elision_element                    { [$1] }
+ | binding_start_list binding_elision_element { $1 @ [$2] }
+
+binding_elision_element:
+ | e=binding_element        { Elt_binding (fst e, snd e) }
+ (* can appear only at the end of a binding_property_list in ECMA *)
+ | "..." i=ident            { Elt_rest i  }
 
 (*************************************************************************)
-(* 1 function declaration                                                *)
+(* Function declarations (and exprs) *)
 (*************************************************************************)
 
-function_declaration:
- | T_FUNCTION name=variable args=parenthesised(separated_list(T_COMMA, variable))
-   block=curly_block(source_element*)
-   { let elements,(_,loc) = block in
-     (name, args, elements, p loc) }
+function_decl:
+ | T_FUNCTION name=ident args=call_signature "{" b=function_body "}"
+    { (name, {async = false; generator = false}, args, b, p $startpos($6)) }
 
-function_expression:
- | T_FUNCTION name=variable? args=parenthesised(separated_list(T_COMMA, variable))
-   block=curly_block(source_element*)
-   { let elements,_ = block in
-     EFun (name, args, elements, p $symbolstartpos) }
+function_expr:
+ | T_FUNCTION name=ident? args=call_signature "{" b=function_body "}"
+   { EFun (name, {async = false; generator = false}, args, b, p $symbolstartpos) }
+
+call_signature: "(" args=formal_parameter_list_opt ")"
+  { args }
+
+function_body: optl(stmt_list) { $1 }
+
+(*----------------------------*)
+(* parameters *)
+(*----------------------------*)
+
+formal_parameter_list_opt:
+ | (*empty*)                   { [] }
+ | formal_parameter_list ","?  { List.rev $1 }
+
+(* must be written in a left-recursive way (see conflicts.txt) *)
+formal_parameter_list:
+ | formal_parameter_list "," formal_parameter { $3::$1 }
+ | formal_parameter                           { [$1] }
+
+(* The ECMA and Typescript grammars imposes more restrictions
+ * (some require_parameter, optional_parameter, rest_parameter)
+ * but I've simplified.
+ * We could also factorize with binding_element as done by ECMA.
+ *)
+formal_parameter:
+ | id=ident                { PIdent {id; default = None} }
+ (* es6: default parameter *)
+ | id=ident e=initializer_   { PIdent {id; default = Some e} }
+  (* until here this is mostly equivalent to the 'binding_element' rule *)
+ | p=binding_pattern e=initializer_? { PPattern (p,e) }
+ (* es6: spread *)
+ | "..." id=ident          { PIdentSpread id }
 
 (*************************************************************************)
-(* 1 expression                                                          *)
+(* generators                                                *)
 (*************************************************************************)
 
-expression:
- | assignment_expression { $1 }
- | e1=expression T_COMMA e2=assignment_expression { ESeq (e1, e2) }
+generator_decl:
+ | T_FUNCTION "*" name=ident args=call_signature "{" b=function_body "}"
+   { (name, {async = false; generator = true}, args, b, p $symbolstartpos) }
 
-assignment_expression:
- | conditional_expression { $1 }
- | e1=left_hand_side_expression op=assignment_operator e2=assignment_expression
-   { EBin (op, e1, e2) }
-
-left_hand_side_expression:
- | new_expression  { $1 }
- | call_expression { $1 }
-
-conditional_expression:
- | post_in_expression { $1 }
- | ternary(post_in_expression, assignment_expression) { $1 }
-
-ternary(condition, consequence):
- | condition=condition T_PLING consequence=consequence
-                       T_COLON alternative=consequence
-   { ECond (condition, consequence, alternative) }
-
-post_in_expression:
- | pre_in_expression { $1 }
- | left=post_in_expression
-   op=comparison_or_logical_or_bit_operator
-   right=post_in_expression
-   { EBin (op, left, right) }
-
-pre_in_expression:
- | left_hand_side_expression
-   { $1 }
- | e=pre_in_expression op=postfix_operator
- | op=prefix_operator e=pre_in_expression
-   { EUn (op, e) }
- | left=pre_in_expression
-   op=arithmetic_or_shift_operator
-   right=pre_in_expression
-   { EBin (op, left, right) }
-
-call_expression:
- | e=member_expression a=arguments
-     { (ECall(e, a, p $symbolstartpos)) }
- | e=call_expression a=arguments
-     { (ECall(e, a, p $symbolstartpos)) }
- | e=call_expression T_LBRACKET e2=expression T_RBRACKET
-     { (EAccess (e, e2)) }
- | e=call_expression T_PERIOD i=identifier_or_kw
-     { (EDot (e, i)) }
-
-new_expression:
- | e=member_expression    { e }
- | T_NEW e=new_expression { (ENew (e,None)) }
-
-member_expression:
- | e=primary_expression
-     { e }
- | e1=member_expression T_LBRACKET e2=expression T_RBRACKET
-     { (EAccess (e1,e2)) }
- | e1=member_expression T_PERIOD i=identifier_or_kw
-     { (EDot(e1,i)) }
- | T_NEW e1=member_expression a=arguments
-     { (ENew(e1, Some a)) }
-
-primary_expression:
- | e=primary_expression_no_statement
- | e=object_literal
- | e=function_expression { e }
-
-primary_expression_no_statement:
- | T_THIS         { (EVar (var (p $symbolstartpos) (Stdlib.Utf8_string.of_string_exn "this"))) }
- | i=variable_with_loc { (EVar i) }
- | n=null_literal    { n }
- | b=boolean_literal { b }
- | n=numeric_literal   { (ENum (Num.of_string_unsafe n)) }
- | s=T_STRING          { (EStr (fst s)) }
- | r=regex_literal                { r }
- | a=array_literal                { a }
- | T_LPAREN e=expression T_RPAREN { (e) }
-
-(*----------------------------*)
-(* 2 no in                    *)
-(*----------------------------*)
-
-expression_no_in:
- | assignment_expression_no_in { $1 }
- | e1=expression_no_in T_COMMA e2=assignment_expression_no_in { ESeq (e1, e2) }
-
-assignment_expression_no_in:
- | conditional_expression_no_in { $1 }
- | e1=left_hand_side_expression op=assignment_operator e2=assignment_expression_no_in
-     { EBin(op,e1,e2) }
-
-conditional_expression_no_in:
- | post_in_expression_no_in { $1 }
- | ternary(post_in_expression_no_in, assignment_expression_no_in) { $1 }
-
-post_in_expression_no_in:
- | pre_in_expression { $1 }
- | left=post_in_expression_no_in
-   op=comparison_or_logical_or_bit_operator_except_in
-   right=post_in_expression
-   { EBin (op, left, right) }
-
-(*----------------------------*)
-(* 2 (no statement)           *)
-(*----------------------------*)
-
-expression_no_statement:
- | assignment_expression_no_statement { $1 }
- | e1=expression_no_statement T_COMMA e2=assignment_expression { ESeq(e1,e2) }
-
-assignment_expression_no_statement:
- | conditional_expression_no_statement { $1 }
- | e1=left_hand_side_expression_no_statement op=assignment_operator e2=assignment_expression
-   { EBin (op,e1,e2) }
-
-conditional_expression_no_statement:
- | post_in_expression_no_statement { $1 }
- | ternary(post_in_expression_no_statement, assignment_expression) { $1 }
-
-post_in_expression_no_statement:
- | pre_in_expression_no_statement { $1 }
- | left=post_in_expression_no_statement
-   op=comparison_or_logical_or_bit_operator
-   right=post_in_expression
-   { EBin (op, left, right) }
-
-pre_in_expression_no_statement:
- | left_hand_side_expression_no_statement
-   { $1 }
- | e=pre_in_expression_no_statement op=postfix_operator
- | op=prefix_operator e=pre_in_expression
-   { EUn (op, e) }
- | left=pre_in_expression_no_statement
-   op=arithmetic_or_shift_operator
-   right=pre_in_expression
-   { EBin (op, left, right) }
-
-left_hand_side_expression_no_statement:
- | new_expression_no_statement { $1 }
- | call_expression_no_statement { $1 }
-
-new_expression_no_statement:
- | member_expression_no_statement { $1 }
- | T_NEW e=new_expression { (ENew (e,None)) }
-
-call_expression_no_statement:
- | e=member_expression_no_statement e2=arguments
-   { ( ECall(e, e2, p $symbolstartpos)) }
- | e=call_expression_no_statement a=arguments
-   { ( ECall(e, a, p $symbolstartpos)) }
- | e=call_expression_no_statement T_LBRACKET e2=expression T_RBRACKET
-   { ( EAccess(e, e2)) }
- | e=call_expression_no_statement T_PERIOD i=identifier_or_kw
-   { ( EDot(e,i)) }
-
-member_expression_no_statement:
- | e=primary_expression_no_statement
-   { e }
- | e1=member_expression_no_statement T_LBRACKET e2=expression T_RBRACKET
-   { ( EAccess(e1, e2)) }
- | e1=member_expression_no_statement T_PERIOD i=identifier_or_kw
-   { ( EDot(e1,i)) }
- | T_NEW e=member_expression a=arguments
-   { (ENew(e,Some a)) }
-
-(*----------------------------*)
-(* 2 scalar                   *)
-(*----------------------------*)
-
-null_literal:
- | T_NULL { (EVar (var (p $symbolstartpos) (Stdlib.Utf8_string.of_string_exn "null"))) }
-
-boolean_literal:
- | T_TRUE  { (EBool true) }
- | T_FALSE { (EBool false) }
-
-numeric_literal:
- | T_NUMBER { let _,f = $1 in (f) }
-
-regex_literal:
- | r=T_REGEXP {
-   let (Utf8 s, f) = r in
-   (ERegexp (s, if String.equal f "" then None else Some f)) }
-
-(*----------------------------*)
-(* 2 array                    *)
-(*----------------------------*)
-
-array_literal:
- | T_LBRACKET e=elison T_RBRACKET
-     { (EArr e) }
- | T_LBRACKET        T_RBRACKET
-     { (EArr []) }
- | T_LBRACKET l=element_list T_RBRACKET
-     { (EArr l) }
- | T_LBRACKET l=element_list_rev last=elison_rev T_RBRACKET
-     { (EArr (List.rev_append l (List.rev last))) }
-
-element_list:
- | element_list_rev { List.rev $1 }
-
-element_list_rev:
- | empty=elison_rev e=assignment_expression { (Some e)::empty }
- | e=assignment_expression { [Some e] }
- | fst=element_list_rev empty=elison e=assignment_expression { (Some e) :: (List.rev_append empty fst) }
-
-object_literal:
- | block=curly_block(empty)
-   { let _pairs, _ = block in EObj [] }
- | block=curly_block(separated_or_terminated_list(T_COMMA, object_key_value))
-   { let pairs, _ = block in EObj pairs }
-
-object_key_value:
- | pair=separated_pair(property_name, T_COLON, assignment_expression) { pair }
-
-(*----------------------------*)
-(* 2 variable                 *)
-(*----------------------------*)
-
-(*----------------------------*)
-(* 2 function call            *)
-(*----------------------------*)
-
-arg:
- | T_ELLIPSIS arg=assignment_expression { arg, `Spread }
- | arg=assignment_expression { arg, `Not_spread }
-
-arguments:
- | args=parenthesised(separated_list(T_COMMA, arg)) { args }
-
-(*----------------------------*)
-(* 2 auxiliary bis            *)
-(*----------------------------*)
+generator_expr:
+ | T_FUNCTION "*" name=ident? args=call_signature "{" b=function_body "}"
+   { EFun (name, {async = false; generator = true}, args, b, p $symbolstartpos) }
 
 (*************************************************************************)
-(* 1 Entities, names                                                     *)
+(* asynchronous functions                                                *)
 (*************************************************************************)
 
-identifier_or_kw:
-  | T_IDENTIFIER {
-     let name, _raw = $1 in
-     name }
-  | T_ASYNC { utf8_s "async" }
-  | T_AWAIT { utf8_s "await" }
-  | T_BREAK { utf8_s "break" }
-  | T_CASE { utf8_s "case" }
-  | T_CATCH { utf8_s "catch" }
-  | T_CLASS { utf8_s "class" }
-  | T_CONST { utf8_s "const" }
-  | T_CONTINUE { utf8_s "continue" }
-  | T_DEBUGGER { utf8_s "debugger" }
-  | T_DECLARE { utf8_s "declare" }
-  | T_DEFAULT { utf8_s "default" }
-  | T_DELETE { utf8_s "delete" }
-  | T_DO { utf8_s "do" }
-  | T_ELSE { utf8_s "else" }
-  | T_ENUM { utf8_s "enum" }
-  | T_EXPORT { utf8_s "export" }
-  | T_EXTENDS { utf8_s "extends" }
-  | T_FALSE { utf8_s "false" }
-  | T_FINALLY { utf8_s "finally" }
-  | T_FOR { utf8_s "for" }
-  | T_FUNCTION { utf8_s "function" }
-  | T_IF { utf8_s "if" }
-  | T_IMPLEMENTS { utf8_s "implements" }
-  | T_IMPORT { utf8_s "import" }
-  | T_IN { utf8_s "in" }
-  | T_INSTANCEOF { utf8_s "instanceof" }
-  | T_INTERFACE { utf8_s "interface" }
-  | T_LET { utf8_s "let" }
-  | T_NEW { utf8_s "new" }
-  | T_NULL { utf8_s "null" }
-  | T_OF { utf8_s "of" }
-  | T_OPAQUE { utf8_s "opaque" }
-  | T_PACKAGE { utf8_s "package" }
-  | T_PRIVATE { utf8_s "private" }
-  | T_PROTECTED { utf8_s "protected" }
-  | T_PUBLIC { utf8_s "public" }
-  | T_RETURN { utf8_s "return" }
-  | T_STATIC { utf8_s "static" }
-  | T_SUPER { utf8_s "super" }
-  | T_SWITCH { utf8_s "switch" }
-  | T_THIS { utf8_s "this" }
-  | T_THROW { utf8_s "throw" }
-  | T_TRUE { utf8_s "true" }
-  | T_TRY { utf8_s "try" }
-  | T_TYPE { utf8_s "type" }
-  | T_TYPEOF { utf8_s "typeof" }
-  | T_VAR { utf8_s "var" }
-  | T_VOID { utf8_s "void" }
-  | T_WHILE { utf8_s "while" }
-  | T_WITH { utf8_s "with" }
-  | T_YIELD { utf8_s "yield" }
+async_decl:
+ | T_ASYNC T_FUNCTION  name=ident args=call_signature "{" b=function_body "}"
+   { (name, {async = true; generator = false}, args, b, p $symbolstartpos) }
 
-variable:
- | i=variable_with_loc { i }
+async_function_expr:
+ | T_ASYNC T_FUNCTION name=ident? args=call_signature "{" b=function_body "}"
+   { EFun (name, {async = true; generator = false}, args, b, p $symbolstartpos) }
 
-variable_with_loc:
-  | i=T_IDENTIFIER {
-          let name, _raw = i in
-          var (p $symbolstartpos) name
-        }
-  | ident_semi_keyword { var (p $symbolstartpos) (utf8_s (Js_token.to_string $1)) }
+(*************************************************************************)
+(* Stmt *)
+(*************************************************************************)
+%inline
+stmt: s=stmt1 { s, p $symbolstartpos }
 
-(* add here keywords which are not considered reserved by ECMA *)
-ident_semi_keyword:
- | T_OF { T_OF }
- | T_TYPE { T_TYPE }
- | T_DECLARE { T_DECLARE }
- | T_PUBLIC { T_PUBLIC } | T_PRIVATE { T_PRIVATE } | T_PROTECTED { T_PROTECTED }
- (* can have AS and ASYNC here but need to restrict arrow_function then *)
- | T_ASYNC { T_ASYNC }
- (* TODO: would like to add T_IMPORT here, but cause conflicts *)
- | T_PACKAGE { T_PACKAGE }
- | T_IMPLEMENTS { T_IMPLEMENTS }
- | T_OPAQUE { T_OPAQUE }
+stmt1:
+ | block     { Block $1 }
+ | variable_stmt   { $1 }
+ | empty_stmt      { $1 }
+ | expr_stmt       { $1 }
+ | if_stmt         { $1 }
+ | iteration_stmt  { $1 }
+ | continue_stmt   { $1 }
+ | break_stmt      { $1 }
+ | return_stmt     { $1 }
+ | labelled_stmt   { $1 }
+ | switch_stmt     { $1 }
+ | throw_stmt      { $1 }
+ | try_stmt        { $1 }
+ | debugger_stmt   { $1 }
 
 label:
   | T_IDENTIFIER {
           let name, _raw = $1 in
           Label.of_string name }
 
-property_name:
- | i=identifier_or_kw { PNI i }
- | s=T_STRING         {
-    let s, _len = s in PNS s }
- | n=numeric_literal  { PNN (Num.of_string_unsafe (n)) }
+(* Library definitions *)
 
-(*************************************************************************)
-(* 1 xxx_opt, xxx_list                                                   *)
-(*************************************************************************)
+block: "{" l=optl(stmt_list) "}" { l }
 
-elison_rev:
- | T_COMMA { [] }
- | elison T_COMMA { None :: $1 }
+stmt_list: item+ { $1 }
 
-elison: elison_rev {$1}
- (* | elison_rev { List.rev $1} *)
+empty_stmt:
+ | T_SEMICOLON { Empty_statement }
 
-curly_block(X):
- | T_LCURLY x=X T_RCURLY { x, ($startpos($1),$startpos($3)) }
+expr_stmt:
+ | expr_no_stmt sc { Expression_statement $1 }
+
+if_stmt:
+ | T_IF "(" c=expr ")" t=stmt T_ELSE e=stmt
+     { If_statement (c, t, Some e) }
+ | T_IF "(" c=expr ")" t=stmt %prec p_IF
+     { If_statement (c, t, None) }
+
+iteration_stmt:
+ | T_DO body=stmt T_WHILE "(" condition=expr ")" sc 
+    { Do_while_statement (body, condition) }
+ | T_WHILE "(" condition=expr ")" body=stmt
+     { While_statement (condition, body) }
+
+ | T_FOR "(" i=expr_no_in? ";" c=expr? ";" incr=expr? ")" st=stmt
+   { For_statement (Left i, c, incr, st) }
+ | T_FOR "(" l=for_variable_decl ";" c=expr? ";" incr=expr? ")" st=stmt
+   { For_statement (Right l, c, incr, st) }
+
+ | T_FOR "(" left=left_hand_side_expr T_IN right=expr ")" body=stmt
+   { ForIn_statement (Left left, right, body) }
+ | T_FOR "(" left=for_single_variable_decl T_IN right=expr ")" body=stmt
+   { ForIn_statement (Right left, right, body) }
+
+ | T_FOR "(" left=left_hand_side_expr T_OF right=assignment_expr ")" body=stmt
+   { ForOf_statement (Left left, right, body) }
+ | T_FOR "(" left=for_single_variable_decl T_OF right=assignment_expr ")" body=stmt
+   { ForOf_statement (Right left, right, body) }
+
+initializer_no_in:
+ | "=" e=assignment_expr_no_in { e, p $symbolstartpos }
+
+continue_stmt:
+ | T_CONTINUE l=label? sc { (Continue_statement (l)) }
+
+break_stmt:
+ | T_BREAK l=label? sc { (Break_statement (l)) }
+
+return_stmt:
+ | T_RETURN e=expr? sc { (Return_statement e) }
+
+switch_stmt:
+ | T_SWITCH "(" subject=expr ")" cb=case_block
+   { let c1, d, c2 = cb in
+     Switch_statement (subject, c1, d, c2)
+   }
+
+labelled_stmt:
+ | l=label ":" s=stmt { Labelled_statement (l, s)}
+
+throw_stmt:
+ | T_THROW e=expr sc { (Throw_statement e) }
+
+try_stmt:
+ | T_TRY b=block c=catch { (Try_statement (b, Some c, None)) }
+ | T_TRY b=block         f=finally { (Try_statement (b, None, Some f)) }
+ | T_TRY b=block c=catch f=finally { (Try_statement (b, Some c, Some f)) }
+
+catch:
+ | T_CATCH "(" p=formal_parameter ")" b=block { Some p,b }
+ | T_CATCH b=block { None,b }
+
+finally:
+ | T_FINALLY b=block { b }
+
+debugger_stmt:
+ | T_DEBUGGER { Debugger_statement }
 
 (*----------------------------*)
-(* Infix binary operators     *)
+(* auxillary stmts *)
 (*----------------------------*)
 
-%inline comparison_or_logical_or_bit_operator_except_in:
- | T_LESS_THAN          { Lt         }
- | T_GREATER_THAN       { Gt         }
- | T_LESS_THAN_EQUAL    { Le         }
- | T_GREATER_THAN_EQUAL { Ge         }
- | T_INSTANCEOF         { InstanceOf }
- | T_EQUAL              { EqEq       }
- | T_NOT_EQUAL          { NotEq      }
- | T_STRICT_EQUAL       { EqEqEq     }
- | T_STRICT_NOT_EQUAL   { NotEqEq    }
- | T_BIT_AND            { Band       }
- | T_BIT_XOR            { Bxor       }
- | T_BIT_OR             { Bor        }
- | T_AND                { And        }
- | T_OR                 { Or         }
+case_block:
+ | "{" case_clause* "}" { $2, None, [] }
+ | "{" case_clause* default_clause case_clause* "}" { $2, Some $3, $4 }
 
-%inline comparison_or_logical_or_bit_operator:
- | op=comparison_or_logical_or_bit_operator_except_in { op }
- | T_IN { In }
+case_clause:
+ | T_CASE e=expr ":" s= optl(stmt_list) { e,s }
 
-%inline arithmetic_or_shift_operator:
- | T_MULT    { Mul   }
- | T_DIV     { Div   }
- | T_MOD     { Mod   }
- | T_PLUS    { Plus  }
- | T_MINUS   { Minus }
- | T_LSHIFT  { Lsl   }
- | T_RSHIFT  { Asr   }
- | T_RSHIFT3 { Lsr   }
+default_clause:
+ | T_DEFAULT ":" list=optl(stmt_list) { list }
 
-%inline prefix_operator:
- | T_DELETE  { Delete }
- | T_VOID    { Void   }
- | T_TYPEOF  { Typeof }
- | T_INCR    { IncrB  }
- | T_INCR_NB { IncrB  }
- | T_DECR    { DecrB  }
- | T_DECR_NB { DecrB  }
- | T_PLUS    { Pl     }
- | T_MINUS   { Neg    }
- | T_BIT_NOT { Bnot   }
- | T_NOT     { Not    }
+(*************************************************************************)
+(* Exprs                                                          *)
+(*************************************************************************)
 
-postfix_operator:
- | T_INCR_NB { IncrA }
- | T_DECR_NB { DecrA }
+expr:
+ | assignment_expr { $1 }
+ | e1=expr "," e2=assignment_expr { ESeq (e1, e2) }
+
+assignment_expr:
+ | conditional_expr(d1) { $1 }
+ | e1=left_hand_side_expr_(d1) op=assignment_operator e2=assignment_expr
+    { EBin (op, e1, e2) }
+ | arrow_function { $1 }
+ | T_YIELD { EYield None }
+ | T_YIELD e=assignment_expr { EYield (Some e) }
+ | T_YIELD "*" e=assignment_expr { EYield (Some e) }
+
+left_hand_side_expr: left_hand_side_expr_(d1) { $1 }
+
+(*----------------------------*)
+(* Generic part (to factorize rules) *)
+(*----------------------------*)
+
+conditional_expr(x):
+ | post_in_expr(x) { $1 }
+  | c=post_in_expr (x) "?" a=assignment_expr ":" b=assignment_expr {
+                         ECond (c, a, b)}
+
+left_hand_side_expr_(x):
+ | new_expr(x)  { $1 }
+ | call_expr(x) { $1 }
+
+post_in_expr(x):
+ | pre_in_expr(x) { $1 }
+
+ | post_in_expr(x) T_LESS_THAN post_in_expr(d1)          { EBin(Lt, $1, $3) }
+ | post_in_expr(x) T_GREATER_THAN post_in_expr(d1)       { EBin(Gt, $1, $3) }
+ | post_in_expr(x) T_LESS_THAN_EQUAL post_in_expr(d1)    { EBin(Le, $1, $3) }
+ | post_in_expr(x) T_GREATER_THAN_EQUAL post_in_expr(d1) { EBin(Ge, $1, $3) }
+ | post_in_expr(x) T_INSTANCEOF post_in_expr(d1)
+    { EBin (InstanceOf, $1, $3) }
+
+ (* also T_IN! *)
+ | post_in_expr(x) T_IN post_in_expr(d1)             { EBin (In, $1, $3) }
+
+ | post_in_expr(x) T_EQUAL post_in_expr(d1)          { EBin(EqEq, $1, $3) }
+ | post_in_expr(x) T_NOT_EQUAL post_in_expr(d1)      { EBin(NotEq, $1, $3) }
+ | post_in_expr(x) T_STRICT_EQUAL post_in_expr(d1)   { EBin(EqEqEq, $1, $3) }
+ | post_in_expr(x) T_STRICT_NOT_EQUAL post_in_expr(d1)   { EBin(NotEqEq, $1, $3) }
+ | post_in_expr(x) T_BIT_AND post_in_expr(d1)        { EBin(Band, $1, $3) }
+ | post_in_expr(x) T_BIT_XOR post_in_expr(d1)        { EBin(Bxor, $1, $3) }
+ | post_in_expr(x) T_BIT_OR post_in_expr(d1)         { EBin(Bor, $1, $3) }
+ | post_in_expr(x) T_AND post_in_expr(d1)            { EBin(And, $1, $3) }
+ | post_in_expr(x) T_OR post_in_expr(d1)             { EBin(Or, $1, $3) }
+ | post_in_expr(x) T_PLING_PLING post_in_expr(d1)    { EBin(Coalesce, $1, $3) }
+
+(* called unary_expr and update_expr in ECMA *)
+pre_in_expr(x):
+ | left_hand_side_expr_(x)                     { $1 }
+
+ | pre_in_expr(x) T_INCR_NB (* %prec p_POSTFIX*)
+    { EUn (IncrA, $1) }
+ | pre_in_expr(x) T_DECR_NB (* %prec p_POSTFIX*)
+    { EUn (DecrA, $1) }
+ | T_INCR pre_in_expr(d1)
+  { EUn (IncrB, $2) }
+ | T_DECR pre_in_expr(d1)
+  { EUn (DecrB, $2) }
+ | T_INCR_NB pre_in_expr(d1)
+  { EUn (IncrB, $2) }
+ | T_DECR_NB pre_in_expr(d1)
+  { EUn (DecrB, $2) }
+
+ | T_DELETE pre_in_expr(d1)                    { EUn (Delete, $2) }
+ | T_VOID pre_in_expr(d1)                      { EUn (Void, $2) }
+  | T_TYPEOF pre_in_expr(d1)                   { EUn (Typeof, $2) }
+ | T_PLUS pre_in_expr(d1)                      { EUn (Pl, $2) }
+ | T_MINUS pre_in_expr(d1)                     { EUn (Neg, $2)}
+ | T_BIT_NOT pre_in_expr(d1)                   { EUn (Bnot, $2) }
+ | T_NOT pre_in_expr(d1)                       { EUn (Not, $2) }
+ (* es7: *)
+ | T_AWAIT pre_in_expr(d1)                     { EUn (Await, $2) }
+
+ | pre_in_expr(x) "*" pre_in_expr(d1)       { EBin(Mul, $1, $3) }
+ | pre_in_expr(x) T_DIV pre_in_expr(d1)     { EBin(Div, $1, $3) }
+ | pre_in_expr(x) T_MOD pre_in_expr(d1)     { EBin(Mod, $1, $3) }
+ | pre_in_expr(x) T_PLUS pre_in_expr(d1)    { EBin(Plus, $1, $3) }
+ | pre_in_expr(x) T_MINUS pre_in_expr(d1)   { EBin(Minus, $1, $3) }
+ | pre_in_expr(x) T_LSHIFT pre_in_expr(d1)  { EBin(Lsl, $1, $3) }
+ | pre_in_expr(x) T_RSHIFT pre_in_expr(d1)  { EBin(Asr, $1, $3) }
+ | pre_in_expr(x) T_RSHIFT3 pre_in_expr(d1) { EBin(Lsr, $1, $3) }
+
+ (* es7: *)
+ | pre_in_expr(x) T_EXP pre_in_expr(d1) { EBin(Exp, $1, $3) }
+
+call_expr(x):
+ | T_IMPORT a=arguments
+     { (ECall(EVar (var (p $symbolstartpos) (Stdlib.Utf8_string.of_string_exn "import")), ANormal, a, p $symbolstartpos)) }
+ | e=member_expr(x) a=arguments
+     { (ECall(e, ANormal, a, p $symbolstartpos)) }
+ | e=member_expr(x) T_PLING_PERIOD a=arguments
+     { (ECall(e, ANullish, a, p $symbolstartpos)) }
+ | e=call_expr(x) a=arguments
+     { (ECall(e, ANormal, a, p $symbolstartpos)) }
+ | e=call_expr(x) T_PLING_PERIOD a=arguments
+     { (ECall(e, ANullish, a, p $symbolstartpos)) }
+ | e=call_expr(x) "[" e2=expr "]"
+     { (EAccess (e, ANormal,  e2)) }
+ | e=call_expr(x) T_PLING_PERIOD "[" e2=expr "]"
+     { (EAccess (e, ANullish, e2)) }
+ | e=call_expr(x) a=access i=method_name
+    { EDot (e,a,i) }
+
+new_expr(x):
+ | e=member_expr(x)    { e }
+ | T_NEW e=new_expr(d1) { (ENew (e,None)) }
+
+access:
+  | "." { ANormal }
+  | T_PLING_PERIOD { ANullish }
+
+member_expr(x):
+ | e=primary_expr(x)
+     { e }
+ | e1=member_expr(x) "[" e2=expr "]"
+     { (EAccess (e1,ANormal, e2)) }
+ | e1=member_expr(x) T_PLING_PERIOD "[" e2=expr "]"
+     { (EAccess (e1,ANullish, e2)) }
+ | e1=member_expr(x) ak=access i=field_name
+     { (EDot(e1,ak,i)) }
+ | T_NEW e1=member_expr(d1) a=arguments
+     { (ENew(e1, Some a)) }
+
+primary_expr(x):
+ | e=primary_expr_no_braces
+ | e=x { e }
+
+d1: primary_with_stmt { $1 }
+
+primary_with_stmt:
+ | object_literal            { $1 }
+ | function_expr       { $1 }
+ (* es6: *)
+ | generator_expr      { $1 }
+ (* es7: *)
+ | async_function_expr { $1 }
+
+
+primary_expr_no_braces:
+ | T_THIS                { EVar (var (p $symbolstartpos) (Stdlib.Utf8_string.of_string_exn "this")) }
+ | i=ident               { EVar i }
+ | n=null_literal        { n }
+ | b=boolean_literal     { b }
+ | n=numeric_literal     { ENum (Num.of_string_unsafe n) }
+ | n=big_numeric_literal { ENum (Num.of_string_unsafe n) }
+ | s=string_literal      { s }
+ | r=regex_literal       { r }
+ | a=array_literal       { a }
+ | "(" e=expr ")"        { e }
+
+(*----------------------------*)
+(* scalar *)
+(*----------------------------*)
+boolean_literal:
+ | T_TRUE  { (EBool true) }
+ | T_FALSE { (EBool false) }
+
+null_literal:
+ | T_NULL { (EVar (var (p $symbolstartpos) (Stdlib.Utf8_string.of_string_exn "null"))) }
+
+numeric_literal:
+ | T_NUMBER { let _,f = $1 in (f) }
+
+big_numeric_literal:
+ | T_BIGINT { let _,f = $1 in (f) }
+
+regex_literal:
+ | r=T_REGEXP {
+   let (Utf8 s, f) = r in
+   (ERegexp (s, if String.equal f "" then None else Some f)) }
+
+string_literal: s=T_STRING { (EStr (fst s)) }
+
+(*----------------------------*)
+(* assign *)
+(*----------------------------*)
 
 assignment_operator:
  | T_ASSIGN         { Eq }
  | T_MULT_ASSIGN    { StarEq }
+ | T_EXP_ASSIGN     { ExpEq }
  | T_DIV_ASSIGN     { SlashEq }
  | T_MOD_ASSIGN     { ModEq }
  | T_PLUS_ASSIGN    { PlusEq }
@@ -753,16 +743,261 @@ assignment_operator:
  | T_BIT_AND_ASSIGN { BandEq }
  | T_BIT_XOR_ASSIGN { BxorEq }
  | T_BIT_OR_ASSIGN  { BorEq }
+ | T_AND_ASSIGN     { AndEq }
+ | T_OR_ASSIGN      { OrEq }
+ | T_NULLISH_ASSIGN { CoalesceEq }
 
-(* Library definitions *)
+(*----------------------------*)
+(* array                    *)
+(*----------------------------*)
 
-either(a, b): a { $1 } | b { $1 }
+array_literal:
+ | "[" e=optl(elision) "]" { (EArr e) }
+ | "[" l=element_list_rev last=optl(elision) "]"
+     { (EArr (List.rev_append l (List.rev last))) }
 
-empty: {}
+element_list_rev:
+ | empty=optl(elision) e=element { e::empty }
+ | l=element_list_rev "," e=element { e :: l }
+ | l=element_list_rev "," empty=elision e=element { e :: (List.rev_append empty l) }
 
-%inline parenthesised(ITEM): T_LPAREN item=ITEM T_RPAREN { item }
+element:
+ | assignment_expr { Element $1 }
+ (* es6: spread operator: *)
+ | "..." assignment_expr { ElementSpread $2 }
 
-separated_or_terminated_list(separator, X):
- | x=X { [x] }
- | x=X separator { [x] }
- | x=X separator xs=separated_or_terminated_list(separator, X) { x :: xs }
+(*----------------------------*)
+(* object *)
+(*----------------------------*)
+
+object_literal:
+ | "{" "}"                                      { EObj [] }
+ | "{" listc(property_name_and_value) ","? "}"  { EObj $2 }
+
+property_name_and_value:
+ | property_name ":" assignment_expr    { Property ($1, $3) }
+ (* es6: *)
+ | id=id                                   { Property (PNI id, EVar (var (p $symbolstartpos) id)) }
+ (* es6: spread operator: *)
+ | "..." assignment_expr                { PropertySpread($2) }
+ | T_GET name=id args=call_signature "{" b=function_body "}" { PropertyGet(name,args,b) }
+ | T_SET name=id args=call_signature "{" b=function_body "}" { PropertySet(name,args,b) }
+ | name=id args=call_signature "{" b=function_body "}" {
+      PropertyMethod(name, (None, {async = false; generator = false}, args, b, p $symbolstartpos)) }
+ | T_ASYNC name=id args=call_signature "{" b=function_body "}" {
+      PropertyMethod(name, (None, {async = true; generator = false}, args, b, p $symbolstartpos)) }
+ | "*" name=id args=call_signature "{" b=function_body "}" {
+      PropertyMethod(name, (None, {async = false; generator = true}, args, b, p $symbolstartpos)) }
+ | T_ASYNC "*" name=id args=call_signature "{" b=function_body "}" {
+      PropertyMethod(name, (None, {async = true; generator = true}, args, b, p $symbolstartpos)) }
+ | "[" p=assignment_expr "]" ":" e=assignment_expr { PropertyComputed (p,e) }
+(*----------------------------*)
+(* function call *)
+(*----------------------------*)
+
+arguments: "(" argument_list_opt ")" { $2 }
+
+argument_list_opt:
+ | (*empty*)   { [] }
+ (* argument_list must be written in a left-recursive way(see conflicts.txt) *)
+ | listc(argument) ","?  { $1  }
+
+(* assignment_expr because expr supports sequence of exprs with ',' *)
+argument:
+ | assignment_expr       { Arg $1 }
+ (* es6: spread operator, allowed not only in last position *)
+ | "..." assignment_expr { ArgSpread $2 }
+
+(*----------------------------*)
+(* interpolated strings *)
+(*----------------------------*)
+
+(* TODO *)
+
+(*----------------------------*)
+(* arrow (short lambda) *)
+(*----------------------------*)
+
+(* TODO conflict with as then in indent_keyword_bis *)
+arrow_function:
+  | i=ident T_ARROW b=arrow_body {  EArrow({async = false; generator = false}, [param' i],b, p $symbolstartpos) }
+  | "(" ")" T_ARROW b=arrow_body
+    { EArrow ({async = false; generator = false}, [],b, p $symbolstartpos) }
+  | T_LPAREN_ARROW a=formal_parameter_list_opt ")" T_ARROW b=arrow_body
+    { EArrow ({async = false; generator = false}, a,b, p $symbolstartpos) }
+
+
+(* was called consise body in spec *)
+arrow_body:
+ | b=function_body { b }
+ (* see conflicts.txt for why the %prec *)
+ | e=assignment_expr_no_stmt (* %prec LOW_PRIORITY_RULE *) { [(Return_statement (Some e), N)] }
+ (* ugly *)
+ | e=function_expr { [(Expression_statement e, N)] }
+
+(*----------------------------*)
+(* no in                    *)
+(*----------------------------*)
+
+expr_no_in:
+ | assignment_expr_no_in { $1 }
+ | e1=expr_no_in "," e2=assignment_expr_no_in { ESeq (e1, e2) }
+
+assignment_expr_no_in:
+ | conditional_expr_no_in { $1 }
+ | e1=left_hand_side_expr_(d1) op=assignment_operator e2=assignment_expr_no_in
+     { EBin(op,e1,e2) }
+
+conditional_expr_no_in:
+ | post_in_expr_no_in { $1 }
+ | c=post_in_expr_no_in "?" a=assignment_expr_no_in ":" b=assignment_expr_no_in
+   { ECond (c, a, b) }
+
+post_in_expr_no_in:
+ | pre_in_expr(d1) { $1 }
+ | post_in_expr_no_in T_LESS_THAN post_in_expr(d1)        { EBin (Lt, $1, $3) }
+ | post_in_expr_no_in T_GREATER_THAN post_in_expr(d1)     { EBin (Gt, $1, $3) }
+ | post_in_expr_no_in T_LESS_THAN_EQUAL post_in_expr(d1)  { EBin (Le, $1, $3) }
+ | post_in_expr_no_in T_GREATER_THAN_EQUAL post_in_expr(d1) { EBin (Ge, $1, $3) }
+ | post_in_expr_no_in T_INSTANCEOF post_in_expr(d1) { EBin(InstanceOf, $1, $3) }
+
+ (* no T_IN case *)
+
+ | post_in_expr_no_in T_EQUAL post_in_expr(d1)         { EBin (EqEq, $1, $3) }
+ | post_in_expr_no_in T_NOT_EQUAL post_in_expr(d1)     { EBin (NotEq, $1, $3) }
+ | post_in_expr_no_in T_STRICT_EQUAL post_in_expr(d1)  { EBin (EqEqEq, $1, $3)}
+ | post_in_expr_no_in T_STRICT_NOT_EQUAL post_in_expr(d1) { EBin (NotEqEq, $1, $3) }
+ | post_in_expr_no_in T_BIT_AND post_in_expr(d1)       { EBin (Band, $1, $3)}
+ | post_in_expr_no_in T_BIT_XOR post_in_expr(d1)       { EBin (Bxor, $1, $3)}
+ | post_in_expr_no_in T_BIT_OR post_in_expr(d1)        { EBin (Bor, $1, $3) }
+ | post_in_expr_no_in T_AND post_in_expr(d1)           { EBin (And, $1, $3) }
+ | post_in_expr_no_in T_OR post_in_expr(d1)            { EBin (Or, $1, $3) }
+ | post_in_expr_no_in T_PLING_PLING post_in_expr(d1)   { EBin (Coalesce, $1, $3) }
+
+(*----------------------------*)
+(* (no stmt, and no object literal like { v: 1 }) *)
+(*----------------------------*)
+expr_no_stmt:
+ | assignment_expr_no_stmt { $1 }
+ | expr_no_stmt "," assignment_expr { ESeq ($1, $3) }
+
+(* coupling: with assignment_expr *)
+assignment_expr_no_stmt:
+ | conditional_expr(primary_no_stmt) { $1 }
+ | e1=left_hand_side_expr_(primary_no_stmt) op=assignment_operator e2=assignment_expr
+   { EBin (op,e1,e2) }
+ (* es6: *)
+ | arrow_function { $1 }
+ (* es6: *)
+ | T_YIELD { EYield None }
+ | T_YIELD e=assignment_expr { EYield (Some e) }
+ | T_YIELD "*" e=assignment_expr { EYield (Some e) }
+
+(* no object_literal here *)
+primary_no_stmt: T_ERROR TComment { assert false }
+
+(*************************************************************************)
+(* Entities, names *)
+(*************************************************************************)
+(* used for entities, parameters, labels, etc. *)
+id:
+ | T_IDENTIFIER { fst $1 }
+  | ident_semi_keyword { utf8_s (Js_token.to_string $1) }
+
+ident:
+  | id { var (p $symbolstartpos) $1 }
+
+(* add here keywords which are not considered reserved by ECMA *)
+ident_semi_keyword:
+ (* TODO: would like to add T_IMPORT here, but cause conflicts *)
+ (* can have AS and ASYNC here but need to restrict arrow_function then *)
+ | T_FROM
+ | T_GET { T_GET }
+ | T_META { T_META }
+ | T_OF { T_OF }
+ | T_SET { T_SET }
+ | T_TARGET {T_TARGET }
+
+  (* future reserved words in strict mode code. *)
+  | T_IMPLEMENTS { T_IMPLEMENTS }
+  | T_INTERFACE { T_INTERFACE }
+  | T_PACKAGE { T_PACKAGE }
+  | T_PRIVATE { T_PRIVATE }
+  | T_PROTECTED {T_PROTECTED }
+  | T_PUBLIC { T_PUBLIC }
+
+(* alt: use the _last_non_whitespace_like_token trick and look if
+ * previous token was a period to return a T_ID
+ *)
+ident_keyword:
+ | ident_keyword_bis { utf8_s (Js_token.to_string $1) }
+
+ident_keyword_bis:
+  | T_AWAIT { T_AWAIT }
+  | T_BREAK { T_BREAK }
+  | T_CASE { T_CASE }
+  | T_CATCH { T_CATCH }
+  | T_CLASS { T_CLASS }
+  | T_CONST { T_CONST }
+  | T_CONTINUE { T_CONTINUE }
+  | T_DEBUGGER { T_DEBUGGER }
+  | T_DEFAULT { T_DEFAULT }
+  | T_DELETE { T_DELETE }
+  | T_DO { T_DO }
+  | T_ELSE { T_ELSE }
+  | T_ENUM { T_ENUM }
+  | T_EXPORT { T_EXPORT }
+  | T_EXTENDS { T_EXTENDS }
+  | T_FALSE { T_FALSE }
+  | T_FINALLY { T_FINALLY }
+  | T_FOR { T_FOR }
+  | T_FUNCTION { T_FUNCTION }
+  | T_IF { T_IF }
+  | T_IMPORT { T_IMPORT }
+  | T_IN { T_IN }
+  | T_INSTANCEOF { T_INSTANCEOF }
+  | T_NEW { T_NEW }
+  | T_NULL { T_NULL }
+  | T_RETURN { T_RETURN }
+  | T_SUPER { T_SUPER }
+  | T_SWITCH { T_SWITCH }
+  | T_THIS { T_THIS }
+  | T_THROW { T_THROW }
+  | T_TRUE { T_TRUE }
+  | T_TRY { T_TRY }
+  | T_TYPEOF { T_TYPEOF }
+  | T_VAR { T_VAR }
+  | T_VOID { T_VOID }
+  | T_WHILE { T_WHILE }
+  | T_WITH { T_WITH }
+  | T_YIELD { T_YIELD }
+  (* reserved words in strict mode code. *)
+  | T_LET { T_LET }
+  | T_STATIC { T_STATIC }
+
+field_name:
+ | id            { $1 }
+ | ident_keyword { $1 }
+
+method_name:
+ | id            { $1 }
+ | ident_keyword { $1 }
+
+property_name:
+ | i=id { PNI i }
+ | i=ident_keyword { PNI i }
+ | s=T_STRING         {
+    let s, _len = s in PNS s }
+ | n=numeric_literal  { PNN (Num.of_string_unsafe (n)) }
+ | n=big_numeric_literal  { PNN (Num.of_string_unsafe (n)) }
+
+(*************************************************************************)
+(* Misc *)
+(*************************************************************************)
+sc:
+ | ";"                 { $1 }
+ | T_VIRTUAL_SEMICOLON { $1 }
+
+elision:
+ | ","         { [ElementHole] }
+ | elision "," { $1 @ [ElementHole] }

--- a/compiler/lib/js_token.ml
+++ b/compiler/lib/js_token.ml
@@ -27,7 +27,6 @@ type t =
   | T_NUMBER of (number_type * string)
   | T_BIGINT of (bigint_type * string)
   | T_STRING of (Utf8_string.t * int)
-  | T_TEMPLATE_PART of (Utf8_string.t * bool)
   | T_IDENTIFIER of (Utf8_string.t * string)
   | T_REGEXP of (Utf8_string.t * string)
   (* /pattern/flags *)
@@ -146,6 +145,9 @@ type t =
   | T_FROM
   | T_TARGET
   | T_META
+  | T_BACKQUOTE
+  | T_DOLLARCURLY
+  | T_ENCAPSED_STRING of string
   (* Extra tokens *)
   | T_ERROR of string
   | T_EOF
@@ -297,8 +299,10 @@ let to_string = function
   | T_EXP -> "**"
   | T_EOF -> ""
   | T_BIGINT (_, raw) -> raw
-  | T_TEMPLATE_PART (Utf8 s, _) -> s
   | T_LPAREN_ARROW -> "("
+  | T_BACKQUOTE -> "`"
+  | T_DOLLARCURLY -> "${"
+  | T_ENCAPSED_STRING s -> s
 
 let to_string_extra x =
   to_string x
@@ -313,6 +317,7 @@ let to_string_extra x =
   | TAnnot _ -> "(annot)"
   | T_ERROR _ -> "(error)"
   | T_LPAREN_ARROW -> "(arrow)"
+  | T_ENCAPSED_STRING _ -> "(encaps)"
   | _ -> ""
 
 let is_keyword s =

--- a/compiler/lib/js_token.ml
+++ b/compiler/lib/js_token.ml
@@ -91,12 +91,11 @@ type t =
   | T_PUBLIC
   | T_YIELD
   | T_DEBUGGER
-  | T_DECLARE
-  | T_TYPE
-  | T_OPAQUE
   | T_OF
   | T_ASYNC
   | T_AWAIT
+  | T_GET
+  | T_SET
   (* Operators *)
   | T_RSHIFT3_ASSIGN
   | T_RSHIFT_ASSIGN
@@ -144,12 +143,16 @@ type t =
   | T_BIT_NOT
   | T_INCR
   | T_DECR
+  | T_FROM
+  | T_TARGET
+  | T_META
   (* Extra tokens *)
   | T_ERROR of string
   | T_EOF
   | T_VIRTUAL_SEMICOLON
   | T_DECR_NB
   | T_INCR_NB
+  | T_LPAREN_ARROW
   | TAnnot of Annot.t
   | TComment of string
   | TCommentLineDirective of string
@@ -277,12 +280,14 @@ let to_string = function
   | T_PROTECTED -> "protected"
   | T_PUBLIC -> "public"
   | T_YIELD -> "yield"
-  | T_DECLARE -> "declare"
-  | T_TYPE -> "type"
-  | T_OPAQUE -> "opaque"
   | T_OF -> "of"
   | T_ASYNC -> "async"
   | T_AWAIT -> "await"
+  | T_GET -> "get"
+  | T_SET -> "set"
+  | T_FROM -> "from"
+  | T_TARGET -> "target"
+  | T_META -> "meta"
   | T_EXP_ASSIGN -> "**="
   | T_NULLISH_ASSIGN -> "??="
   | T_AND_ASSIGN -> "&&="
@@ -293,6 +298,7 @@ let to_string = function
   | T_EOF -> ""
   | T_BIGINT (_, raw) -> raw
   | T_TEMPLATE_PART (Utf8 s, _) -> s
+  | T_LPAREN_ARROW -> "("
 
 let to_string_extra x =
   to_string x
@@ -306,6 +312,7 @@ let to_string_extra x =
   | T_VIRTUAL_SEMICOLON -> " (virtual)"
   | TAnnot _ -> "(annot)"
   | T_ERROR _ -> "(error)"
+  | T_LPAREN_ARROW -> "(arrow)"
   | _ -> ""
 
 let is_keyword s =
@@ -319,7 +326,6 @@ let is_keyword s =
   | "const" -> Some T_CONST
   | "continue" -> Some T_CONTINUE
   | "debugger" -> Some T_DEBUGGER
-  | "declare" -> Some T_DECLARE
   | "default" -> Some T_DEFAULT
   | "delete" -> Some T_DELETE
   | "do" -> Some T_DO
@@ -341,7 +347,6 @@ let is_keyword s =
   | "new" -> Some T_NEW
   | "null" -> Some T_NULL
   | "of" -> Some T_OF
-  | "opaque" -> Some T_OPAQUE
   | "package" -> Some T_PACKAGE
   | "private" -> Some T_PRIVATE
   | "protected" -> Some T_PROTECTED
@@ -354,11 +359,15 @@ let is_keyword s =
   | "throw" -> Some T_THROW
   | "true" -> Some T_TRUE
   | "try" -> Some T_TRY
-  | "type" -> Some T_TYPE
   | "typeof" -> Some T_TYPEOF
   | "var" -> Some T_VAR
   | "void" -> Some T_VOID
   | "while" -> Some T_WHILE
   | "with" -> Some T_WITH
   | "yield" -> Some T_YIELD
+  | "get" -> Some T_GET
+  | "set" -> Some T_SET
+  | "from" -> Some T_FROM
+  | "target" -> Some T_TARGET
+  | "meta" -> Some T_META
   | _ -> None

--- a/compiler/lib/js_token.mli
+++ b/compiler/lib/js_token.mli
@@ -90,12 +90,11 @@ type t =
   | T_PUBLIC
   | T_YIELD
   | T_DEBUGGER
-  | T_DECLARE
-  | T_TYPE
-  | T_OPAQUE
   | T_OF
   | T_ASYNC
   | T_AWAIT
+  | T_GET
+  | T_SET
   (* Operators *)
   | T_RSHIFT3_ASSIGN
   | T_RSHIFT_ASSIGN
@@ -143,12 +142,16 @@ type t =
   | T_BIT_NOT
   | T_INCR
   | T_DECR
+  | T_FROM
+  | T_TARGET
+  | T_META
   (* Extra tokens *)
   | T_ERROR of string
   | T_EOF
   | T_VIRTUAL_SEMICOLON
   | T_DECR_NB
   | T_INCR_NB
+  | T_LPAREN_ARROW
   | TAnnot of Annot.t
   | TComment of string
   | TCommentLineDirective of string

--- a/compiler/lib/js_token.mli
+++ b/compiler/lib/js_token.mli
@@ -26,7 +26,6 @@ type t =
   | T_NUMBER of (number_type * string)
   | T_BIGINT of (bigint_type * string)
   | T_STRING of (Utf8_string.t * int)
-  | T_TEMPLATE_PART of (Utf8_string.t * bool)
   | T_IDENTIFIER of (Utf8_string.t * string)
   | T_REGEXP of (Utf8_string.t * string)
   (* /pattern/flags *)
@@ -145,6 +144,9 @@ type t =
   | T_FROM
   | T_TARGET
   | T_META
+  | T_BACKQUOTE
+  | T_DOLLARCURLY
+  | T_ENCAPSED_STRING of string
   (* Extra tokens *)
   | T_ERROR of string
   | T_EOF

--- a/compiler/lib/js_traverse.mli
+++ b/compiler/lib/js_traverse.mli
@@ -29,6 +29,8 @@ class type mapper =
 
     method switch_case : expression -> expression
 
+    method fun_decl : Javascript.function_declaration -> Javascript.function_declaration
+
     method initialiser : expression * location -> expression * location
 
     method initialiser_o :
@@ -52,14 +54,50 @@ class type mapper =
 
     method ident : ident -> ident
 
-    method param : formal_parameter -> formal_parameter
+    method formal_parameter_list :
+      Javascript.formal_parameter_list -> Javascript.formal_parameter_list
 
     method program : program -> program
 
     method function_body : statement_list -> statement_list
   end
 
+class type iterator =
+  object
+    method early_error : Javascript.early_error -> unit
+
+    method expression : Javascript.expression -> unit
+
+    method expression_o : Javascript.expression option -> unit
+
+    method switch_case : Javascript.expression -> unit
+
+    method initialiser : Javascript.expression * Javascript.location -> unit
+
+    method initialiser_o : (Javascript.expression * Javascript.location) option -> unit
+
+    method for_binding :
+      Javascript.variable_declaration_kind -> Javascript.for_binding -> unit
+
+    method variable_declaration :
+      Javascript.variable_declaration_kind -> Javascript.variable_declaration -> unit
+
+    method statement : Javascript.statement -> unit
+
+    method statement_o : (Javascript.statement * Javascript.location) option -> unit
+
+    method statements : Javascript.statement_list -> unit
+
+    method ident : Javascript.ident -> unit
+
+    method program : Javascript.program -> unit
+
+    method function_body : Javascript.statement_list -> unit
+  end
+
 class map : mapper
+
+class iter : iterator
 
 class subst :
   (ident -> ident)
@@ -75,7 +113,7 @@ type t =
 
 type block =
   | Catch of formal_parameter
-  | Params of formal_parameter list
+  | Params of formal_parameter_list
   | Normal
 
 class type freevar =

--- a/compiler/lib/js_traverse.mli
+++ b/compiler/lib/js_traverse.mli
@@ -29,7 +29,11 @@ class type mapper =
 
     method switch_case : expression -> expression
 
+    method block : Javascript.statement_list -> Javascript.statement_list
+
     method fun_decl : Javascript.function_declaration -> Javascript.function_declaration
+
+    method class_decl : Javascript.class_declaration -> Javascript.class_declaration
 
     method initialiser : expression * location -> expression * location
 
@@ -124,7 +128,7 @@ class type freevar =
 
     method merge_block_info : 'a -> unit
 
-    method block : block -> unit
+    method record_block : block -> unit
 
     method def_var : ident -> unit
 

--- a/compiler/lib/linker.ml
+++ b/compiler/lib/linker.ml
@@ -44,10 +44,10 @@ end = struct
     match p with
     | [] -> None
     | ( Javascript.Function_declaration
-          (Javascript.S { Javascript.name = Utf8 n; _ }, _, l, _, _)
+          (Javascript.S { Javascript.name = Utf8 n; _ }, (_, { list; rest = None }, _, _))
       , _ )
       :: _
-      when String.equal name n -> Some (List.length l)
+      when String.equal name n -> Some (List.length list)
     | _ :: rem -> find rem ~name
 end
 

--- a/compiler/lib/macro.ml
+++ b/compiler/lib/macro.ml
@@ -26,26 +26,30 @@ class macro_mapper =
     method expression x =
       let module J = Javascript in
       match x with
-      | J.ECall (J.EVar (J.S { name = Utf8 name; _ }), args, _) -> (
+      | J.ECall (J.EVar (J.S { name = Utf8 name; _ }), (ANormal | ANullish), args, _) -> (
           match name, args with
-          | "FLAG", [ (J.EStr (Utf8 s), `Not_spread) ] ->
+          | "FLAG", [ J.Arg (J.EStr (Utf8 s)) ] ->
               let i = if Config.Flag.find s then 1l else 0l in
               J.ENum (J.Num.of_int32 i)
-          | "BLOCK", (J.ENum tag, `Not_spread) :: (_ :: _ as args)
+          | "BLOCK", J.Arg (J.ENum tag) :: (_ :: _ as args)
             when List.for_all args ~f:(function
-                     | _, `Not_spread -> true
-                     | _ -> false) ->
+                     | J.Arg _ -> true
+                     | J.ArgSpread _ -> false) ->
               let tag = Int32.to_int (J.Num.to_int32 tag) in
-              let args = List.map args ~f:(fun (e, _) -> m#expression e) in
+              let args =
+                List.map args ~f:(function
+                    | J.Arg e -> m#expression e
+                    | J.ArgSpread _ -> assert false)
+              in
               Mlvalue.Block.make ~tag ~args
-          | "TAG", [ (e, `Not_spread) ] -> Mlvalue.Block.tag (m#expression e)
-          | "LENGTH", [ (e, `Not_spread) ] -> Mlvalue.Array.length (m#expression e)
-          | "FIELD", [ (e, `Not_spread); (J.ENum n, `Not_spread) ] ->
+          | "TAG", [ J.Arg e ] -> Mlvalue.Block.tag (m#expression e)
+          | "LENGTH", [ J.Arg e ] -> Mlvalue.Array.length (m#expression e)
+          | "FIELD", [ J.Arg e; J.Arg (J.ENum n) ] ->
               let idx = Int32.to_int (J.Num.to_int32 n) in
               Mlvalue.Block.field (m#expression e) idx
-          | "FIELD", [ _; (J.EUn (J.Neg, _), `Not_spread) ] ->
+          | "FIELD", [ _; J.Arg (J.EUn (J.Neg, _)) ] ->
               failwith "Negative field indexes are not allowed"
-          | "ISBLOCK", [ (e, `Not_spread) ] -> Mlvalue.is_block (m#expression e)
+          | "ISBLOCK", [ J.Arg e ] -> Mlvalue.is_block (m#expression e)
           | (("BLOCK" | "TAG" | "LENGTH" | "FIELD" | "ISBLOCK" | "FLAG") as name), _ ->
               failwith
                 (Format.sprintf "macro %s called with inappropriate arguments" name)

--- a/compiler/lib/mlvalue.ml
+++ b/compiler/lib/mlvalue.ml
@@ -36,20 +36,22 @@ let is_immediate e = type_of_is_number J.EqEqEq e
 module Block = struct
   let make ~tag ~args =
     J.EArr
-      (List.map ~f:(fun x -> Some x) (J.ENum (J.Num.of_int32 (Int32.of_int tag)) :: args))
+      (List.map
+         ~f:(fun x -> J.Element x)
+         (J.ENum (J.Num.of_int32 (Int32.of_int tag)) :: args))
 
-  let tag e = J.EAccess (e, zero)
+  let tag e = J.EAccess (e, ANormal, zero)
 
   let field e idx =
     let adjusted = J.ENum (J.Num.of_int32 (Int32.of_int (idx + 1))) in
-    J.EAccess (e, adjusted)
+    J.EAccess (e, ANormal, adjusted)
 end
 
 module Array = struct
   let make = Block.make
 
   let length e =
-    let underlying = J.EDot (e, Utf8_string.of_string_exn "length") in
+    let underlying = J.EDot (e, ANormal, Utf8_string.of_string_exn "length") in
     J.EBin (J.Minus, underlying, one)
 
   let field e i =
@@ -57,9 +59,9 @@ module Array = struct
     | J.ENum n ->
         let idx = J.Num.to_int32 n in
         let adjusted = J.ENum (J.Num.of_int32 (Int32.add idx 1l)) in
-        J.EAccess (e, adjusted)
+        J.EAccess (e, ANormal, adjusted)
     | J.EUn (J.Neg, _) -> failwith "Negative field indexes are not allowed"
     | _ ->
         let adjusted = J.EBin (J.Plus, one, i) in
-        J.EAccess (e, adjusted)
+        J.EAccess (e, ANormal, adjusted)
 end

--- a/compiler/lib/parse_js.mli
+++ b/compiler/lib/parse_js.mli
@@ -31,6 +31,9 @@ exception Parsing_error of Parse_info.t
 
 val parse : Lexer.t -> Javascript.program
 
-val parse' : Lexer.t -> Javascript.program_with_annots * (Js_token.t * Parse_info.t) list
+val parse' :
+     Lexer.t
+  -> ((Js_token.Annot.t * Parse_info.t) list * Javascript.program) list
+     * (Js_token.t * Parse_info.t) list
 
 val parse_expr : Lexer.t -> Javascript.expression

--- a/compiler/tests-compiler/exports.ml
+++ b/compiler/tests-compiler/exports.ml
@@ -34,18 +34,18 @@ let%expect_test "static eval of string get" =
     let clean_statement st =
       let open Js_of_ocaml_compiler.Javascript in
       match st with
-      | Function_declaration (name, k, param, body, loc1), loc2 -> (
+      | Function_declaration (name, (k, param, body, loc1)), loc2 -> (
           match List.filter use_jsoo_exports body with
           | [] -> None
-          | body -> Some (Function_declaration (name, k, param, body, loc1), loc2))
-      | ( Expression_statement (ECall (EFun (name, k, param, body, loc1), ANormal, a, l))
+          | body -> Some (Function_declaration (name, (k, param, body, loc1)), loc2))
+      | ( Expression_statement (ECall (EFun (name, (k, param, body, loc1)), ANormal, a, l))
         , loc ) -> (
           match List.filter use_jsoo_exports body with
           | [] -> None
           | body ->
               Some
                 ( Expression_statement
-                    (ECall (EFun (name, k, param, body, loc1), ANormal, a, l))
+                    (ECall (EFun (name, (k, param, body, loc1)), ANormal, a, l))
                 , loc ))
       | _, _ -> Some st
     in

--- a/compiler/tests-compiler/gh1051.ml
+++ b/compiler/tests-compiler/gh1051.ml
@@ -22,12 +22,11 @@
 let prog = {|let () = Printf.printf "%nx" 0xffffffffn;;|}
 
 let%expect_test _ =
-  Util.compile_and_run prog;
+  Util.compile_and_run ~skip_modern:true prog;
   [%expect
     {|
 Warning: integer overflow: integer 0xffffffff (4294967295) truncated to 0xffffffff (-1); the generated code might be incorrect.
-ffffffff
-Warning: integer overflow: integer 0xffffffff (4294967295) truncated to 0xffffffff (-1); the generated code might be incorrect. |}];
+ffffffff |}];
   ()
 
 let%expect_test _ =

--- a/compiler/tests-compiler/gh1051.ml
+++ b/compiler/tests-compiler/gh1051.ml
@@ -26,8 +26,8 @@ let%expect_test _ =
   [%expect
     {|
 Warning: integer overflow: integer 0xffffffff (4294967295) truncated to 0xffffffff (-1); the generated code might be incorrect.
-Warning: integer overflow: integer 0xffffffff (4294967295) truncated to 0xffffffff (-1); the generated code might be incorrect.
-ffffffff |}];
+ffffffff
+Warning: integer overflow: integer 0xffffffff (4294967295) truncated to 0xffffffff (-1); the generated code might be incorrect. |}];
   ()
 
 let%expect_test _ =

--- a/compiler/tests-compiler/js_parser_printer.ml
+++ b/compiler/tests-compiler/js_parser_printer.ml
@@ -445,6 +445,100 @@ let%expect_test "string template" =
     s=
      `asd ${ /*<< 7 20>>*/ f(`space ${test} space`,32)} te`; |}]
 
+let%expect_test "from keyword" =
+  (* GH#1017 *)
+  print
+    ~report:true
+    ~compact:false
+    {|
+({key:"from",
+ value:
+   function from(field,get)
+     {if(!get)get=function get(x){return x;};
+      return this.compute([field],function(state){return get(state.field(field));});}}) |};
+  [%expect
+    {|
+    /*<< 2 0>>*/ ({key:"from",
+     value:
+     function from(field,get)
+      { /*<< 5 6>>*/ if(! get)
+         /*<< 5 14>>*/ get
+        =
+        function get(x){ /*<< 5 34>>*/ return x /*<< 5 18>>*/ };
+        /*<< 6 6>>*/ return  /*<< 6 13>>*/ this.compute
+               ([field],
+                function(state)
+                 { /*<< 6 50>>*/ return  /*<< 6 57>>*/ get
+                          ( /*<< 6 61>>*/ state.field(field)) /*<< 6 34>>*/ }) /*<< 4 3>>*/ }}); |}]
+
+let%expect_test "new.target" =
+  (* GH#1017 *)
+  print ~report:true ~compact:false {|
+    var s = new.target
+ |};
+
+  [%expect {|
+    /*<< 2 4>>*/  /*<< 2 10>>*/ var s=new.target; |}]
+
+let%expect_test "super" =
+  (* GH#1017 *)
+  print
+    ~report:true
+    ~compact:false
+    {|
+class x extends p {
+    constructor() {
+      super(a,b,c);
+    }
+    foo() {
+
+      var s = super[d]
+      var s = super.d
+    }
+
+    static bar() {
+
+      var s = super[d]
+      var s = super.d
+    }
+   x = 3
+
+   static y = 5
+
+   #z = 6
+
+   static #t = 2
+
+   static { var x = 3 }
+}
+ |};
+
+  [%expect
+    {|
+     /*<< 2 0>>*/ class
+    x
+    extends
+    p{constructor(){ /*<< 4 6>>*/  /*<< 4 6>>*/ super(a,b,c) /*<< 3 4>>*/ }
+    foo()
+     { /*<< 8 6>>*/  /*<< 8 12>>*/ var s=super[d];
+       /*<< 9 6>>*/  /*<< 9 12>>*/ var s=super.d /*<< 6 4>>*/ }
+    static
+    bar()
+     { /*<< 14 6>>*/  /*<< 14 12>>*/ var s=super[d];
+       /*<< 15 6>>*/  /*<< 15 12>>*/ var s=super.d /*<< 12 11>>*/ }
+    x=
+     /*<< 17 5>>*/ 3
+    static
+    y=
+     /*<< 19 12>>*/ 5
+    #z=
+     /*<< 21 6>>*/ 6
+    static
+    #t=
+     /*<< 23 13>>*/ 2
+    static{ /*<< 25 12>>*/  /*<< 25 18>>*/ var x=3}
+    } |}]
+
 let%expect_test "error reporting" =
   (try
      print ~invalid:true ~compact:false {|

--- a/compiler/tests-compiler/jsopt.ml
+++ b/compiler/tests-compiler/jsopt.ml
@@ -337,8 +337,8 @@ let%expect_test "string sharing" =
        {"use strict";
         var
          str_npi_xcf_x80="npi\xcf\x80",
-         str_npi="npiπ",
          str_abc_def="abc\\def",
+         str_npi="npiπ",
          str_abcdef="abcdef",
          runtime=globalThis.jsoo_runtime,
          s3=str_abcdef,
@@ -448,8 +448,8 @@ let%expect_test "string sharing" =
        {"use strict";
         var
          str_npi_xcf_x80="npi\xcf\x80",
-         str_npi="npiπ",
          str_abc_def="abc\\def",
+         str_npi="npiπ",
          str_abcdef="abcdef",
          runtime=globalThis.jsoo_runtime,
          caml_string_of_jsbytes=runtime.caml_string_of_jsbytes,

--- a/compiler/tests-compiler/jsopt.ml
+++ b/compiler/tests-compiler/jsopt.ml
@@ -337,9 +337,9 @@ let%expect_test "string sharing" =
        {"use strict";
         var
          str_npi_xcf_x80="npi\xcf\x80",
-         str_abc_def="abc\\def",
          str_npi="npiπ",
          str_abcdef="abcdef",
+         str_abc_def="abc\\def",
          runtime=globalThis.jsoo_runtime,
          s3=str_abcdef,
          s6=str_npi_xcf_x80,
@@ -448,9 +448,9 @@ let%expect_test "string sharing" =
        {"use strict";
         var
          str_npi_xcf_x80="npi\xcf\x80",
-         str_abc_def="abc\\def",
          str_npi="npiπ",
          str_abcdef="abcdef",
+         str_abc_def="abc\\def",
          runtime=globalThis.jsoo_runtime,
          caml_string_of_jsbytes=runtime.caml_string_of_jsbytes,
          s3=caml_string_of_jsbytes(str_abcdef),

--- a/compiler/tests-compiler/jsopt.ml
+++ b/compiler/tests-compiler/jsopt.ml
@@ -337,8 +337,8 @@ let%expect_test "string sharing" =
        {"use strict";
         var
          str_npi_xcf_x80="npi\xcf\x80",
-         str_npi="npiπ",
          str_abcdef="abcdef",
+         str_npi="npiπ",
          str_abc_def="abc\\def",
          runtime=globalThis.jsoo_runtime,
          s3=str_abcdef,
@@ -448,8 +448,8 @@ let%expect_test "string sharing" =
        {"use strict";
         var
          str_npi_xcf_x80="npi\xcf\x80",
-         str_npi="npiπ",
          str_abcdef="abcdef",
+         str_npi="npiπ",
          str_abc_def="abc\\def",
          runtime=globalThis.jsoo_runtime,
          caml_string_of_jsbytes=runtime.caml_string_of_jsbytes,

--- a/compiler/tests-compiler/minify.ml
+++ b/compiler/tests-compiler/minify.ml
@@ -213,3 +213,48 @@ a = function (aaa,b,c,yyy) {
           2: b=2;var
           3: f=3;return b+b}else{let
           4: b=3,c=b;return b*e}}; |}])
+
+let%expect_test _ =
+  with_temp_dir ~f:(fun () ->
+      let js_prog =
+        {|
+        var long1 = 1;
+        let long2 = 2;
+        const long3 = 3;
+        function f () {
+          var long1 = 1;
+          let long2 = 2;
+          const long3 = 3;
+        }
+        |}
+      in
+      let js_file =
+        js_prog |> Filetype.js_text_of_string |> Filetype.write_js ~name:"test.js"
+      in
+      let js_min_file =
+        js_file |> jsoo_minify ~flags:[ "--enable"; "shortvar" ] ~pretty:false
+      in
+      print_file (Filetype.path_of_js_file js_file);
+      print_file (Filetype.path_of_js_file js_min_file);
+      [%expect
+        {|
+        $ cat "test.js"
+          1:
+          2:         var long1 = 1;
+          3:         let long2 = 2;
+          4:         const long3 = 3;
+          5:         function f () {
+          6:           var long1 = 1;
+          7:           let long2 = 2;
+          8:           const long3 = 3;
+          9:         }
+         10:
+        $ cat "test.min.js"
+          1: var
+          2: long1=1;let
+          3: a=2;const
+          4: b=3;function
+          5: f(){var
+          6: a=1;let
+          7: b=2;const
+          8: c=3} |}])

--- a/compiler/tests-compiler/sourcemap.ml
+++ b/compiler/tests-compiler/sourcemap.ml
@@ -71,7 +71,6 @@ let%expect_test _ =
        10:   (globalThis));
        11:
        12: //# sourceMappingURL=test.map
-      null:-1:-1 -> 5:4
       /dune-root/test.ml:1:4 -> 6:13
       /dune-root/test.ml:1:7 -> 6:16
       /dune-root/test.ml:1:11 -> 6:19

--- a/compiler/tests-compiler/util/util.ml
+++ b/compiler/tests-compiler/util/util.ml
@@ -502,7 +502,14 @@ let compile_and_run_bytecode ?unix s =
       |> run_bytecode
       |> print_endline)
 
-let compile_and_run ?debug ?(flags = []) ?effects ?use_js_string ?unix s =
+let compile_and_run
+    ?debug
+    ?(skip_modern = false)
+    ?(flags = [])
+    ?effects
+    ?use_js_string
+    ?unix
+    s =
   with_temp_dir ~f:(fun () ->
       let bytecode_file =
         s
@@ -520,21 +527,23 @@ let compile_and_run ?debug ?(flags = []) ?effects ?use_js_string ?unix s =
         |> run_javascript
       in
       print_endline output_without_stdlib_modern;
-      let output_with_stdlib_modern =
-        compile_bc_to_javascript
-          ~flags:(flags @ [ "+stdlib_modern.js" ])
-          ?effects
-          ?use_js_string
-          ?sourcemap:debug
-          bytecode_file
-        |> run_javascript
-      in
-      if not (String.equal output_without_stdlib_modern output_with_stdlib_modern)
-      then (
-        print_endline "Output was different with stdlib_modern.js:";
-        print_endline "===========================================";
-        print_string output_with_stdlib_modern;
-        print_endline "==========================================="))
+      if not skip_modern
+      then
+        let output_with_stdlib_modern =
+          compile_bc_to_javascript
+            ~flags:(flags @ [ "+stdlib_modern.js" ])
+            ?effects
+            ?use_js_string
+            ?sourcemap:debug
+            bytecode_file
+          |> run_javascript
+        in
+        if not (String.equal output_without_stdlib_modern output_with_stdlib_modern)
+        then (
+          print_endline "Output was different with stdlib_modern.js:";
+          print_endline "===========================================";
+          print_string output_with_stdlib_modern;
+          print_endline "==========================================="))
 
 let compile_and_parse_whole_program ?(debug = true) ?flags ?effects ?use_js_string ?unix s
     =

--- a/compiler/tests-compiler/util/util.mli
+++ b/compiler/tests-compiler/util/util.mli
@@ -73,6 +73,7 @@ val print_fun_decl : Javascript.program -> string option -> unit
 
 val compile_and_run :
      ?debug:bool
+  -> ?skip_modern:bool
   -> ?flags:string list
   -> ?effects:bool
   -> ?use_js_string:bool

--- a/compiler/tests-compiler/util/util.mli
+++ b/compiler/tests-compiler/util/util.mli
@@ -57,6 +57,10 @@ val extract_sourcemap : Filetype.js_file -> Js_of_ocaml_compiler.Source_map.t op
 
 val run_javascript : Filetype.js_file -> string
 
+val check_javascript : Filetype.js_file -> string
+
+val check_javascript_source : string -> string
+
 val expression_to_string : ?compact:bool -> Javascript.expression -> string
 
 val print_file : string -> unit

--- a/compiler/tests-js-parser/dune
+++ b/compiler/tests-js-parser/dune
@@ -1,6 +1,6 @@
 (executable
-  (name run)
-  (libraries js_of_ocaml_compiler unix str))
+ (name run)
+ (libraries js_of_ocaml_compiler unix str))
 
 ;; $ git clone git@github.com:tc39/test262-parser-tests.git
 ;; $ dune exe compiler/tests-js-parser/run.exe test262-parser-tests/pass/*

--- a/compiler/tests-js-parser/dune
+++ b/compiler/tests-js-parser/dune
@@ -1,0 +1,6 @@
+(executable
+  (name run)
+  (libraries js_of_ocaml_compiler unix str))
+
+;; $ git clone git@github.com:tc39/test262-parser-tests.git
+;; $ dune exe compiler/tests-js-parser/run.exe test262-parser-tests/pass/*

--- a/compiler/tests-js-parser/run.ml
+++ b/compiler/tests-js-parser/run.ml
@@ -1,0 +1,95 @@
+open Js_of_ocaml_compiler
+open Stdlib
+
+let files = Sys.argv |> Array.to_list |> List.tl
+
+let unsupported_syntax = ref []
+
+let fail = ref []
+
+let pass = ref []
+
+let rs =
+  [ Str.regexp_string "class"
+  ; Str.regexp_string "import"
+  ; Str.regexp_string "export"
+  ; Str.regexp_string "`"
+  ; Str.regexp_string "new.target"
+  ; Str.regexp_string "with"
+  ]
+
+let has_unsupported_syntax c =
+  List.exists rs ~f:(fun r ->
+      try
+        let (_ : int) = Str.search_forward r c 0 in
+        true
+      with Not_found -> false)
+
+class clean_loc =
+  object
+    inherit Js_traverse.map
+
+    method! loc _ = N
+  end
+
+let clean_loc = new clean_loc
+
+let _clean_loc p = clean_loc#program p
+
+let p_to_string p =
+  let buffer = Buffer.create 100 in
+  let pp = Pretty_print.to_buffer buffer in
+  let _ = Js_output.program pp p in
+  Buffer.contents buffer
+
+let () =
+  List.iter files ~f:(fun filename ->
+      let add r = r := filename :: !r in
+      let ic = open_in_bin filename in
+      let content = In_channel.input_all ic in
+      close_in ic;
+      try
+        let p1 = Parse_js.Lexer.of_string ~filename content |> Parse_js.parse in
+        (if false
+        then
+          try
+            let explicit =
+              Filename.(
+                concat
+                  (concat (dirname (dirname filename)) "pass-explicit")
+                  (basename filename))
+            in
+            let ic = open_in_bin explicit in
+            let content = In_channel.input_all ic in
+            close_in ic;
+            let p2 =
+              Parse_js.Lexer.of_string ~filename:explicit content |> Parse_js.parse
+            in
+            let p1s = p_to_string p1 and p2s = p_to_string p2 in
+            if not (String.equal p1s p2s)
+            then (
+              Printf.printf ">>>>>>> MISMATCH %s <<<<<<<<<<\n" filename;
+              Printf.printf "%s\n\n%s\n" p1s p2s)
+          with _ -> ());
+        add pass
+      with Parse_js.Parsing_error loc ->
+        if has_unsupported_syntax content
+        then add unsupported_syntax
+        else fail := (filename, loc, content) :: !fail);
+  Printf.printf "Summary:\n";
+  Printf.printf "  skip : %d\n" (List.length !unsupported_syntax);
+  Printf.printf "  fail : %d\n" (List.length !fail);
+  Printf.printf "  pass : %d\n" (List.length !pass);
+  let l = !fail in
+  List.iter l ~f:(fun (f, (pi : Parse_info.t), c) ->
+      Printf.printf "failed to parse %s:%d:%d\n" f pi.line pi.col;
+      List.iteri (String.split_on_char ~sep:'\n' c) ~f:(fun i c ->
+          if i + 1 = pi.line
+          then (
+            let b = Buffer.create (String.length c) in
+            String.fold_utf_8 c () ~f:(fun () i u ->
+                if i = pi.col then Buffer.add_utf_8_uchar b (Uchar.of_int 0x274C);
+                Buffer.add_utf_8_uchar b u);
+            Printf.printf "%s\n" (Buffer.contents b))
+          else Printf.printf "%s\n" c);
+      Printf.printf "\n")

--- a/compiler/tests-js-parser/run.ml
+++ b/compiler/tests-js-parser/run.ml
@@ -21,11 +21,11 @@ let fail = ref []
 let pass = ref []
 
 let rs =
-  [ Str.regexp_string "class"
-  ; Str.regexp_string "import"
+  [ Str.regexp_string "import"
   ; Str.regexp_string "export"
-  ; Str.regexp_string "new.target"
   ; Str.regexp_string "with"
+  ; Str.regexp_string "<!--"
+  ; Str.regexp_string "-->"
   ]
 
 let has_unsupported_syntax c =

--- a/compiler/tests-sourcemap/dump.reference
+++ b/compiler/tests-sourcemap/dump.reference
@@ -5,5 +5,5 @@ b.ml:1:10 -> 18:    function f(x){<>return x - 1 | 0}
 b.ml:1:6 -> 25:    function f(x){return <>x - 1 | 0}
 b.ml:1:15 -> 34:    function f(x){return x - 1 | 0<>}
 b.ml:1:4 -> 21:    var Testlib_B=[0,<>f];
-a.ml:-1:-1 -> 4:    <>var runtime=globalThis.jsoo_runtime;
+a.ml:-1:-1 -> 4:    <>function caml_call1(f,a0)
 a.ml:-1:-1 -> 44:    throw [0,Int,caml_call1(Testlib_B[1],2)]<>}


### PR DESCRIPTION
The PR modernize to JavaScript  support inside js_of_ocaml.

The PR started with a synchronization of the jsoo parser with what's found in semgrep
(see https://github.com/returntocorp/semgrep/blob/develop/languages/javascript/menhir/parser_js.mly)

The JS ast was modified to accommodate the new syntaxes.

The PR doesn't change the syntax used during code generation.
Here are a few ideas for the future:
- use arrow function when possible the reduce generated code size
- use `let` for mutable var, instead of using IIFE

### New syntax added in the PR
- destructing `var [x,y] = [1,2]`
- `let` and  `const` and their local scoping
- spread `...`, in expression and patterns
- arrow `(args) => exp`
- `aync/await`
- `yield` and generator
- Bigint
- Nullish coalescing `??`/`.?`
- ForOf
- `get/set/computed` property for object literal
- string templates
- `class`
- `new.target`
- `super`

### Syntax not included in this PR
- `import/export`
- `with` (probably won't fix given it's deprecated)

### X-links
fix #508 
fix #972
fix #989 
fix #1017
fix #1031

unlock #1161 
Replace #1231

### Checklist

- [x] Update ast
- [x] fix scope of `let` and `const`
- [x] Update parser
- [x] Update parser error recovery to handle `( ... ) => .. `
- [x] Check/fix precedence in js_output
- [x] we need better tests for parser/printer (https://github.com/tc39/test262-parser-tests)
- [x] fix variable rewriting for function in object_literal  