### PR TITLE
Runtime: restore support for zero-arity functions in caml_call_gen

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,7 +23,7 @@
 * Runtime: stub out custom runtime events symbols for OCaml 5.1 (#1414)
 
 ## Bug fixes
-* Effects: fix Js.export and Js.export_all to work with functions
+* Effects: fix Js.export and Js.export_all to work with functions (#1417,#1377)
 * Sourcemap: fix incorrect sourcemap with separate compilation
 * Compiler: fix control flow analysis; some annotions were wrong in the runtime
 * Compiler: js backtrace recording respected in the js runtime and when using effects

--- a/lib/js_of_ocaml/import.ml
+++ b/lib/js_of_ocaml/import.ml
@@ -35,21 +35,21 @@ module Poly = struct
 end
 
 module Int_replace_polymorphic_compare = struct
-  let ( < ) (x : int) y = x < y
+  external ( < ) : int -> int -> bool = "%lessthan"
 
-  let ( <= ) (x : int) y = x <= y
+  external ( <= ) : int -> int -> bool = "%lessequal"
 
-  let ( <> ) (x : int) y = x <> y
+  external ( <> ) : int -> int -> bool = "%notequal"
 
-  let ( = ) (x : int) y = x = y
+  external ( = ) : int -> int -> bool = "%equal"
 
-  let ( > ) (x : int) y = x > y
+  external ( > ) : int -> int -> bool = "%greaterthan"
 
-  let ( >= ) (x : int) y = x >= y
+  external ( >= ) : int -> int -> bool = "%greaterequal"
 
-  let compare (x : int) y = compare x y
+  external compare : int -> int -> int = "%compare"
 
-  let equal (x : int) y = x = y
+  external equal : int -> int -> bool = "%equal"
 
   let max (x : int) y = if x >= y then x else y
 

--- a/lib/js_of_ocaml/js.ml
+++ b/lib/js_of_ocaml/js.ml
@@ -805,6 +805,8 @@ let export_js (field : js_string t) x =
     (Unsafe.pure_js_expr "jsoo_exports")
     field
     (if String.equal (Js.to_string (typeof (Obj.magic x))) "function"
+        (* function with arity/length equal to zero are already wrapped *)
+        && Unsafe.get (Obj.magic x) (Js.string "length") > 0
     then Obj.magic (wrap_callback (Obj.magic x))
     else x)
 

--- a/lib/tests/test_fun_call.ml
+++ b/lib/tests/test_fun_call.ml
@@ -403,3 +403,15 @@ let%expect_test _ =
   f (Obj.magic cb5);
   [%expect {|
     Result: function#2#2 |}]
+
+let%expect_test _ =
+  let open Js_of_ocaml in
+  let f = Js.wrap_callback (fun s -> print_endline s) in
+  Js.export "f" f;
+  let () =
+    Js.Unsafe.fun_call
+      (Js.Unsafe.pure_js_expr "jsoo_exports")##.f
+      [| Js.Unsafe.coerce (Js.string "hello") |]
+  in
+  ();
+  [%expect {| hello |}]


### PR DESCRIPTION
We discovered a bug caused by `caml_call_gen` removing logic for supporting the situation when it is called with a function whose length is 0. Arguably, this is not really a problem with `caml_call_gen` because it is only meant to be given _OCaml_ functions and not general Javascript functions; however, `Js.export` was implemented in such a way that this invariant is not always upheld, even if the `js_of_ocaml` library is used in a type-safe way.

This PR fixes the bug by changing `caml_call_gen`, rather than `Js.export`, since it seems possible for other code to be relying on this condition. I've looked for a while to see if I could find functions other than `Js.export`, but I couldn't find any, so I _think_ it's just that one function, but it's hard to be sure.