### PR TITLE
Fix js backtrace attached to ocaml exn 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,11 +16,13 @@
 * Compiler: stop parsing the builtin js runtime if not necessary
 * Compiler: improve js pretty printer (#1405)
 * Toplevel: Enable separate compilation of toplevels
+* Runtime: js backtrace recording controled by OCAMLRUNPARAM
 
 ## Bug fixes
 - Effects: fix Js.export and Js.export_all to work with functions
 - Sourcemap: fix incorrect sourcemap with separate compilation
 - Compiler: fix control flow analysis; some annotions were wrong in the runtime
+* Compiler: js backtrace recording respected in the js runtime and when using effects
 - Runtime: fix the compilation of some mutually recursive functions
 
 # 5.0.1 (2022-12-20) - Lille

--- a/compiler/lib/generate.ml
+++ b/compiler/lib/generate.ml
@@ -108,7 +108,7 @@ module Share = struct
 
   let add_prim s t =
     let n = try StringMap.find s t.prims with Not_found -> 0 in
-    { t with prims = StringMap.add s (n + 1) t.prims }
+    if n < 0 then t else { t with prims = StringMap.add s (n + 1) t.prims }
 
   let add_special_prim_if_exists s t =
     if Primitive.exists s then { t with prims = StringMap.add s (-1) t.prims } else t

--- a/compiler/tests-check-prim/main.output
+++ b/compiler/tests-check-prim/main.output
@@ -75,9 +75,6 @@ caml_ml_condition_signal
 caml_ml_condition_wait
 jsoo_effect_not_supported
 
-From +fail.js:
-caml_return_exn_constant
-
 From +fs.js:
 caml_ba_map_file
 caml_ba_map_file_bytecode

--- a/compiler/tests-check-prim/main.output5
+++ b/compiler/tests-check-prim/main.output5
@@ -59,9 +59,6 @@ caml_ml_domain_set_name
 From +effect.js:
 jsoo_effect_not_supported
 
-From +fail.js:
-caml_return_exn_constant
-
 From +fs.js:
 caml_ba_map_file
 caml_ba_map_file_bytecode

--- a/compiler/tests-check-prim/unix-unix.output
+++ b/compiler/tests-check-prim/unix-unix.output
@@ -184,9 +184,6 @@ caml_ml_condition_signal
 caml_ml_condition_wait
 jsoo_effect_not_supported
 
-From +fail.js:
-caml_return_exn_constant
-
 From +fs.js:
 caml_ba_map_file
 caml_ba_map_file_bytecode

--- a/compiler/tests-check-prim/unix-unix.output5
+++ b/compiler/tests-check-prim/unix-unix.output5
@@ -168,9 +168,6 @@ caml_ml_domain_set_name
 From +effect.js:
 jsoo_effect_not_supported
 
-From +fail.js:
-caml_return_exn_constant
-
 From +fs.js:
 caml_ba_map_file
 caml_ba_map_file_bytecode

--- a/compiler/tests-check-prim/unix-win32.output
+++ b/compiler/tests-check-prim/unix-win32.output
@@ -149,9 +149,6 @@ caml_ml_condition_signal
 caml_ml_condition_wait
 jsoo_effect_not_supported
 
-From +fail.js:
-caml_return_exn_constant
-
 From +fs.js:
 caml_ba_map_file
 caml_ba_map_file_bytecode

--- a/compiler/tests-check-prim/unix-win32.output5
+++ b/compiler/tests-check-prim/unix-win32.output5
@@ -139,9 +139,6 @@ caml_ml_domain_set_name
 From +effect.js:
 jsoo_effect_not_supported
 
-From +fail.js:
-caml_return_exn_constant
-
 From +fs.js:
 caml_ba_map_file
 caml_ba_map_file_bytecode

--- a/compiler/tests-compiler/effects_continuations.ml
+++ b/compiler/tests-compiler/effects_continuations.ml
@@ -103,25 +103,32 @@ let%expect_test "test-compiler/lib-effects/test1.ml" =
       var _v_ = caml_wrap_exception(_G_);
       if(_v_[1] !== Stdlib[7]){
        var raise$1 = caml_pop_trap();
-       return raise$1(_v_);
+       return raise$1(caml_maybe_attach_backtrace(_v_, 0));
       }
       var n = 0, _w_ = 0;
      }
