### PR TITLE
Support custom runtime events producer primitives

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@
 * Toplevel: Enable separate compilation of toplevels
 * Runtime: js backtrace recording controled by OCAMLRUNPARAM
 * Runtime: support for zstd decompression of marshalled data (ocaml.5.1) (#12006)
+* Runtime: stub out custom runtime events symbols for OCaml 5.1 (#1414)
 
 ## Bug fixes
 - Effects: fix Js.export and Js.export_all to work with functions

--- a/compiler/lib-runtime-files/js_of_ocaml_compiler_runtime_files.ml
+++ b/compiler/lib-runtime-files/js_of_ocaml_compiler_runtime_files.ml
@@ -56,6 +56,7 @@ let runtime =
     ; sync
     ; effect
     ; zstd
+    ; runtime_events
     ]
 
 include Files

--- a/compiler/lib-runtime-files/tests/all.ml
+++ b/compiler/lib-runtime-files/tests/all.ml
@@ -42,6 +42,7 @@ let%expect_test _ =
     +obj.js
     +parsing.js
     +prng.js
+    +runtime_events.js
     +stdlib.js
     +stdlib_modern.js
     +str.js
@@ -84,6 +85,7 @@ let%expect_test _ =
     +obj.js
     +parsing.js
     +prng.js
+    +runtime_events.js
     +stdlib.js
     +str.js
     +sync.js

--- a/compiler/tests-check-prim/main.output
+++ b/compiler/tests-check-prim/main.output
@@ -182,6 +182,18 @@ caml_obj_update_tag
 From +prng.js:
 caml_lxm_next
 
+From +runtime_events.js:
+caml_custom_event_index
+caml_runtime_events_create_cursor
+caml_runtime_events_free_cursor
+caml_runtime_events_pause
+caml_runtime_events_read_poll
+caml_runtime_events_resume
+caml_runtime_events_start
+caml_runtime_events_user_register
+caml_runtime_events_user_resolve
+caml_runtime_events_user_write
+
 From +stdlib.js:
 caml_build_symbols
 caml_is_printable

--- a/compiler/tests-check-prim/main.output5
+++ b/compiler/tests-check-prim/main.output5
@@ -26,12 +26,6 @@ caml_invoke_traced_function
 caml_realloc_global
 caml_reify_bytecode
 caml_reset_afl_instrumentation
-caml_runtime_events_pause
-caml_runtime_events_resume
-caml_runtime_events_start
-caml_runtime_events_user_register
-caml_runtime_events_user_resolve
-caml_runtime_events_user_write
 caml_signbit
 caml_static_release_bytecode
 caml_terminfo_rows
@@ -159,6 +153,15 @@ caml_obj_is_block
 caml_obj_make_forward
 caml_obj_set_tag
 caml_obj_truncate
+
+From +runtime_events.js:
+caml_custom_event_index
+caml_runtime_events_create_cursor
+caml_runtime_events_free_cursor
+caml_runtime_events_read_poll
+caml_runtime_events_user_register
+caml_runtime_events_user_resolve
+caml_runtime_events_user_write
 
 From +stdlib.js:
 caml_build_symbols

--- a/compiler/tests-check-prim/main.output5
+++ b/compiler/tests-check-prim/main.output5
@@ -29,6 +29,9 @@ caml_reset_afl_instrumentation
 caml_runtime_events_pause
 caml_runtime_events_resume
 caml_runtime_events_start
+caml_runtime_events_user_register
+caml_runtime_events_user_resolve
+caml_runtime_events_user_write
 caml_signbit
 caml_static_release_bytecode
 caml_terminfo_rows

--- a/compiler/tests-check-prim/unix-unix.output
+++ b/compiler/tests-check-prim/unix-unix.output
@@ -291,6 +291,18 @@ caml_obj_update_tag
 From +prng.js:
 caml_lxm_next
 
+From +runtime_events.js:
+caml_custom_event_index
+caml_runtime_events_create_cursor
+caml_runtime_events_free_cursor
+caml_runtime_events_pause
+caml_runtime_events_read_poll
+caml_runtime_events_resume
+caml_runtime_events_start
+caml_runtime_events_user_register
+caml_runtime_events_user_resolve
+caml_runtime_events_user_write
+
 From +stdlib.js:
 caml_build_symbols
 caml_is_printable

--- a/compiler/tests-check-prim/unix-unix.output5
+++ b/compiler/tests-check-prim/unix-unix.output5
@@ -26,12 +26,6 @@ caml_invoke_traced_function
 caml_realloc_global
 caml_reify_bytecode
 caml_reset_afl_instrumentation
-caml_runtime_events_pause
-caml_runtime_events_resume
-caml_runtime_events_start
-caml_runtime_events_user_register
-caml_runtime_events_user_resolve
-caml_runtime_events_user_write
 caml_signbit
 caml_static_release_bytecode
 caml_terminfo_rows
@@ -268,6 +262,15 @@ caml_obj_is_block
 caml_obj_make_forward
 caml_obj_set_tag
 caml_obj_truncate
+
+From +runtime_events.js:
+caml_custom_event_index
+caml_runtime_events_create_cursor
+caml_runtime_events_free_cursor
+caml_runtime_events_read_poll
+caml_runtime_events_user_register
+caml_runtime_events_user_resolve
+caml_runtime_events_user_write
 
 From +stdlib.js:
 caml_build_symbols

--- a/compiler/tests-check-prim/unix-unix.output5
+++ b/compiler/tests-check-prim/unix-unix.output5
@@ -29,6 +29,9 @@ caml_reset_afl_instrumentation
 caml_runtime_events_pause
 caml_runtime_events_resume
 caml_runtime_events_start
+caml_runtime_events_user_register
+caml_runtime_events_user_resolve
+caml_runtime_events_user_write
 caml_signbit
 caml_static_release_bytecode
 caml_terminfo_rows

--- a/compiler/tests-check-prim/unix-win32.output
+++ b/compiler/tests-check-prim/unix-win32.output
@@ -256,6 +256,18 @@ caml_obj_update_tag
 From +prng.js:
 caml_lxm_next
 
+From +runtime_events.js:
+caml_custom_event_index
+caml_runtime_events_create_cursor
+caml_runtime_events_free_cursor
+caml_runtime_events_pause
+caml_runtime_events_read_poll
+caml_runtime_events_resume
+caml_runtime_events_start
+caml_runtime_events_user_register
+caml_runtime_events_user_resolve
+caml_runtime_events_user_write
+
 From +stdlib.js:
 caml_build_symbols
 caml_is_printable

--- a/compiler/tests-check-prim/unix-win32.output5
+++ b/compiler/tests-check-prim/unix-win32.output5
@@ -26,9 +26,6 @@ caml_invoke_traced_function
 caml_realloc_global
 caml_reify_bytecode
 caml_reset_afl_instrumentation
-caml_runtime_events_pause
-caml_runtime_events_resume
-caml_runtime_events_start
 caml_signbit
 caml_static_release_bytecode
 caml_terminfo_rows
@@ -231,6 +228,15 @@ caml_obj_is_block
 caml_obj_make_forward
 caml_obj_set_tag
 caml_obj_truncate
+
+From +runtime_events.js:
+caml_custom_event_index
+caml_runtime_events_create_cursor
+caml_runtime_events_free_cursor
+caml_runtime_events_read_poll
+caml_runtime_events_user_register
+caml_runtime_events_user_resolve
+caml_runtime_events_user_write
 
 From +stdlib.js:
 caml_build_symbols

--- a/compiler/tests-runtime-events/dune
+++ b/compiler/tests-runtime-events/dune
@@ -1,0 +1,15 @@
+(env
+ (_
+  (flags
+   (:standard -w -32-69))))
+
+(executables
+ (names test_runtime_events)
+ (libraries runtime_events)
+ (modes js))
+
+(rule
+ (alias runtest)
+ (deps test_runtime_events.bc.js)
+ (action
+  (run node ./test_runtime_events.bc.js)))

--- a/compiler/tests-runtime-events/dune
+++ b/compiler/tests-runtime-events/dune
@@ -5,13 +5,15 @@
 
 (executables
  (names test_runtime_events)
- (enabled_if (>= %{ocaml_version} 5.1.0))
+ (enabled_if
+  (>= %{ocaml_version} 5.1.0))
  (libraries runtime_events)
  (modes js))
 
 (rule
  (alias runtest)
  (deps test_runtime_events.bc.js)
- (enabled_if (>= %{ocaml_version} 5.1.0))
+ (enabled_if
+  (>= %{ocaml_version} 5.1.0))
  (action
   (run node ./test_runtime_events.bc.js)))

--- a/compiler/tests-runtime-events/dune
+++ b/compiler/tests-runtime-events/dune
@@ -5,11 +5,13 @@
 
 (executables
  (names test_runtime_events)
+ (enabled_if (>= %{ocaml_version} 5.1.0))
  (libraries runtime_events)
  (modes js))
 
 (rule
  (alias runtest)
  (deps test_runtime_events.bc.js)
+ (enabled_if (>= %{ocaml_version} 5.1.0))
  (action
   (run node ./test_runtime_events.bc.js)))

--- a/compiler/tests-runtime-events/test_runtime_events.ml
+++ b/compiler/tests-runtime-events/test_runtime_events.ml
@@ -1,0 +1,7 @@
+module RE = Runtime_events
+
+type RE.User.tag += MyTag
+
+let ev = RE.User.register "my_event" MyTag RE.Type.unit
+
+let () = RE.User.write ev ()

--- a/runtime/dune
+++ b/runtime/dune
@@ -28,4 +28,5 @@
   weak.js
   domain.js
   prng.js
-  sync.js))
+  sync.js
+  runtime_events.js))

