### PR TITLE
Sourcemap: stop producing sourcemap mappings with negative lines and columns

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ## Bug fixes
 * Compiler: put custom header at the top of the output file (fix #1441)
 * Compiler (js parser): fix parsing of js labels (fix #1440)
+* Sourcemap: stop producing sourcemaps mappings with negative lines or columns
 
 # 5.1.1 (2023-03-15) - Lille
 ## Bug fixes

--- a/compiler/lib/js_output.ml
+++ b/compiler/lib/js_output.ml
@@ -87,22 +87,13 @@ struct
       | U | Pi { Parse_info.src = None | Some ""; _ } ->
           push_mapping
             (PP.pos f)
-            { Source_map.gen_line = -1
-            ; gen_col = -1
-            ; ori_source = -1
-            ; ori_line = -1
-            ; ori_col = -1
-            ; ori_name = None
-            }
+            { Source_map.gen_line = -1; gen_col = -1; ori_location = None }
       | Pi { Parse_info.src = Some file; line; col; _ } ->
           push_mapping
             (PP.pos f)
             { Source_map.gen_line = -1
             ; gen_col = -1
-            ; ori_source = get_file_index file
-            ; ori_line = line
-            ; ori_col = col
-            ; ori_name = None
+            ; ori_location = Some { source = get_file_index file; line; col; name = None }
             }
 
   let output_debug_info_ident f nm loc =
@@ -115,10 +106,13 @@ struct
             (PP.pos f)
             { Source_map.gen_line = -1
             ; gen_col = -1
-            ; ori_source = get_file_index file
-            ; ori_line = line
-            ; ori_col = col
-            ; ori_name = Some (get_name_index nm)
+            ; ori_location =
+                Some
+                  { source = get_file_index file
+                  ; line
+                  ; col
+                  ; name = Some (get_name_index nm)
+                  }
             }
 
   let ident f = function

--- a/compiler/lib/source_map.mli
+++ b/compiler/lib/source_map.mli
@@ -17,13 +17,17 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *)
 
+type ori_location =
+  { source : int
+  ; line : int
+  ; col : int
+  ; name : int option
+  }
+
 type map =
   { gen_line : int
   ; gen_col : int
-  ; ori_source : int
-  ; ori_line : int
-  ; ori_col : int
-  ; ori_name : int option
+  ; ori_location : ori_location option
   }
 
 type mapping = map list

--- a/compiler/tests-sourcemap/dump.reference
+++ b/compiler/tests-sourcemap/dump.reference
@@ -5,5 +5,3 @@ b.ml:1:10 -> 17:   function f(x){<>return x - 1 | 0;}
 b.ml:1:6 -> 24:   function f(x){return <>x - 1 | 0;}
 b.ml:1:15 -> 34:   function f(x){return x - 1 | 0;<>}
 b.ml:1:4 -> 23:   var Testlib_B = [0, <>f];
-a.ml:-1:-1 -> 3:   <>function caml_call1(f, a0){
-a.ml:-1:-1 -> 2:  <>}

--- a/compiler/tests-sourcemap/dump_sourcemap.ml
+++ b/compiler/tests-sourcemap/dump_sourcemap.ml
@@ -54,17 +54,18 @@ let print_mapping lines (sm : Source_map.t) =
           ^ "<>"
           ^ String.sub line ~pos:col ~len:(len - col)
       in
-      if match file m.ori_source with
-         | "a.ml" | "b.ml" | "c.ml" | "d.ml" -> true
-         | _ -> false
-      then
-        Printf.printf
-          "%s:%d:%d -> %d:%s\n"
-          (file m.ori_source)
-          m.ori_line
-          m.ori_col
-          m.gen_col
-          (mark m.gen_col lines.(m.gen_line - 1)))
+      Option.iter m.ori_location ~f:(fun (ori : Source_map.ori_location) ->
+          if match file ori.source with
+             | "a.ml" | "b.ml" | "c.ml" | "d.ml" -> true
+             | _ -> false
+          then
+            Printf.printf
+              "%s:%d:%d -> %d:%s\n"
+              (file ori.source)
+              ori.line
+              ori.col
+              m.gen_col
+              (mark m.gen_col lines.(m.gen_line - 1))))
 
 let files = Sys.argv |> Array.to_list |> List.tl
 


### PR DESCRIPTION
This patch began by changing the mapping type in compiler/lib/source_map.ml so that it more obviously encodes the possible cases for a particular mapping. All other changes were made in response to the type errors that ensued.

No new tests were added because this change is mostly behavior preserving, and the situation in which behavior changes is demonstrated by changes to existing tests.

The motivation for this change is that the sourcemaps produced by js_of_ocaml are rejected by the [Mozilla sourcemap library](https://github.com/mozilla/source-map). In particular, it's [this error message](https://github.com/mozilla/source-map/blob/4e304db915cecd42505feb007766a034395c6eb7/lib/source-map-consumer.js#L325) that gets triggered.