### PR TITLE
Document two code folding functions

### DIFF
--- a/compiler/lib/code.mli
+++ b/compiler/lib/code.mli
@@ -239,9 +239,20 @@ type 'c fold_blocs = block Addr.Map.t -> Addr.t -> (Addr.t -> 'c -> 'c) -> 'c ->
 
 type fold_blocs_poly = { fold : 'a. 'a fold_blocs } [@@unboxed]
 
+(** [fold_closures p f init] folds [f] over all closures in the program [p],
+    starting from the initial value [init]. For each closure, [f] is called
+    with the following arguments: the closure name (enclosed in
+    {!Stdlib.Some}), its parameter list, the address and parameter instantiation
+    of its first block, and the current accumulator. In addition, [f] is called
+    on the initial block [p.start], with [None] as the closure name.
+    All closures in all blocks of [p] are included in the fold, not only the
+    ones reachable from [p.start]. *)
 val fold_closures :
   program -> (Var.t option -> Var.t list -> cont -> 'd -> 'd) -> 'd -> 'd
 
+(** Similar to {!fold_closures}, but applies the fold function to the
+    innermost closures first. Unlike with {!fold_closures}, only the closures
+    reachable from [p.start] are considered. *)
 val fold_closures_innermost_first :
   program -> (Var.t option -> Var.t list -> cont -> 'd -> 'd) -> 'd -> 'd
 


### PR DESCRIPTION
The functions `Code.fold_closures` and `Code.fold_closures_innermost_first` are very useful but are not documented, and precise effect is not obvious. I propose to add the necessary documentation comments in the MLI.