### PR TITLE
Partly revert 0f2af26e771bdcdede6badf8fe1a411f604fc148

### DIFF
--- a/benchmarks/run.config
+++ b/benchmarks/run.config
@@ -3,7 +3,7 @@
 interpreter node /usr/bin/env node
 #
 #SpiderMonkey: apt-get install libmozjs-91-dev
-#interpreter sm /usr/bin/env js91 -f
+interpreter sm /usr/bin/env js91 -f
 #
 # JSC: apt-get install libjavascriptcoregtk-4.0-bin
-#interpreter nitro /usr/bin/env jsc
+interpreter nitro /usr/bin/env jsc


### PR DESCRIPTION
0f2af26e771bdcdede6badf8fe1a411f604fc148 incorrectly commented out JS engines other than nodes. This commit reverts that.