### PR TITLE
Mention the use case as a compiler, without using the ppx syntax

### DIFF
--- a/manual/overview.wiki
+++ b/manual/overview.wiki
@@ -25,7 +25,7 @@ Js_of_ocaml is composed of multiple packages:
 
 Note: All code examples in this manual use Js_of_ocaml's ppx syntax.
 It is, however, possible to use Js_of_ocaml purely as a compiler
-while using a different library (e.g. gen_js_api, brr) to
+while using a different package (e.g. gen_js_api, brr) to
 provide bindings to the browser APIs.
 
 == Installation

--- a/manual/overview.wiki
+++ b/manual/overview.wiki
@@ -23,6 +23,11 @@ Js_of_ocaml is composed of multiple packages:
   * js_of_ocaml-toplevel, lib and tools to build an ocaml toplevel to
     javascript.
 
+Note: All code examples in this manual use Js_of_ocaml's ppx syntax.
+It is, however, possible to use Js_of_ocaml purely as a compiler
+while using a different library (e.g. gen_js_api, brr) to
+provide bindings to the browser APIs.
+
 == Installation
 
 The easiest way to install js_of_ocaml is to use opam.


### PR DESCRIPTION
I believe that the following disclaimer on the overview page of the manual would be helpful:

"Note: All code examples in this manual use Js_of_ocaml's ppx syntax.
It is, however, possible to use Js_of_ocaml purely as a compiler
while using a different package (e.g. gen_js_api, brr) to
provide bindings to the browser APIs."

This helps people understand that there are different ways to use js_of_ocaml (with ppx or with a different library that provides browser API bindings), and that they can only use the code examples from the manual if they are using the ppx. In particular, it is helpful to redirect people who are working on existing codebases that use jsoo without its ppx to their respective library docs.

If mentioning specific libraries that people use with jsoo is not reasonable, we can remove that.