### PR TITLE
Fix marshal sharing strings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 * Compiler: reduce memory consumption when parsing js
 * Compiler: parsing js can return a list of token, the list was sometime incorrect
 * Sourcemap: stop producing sourcemaps mappings with negative lines or columns
+* Runtime: fix marshalling with sharing and string (use-js-string)
 
 # 5.1.1 (2023-03-15) - Lille
 ## Bug fixes

--- a/compiler/tests-jsoo/test_marshal.ml
+++ b/compiler/tests-jsoo/test_marshal.ml
@@ -154,3 +154,15 @@ let%expect_test _ =
   in
   Printf.printf "%s ... (%d)\n" (String.sub s 0 20) (String.length s);
   [%expect {| cccccccccccccccccccc ... (10000) |}]
+
+
+let%expect_test "test sharing of string" =
+  let s = "AString" in
+  let p = s,s in
+  let obj = [p; p] in
+  Printf.printf "%S" (Marshal.to_string s []);
+  [%expect
+    {| "\132\149\166\190\000\000\000\b\000\000\000\001\000\000\000\003\000\000\000\002'AString" |}];
+  Printf.printf "%S" (Marshal.to_string obj []);
+  [%expect
+    {| "\132\149\166\190\000\000\000\016\000\000\000\004\000\000\000\012\000\000\000\011\160\160'AString\004\001\160\004\003@" |}]

--- a/compiler/tests-jsoo/test_marshal.ml
+++ b/compiler/tests-jsoo/test_marshal.ml
@@ -155,11 +155,10 @@ let%expect_test _ =
   Printf.printf "%s ... (%d)\n" (String.sub s 0 20) (String.length s);
   [%expect {| cccccccccccccccccccc ... (10000) |}]
 
-
 let%expect_test "test sharing of string" =
   let s = "AString" in
-  let p = s,s in
-  let obj = [p; p] in
+  let p = s, s in
+  let obj = [ p; p ] in
   Printf.printf "%S" (Marshal.to_string s []);
   [%expect
     {| "\132\149\166\190\000\000\000\b\000\000\000\001\000\000\000\003\000\000\000\002'AString" |}];

--- a/runtime/marshal.js
+++ b/runtime/marshal.js
@@ -552,7 +552,7 @@ function caml_marshal_data_size (s, ofs) {
 
 //Provides: MlObjectTable
 var MlObjectTable;
-if (typeof globalThis.WeakMap === 'undefined') {
+if (typeof globalThis.Map === 'undefined') {
   MlObjectTable = function() {
     /* polyfill (using linear search) */
     function NaiveLookup(objs) { this.objs = objs; }
@@ -572,7 +572,7 @@ if (typeof globalThis.WeakMap === 'undefined') {
 }
 else {
   MlObjectTable = function MlObjectTable() {
-    this.objs = []; this.lookup = new globalThis.WeakMap();
+    this.objs = []; this.lookup = new globalThis.Map();
   };
 }
 
@@ -715,6 +715,7 @@ var caml_output_val = function (){
         writer.size_32 += 1 + (((len + 4) / 4)|0);
         writer.size_64 += 1 + (((len + 8) / 8)|0);
       } else if (caml_is_ml_string(v)) {
+        if (memo(v)) return;
         var len = caml_ml_string_length(v);
         if (len < 0x20)
           writer.write (8, 0x20 /*cst.PREFIX_SMALL_STRING*/ + len);


### PR DESCRIPTION
Marshaling with jsoo when `use-js-string` is enabled could return incorrect result when sharing is involved.
This is because strrings were not considered for sharing, and would simply be ignored when computing offset of other shared object.

Fix #1456