### PR TITLE
Improve benchmarking scripts

### DIFF
--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -230,7 +230,7 @@ nativejs.svg: __run
 
 
 %.pdf: %.svg
-	inkscape -D --export-pdf="$@" -w 210 -h 297 $<
+	inkscape -D --export-type="pdf" --export-filename="$@" -w 210 -h 297 $<
 
 
 nativejs.png: nativejs.svg

--- a/benchmarks/run.config
+++ b/benchmarks/run.config
@@ -1,9 +1,9 @@
 #
 #interpreter v8 / node: apt-get install nodejs
-interpreter node /usr/bin/node
+interpreter node /usr/bin/env node
 #
 #SpiderMonkey: apt-get install libmozjs-91-dev
-interpreter sm /usr/bin/js91 -f
+#interpreter sm /usr/bin/env js91 -f
 #
 # JSC: apt-get install libjavascriptcoregtk-4.0-bin
-interpreter nitro /usr/bin/jsc
+#interpreter nitro /usr/bin/env jsc


### PR DESCRIPTION
Fixes a deprecated option for Inkscape, and stop assuming that the JS engines are installed in /usr/bin.

Slightly unrelated: for me both inkscape and cairosvg crash when trying to convert the SVG graphs to PDF, am I the only one in this case?
(cairosvg command: `cairosvg <name>.svg -o <name>.pdf`)