### PR TITLE
Global flow analysis: fix assert failure

### DIFF
--- a/compiler/lib/global_flow.ml
+++ b/compiler/lib/global_flow.ml
@@ -431,7 +431,7 @@ let propagate st ~update approx x =
                   | Phi _ | Expr _ -> assert false)
                 known
           | Top -> Top)
-      | Prim (Array_get, _) -> assert false
+      | Prim (Array_get, _) -> Domain.others
       | Prim ((Vectlength | Not | IsInt | Eq | Neq | Lt | Le | Ult), _) ->
           (* The result of these primitive is neither a function nor a
              block *)


### PR DESCRIPTION
Do not fail when accessing a constant string as if it were an array:
https://github.com/ocsigen/js_of_ocaml/blob/eae34864ebe70c3e93d373e87fcd7432f5a6d1d4/compiler/tests-jsoo/test_obj.ml#L49-L52
This fixes #1400.