### PR TITLE
Fix "clean" target for effect benchmarking

### DIFF
--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -257,7 +257,7 @@ _noperf:
 
 
 clean: _noperf
-	rm -rf results build __precomp __run *.svg *.pdf *~ precomptmp __missingsizes __missingcompiletimes
+	rm -rf results build __precomp __run __run_effects *.svg *.pdf *~ precomptmp __missingsizes __missingcompiletimes
 
 
 copy-extra-bc:


### PR DESCRIPTION
The `clean` Makefile target is not removed by `make clean`, resulting in errors if you run in sequence `make clean` and `make graphseff` (or `make clean` and just `make`).