### PR TITLE
JavaScript parser: fix parsing of labels

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 ## Bug fixes
 * Compiler: put custom header at the top of the output file (fix #1441)
+* Compiler (js parser): fix parsing of js labels (fix #1440)
 
 # 5.1.1 (2023-03-15) - Lille
 ## Bug fixes

--- a/compiler/lib/js_parser.mly
+++ b/compiler/lib/js_parser.mly
@@ -509,9 +509,7 @@ stmt1:
  | debugger_stmt   { $1 }
 
 label:
-  | T_IDENTIFIER {
-          let name, _raw = $1 in
-          Label.of_string name }
+  | id { Label.of_string $1 }
 
 (* Library definitions *)
 

--- a/compiler/tests-compiler/js_parser_printer.ml
+++ b/compiler/tests-compiler/js_parser_printer.ml
@@ -1035,3 +1035,28 @@ var y = async => async
     2: 0:var, 4:y (identifier), 6:=, 8:{, 10:async, 15::, 17:35, 19:}, 0:; (virtual),
     4: 0:var, 4:y (identifier), 6:=, 8:async, 14:x (identifier), 16:=>, 19:x (identifier), 0:; (virtual),
     5: 0:var, 4:y (identifier), 6:=, 8:async, 14:=>, 17:async, 0:; (virtual), |}]
+
+let%expect_test "label parsing" =
+  parse_print_token
+    ~extra:true
+    {|
+get:{of:{from:{async:{break async}break from}break of}break get}
+|};
+  [%expect.unreachable]
+[@@expect.uncaught_exn {|
+  (* CR expect_test_collector: This test expectation appears to contain a backtrace.
+     This is strongly discouraged as backtraces are fragile.
+     Please change this test to not include a backtrace. *)
+
+  ("Js_of_ocaml_compiler.Parse_js.Parsing_error(_)")
+  Raised at Js_of_ocaml_compiler__Parse_js.parse_aux in file "compiler/lib/parse_js.ml", line 425, characters 6-37
+  Called from Js_of_ocaml_compiler__Parse_js.parse' in file "compiler/lib/parse_js.ml", line 440, characters 16-59
+  Called from Js_parser_printer_15__Js_parser_printer.parse_print_token in file "compiler/tests-compiler/js_parser_printer.ml", line 700, characters 8-27
+  Re-raised at Js_parser_printer_15__Js_parser_printer.parse_print_token in file "compiler/tests-compiler/js_parser_printer.ml", line 703, characters 6-13
+  Called from Js_parser_printer_15__Js_parser_printer.(fun) in file "compiler/tests-compiler/js_parser_printer.ml", line 1040, characters 2-110
+  Called from Expect_test_collector.Make.Instance_io.exec in file "collector/expect_test_collector.ml", line 262, characters 12-19
+
+  Trailing output
+  ---------------
+
+  cannot parse l:2:3@. |}]

--- a/compiler/tests-compiler/js_parser_printer.ml
+++ b/compiler/tests-compiler/js_parser_printer.ml
@@ -1042,21 +1042,5 @@ let%expect_test "label parsing" =
     {|
 get:{of:{from:{async:{break async}break from}break of}break get}
 |};
-  [%expect.unreachable]
-[@@expect.uncaught_exn {|
-  (* CR expect_test_collector: This test expectation appears to contain a backtrace.
-     This is strongly discouraged as backtraces are fragile.
-     Please change this test to not include a backtrace. *)
-
-  ("Js_of_ocaml_compiler.Parse_js.Parsing_error(_)")
-  Raised at Js_of_ocaml_compiler__Parse_js.parse_aux in file "compiler/lib/parse_js.ml", line 425, characters 6-37
-  Called from Js_of_ocaml_compiler__Parse_js.parse' in file "compiler/lib/parse_js.ml", line 440, characters 16-59
-  Called from Js_parser_printer_15__Js_parser_printer.parse_print_token in file "compiler/tests-compiler/js_parser_printer.ml", line 700, characters 8-27
-  Re-raised at Js_parser_printer_15__Js_parser_printer.parse_print_token in file "compiler/tests-compiler/js_parser_printer.ml", line 703, characters 6-13
-  Called from Js_parser_printer_15__Js_parser_printer.(fun) in file "compiler/tests-compiler/js_parser_printer.ml", line 1040, characters 2-110
-  Called from Expect_test_collector.Make.Instance_io.exec in file "collector/expect_test_collector.ml", line 262, characters 12-19
-
-  Trailing output
-  ---------------
-
-  cannot parse l:2:3@. |}]
+  [%expect
+    {| 2: 0:get, 3::, 4:{, 5:of, 7::, 8:{, 9:from, 13::, 14:{, 15:async, 20::, 21:{, 22:break, 28:async, 0:; (virtual), 33:}, 34:break, 40:from, 0:; (virtual), 44:}, 45:break, 51:of, 0:; (virtual), 53:}, 54:break, 60:get, 0:; (virtual), 63:}, |}]


### PR DESCRIPTION
Identifiers such as 'of' and 'async' are valid labels.
Fixes #1440.