-     try{if(caml_string_equal(s, cst$0)) throw Stdlib[8]; var _B_ = 7, m = _B_;}
+     try{
+      if(caml_string_equal(s, cst$0))
+       throw caml_maybe_attach_backtrace(Stdlib[8], 1);
+      var _B_ = 7, m = _B_;
+     }
      catch(_F_){
       var _x_ = caml_wrap_exception(_F_);
-      if(_x_ !== Stdlib[8]){var raise$0 = caml_pop_trap(); return raise$0(_x_);}
+      if(_x_ !== Stdlib[8]){
+       var raise$0 = caml_pop_trap();
+       return raise$0(caml_maybe_attach_backtrace(_x_, 0));
+      }
       var m = 0, _y_ = 0;
      }
      runtime.caml_push_trap
       (function(_E_){
         if(_E_ === Stdlib[8]) return cont(0);
         var raise = caml_pop_trap();
-        return raise(_E_);
+        return raise(caml_maybe_attach_backtrace(_E_, 0));
        });
      if(caml_string_equal(s, cst)){
       var _z_ = Stdlib[8], raise = caml_pop_trap();
-      return raise(_z_);
+      return raise(caml_maybe_attach_backtrace(_z_, 1));
      }
      var _A_ = Stdlib[79];
      return caml_cps_call2

--- a/compiler/tests-compiler/effects_exceptions.ml
+++ b/compiler/tests-compiler/effects_exceptions.ml
@@ -62,25 +62,32 @@ let%expect_test "test-compiler/lib-effects/test1.ml" =
       var _i_ = caml_wrap_exception(_t_);
       if(_i_[1] !== Stdlib[7]){
        var raise$1 = caml_pop_trap();
-       return raise$1(_i_);
+       return raise$1(caml_maybe_attach_backtrace(_i_, 0));
       }
       var n = 0, _j_ = 0;
      }
-     try{if(caml_string_equal(s, cst$0)) throw Stdlib[8]; var _o_ = 7, m = _o_;}
+     try{
+      if(caml_string_equal(s, cst$0))
+       throw caml_maybe_attach_backtrace(Stdlib[8], 1);
+      var _o_ = 7, m = _o_;
+     }
      catch(_s_){
       var _k_ = caml_wrap_exception(_s_);
-      if(_k_ !== Stdlib[8]){var raise$0 = caml_pop_trap(); return raise$0(_k_);}
+      if(_k_ !== Stdlib[8]){
+       var raise$0 = caml_pop_trap();
+       return raise$0(caml_maybe_attach_backtrace(_k_, 0));
+      }
       var m = 0, _l_ = 0;
      }
      caml_push_trap
       (function(_r_){
         if(_r_ === Stdlib[8]) return cont(0);
         var raise = caml_pop_trap();
-        return raise(_r_);
+        return raise(caml_maybe_attach_backtrace(_r_, 0));
        });
      if(caml_string_equal(s, cst)){
       var _m_ = Stdlib[8], raise = caml_pop_trap();
-      return raise(_m_);
+      return raise(caml_maybe_attach_backtrace(_m_, 1));
      }
      var _n_ = Stdlib[79];
      return caml_cps_call2
@@ -104,8 +111,11 @@ let%expect_test "test-compiler/lib-effects/test1.ml" =
                     var l = match[2];
                     return caml_cps_exact_call1(_h_, l);
                    }
-                   var exn = match[2], raise = caml_pop_trap();
-                   return raise(exn);
+                   var
+                    exn = match[2],
+                    raise = caml_pop_trap(),
+                    exn$0 = caml_maybe_attach_backtrace(exn, 1);
+                   return raise(exn$0);
                   });
         }
         return _h_(l);