--- a/runtime/runtime_events.js
+++ b/runtime/runtime_events.js
@@ -1,0 +1,9 @@
+//Provides: caml_runtime_events_user_register
+function caml_runtime_events_user_register(event_name, event_tag, event_type) {
+  return 0;
+}
+
+//Provides: caml_runtime_events_user_write
+function caml_runtime_events_user_write(event, event_content) {
+
+}

--- a/runtime/runtime_events.js
+++ b/runtime/runtime_events.js
@@ -1,9 +1,50 @@
+
+//Provides: caml_custom_event_index
+var caml_custom_event_index = 0;
+
 //Provides: caml_runtime_events_user_register
+//Requires: caml_custom_event_index
 function caml_runtime_events_user_register(event_name, event_tag, event_type) {
-  return 0;
+  caml_custom_event_index += 1;
+  return [0, caml_custom_event_index, event_name, event_type, event_tag];
 }
 
 //Provides: caml_runtime_events_user_write
 function caml_runtime_events_user_write(event, event_content) {
+  return 0;
+}
 
+//Provides: caml_runtime_events_user_resolve
+function caml_runtime_events_user_resolve() {
+  return 0;
+}
+
+//Provides: caml_runtime_events_start
+function caml_runtime_events_start() {
+  return 0;
+}
+
+//Provides: caml_runtime_events_stop
+function caml_runtime_events_stop() {
+  return 0;
+}
+
+//Provides: caml_runtime_events_resume
+function caml_runtime_events_resume() {
+  return 0;
+}
+
+//Provides: caml_runtime_events_create_cursor
+function caml_runtime_events_create_cursor(target) {
+  return {};
+}
+
+//Provides: caml_runtime_events_free_cursor
+function caml_runtime_events_free_cursor(cursor) {
+  return 0;
+}
+
+//Provides: caml_runtime_events_read_poll
+function caml_runtime_events_read_poll(cursor, callbacks, num) {
+  return 0;
 }

--- a/runtime/runtime_events.js
+++ b/runtime/runtime_events.js
@@ -24,8 +24,8 @@ function caml_runtime_events_start() {
   return 0;
 }
 
-//Provides: caml_runtime_events_stop
-function caml_runtime_events_stop() {
+//Provides: caml_runtime_events_pause
+function caml_runtime_events_pause() {
   return 0;
 }
 


### PR DESCRIPTION
https://github.com/ocaml/ocaml/pull/11474 introduces new primitives in the runtime that enables libraries to emit custom events in the runtime event tracing system. This feature will appear in the next release of OCaml.

For now the implementation is just a stub that does nothing with the event, so that linking with these libraries still works. 