### PR TITLE
Support conversion of Uint8ClampedArray typed arrays to bigarrays.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 ## Features/Changes
 * Misc: Bump magic number for ocaml 5.1
 * Misc: changes to stay compatible with the next version of ppx_expect
+* Runtime: support conversion of Uint8ClampedArray typed arrays to bigarrays.
+
 
 ## Bug fixes
 * Compiler: fix location for parsing errors when last token is a virtual semicolon

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,7 @@
 ## Features/Changes
 * Misc: Bump magic number for ocaml 5.1
 * Misc: changes to stay compatible with the next version of ppx_expect
-* Runtime: support conversion of Uint8ClampedArray typed arrays to bigarrays.
-
+* Runtime: support conversion of Uint8ClampedArray typed arrays to bigarrays (#1472)
 
 ## Bug fixes
 * Compiler: fix location for parsing errors when last token is a virtual semicolon
@@ -12,6 +11,7 @@
 * Compiler: consise body should allow any expression but object literals
 * Compiler: preserve [new] without arguments [new C] (vs [new C()]
 * Compiler: remove invalid rewriting of js (#1471, #1469)
+* Runtime: fix int32 values returned from bigarrays when wrapping Uint32Array objects (#1472)
 
 # 5.2.0 (2023-04-28) - Lille
 ## Features/Changes

--- a/compiler/lib/reserved.ml
+++ b/compiler/lib/reserved.ml
@@ -153,6 +153,7 @@ let provided =
     ; "Uint16Array"
     ; "Uint32Array"
     ; "Uint8Array"
+    ; "Uint8ClampedArray"
     ; "atob"
     ; "btoa"
     ; "clearInterval"

--- a/runtime/bigarray.js
+++ b/runtime/bigarray.js
@@ -895,5 +895,10 @@ function caml_ba_kind_of_typed_array(ta){
 //Requires: caml_ba_create_unsafe
 function caml_ba_from_typed_array(ta){
   var kind = caml_ba_kind_of_typed_array(ta);
+  var ta =
+      /* Needed to avoid unsigned setters overflowing
+         the range of OCaml [int32] values. */
+      ta instanceof Uint32Array ?
+      new Int32Array(ta.buffer ,ta.byteOffset, ta.length) : ta;
   return caml_ba_create_unsafe(kind, 0, [ta.length], ta);
 }

--- a/runtime/bigarray.js
+++ b/runtime/bigarray.js
@@ -881,6 +881,7 @@ function caml_ba_kind_of_typed_array(ta){
   else if (ta instanceof Float64Array) kind = 1;
   else if (ta instanceof Int8Array) kind = 2;
   else if (ta instanceof Uint8Array) kind = 3;
+  else if (ta instanceof Uint8ClampedArray) kind = 3;
   else if (ta instanceof Int16Array) kind = 4;
   else if (ta instanceof Uint16Array) kind = 5;
   else if (ta instanceof Int32Array) kind = 6;


### PR DESCRIPTION
These arrays are used for example by [`ImageData`](https://developer.mozilla.org/en-US/docs/Web/API/ImageData) objects.