--- a/compiler/tests-compiler/eliminate_exception_handler.ml
+++ b/compiler/tests-compiler/eliminate_exception_handler.ml
@@ -51,5 +51,7 @@ try raise Not_found with
   print_fun_decl program (Some "some_name");
   [%expect
     {|
-    function some_name(param){try{throw Stdlib[8];}catch(_a_){return 0;}}
+    function some_name(param){
+     try{throw caml_maybe_attach_backtrace(Stdlib[8], 1);}catch(_a_){return 0;}
+    }
     //end |}]

--- a/compiler/tests-compiler/exceptions.ml
+++ b/compiler/tests-compiler/exceptions.ml
@@ -34,18 +34,25 @@ let prevent_inline = some_name
     {|
     function some_name(param){
      try{
-      try{throw Stdlib[8];}catch(x$0){var x = caml_wrap_exception(x$0), i$0 = x;}
+      try{throw caml_maybe_attach_backtrace(Stdlib[8], 1);}
+      catch(x$0){var x = caml_wrap_exception(x$0), i$0 = x;}
      }
      catch(i$1){var i = caml_wrap_exception(i$1), i$0 = i;}
-     throw i$0;
+     throw caml_maybe_attach_backtrace(i$0, 1);
     }
     //end |}];
   print_fun_decl (program ~debug:false) None;
   [%expect
     {|
     function _a_(_b_){
-     try{try{throw Stdlib[8];}catch(_f_){var _d_ = caml_wrap_exception(_f_);}}
-     catch(_e_){var _c_ = caml_wrap_exception(_e_); throw _c_;}
-     throw _d_;
+     try{
+      try{throw caml_maybe_attach_backtrace(Stdlib[8], 1);}
+      catch(_f_){var _d_ = caml_wrap_exception(_f_);}
+     }
+     catch(_e_){
+      var _c_ = caml_wrap_exception(_e_);
+      throw caml_maybe_attach_backtrace(_c_, 1);
+     }
+     throw caml_maybe_attach_backtrace(_d_, 1);
     }
     //end |}]

--- a/compiler/tests-compiler/exports.ml
+++ b/compiler/tests-compiler/exports.ml
@@ -53,7 +53,15 @@ let%expect_test "static eval of string get" =
   in
   let program =
     compile_and_parse_whole_program
-      ~flags:[ "--wrap-with-fun"; "Loader"; "--target-env"; "browser"; "--no-extern-fs" ]
+      ~flags:
+        [ "--wrap-with-fun"
+        ; "Loader"
+        ; "--target-env"
+        ; "browser"
+        ; "--no-extern-fs"
+        ; "--enable"
+        ; "vardecl"
+        ]
       {|
       external pure_js_expr : string -> 'a = "caml_pure_js_expr"
       external set : 'a -> 'b -> 'c -> unit = "caml_js_set"
@@ -72,7 +80,15 @@ let%expect_test "static eval of string get" =
     //end |}];
   let program =
     compile_and_parse_whole_program
-      ~flags:[ "--wrap-with-fun"; "Loader"; "--target-env"; "browser"; "--no-extern-fs" ]
+      ~flags:
+        [ "--wrap-with-fun"
+        ; "Loader"
+        ; "--target-env"
+        ; "browser"
+        ; "--no-extern-fs"
+        ; "--enable"
+        ; "vardecl"
+        ]
       {|
       external pure_js_expr : string -> 'a = "caml_pure_js_expr"
       external set : 'a -> 'b -> 'c -> unit = "caml_js_set"
@@ -87,7 +103,7 @@ let%expect_test "static eval of string get" =
     //end |}];
   let program =
     compile_and_parse_whole_program
-      ~flags:[ "--target-env"; "browser"; "--no-extern-fs" ]
+      ~flags:[ "--target-env"; "browser"; "--no-extern-fs"; "--enable"; "vardecl" ]
       {|
       external pure_js_expr : string -> 'a = "caml_pure_js_expr"
       external set : 'a -> 'b -> 'c -> unit = "caml_js_set"
@@ -106,7 +122,7 @@ let%expect_test "static eval of string get" =
     //end |}];
   let program =
     compile_and_parse_whole_program
-      ~flags:[ "--target-env"; "browser"; "--no-extern-fs" ]
+      ~flags:[ "--target-env"; "browser"; "--no-extern-fs"; "--enable"; "vardecl" ]
       {|
       external pure_js_expr : string -> 'a = "caml_pure_js_expr"
       external set : 'a -> 'b -> 'c -> unit = "caml_js_set"

--- a/compiler/tests-compiler/gh1354.ml
+++ b/compiler/tests-compiler/gh1354.ml
@@ -48,6 +48,7 @@ with Exit ->
        "use strict";
        var
         runtime = globalThis.jsoo_runtime,
+        caml_maybe_attach_backtrace = runtime.caml_maybe_attach_backtrace,
         caml_wrap_exception = runtime.caml_wrap_exception;
        function caml_call2(f, a0, a1){
         return (f.l >= 0 ? f.l : f.l = f.length) == 2
@@ -62,10 +63,10 @@ with Exit ->
         _d_ =
           [0, [4, 0, 0, 0, [12, 10, 0]], runtime.caml_string_of_jsbytes("%d\n")],
         _a_ = 0;
-       try{0; _b_ = _a_ + 1 | 0; throw Stdlib[3];}
+       try{0; _b_ = _a_ + 1 | 0; throw caml_maybe_attach_backtrace(Stdlib[3], 1);}
        catch(_e_){
         var _c_ = caml_wrap_exception(_e_);
-        if(_c_ !== Stdlib[3]) throw _c_;
+        if(_c_ !== Stdlib[3]) throw caml_maybe_attach_backtrace(_c_, 0);
         caml_call2(Stdlib_Printf[3], _d_, _b_ | 0);
         var Test = [0];
         runtime.caml_register_global(3, Test, "Test");
@@ -110,6 +111,7 @@ with Exit ->
        "use strict";
        var
         runtime = globalThis.jsoo_runtime,
+        caml_maybe_attach_backtrace = runtime.caml_maybe_attach_backtrace,
         caml_string_of_jsbytes = runtime.caml_string_of_jsbytes,
         caml_wrap_exception = runtime.caml_wrap_exception;
        function caml_call3(f, a0, a1, a2){
@@ -137,15 +139,21 @@ with Exit ->
         0;
         _c_ = _f_;
         var _g_ = _f_;
-        try{var _i_ = _f_ + 1 | 0; 0; _g_ = _i_; _c_ = _i_; throw Stdlib[3];}
+        try{
+         var _i_ = _f_ + 1 | 0;
+         0;
+         _g_ = _i_;
+         _c_ = _i_;
+         throw caml_maybe_attach_backtrace(Stdlib[3], 1);
+        }
         catch(_k_){
          caml_call3(Stdlib_Printf[3], _h_, _g_ | 0, _b_);
-         throw Stdlib[3];
+         throw caml_maybe_attach_backtrace(Stdlib[3], 1);
         }
        }
        catch(_j_){
         var _d_ = caml_wrap_exception(_j_);
-        if(_d_ !== Stdlib[3]) throw _d_;
+        if(_d_ !== Stdlib[3]) throw caml_maybe_attach_backtrace(_d_, 0);
         caml_call3(Stdlib_Printf[3], _e_, _c_ | 0, _b_);
         var Test = [0];
         runtime.caml_register_global(4, Test, "Test");
@@ -189,6 +197,7 @@ with Exit ->
        "use strict";
        var
         runtime = globalThis.jsoo_runtime,
+        caml_maybe_attach_backtrace = runtime.caml_maybe_attach_backtrace,
         caml_string_of_jsbytes = runtime.caml_string_of_jsbytes,
         caml_wrap_exception = runtime.caml_wrap_exception;
        function caml_call2(f, a0, a1){
@@ -206,12 +215,21 @@ with Exit ->
         _a_ = 0;
        try{
         var _e_ = _a_;
-        try{var _g_ = _a_ + 1 | 0; 0; _e_ = _g_; _b_ = _g_; throw Stdlib[3];}
-        catch(_i_){caml_call2(Stdlib_Printf[3], _f_, _e_); throw Stdlib[3];}
+        try{
+         var _g_ = _a_ + 1 | 0;
+         0;
+         _e_ = _g_;
+         _b_ = _g_;
+         throw caml_maybe_attach_backtrace(Stdlib[3], 1);
+        }
+        catch(_i_){
+         caml_call2(Stdlib_Printf[3], _f_, _e_);
+         throw caml_maybe_attach_backtrace(Stdlib[3], 1);
+        }
        }
        catch(_h_){
         var _c_ = caml_wrap_exception(_h_);
-        if(_c_ !== Stdlib[3]) throw _c_;
+        if(_c_ !== Stdlib[3]) throw caml_maybe_attach_backtrace(_c_, 0);
         caml_call2(Stdlib_Printf[3], _d_, _b_);
         var Test = [0];
         runtime.caml_register_global(4, Test, "Test");

--- a/compiler/tests-compiler/loops.ml
+++ b/compiler/tests-compiler/loops.ml
@@ -173,7 +173,8 @@ let for_for_while () =
       for(;;)
        for(;;){
         if(10 > caml_div(k, j)){
-         try{caml_div(k, j);}catch(_c_){throw Stdlib[8];}
+         try{caml_div(k, j);}
+         catch(_c_){throw caml_maybe_attach_backtrace(Stdlib[8], 1);}
          id[1]++;
          continue;
         }
@@ -257,7 +258,7 @@ let f t x =
      catch(_f_){
       var _c_ = caml_wrap_exception(_f_);
       if(_c_ === Stdlib[8]) return - 1;
-      throw _c_;
+      throw caml_maybe_attach_backtrace(_c_, 0);
      }
      if(val$0 && ! val$0[2]){
       var x$1 = val$0[1], x$0 = x$1;
@@ -266,7 +267,7 @@ let f t x =
        try{var val = caml_call2(Stdlib_Hashtbl[6], t, x$0); switch$0 = 1;}
        catch(_e_){
         var _a_ = caml_wrap_exception(_e_);
-        if(_a_ !== Stdlib[3]) throw _a_;
+        if(_a_ !== Stdlib[3]) throw caml_maybe_attach_backtrace(_a_, 0);
         var _d_ = 0;
        }
        if(switch$0){
@@ -455,7 +456,7 @@ let add_substitute =
        continue;
       }
       var start$0 = i$4 + 1 | 0;
-      if(lim$1 <= start$0) throw Stdlib[8];
+      if(lim$1 <= start$0) throw caml_maybe_attach_backtrace(Stdlib[8], 1);
       var opening = caml_string_get(s, start$0), switch$0 = 0;
       if(40 !== opening && 123 !== opening){
        var start = start$0 + 1 | 0, lim$0 = caml_ml_string_length(s), i$2 = start;
@@ -490,11 +491,14 @@ let add_substitute =
        var new_start = start$0 + 1 | 0, k$2 = 0;
        if(40 === opening)
         var closing = 41;
-       else{if(123 !== opening) throw [0, Assert_failure, _a_]; var closing = 125;
+       else{
+        if(123 !== opening)
+         throw caml_maybe_attach_backtrace([0, Assert_failure, _a_], 1);
+        var closing = 125;
        }
        var lim = caml_ml_string_length(s), k = k$2, stop = new_start;
        for(;;){
-        if(lim <= stop) throw Stdlib[8];
+        if(lim <= stop) throw caml_maybe_attach_backtrace(Stdlib[8], 1);
         if(caml_string_get(s, stop) === opening){
          var i = stop + 1 | 0, k$0 = k + 1 | 0, k = k$0, stop = i;
          continue;

--- a/compiler/tests-compiler/match_with_exn.ml
+++ b/compiler/tests-compiler/match_with_exn.ml
@@ -77,7 +77,7 @@ let fun2 () =
      try{var i$1 = caml_call1(Stdlib_Random[5], 2);}
      catch(_e_){
       var _d_ = caml_wrap_exception(_e_);
-      if(_d_[1] !== A) throw _d_;
+      if(_d_[1] !== A) throw caml_maybe_attach_backtrace(_d_, 0);
       var i = _d_[2];
       if(2 !== i) return i + 2 | 0;
       var i$0 = i;
@@ -98,7 +98,7 @@ let fun2 () =
       }
       else
        switch$1 = 1;
-      if(switch$1) throw _a_;
+      if(switch$1) throw caml_maybe_attach_backtrace(_a_, 0);
      }
      if(! switch$0){if(0 !== i$0) return i$0 + 1 | 0; var i = i$0;}
      return i;

--- a/compiler/tests-compiler/mutable_closure.ml
+++ b/compiler/tests-compiler/mutable_closure.ml
@@ -165,7 +165,7 @@ let%expect_test _ =
        indirect$0 = caml_call2(Stdlib_List[19], _d_, _c_),
        direct$0 = direct[1];
       if(runtime.caml_equal(indirect$0, direct$0)) return 0;
-      throw [0, Assert_failure, _b_];
+      throw caml_maybe_attach_backtrace([0, Assert_failure, _b_], 1);
      }
     }
     //end|}]

--- a/compiler/tests-compiler/tailcall.ml
+++ b/compiler/tests-compiler/tailcall.ml
@@ -62,7 +62,8 @@ let%expect_test _ =
      function odd(x){return caml_trampoline(odd$0(0, x));}
      function even(x){return caml_trampoline(even$0(0, x));}
      var _c_ = even(1);
-     if(odd(1) === _c_) throw [0, Assert_failure, _b_];
+     if(odd(1) === _c_)
+      throw caml_maybe_attach_backtrace([0, Assert_failure, _b_], 1);
      try{odd(5000); var _d_ = log_success(0); return _d_;}
      catch(_e_){return caml_call1(log_failure, cst_too_much_recursion);}
     }
@@ -102,7 +103,8 @@ let%expect_test _ =
      function odd(x){return caml_trampoline(odd$0(x));}
      function even(x){return caml_trampoline(even$0(x));}
      var _c_ = even(1);
-     if(odd(1) === _c_) throw [0, Assert_failure, _b_];
+     if(odd(1) === _c_)
+      throw caml_maybe_attach_backtrace([0, Assert_failure, _b_], 1);
      try{odd(5000); var _d_ = log_success(0); return _d_;}
      catch(_e_){return caml_call1(log_failure, cst_too_much_recursion);}
     }

--- a/runtime/backtrace.js
+++ b/runtime/backtrace.js
@@ -15,16 +15,37 @@
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
+
+//Provides: caml_record_backtrace_flag
+//Requires: jsoo_sys_getenv
+var caml_record_backtrace_flag = FLAG("with-js-error");
+
+(function () {
+  var r = jsoo_sys_getenv("OCAMLRUNPARAM")
+  if(r !== undefined){
+    var l = r.split(",");
+    for(var i = 0; i < l.length; i++){
+      if(l[i] == "b") { caml_record_backtrace_flag = 1; break }
+      else if (l[i].startsWith("b=")) {
+        caml_record_backtrace_flag = +(l[i].slice(2))}
+      else continue;
+    }
+  }
+}) ()
+
+
 //Provides: caml_ml_debug_info_status const
 function caml_ml_debug_info_status () { return 0; }
-//Provides: caml_backtrace_status const
-function caml_backtrace_status () { return 0; }
+//Provides: caml_backtrace_status
+//Requires: caml_record_backtrace_flag
+function caml_backtrace_status (_unit) { return caml_record_backtrace_flag ? 1 : 0; }
 //Provides: caml_get_exception_backtrace const
 function caml_get_exception_backtrace () { return 0; }
 //Provides: caml_get_exception_raw_backtrace const
 function caml_get_exception_raw_backtrace () { return [0]; }
 //Provides: caml_record_backtrace
-function caml_record_backtrace () { return 0; }
+//Requires: caml_record_backtrace_flag
+function caml_record_backtrace (b) { caml_record_backtrace_flag = b; return 0; }
 //Provides: caml_convert_raw_backtrace const
 function caml_convert_raw_backtrace () { return [0]; }
 //Provides: caml_raw_backtrace_length

--- a/runtime/fail.js
+++ b/runtime/fail.js
@@ -20,14 +20,13 @@
 //Provides: caml_raise_constant (const)
 function caml_raise_constant (tag) { throw tag; }
 
-//Provides: caml_return_exn_constant (const)
-function caml_return_exn_constant (tag) { return tag; }
-
 //Provides: caml_raise_with_arg (const, mutable)
-function caml_raise_with_arg (tag, arg) { throw [0, tag, arg]; }
+//Requires: caml_maybe_attach_backtrace
+function caml_raise_with_arg (tag, arg) { throw caml_maybe_attach_backtrace([0, tag, arg]); }
 
 //Provides: caml_raise_with_args (const, mutable)
-function caml_raise_with_args (tag, args) { throw [0, tag].concat(args); }
+//Requires: caml_maybe_attach_backtrace
+function caml_raise_with_args (tag, args) { throw caml_maybe_attach_backtrace([0, tag].concat(args)); }
 
 //Provides: caml_raise_with_string (const, const)
 //Requires: caml_raise_with_arg, caml_string_of_jsbytes

--- a/runtime/graphics.js
+++ b/runtime/graphics.js
@@ -22,11 +22,12 @@ var caml_gr_state;
 //Provides: caml_gr_state_get
 //Requires: caml_gr_state
 //Requires: caml_named_value, caml_string_of_jsbytes
+//Requires: caml_maybe_attach_backtrace
 function caml_gr_state_get() {
   if(caml_gr_state) {
     return caml_gr_state;
   }
-  throw [0,caml_named_value("Graphics.Graphic_failure"), caml_string_of_jsbytes("Not initialized")]
+  throw caml_maybe_attach_backtrace([0,caml_named_value("Graphics.Graphic_failure"), caml_string_of_jsbytes("Not initialized")]);
 }
 //Provides: caml_gr_state_set
 //Requires: caml_gr_state,caml_gr_state_init

--- a/runtime/jslib.js
+++ b/runtime/jslib.js
@@ -154,6 +154,14 @@ function caml_wrap_exception(e) {
     return e;
 }
 
+//Provides: caml_maybe_attach_backtrace
+//Requires: caml_exn_with_js_backtrace
+function caml_maybe_attach_backtrace(exn, force) {
+  if(FLAG("with-js-error"))
+    return caml_exn_with_js_backtrace(exn, force);
+  else return exn
+}
+
 // Experimental
 //Provides: caml_exn_with_js_backtrace
 //Requires: caml_global_data

--- a/runtime/jslib.js
+++ b/runtime/jslib.js
@@ -161,11 +161,27 @@ function caml_wrap_exception(e) {
 
 //Provides: caml_maybe_attach_backtrace
 //Requires: caml_exn_with_js_backtrace
+//Requires: jsoo_sys_getenv
 function caml_maybe_attach_backtrace(exn, force) {
-  if(FLAG("with-js-error"))
+  if(jsoo_record_backtrace)
     return caml_exn_with_js_backtrace(exn, force);
   else return exn
 }
+
+var jsoo_record_backtrace = FLAG("with-js-error");
+
+(function () {
+  var r = jsoo_sys_getenv("OCAMLRUNPARAM")
+  if(r !== undefined){
+    var l = r.split(",");
+    for(var i = 0; i < l.length; i++){
+      if(l[i] == "b") { jsoo_record_backtrace = 1; break }
+      else if (l[i].startsWith("b=")) {
+        jsoo_record_backtrace = +(l[i].slice(2))}
+      else continue;
+    }
+  }
+}) ()
 
 // Experimental
 //Provides: caml_exn_with_js_backtrace

--- a/runtime/jslib.js
+++ b/runtime/jslib.js
@@ -161,27 +161,12 @@ function caml_wrap_exception(e) {
 
 //Provides: caml_maybe_attach_backtrace
 //Requires: caml_exn_with_js_backtrace
-//Requires: jsoo_sys_getenv
+//Requires: caml_record_backtrace_flag
 function caml_maybe_attach_backtrace(exn, force) {
-  if(jsoo_record_backtrace)
+  if(caml_record_backtrace_flag)
     return caml_exn_with_js_backtrace(exn, force);
   else return exn
 }
-
-var jsoo_record_backtrace = FLAG("with-js-error");
-
-(function () {
-  var r = jsoo_sys_getenv("OCAMLRUNPARAM")
-  if(r !== undefined){
-    var l = r.split(",");
-    for(var i = 0; i < l.length; i++){
-      if(l[i] == "b") { jsoo_record_backtrace = 1; break }
-      else if (l[i].startsWith("b=")) {
-        jsoo_record_backtrace = +(l[i].slice(2))}
-      else continue;
-    }
-  }
-}) ()
 
 // Experimental
 //Provides: caml_exn_with_js_backtrace

--- a/runtime/sys.js
+++ b/runtime/sys.js
@@ -91,6 +91,7 @@ function caml_fatal_uncaught_exception(err){
       var at_exit = caml_named_value("Pervasives.do_at_exit");
       if(at_exit) caml_callback(at_exit, [0]);
       console.error("Fatal error: exception " + msg + "\n");
+      if(err.js_error) throw err.js_error;
     }
   }
   else {
@@ -105,22 +106,30 @@ function caml_set_static_env(k,v){
   globalThis.jsoo_static_env[k] = v;
   return 0;
 }
-//Provides: caml_sys_getenv (const)
-//Requires: caml_raise_not_found
-//Requires: caml_string_of_jsstring
-//Requires: caml_jsstring_of_string
-function caml_sys_getenv (name) {
+
+//Provides: jsoo_sys_getenv (const)
+function jsoo_sys_getenv(n) {
   var process = globalThis.process;
-  var n = caml_jsstring_of_string(name);
   //nodejs env
   if(process
      && process.env
      && process.env[n] != undefined)
-    return caml_string_of_jsstring(process.env[n]);
+    return process.env[n];
   if(globalThis.jsoo_static_env
      && globalThis.jsoo_static_env[n])
-    return caml_string_of_jsstring(globalThis.jsoo_static_env[n])
-  caml_raise_not_found ();
+    return globalThis.jsoo_static_env[n]
+}
+
+//Provides: caml_sys_getenv (const)
+//Requires: caml_raise_not_found
+//Requires: caml_string_of_jsstring
+//Requires: caml_jsstring_of_string
+//Requires: jsoo_sys_getenv
+function caml_sys_getenv (name) {
+  var r = jsoo_sys_getenv(caml_jsstring_of_string(name));
+  if(r === undefined)
+    caml_raise_not_found ();
+  return caml_string_of_jsstring(r)
 }
 
 //Provides: caml_sys_unsafe_getenv


### PR DESCRIPTION
Fix https://github.com/ocsigen/js_of_ocaml/issues/1347

Fix https://github.com/ocsigen/js_of_ocaml/issues/1045
One can control backtrace recording with OCAMLRUNPARAM env variable
```shell
$ OCAMLRUNPARAM=b=0 node ./q.js 12
Fatal error: exception Not_found

$ OCAMLRUNPARAM=b=1 node ./q.js 12
Fatal error: exception Not_found

/js_of_ocaml/q.js:1474
      if(err.js_error) throw err.js_error;
                       ^

Error: Js exception containing backtrace
    at caml_exn_with_js_backtrace (/js_of_ocaml/q.js:31:21)
    at caml_maybe_attach_backtrace (/js_of_ocaml/q.js:36:15)
    at f (/js_of_ocaml/q.js:1560:25)
    at f (/js_of_ocaml/q.js:1563:15)
    at f (/js_of_ocaml/q.js:1563:15)
    at /js_of_ocaml/q.js:1566:12
    at Object.<anonymous> (/js_of_ocaml/q.js:1574:3)
    at Module._compile (node:internal/modules/cjs/loader:1101:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
```