### PR TITLE
Improve compatibility with Wasm_of_ocaml

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 * Runtime: fix Dom_html.onIE (#1493)
 * Compiler: fix global flow analysis (#1494)
+* Runtime: add conversion functions + strict equality for compatibility with Wasm_of_ocaml (#1492)
 
 # 5.4.0 (2023-07-06) - Lille
 

--- a/compiler/lib/generate.ml
+++ b/compiler/lib/generate.ml
@@ -1162,6 +1162,8 @@ let _ =
       J.EUn (J.Delete, J.EAccess (cx, ANormal, cy)));
   register_bin_prim "caml_js_equals" `Mutable (fun cx cy _ ->
       bool (J.EBin (J.EqEq, cx, cy)));
+  register_bin_prim "caml_js_strict_equals" `Mutable (fun cx cy _ ->
+      bool (J.EBin (J.EqEqEq, cx, cy)));
   register_bin_prim "caml_js_instanceof" `Mutator (fun cx cy _ ->
       bool (J.EBin (J.InstanceOf, cx, cy)));
   register_un_prim "caml_js_typeof" `Mutator (fun cx _ -> J.EUn (J.Typeof, cx))

--- a/compiler/lib/generate.ml
+++ b/compiler/lib/generate.ml
@@ -2186,6 +2186,10 @@ let init () =
     ; "caml_ensure_stack_capacity", "%identity"
     ; "caml_js_from_float", "%identity"
     ; "caml_js_to_float", "%identity"
+    ; "caml_js_from_int32", "%identity"
+    ; "caml_js_from_nativeint", "%identity"
+    ; "caml_js_to_int32", "caml_int_of_float"
+    ; "caml_js_to_nativeint", "caml_int_of_float"
     ];
   Hashtbl.iter
     (fun name (k, _) -> Primitive.register name k None None)

--- a/compiler/tests-compiler/jsopt.ml
+++ b/compiler/tests-compiler/jsopt.ml
@@ -48,6 +48,14 @@ module Js = struct
 
   external float_of_number : t -> float = "caml_js_to_float"
 
+  external number_of_int32 : int32 -> t = "caml_js_from_int32"
+
+  external int32_of_number : t -> int32 = "caml_js_to_int32"
+
+  external number_of_nativeint : nativeint -> t = "caml_js_from_nativeint"
+
+  external nativeint_of_number : t -> nativeint = "caml_js_to_nativeint"
+
   external typeof : t -> t = "caml_js_typeof"
 
   external instanceof : t -> t -> bool = "caml_js_instanceof"

--- a/examples/cubes/cubes.ml
+++ b/examples/cubes/cubes.ml
@@ -65,64 +65,64 @@ let on_cube c i j k f =
   let x = float (i - k + n - 1) *. w in
   let y = (float (n - 1 - j) *. h) +. (float (i + k) *. h /. 2.) in
   c##save;
-  c##translate x y;
+  c##translate (Js.float x) (Js.float y);
   f c;
   c##restore
 
 let draw_top c =
   c##.fillStyle := top;
   c##beginPath;
-  c##moveTo w 0.;
-  c##lineTo (2. *. w) (h /. 2.);
-  c##lineTo w h;
-  c##lineTo 0. (h /. 2.);
+  c##moveTo (Js.float w) (Js.float 0.);
+  c##lineTo (Js.float (2. *. w)) (Js.float (h /. 2.));
+  c##lineTo (Js.float w) (Js.float h);
+  c##lineTo (Js.float 0.) (Js.float (h /. 2.));
   c##fill
 
 let top_edges c =
   c##beginPath;
-  c##moveTo 0. (h /. 2.);
-  c##lineTo w 0.;
-  c##lineTo (2. *. w) (h /. 2.);
+  c##moveTo (Js.float 0.) (Js.float (h /. 2.));
+  c##lineTo (Js.float w) (Js.float 0.);
+  c##lineTo (Js.float (2. *. w)) (Js.float (h /. 2.));
   c##stroke
 
 let draw_right c =
   c##.fillStyle := right;
   c##beginPath;
-  c##moveTo w h;
-  c##lineTo w (2. *. h);
-  c##lineTo (2. *. w) (1.5 *. h);
-  c##lineTo (2. *. w) (h /. 2.);
+  c##moveTo (Js.float w) (Js.float h);
+  c##lineTo (Js.float w) (Js.float (2. *. h));
+  c##lineTo (Js.float (2. *. w)) (Js.float (1.5 *. h));
+  c##lineTo (Js.float (2. *. w)) (Js.float (h /. 2.));
   c##fill
 
 let right_edges c =
   c##beginPath;
-  c##moveTo w (2. *. h);
-  c##lineTo w h;
-  c##lineTo (2. *. w) (h /. 2.);
+  c##moveTo (Js.float w) (Js.float (2. *. h));
+  c##lineTo (Js.float w) (Js.float h);
+  c##lineTo (Js.float (2. *. w)) (Js.float (h /. 2.));
   c##stroke
 
 let draw_left c =
   c##.fillStyle := left;
   c##beginPath;
-  c##moveTo w h;
-  c##lineTo w (2. *. h);
-  c##lineTo 0. (1.5 *. h);
-  c##lineTo 0. (h /. 2.);
+  c##moveTo (Js.float w) (Js.float h);
+  c##lineTo (Js.float w) (Js.float (2. *. h));
+  c##lineTo (Js.float 0.) (Js.float (1.5 *. h));
+  c##lineTo (Js.float 0.) (Js.float (h /. 2.));
   c##fill
 
 let left_edges c =
   c##beginPath;
-  c##moveTo w h;
-  c##lineTo 0. (h /. 2.);
-  c##lineTo 0. (1.5 *. h);
+  c##moveTo (Js.float w) (Js.float h);
+  c##lineTo (Js.float 0.) (Js.float (h /. 2.));
+  c##lineTo (Js.float 0.) (Js.float (1.5 *. h));
   c##stroke
 
 let remaining_edges c =
   c##beginPath;
-  c##moveTo 0. (float n *. 1.5 *. h);
-  c##lineTo (float n *. w) (float n *. 2. *. h);
-  c##lineTo (float n *. 2. *. w) (float n *. 1.5 *. h);
-  c##lineTo (float n *. 2. *. w) (float n *. 0.5 *. h);
+  c##moveTo (Js.float 0.) (Js.float (float n *. 1.5 *. h));
+  c##lineTo (Js.float (float n *. w)) (Js.float (float n *. 2. *. h));
+  c##lineTo (Js.float (float n *. 2. *. w)) (Js.float (float n *. 1.5 *. h));
+  c##lineTo (Js.float (float n *. 2. *. w)) (Js.float (float n *. 0.5 *. h));
   c##stroke
 
 let tile c a (top, right, left) =
@@ -163,15 +163,31 @@ let create_canvas () =
 
 let redraw ctx canvas a =
   let c = canvas##getContext Html._2d_ in
-  c##setTransform 1. 0. 0. 1. 0. 0.;
-  c##clearRect 0. 0. (float canvas##.width) (float canvas##.height);
-  c##setTransform 1. 0. 0. 1. 0.5 0.5;
+  c##setTransform
+    (Js.float 1.)
+    (Js.float 0.)
+    (Js.float 0.)
+    (Js.float 1.)
+    (Js.float 0.)
+    (Js.float 0.);
+  c##clearRect
+    (Js.float 0.)
+    (Js.float 0.)
+    (Js.float (float canvas##.width))
+    (Js.float (float canvas##.height));
+  c##setTransform
+    (Js.float 1.)
+    (Js.float 0.)
+    (Js.float 0.)
+    (Js.float 1.)
+    (Js.float 0.5)
+    (Js.float 0.5);
   c##.globalCompositeOperation := Js.string "lighter";
   tile c a (draw_top, draw_right, draw_left);
   c##.globalCompositeOperation := Js.string "source-over";
   tile c a (top_edges, right_edges, left_edges);
   remaining_edges c;
-  ctx##drawImage_fromCanvas canvas 0. 0.
+  ctx##drawImage_fromCanvas canvas (Js.float 0.) (Js.float 0.)
 
 let ( >>= ) = Lwt.bind
 

--- a/examples/graph_viewer/viewer_js.ml
+++ b/examples/graph_viewer/viewer_js.ml
@@ -50,24 +50,38 @@ module Common = Viewer_common.F (struct
 
   let restore ctx = ctx##restore
 
-  let scale ctx ~sx ~sy = ctx##scale sx sy
+  let scale ctx ~sx ~sy = ctx##scale (Js.float sx) (Js.float sy)
 
-  let translate ctx ~tx ~ty = ctx##translate tx ty
+  let translate ctx ~tx ~ty = ctx##translate (Js.float tx) (Js.float ty)
 
   let begin_path ctx = ctx##beginPath
 
   let close_path ctx = ctx##closePath
 
-  let move_to ctx ~x ~y = ctx##moveTo x y
+  let move_to ctx ~x ~y = ctx##moveTo (Js.float x) (Js.float y)
 
-  let line_to ctx ~x ~y = ctx##lineTo x y
+  let line_to ctx ~x ~y = ctx##lineTo (Js.float x) (Js.float y)
 
-  let curve_to ctx ~x1 ~y1 ~x2 ~y2 ~x3 ~y3 = ctx##bezierCurveTo x1 y1 x2 y2 x3 y3
+  let curve_to ctx ~x1 ~y1 ~x2 ~y2 ~x3 ~y3 =
+    ctx##bezierCurveTo
+      (Js.float x1)
+      (Js.float y1)
+      (Js.float x2)
+      (Js.float y2)
+      (Js.float x3)
+      (Js.float y3)
 
   let arc ctx ~xc ~yc ~radius ~angle1 ~angle2 =
-    ctx##arc xc yc radius angle1 angle2 Js._true
+    ctx##arc
+      (Js.float xc)
+      (Js.float yc)
+      (Js.float radius)
+      (Js.float angle1)
+      (Js.float angle2)
+      Js._true
 
-  let rectangle ctx ~x ~y ~width ~height = ctx##rect x y width height
+  let rectangle ctx ~x ~y ~width ~height =
+    ctx##rect (Js.float x) (Js.float y) (Js.float width) (Js.float height)
 
   let fill ctx c =
     ctx##.fillStyle := c;
@@ -86,12 +100,12 @@ module Common = Viewer_common.F (struct
     (match fill_color with
     | Some c ->
         ctx##.fillStyle := c;
-        ctx##fillText txt x y
+        ctx##fillText txt (Js.float x) (Js.float y)
     | None -> ());
     match stroke_color with
     | Some c ->
         ctx##.strokeStyle := c;
-        ctx##strokeText txt x y
+        ctx##strokeText txt (Js.float x) (Js.float y)
     | None -> ()
 
   type window = Html.canvasElement Js.t
@@ -102,7 +116,7 @@ module Common = Viewer_common.F (struct
 
   let get_drawable w =
     let ctx = w##getContext Html._2d_ in
-    ctx##.lineWidth := 2.;
+    ctx##.lineWidth := Js.float 2.;
     w, ctx
 
   let make_pixmap _ width height =
@@ -126,14 +140,14 @@ module Common = Viewer_common.F (struct
       ((p, _) : pixmap) =
     c##drawImage_fullFromCanvas
       p
-      (float xsrc)
-      (float ysrc)
-      (float width)
-      (float height)
-      (float x)
-      (float y)
-      (float width)
-      (float height)
+      (Js.float (float xsrc))
+      (Js.float (float ysrc))
+      (Js.float (float width))
+      (Js.float (float height))
+      (Js.float (float x))
+      (Js.float (float y))
+      (Js.float (float width))
+      (Js.float (float height))
 
   (****)
 
@@ -353,7 +367,7 @@ Firebug.console##log_2(Js.string "update", Js.date##now());
       redraw_queued := true;
       let (_ : Html.animation_frame_request_id) =
         Html.window##requestAnimationFrame
-          (Js.wrap_callback (fun (_ : float) ->
+          (Js.wrap_callback (fun _ ->
                redraw_queued := false;
                redraw st (get_scale ()) hadj#value vadj#value canvas))
       in

--- a/examples/hyperbolic/hypertree.ml
+++ b/examples/hyperbolic/hypertree.ml
@@ -481,11 +481,26 @@ debug_msg (Format.sprintf "Touch end");
 let roundRectPath c x y w h r =
   let r = min r (min w h /. 2.) in
   c##beginPath;
-  c##moveTo (x +. r) y;
-  c##arcTo (x +. w) y (x +. w) (y +. r) r;
-  c##arcTo (x +. w) (y +. h) (x +. w -. r) (y +. h) r;
-  c##arcTo x (y +. h) x (y +. h -. r) r;
-  c##arcTo x y (x +. r) y r
+  c##moveTo (Js.float (x +. r)) (Js.float y);
+  c##arcTo
+    (Js.float (x +. w))
+    (Js.float y)
+    (Js.float (x +. w))
+    (Js.float (y +. r))
+    (Js.float r);
+  c##arcTo
+    (Js.float (x +. w))
+    (Js.float (y +. h))
+    (Js.float (x +. w -. r))
+    (Js.float (y +. h))
+    (Js.float r);
+  c##arcTo
+    (Js.float x)
+    (Js.float (y +. h))
+    (Js.float x)
+    (Js.float (y +. h -. r))
+    (Js.float r);
+  c##arcTo (Js.float x) (Js.float y) (Js.float (x +. r)) (Js.float y) (Js.float r)
 
 let text_size_div =
   let doc = Html.document in
@@ -567,9 +582,15 @@ let pi = 4. *. atan 1.
 
 let ellipse_arc c cx cy rx ry start fin clock_wise =
   c##save;
-  c##translate cx cy;
-  c##scale rx ry;
-  c##arc 0. 0. 1. start fin clock_wise;
+  c##translate (Js.float cx) (Js.float cy);
+  c##scale (Js.float rx) (Js.float ry);
+  c##arc
+    (Js.float 0.)
+    (Js.float 0.)
+    (Js.float 1.)
+    (Js.float start)
+    (Js.float fin)
+    clock_wise;
   c##restore
 
 let arc c (rx, ry, dx, dy) z0 z1 z2 =
@@ -584,11 +605,11 @@ Firebug.console##log_4(start, fin, alpha, (alpha > pi));
   if rx = ry
   then
     c##arc
-      ((z0.x *. rx) +. dx)
-      ((z0.y *. rx) +. dy)
-      (rd *. rx)
-      start
-      fin
+      (Js.float ((z0.x *. rx) +. dx))
+      (Js.float ((z0.y *. rx) +. dy))
+      (Js.float (rd *. rx))
+      (Js.float start)
+      (Js.float fin)
       (Js.bool (alpha > pi))
   else
     ellipse_arc
@@ -604,8 +625,8 @@ Firebug.console##log_4(start, fin, alpha, (alpha > pi));
 
 let line c (rx, ry, dx, dy) z1 z2 =
   c##beginPath;
-  c##moveTo ((z1.x *. rx) +. dx) ((z1.y *. ry) +. dy);
-  c##lineTo ((z2.x *. rx) +. dx) ((z2.y *. ry) +. dy);
+  c##moveTo (Js.float ((z1.x *. rx) +. dx)) (Js.float ((z1.y *. ry) +. dy));
+  c##lineTo (Js.float ((z2.x *. rx) +. dx)) (Js.float ((z2.y *. ry) +. dy));
   c##stroke
 
 (*
@@ -640,7 +661,11 @@ let draw canvas vertices edges nodes boxes =
   Firebug.console##time (Js.string "draw");
   let c = canvas##getContext Html._2d_ in
   let ((rx, ry, dx, dy) as transf) = screen_transform canvas in
-  c##clearRect 0. 0. (float canvas##.width) (float canvas##.height);
+  c##clearRect
+    (Js.float 0.)
+    (Js.float 0.)
+    (Js.float (float canvas##.width))
+    (Js.float (float canvas##.height));
   let padding = opt_style style##.padding 0. in
   c##beginPath;
   ellipse_arc c dx dy (rx +. padding) (ry +. padding) 0. 7. Js._false;
@@ -648,10 +673,10 @@ let draw canvas vertices edges nodes boxes =
       c##.fillStyle := color;
       c##fill);
   Js.Optdef.iter style##.boundaryColor (fun color ->
-      c##.lineWidth := 1.;
+      c##.lineWidth := Js.float 1.;
       c##.strokeStyle := color;
       c##stroke);
-  c##.lineWidth := 2.;
+  c##.lineWidth := Js.float 2.;
   c##.lineCap := Js.string "round";
   c##.strokeStyle := opt_style style##.treeColor tree_color;
   let rx, ry, _, _ = transf in
@@ -661,7 +686,7 @@ let draw canvas vertices edges nodes boxes =
     let z' = vertices.(j') in
     if rx *. ry *. sq_norm_sub z z' > 4.
     then (
-      c##.lineWidth := w;
+      c##.lineWidth := Js.float w;
       segment c transf z z')
   done;
   let image_count = ref 0 in
@@ -721,13 +746,18 @@ let draw canvas vertices edges nodes boxes =
 *)
                   let blur = 7. *. scale in
                   let offset = 5. *. scale in
-                  c##.shadowBlur := if blur < 1. then 0. else blur;
-                  c##.shadowOffsetX := if blur < 1. then 0. else offset;
-                  c##.shadowOffsetY := if blur < 1. then 0. else offset;
+                  c##.shadowBlur := Js.float (if blur < 1. then 0. else blur);
+                  c##.shadowOffsetX := Js.float (if blur < 1. then 0. else offset);
+                  c##.shadowOffsetY := Js.float (if blur < 1. then 0. else offset);
                   c##.shadowColor := Js.string "black");
                 let x = (z.x *. rx) +. dx in
                 let y = (z.y *. ry) +. dy in
-                c##drawImage_withSize img (x -. w) (y -. h) (2. *. w) (2. *. h);
+                c##drawImage_withSize
+                  img
+                  (Js.float (x -. w))
+                  (Js.float (y -. h))
+                  (Js.float (2. *. w))
+                  (Js.float (2. *. h));
                 (*
               c##drawImage_fromCanvasWithSize
                    (img, x -. w, y -. h, 2. *. w, 2. *. h);
@@ -757,19 +787,19 @@ let draw canvas vertices edges nodes boxes =
           c##beginPath;
           c##.fillStyle := opt_style style##.nodeBackgroundColor tree_color;
           c##arc
-            ((z.x *. rx) +. dx)
-            ((z.y *. ry) +. dy)
-            (sqrt ((w *. w) +. (h *. h)))
-            0.
-            7.
+            (Js.float ((z.x *. rx) +. dx))
+            (Js.float ((z.y *. ry) +. dy))
+            (Js.float (sqrt ((w *. w) +. (h *. h))))
+            (Js.float 0.)
+            (Js.float 7.)
             Js._false;
           c##fill);
         c##drawImage_fromCanvasWithSize
           txt
-          ((z.x *. rx) +. dx -. w)
-          ((z.y *. ry) +. dy -. h)
-          (2. *. w)
-          (2. *. h)
+          (Js.float ((z.x *. rx) +. dx -. w))
+          (Js.float ((z.y *. ry) +. dy -. h))
+          (Js.float (2. *. w))
+          (Js.float (2. *. h))
     | `Txt (_, None, _) | `None -> ()
   done;
   Firebug.console##timeEnd (Js.string "draw");
@@ -793,7 +823,7 @@ let rec randomize_tree n =
   let (Node (_info, ch)) = n in
   for i = Array.length ch - 1 downto 0 do
     let v = ch.(i) in
-    let j = truncate (Js.math##random *. float (i + 1)) in
+    let j = truncate (Js.to_float Js.math##random *. float (i + 1)) in
     ch.(i) <- ch.(j);
     ch.(j) <- v
   done;
@@ -813,7 +843,7 @@ let schedule_redraw () =
     need_redraw := true;
     let (_ : Html.animation_frame_request_id) =
       Html.window##requestAnimationFrame
-        (Js.wrap_callback (fun (_ : float) -> if !need_redraw then perform_redraw ()))
+        (Js.wrap_callback (fun _ -> if !need_redraw then perform_redraw ()))
     in
     ())
 
@@ -857,7 +887,7 @@ let compute_text_node info =
   c##.fillStyle := opt_style style##.nodeColor (Js.string "black");
   c##.textAlign := Js.string "center";
   c##.textBaseline := Js.string "middle";
-  c##fillText (Js.string info) (float w /. 2.) (float h /. 2.);
+  c##fillText (Js.string info) (Js.float (float w /. 2.)) (Js.float (float h /. 2.));
   canvas
 
 let compute_text_nodes node_names nodes =
@@ -1096,15 +1126,15 @@ let close_button over =
   let canvas = create_canvas size size in
   let c = canvas##getContext Html._2d_ in
   c##save;
-  c##.lineWidth := 2.;
+  c##.lineWidth := Js.float 2.;
   c##.strokeStyle := color;
   if over
   then (
-    c##.shadowBlur := offset;
+    c##.shadowBlur := Js.float offset;
     c##.shadowColor := color);
   c##beginPath;
-  let a = offset +. (lw /. sqrt 2.) in
-  let b = float size -. offset -. (lw /. sqrt 2.) in
+  let a = Js.float (offset +. (lw /. sqrt 2.)) in
+  let b = Js.float (float size -. offset -. (lw /. sqrt 2.)) in
   c##moveTo a a;
   c##lineTo b b;
   c##moveTo a b;
@@ -1247,7 +1277,12 @@ let show_image all_messages image_info name small_image =
     | Some small_image ->
         let canvas = create_canvas info.width info.height in
         let c = canvas##getContext Html._2d_ in
-        c##drawImage_withSize small_image 0. 0. (float info.width) (float info.height);
+        c##drawImage_withSize
+          small_image
+          (Js.float 0.)
+          (Js.float 0.)
+          (Js.float (float info.width))
+          (Js.float (float info.height));
         canvas##.style##.display := Js.string "block";
         canvas##.style##.height := Js.string "auto";
         canvas##.style##.width := Js.string "auto";

--- a/examples/planet/planet.ml
+++ b/examples/planet/planet.ml
@@ -355,7 +355,13 @@ let shadow texture =
   let canvas = create_canvas w h in
   let ctx = canvas##getContext Html._2d_ in
   let w, h = w / 8, h / 8 in
-  let img = ctx##getImageData 0. 0. (float w) (float h) in
+  let img =
+    ctx##getImageData
+      (Js.float 0.)
+      (Js.float 0.)
+      (Js.float (float w))
+      (Js.float (float h))
+  in
   let data = img##.data in
   let inv_gamma = 1. /. gamma in
   let update_shadow obliquity =
@@ -382,12 +388,14 @@ let shadow texture =
         Html.pixel_set data (k' + 3) c
       done
     done;
-    ctx##putImageData img 0. 0.;
+    ctx##putImageData img (Js.float 0.) (Js.float 0.);
     ctx##.globalCompositeOperation := Js.string "copy";
     ctx##save;
-    ctx##scale (8. *. float (w + 2) /. float w) (8. *. float (h + 2) /. float h);
-    ctx##translate (-1.) (-1.);
-    ctx##drawImage_fromCanvas canvas 0. 0.;
+    ctx##scale
+      (Js.float (8. *. float (w + 2) /. float w))
+      (Js.float (8. *. float (h + 2) /. float h));
+    ctx##translate (Js.float (-1.)) (Js.float (-1.));
+    ctx##drawImage_fromCanvas canvas (Js.float 0.) (Js.float 0.);
     ctx##restore
   in
   update_shadow obliquity;
@@ -401,15 +409,15 @@ let shadow texture =
     then (
       no_lighting := false;
       let phi = mod_float phi (2. *. pi) in
-      ctx'##drawImage texture 0. 0.;
+      ctx'##drawImage texture (Js.float 0.) (Js.float 0.);
       let i =
         truncate (mod_float (((2. *. pi) -. phi) *. float w /. 2. /. pi) (float w))
       in
-      ctx'##drawImage_fromCanvas canvas (float i) 0.;
-      ctx'##drawImage_fromCanvas canvas (float i -. float w) 0.)
+      ctx'##drawImage_fromCanvas canvas (Js.float (float i)) (Js.float 0.);
+      ctx'##drawImage_fromCanvas canvas (Js.float (float i -. float w)) (Js.float 0.))
     else if not !no_lighting
     then (
-      ctx'##drawImage texture 0. 0.;
+      ctx'##drawImage texture (Js.float 0.) (Js.float 0.);
       no_lighting := true)
   in
   (*
@@ -481,9 +489,9 @@ let draw ctx _img shd o _uv normals face_info dir =
       if dot_product normals.(i) dir >= 0.
       then (
         ctx##beginPath;
-        ctx##moveTo x1 y1;
-        ctx##lineTo x2 y2;
-        ctx##lineTo x3 y3;
+        ctx##moveTo (Js.float x1) (Js.float y1);
+        ctx##lineTo (Js.float x2) (Js.float y2);
+        ctx##lineTo (Js.float x3) (Js.float y3);
         ctx##closePath;
         ctx##save;
         ctx##clip;
@@ -498,7 +506,13 @@ let draw ctx _img shd o _uv normals face_info dir =
         let d = (dy2 *. dv3) -. (dy3 *. dv2) in
         let e = (dy2 *. du3) -. (dy3 *. du2) in
         let f = y1 -. (d *. u1) -. (e *. v1) in
-        ctx##transform a d b e c f;
+        ctx##transform
+          (Js.float a)
+          (Js.float d)
+          (Js.float b)
+          (Js.float e)
+          (Js.float c)
+          (Js.float f);
         (*
 let (u1, v1) = uv.(v1) in
 let (u2, v2) = uv.(v2) in
@@ -546,7 +560,16 @@ let v' = min th (max v1 (max v2 v3) +. 4.) in
 let du = u' -. u in
 let dv = v' -. v in
 *)
-        ctx##drawImage_fullFromCanvas shd u v du dv u v du dv;
+        ctx##drawImage_fullFromCanvas
+          shd
+          (Js.float u)
+          (Js.float v)
+          (Js.float du)
+          (Js.float dv)
+          (Js.float u)
+          (Js.float v)
+          (Js.float du)
+          (Js.float dv);
         ctx##restore))
     o.faces
 
@@ -694,7 +717,7 @@ let start _ =
                       Js._true))
                  Js._true);
           Js._false);
-    let ti = ref (new%js Js.date_now)##getTime in
+    let ti = ref (Js.to_float (new%js Js.date_now)##getTime) in
     let fps = ref 0. in
     let rec loop t phi =
       let rotation = xz_rotation (phi -. !phi_rot) in
@@ -702,21 +725,40 @@ let start _ =
       let m = matrix_mul !m (matrix_mul !m_obliq rotation) in
       let o' = rotate_object m o in
       let v' = rotate_normal m v in
-      ctx'##clearRect 0. 0. (float width) (float height);
+      ctx'##clearRect
+        (Js.float 0.)
+        (Js.float 0.)
+        (Js.float (float width))
+        (Js.float (float height));
       ctx'##save;
       if !clipped
       then (
         ctx'##beginPath;
-        ctx'##arc r r (r *. 0.95) 0. (-2. *. pi) Js._true;
+        ctx'##arc
+          (Js.float r)
+          (Js.float r)
+          (Js.float (r *. 0.95))
+          (Js.float 0.)
+          (Js.float (-2. *. pi))
+          Js._true;
         ctx'##clip);
-      ctx'##setTransform (r -. 2.) 0. 0. (r -. 2.) r r;
+      ctx'##setTransform
+        (Js.float (r -. 2.))
+        (Js.float 0.)
+        (Js.float 0.)
+        (Js.float (r -. 2.))
+        (Js.float r)
+        (Js.float r);
       ctx'##.globalCompositeOperation := Js.string "lighter";
       draw ctx' texture shd o' uv normals face_info v';
       ctx'##restore;
       ctx##.globalCompositeOperation := Js.string "copy";
-      ctx##drawImage_fromCanvas canvas' 0. 0.;
-      (try ignore (ctx##getImageData 0. 0. 1. 1.) with _ -> ());
-      let t' = (new%js Js.date_now)##getTime in
+      ctx##drawImage_fromCanvas canvas' (Js.float 0.) (Js.float 0.);
+      (try
+         ignore
+           (ctx##getImageData (Js.float 0.) (Js.float 0.) (Js.float 1.) (Js.float 1.))
+       with _ -> ());
+      let t' = Js.to_float (new%js Js.date_now)##getTime in
       (fps :=
          let hz = 1000. /. (t' -. !ti) in
          if !fps = 0. then hz else (0.9 *. !fps) +. (0.1 *. hz));
@@ -724,7 +766,7 @@ let start _ =
       ti := t';
       Lwt_js.sleep 0.01
       >>= fun () ->
-      let t' = (new%js Js.date_now)##getTime in
+      let t' = Js.to_float (new%js Js.date_now)##getTime in
       let dt = t' -. t in
       let dt = if dt < 0. then 0. else if dt > 1000. then 0. else dt in
       let angle = 2. *. pi *. dt /. 1000. /. 10. in
@@ -734,7 +776,7 @@ if true then Lwt.return () else
       if (not !paused) && !follow then phi_rot := !phi_rot +. angle;
       loop t' (if !paused then phi else phi +. angle)
     in
-    loop (new%js Js.date_now)##getTime 0.);
+    loop (Js.to_float (new%js Js.date_now)##getTime) 0.);
   Js._false
 
 let _ = Html.window##.onload := Html.handler start

--- a/examples/test_wheel/test_wheel.ml
+++ b/examples/test_wheel/test_wheel.ml
@@ -21,9 +21,9 @@ let () =
         let wheelDelta = event##.wheelDelta in
         let wheelDeltaX = event##.wheelDeltaX in
         let wheelDeltaY = event##.wheelDeltaY in
-        Printf.printf "deltaX: %f; " deltaX;
-        Printf.printf "deltaY: %f; " deltaY;
-        Printf.printf "deltaZ: %f; " deltaZ;
+        Printf.printf "deltaX: %f; " (Js.to_float deltaX);
+        Printf.printf "deltaY: %f; " (Js.to_float deltaY);
+        Printf.printf "deltaZ: %f; " (Js.to_float deltaZ);
         Printf.printf
           "deltaMode: %s; "
           (match deltaMode with

--- a/examples/webgl/webgldemo.ml
+++ b/examples/webgl/webgldemo.ml
@@ -273,11 +273,11 @@ let start (pos, norm) =
   in
   check_error gl;
   debug "ready";
-  let get_time () = (new%js date_now)##getTime in
+  let get_time () = Js.to_float (new%js date_now)##getTime in
   let last_draw = ref (get_time ()) in
   let draw_times = Queue.create () in
   let rec f () =
-    let t = (new%js date_now)##getTime /. 1000. in
+    let t = Js.to_float (new%js date_now)##getTime /. 1000. in
     let mat' = Proj3D.mult mat (Proj3D.rotate_y (1. *. t)) in
     gl##uniformMatrix4fv_typed proj_loc _false (Proj3D.array mat');
     gl##clear (gl##._DEPTH_BUFFER_BIT_ lor gl##._COLOR_BUFFER_BIT_);

--- a/lib/js_of_ocaml/dom.ml
+++ b/lib/js_of_ocaml/dom.ml
@@ -360,7 +360,7 @@ class type event_listener_options = object
 end
 
 let addEventListenerWithOptions (e : (< .. > as 'a) t) typ ?capture ?once ?passive h =
-  if (Js.Unsafe.coerce e)##.addEventListener == Js.undefined
+  if not (Js.Optdef.test (Js.Unsafe.coerce e)##.addEventListener)
   then
     let ev = (Js.string "on")##concat typ in
     let callback e = Js.Unsafe.call (h, e, [||]) in

--- a/lib/js_of_ocaml/dom_html.ml
+++ b/lib/js_of_ocaml/dom_html.ml
@@ -2469,8 +2469,8 @@ let rec unsafeCreateElementEx ?_type ?name doc elt =
                  Js.Unsafe.coerce
                    (document##createElement (Js.string "<input name=\"x\">"))
                in
-               el##.tagName##toLowerCase == Js.string "input"
-               && el##.name == Js.string "x"
+               Js.equals el##.tagName##toLowerCase (Js.string "input")
+               && Js.equals el##.name (Js.string "x")
              with _ -> false
           then `Extended
           else `Standard;
@@ -2653,12 +2653,12 @@ let html_element : htmlElement t constr = Js.Unsafe.global##._HTMLElement
 
 module CoerceTo = struct
   let element : #Dom.node Js.t -> element Js.t Js.opt =
-    if def html_element == undefined
+    if not (Js.Optdef.test (def html_element))
     then
       (* ie < 9 does not have HTMLElement: we have to cheat to check
          that something is an html element *)
       fun e ->
-      if def (Js.Unsafe.coerce e)##.innerHTML == undefined
+      if not (Js.Optdef.test (def (Js.Unsafe.coerce e)##.innerHTML))
       then Js.null
       else Js.some (Js.Unsafe.coerce e)
     else
@@ -2666,7 +2666,7 @@ module CoerceTo = struct
       if Js.instanceof e html_element then Js.some (Js.Unsafe.coerce e) else Js.null
 
   let unsafeCoerce tag (e : #element t) =
-    if e##.tagName##toLowerCase == Js.string tag
+    if Js.equals e##.tagName##toLowerCase (Js.string tag)
     then Js.some (Js.Unsafe.coerce e)
     else Js.null
 
@@ -2793,7 +2793,7 @@ module CoerceTo = struct
   let video e = unsafeCoerce "video" e
 
   let unsafeCoerceEvent constr (ev : #event t) =
-    if def constr != undefined && Js.instanceof ev constr
+    if Js.Optdef.test (def constr) && Js.instanceof ev constr
     then Js.some (Js.Unsafe.coerce ev)
     else Js.null
 

--- a/lib/js_of_ocaml/dom_html.ml
+++ b/lib/js_of_ocaml/dom_html.ml
@@ -365,11 +365,11 @@ and mousewheelEvent = object
 
   method wheelDeltaY : int optdef readonly_prop
 
-  method deltaX : float readonly_prop
+  method deltaX : number_t readonly_prop
 
-  method deltaY : float readonly_prop
+  method deltaY : number_t readonly_prop
 
-  method deltaZ : float readonly_prop
+  method deltaZ : number_t readonly_prop
 
   method deltaMode : delta_mode readonly_prop
 end
@@ -560,13 +560,13 @@ and pointerEvent = object
 
   method pointerId : int Js.readonly_prop
 
-  method width : float Js.readonly_prop
+  method width : number_t Js.readonly_prop
 
-  method height : float Js.readonly_prop
+  method height : number_t Js.readonly_prop
 
-  method pressure : float Js.readonly_prop
+  method pressure : number_t Js.readonly_prop
 
-  method tangentialPressure : float Js.readonly_prop
+  method tangentialPressure : number_t Js.readonly_prop
 
   method tiltX : int Js.readonly_prop
 
@@ -620,7 +620,7 @@ and animationEvent = object
 
   method animationName : js_string t readonly_prop
 
-  method elapsedTime : float readonly_prop
+  method elapsedTime : number_t readonly_prop
 
   method pseudoElement : js_string t readonly_prop
 end
@@ -630,7 +630,7 @@ and transitionEvent = object
 
   method propertyName : js_string t readonly_prop
 
-  method elapsedTime : float readonly_prop
+  method elapsedTime : number_t readonly_prop
 
   method pseudoElement : js_string t readonly_prop
 end
@@ -740,17 +740,17 @@ and element = object
 end
 
 and clientRect = object
-  method top : float readonly_prop
+  method top : number_t readonly_prop
 
-  method right : float readonly_prop
+  method right : number_t readonly_prop
 
-  method bottom : float readonly_prop
+  method bottom : number_t readonly_prop
 
-  method left : float readonly_prop
+  method left : number_t readonly_prop
 
-  method width : float optdef readonly_prop
+  method width : number_t optdef readonly_prop
 
-  method height : float optdef readonly_prop
+  method height : number_t optdef readonly_prop
 end
 
 and clientRectList = object
@@ -1606,9 +1606,9 @@ end
 class type timeRanges = object
   method length : int readonly_prop
 
-  method start : int -> float meth
+  method start : int -> number_t meth
 
-  method end_ : int -> float meth
+  method end_ : int -> number_t meth
 end
 
 type networkState =
@@ -1645,9 +1645,9 @@ class type mediaElement = object
 
   method currentSrc : js_string t readonly_prop
 
-  method currentTime : float prop
+  method currentTime : number_t prop
 
-  method duration : float readonly_prop
+  method duration : number_t readonly_prop
 
   method ended : bool t readonly_prop
 
@@ -1663,7 +1663,7 @@ class type mediaElement = object
 
   method paused : bool t readonly_prop
 
-  method playbackRate : float prop
+  method playbackRate : number_t prop
 
   method played : timeRanges t readonly_prop
 
@@ -1679,7 +1679,7 @@ class type mediaElement = object
 
   method src : js_string t prop
 
-  method volume : float prop
+  method volume : number_t prop
 
   method oncanplay : ('self t, mediaEvent t) event_listener writeonly_prop
 
@@ -1743,7 +1743,7 @@ class type canvasElement = object
 
   method toDataURL_type : js_string t -> js_string t meth
 
-  method toDataURL_type_compression : js_string t -> float -> js_string t meth
+  method toDataURL_type_compression : js_string t -> number_t -> js_string t meth
 
   method getContext : js_string t -> canvasRenderingContext2D t meth
 end
@@ -1755,17 +1755,19 @@ and canvasRenderingContext2D = object
 
   method restore : unit meth
 
-  method scale : float -> float -> unit meth
+  method scale : number_t -> number_t -> unit meth
 
-  method rotate : float -> unit meth
+  method rotate : number_t -> unit meth
 
-  method translate : float -> float -> unit meth
+  method translate : number_t -> number_t -> unit meth
 
-  method transform : float -> float -> float -> float -> float -> float -> unit meth
+  method transform :
+    number_t -> number_t -> number_t -> number_t -> number_t -> number_t -> unit meth
 
-  method setTransform : float -> float -> float -> float -> float -> float -> unit meth
+  method setTransform :
+    number_t -> number_t -> number_t -> number_t -> number_t -> number_t -> unit meth
 
-  method globalAlpha : float prop
+  method globalAlpha : number_t prop
 
   method globalCompositeOperation : js_string t prop
 
@@ -1781,10 +1783,17 @@ and canvasRenderingContext2D = object
 
   method fillStyle_pattern : canvasPattern t writeonly_prop
 
-  method createLinearGradient : float -> float -> float -> float -> canvasGradient t meth
+  method createLinearGradient :
+    number_t -> number_t -> number_t -> number_t -> canvasGradient t meth
 
   method createRadialGradient :
-    float -> float -> float -> float -> float -> float -> canvasGradient t meth
+       number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> canvasGradient t meth
 
   method createPattern : imageElement t -> js_string t -> canvasPattern t meth
 
@@ -1792,45 +1801,47 @@ and canvasRenderingContext2D = object
 
   method createPattern_fromVideo : videoElement t -> js_string t -> canvasPattern t meth
 
-  method lineWidth : float prop
+  method lineWidth : number_t prop
 
   method lineCap : js_string t prop
 
   method lineJoin : js_string t prop
 
-  method miterLimit : float prop
+  method miterLimit : number_t prop
 
-  method shadowOffsetX : float prop
+  method shadowOffsetX : number_t prop
 
-  method shadowOffsetY : float prop
+  method shadowOffsetY : number_t prop
 
-  method shadowBlur : float prop
+  method shadowBlur : number_t prop
 
   method shadowColor : js_string t prop
 
-  method clearRect : float -> float -> float -> float -> unit meth
+  method clearRect : number_t -> number_t -> number_t -> number_t -> unit meth
 
-  method fillRect : float -> float -> float -> float -> unit meth
+  method fillRect : number_t -> number_t -> number_t -> number_t -> unit meth
 
-  method strokeRect : float -> float -> float -> float -> unit meth
+  method strokeRect : number_t -> number_t -> number_t -> number_t -> unit meth
 
   method beginPath : unit meth
 
   method closePath : unit meth
 
-  method moveTo : float -> float -> unit meth
+  method moveTo : number_t -> number_t -> unit meth
 
-  method lineTo : float -> float -> unit meth
+  method lineTo : number_t -> number_t -> unit meth
 
-  method quadraticCurveTo : float -> float -> float -> float -> unit meth
+  method quadraticCurveTo : number_t -> number_t -> number_t -> number_t -> unit meth
 
-  method bezierCurveTo : float -> float -> float -> float -> float -> float -> unit meth
+  method bezierCurveTo :
+    number_t -> number_t -> number_t -> number_t -> number_t -> number_t -> unit meth
 
-  method arcTo : float -> float -> float -> float -> float -> unit meth
+  method arcTo : number_t -> number_t -> number_t -> number_t -> number_t -> unit meth
 
-  method rect : float -> float -> float -> float -> unit meth
+  method rect : number_t -> number_t -> number_t -> number_t -> unit meth
 
-  method arc : float -> float -> float -> float -> float -> bool t -> unit meth
+  method arc :
+    number_t -> number_t -> number_t -> number_t -> number_t -> bool t -> unit meth
 
   method fill : unit meth
 
@@ -1838,9 +1849,9 @@ and canvasRenderingContext2D = object
 
   method clip : unit meth
 
-  method isPointInPath : float -> float -> bool t meth
+  method isPointInPath : number_t -> number_t -> bool t meth
 
-  method drawFocusRing : #element t -> float -> float -> bool t -> bool t meth
+  method drawFocusRing : #element t -> number_t -> number_t -> bool t -> bool t meth
 
   method font : js_string t prop
 
@@ -1848,80 +1859,82 @@ and canvasRenderingContext2D = object
 
   method textBaseline : js_string t prop
 
-  method fillText : js_string t -> float -> float -> unit meth
+  method fillText : js_string t -> number_t -> number_t -> unit meth
 
-  method fillText_withWidth : js_string t -> float -> float -> float -> unit meth
+  method fillText_withWidth : js_string t -> number_t -> number_t -> number_t -> unit meth
 
-  method strokeText : js_string t -> float -> float -> unit meth
+  method strokeText : js_string t -> number_t -> number_t -> unit meth
 
-  method strokeText_withWidth : js_string t -> float -> float -> float -> unit meth
+  method strokeText_withWidth :
+    js_string t -> number_t -> number_t -> number_t -> unit meth
 
   method measureText : js_string t -> textMetrics t meth
 
-  method drawImage : imageElement t -> float -> float -> unit meth
+  method drawImage : imageElement t -> number_t -> number_t -> unit meth
 
   method drawImage_withSize :
-    imageElement t -> float -> float -> float -> float -> unit meth
+    imageElement t -> number_t -> number_t -> number_t -> number_t -> unit meth
 
   method drawImage_full :
        imageElement t
-    -> float
-    -> float
-    -> float
-    -> float
-    -> float
-    -> float
-    -> float
-    -> float
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
     -> unit meth
 
-  method drawImage_fromCanvas : canvasElement t -> float -> float -> unit meth
+  method drawImage_fromCanvas : canvasElement t -> number_t -> number_t -> unit meth
 
   method drawImage_fromCanvasWithSize :
-    canvasElement t -> float -> float -> float -> float -> unit meth
+    canvasElement t -> number_t -> number_t -> number_t -> number_t -> unit meth
 
   method drawImage_fullFromCanvas :
        canvasElement t
-    -> float
-    -> float
-    -> float
-    -> float
-    -> float
-    -> float
-    -> float
-    -> float
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
     -> unit meth
 
-  method drawImage_fromVideoWithVideo : videoElement t -> float -> float -> unit meth
+  method drawImage_fromVideoWithVideo :
+    videoElement t -> number_t -> number_t -> unit meth
 
   method drawImage_fromVideoWithSize :
-    videoElement t -> float -> float -> float -> float -> unit meth
+    videoElement t -> number_t -> number_t -> number_t -> number_t -> unit meth
 
   method drawImage_fullFromVideo :
        videoElement t
-    -> float
-    -> float
-    -> float
-    -> float
-    -> float
-    -> float
-    -> float
-    -> float
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
     -> unit meth
 
   method createImageData : int -> int -> imageData t meth
 
-  method getImageData : float -> float -> float -> float -> imageData t meth
+  method getImageData : number_t -> number_t -> number_t -> number_t -> imageData t meth
 
-  method putImageData : imageData t -> float -> float -> unit meth
+  method putImageData : imageData t -> number_t -> number_t -> unit meth
 end
 
 and canvasGradient = object
-  method addColorStop : float -> js_string t -> unit meth
+  method addColorStop : number_t -> js_string t -> unit meth
 end
 
 and textMetrics = object
-  method width : float readonly_prop
+  method width : number_t readonly_prop
 end
 
 and imageData = object
@@ -2272,16 +2285,16 @@ class type window = object
 
   method print : unit meth
 
-  method setInterval : (unit -> unit) Js.callback -> float -> interval_id meth
+  method setInterval : (unit -> unit) Js.callback -> number_t -> interval_id meth
 
   method clearInterval : interval_id -> unit meth
 
-  method setTimeout : (unit -> unit) Js.callback -> float -> timeout_id meth
+  method setTimeout : (unit -> unit) Js.callback -> number_t -> timeout_id meth
 
   method clearTimeout : timeout_id -> unit meth
 
   method requestAnimationFrame :
-    (float -> unit) Js.callback -> animation_frame_request_id meth
+    (number_t -> unit) Js.callback -> animation_frame_request_id meth
 
   method cancelAnimationFrame : animation_frame_request_id -> unit meth
 
@@ -2328,7 +2341,7 @@ class type window = object
 
   method _URL : _URL t readonly_prop
 
-  method devicePixelRatio : float readonly_prop
+  method devicePixelRatio : number_t readonly_prop
 end
 
 let window : window t = Js.Unsafe.global

--- a/lib/js_of_ocaml/dom_html.mli
+++ b/lib/js_of_ocaml/dom_html.mli
@@ -374,11 +374,11 @@ and mousewheelEvent = object
 
   method wheelDeltaY : int optdef readonly_prop
 
-  method deltaX : float readonly_prop
+  method deltaX : number_t readonly_prop
 
-  method deltaY : float readonly_prop
+  method deltaY : number_t readonly_prop
 
-  method deltaZ : float readonly_prop
+  method deltaZ : number_t readonly_prop
 
   method deltaMode : delta_mode readonly_prop
 end
@@ -571,13 +571,13 @@ and pointerEvent = object
 
   method pointerId : int Js.readonly_prop
 
-  method width : float Js.readonly_prop
+  method width : number_t Js.readonly_prop
 
-  method height : float Js.readonly_prop
+  method height : number_t Js.readonly_prop
 
-  method pressure : float Js.readonly_prop
+  method pressure : number_t Js.readonly_prop
 
-  method tangentialPressure : float Js.readonly_prop
+  method tangentialPressure : number_t Js.readonly_prop
 
   method tiltX : int Js.readonly_prop
 
@@ -632,7 +632,7 @@ and animationEvent = object
 
   method animationName : js_string t readonly_prop
 
-  method elapsedTime : float readonly_prop
+  method elapsedTime : number_t readonly_prop
 
   method pseudoElement : js_string t readonly_prop
 end
@@ -642,7 +642,7 @@ and transitionEvent = object
 
   method propertyName : js_string t readonly_prop
 
-  method elapsedTime : float readonly_prop
+  method elapsedTime : number_t readonly_prop
 
   method pseudoElement : js_string t readonly_prop
 end
@@ -757,17 +757,17 @@ end
 
 (** Rectangular box (used for element bounding boxes) *)
 and clientRect = object
-  method top : float readonly_prop
+  method top : number_t readonly_prop
 
-  method right : float readonly_prop
+  method right : number_t readonly_prop
 
-  method bottom : float readonly_prop
+  method bottom : number_t readonly_prop
 
-  method left : float readonly_prop
+  method left : number_t readonly_prop
 
-  method width : float optdef readonly_prop
+  method width : number_t optdef readonly_prop
 
-  method height : float optdef readonly_prop
+  method height : number_t optdef readonly_prop
 end
 
 and clientRectList = object
@@ -1432,9 +1432,9 @@ end
 class type timeRanges = object
   method length : int readonly_prop
 
-  method start : int -> float meth
+  method start : int -> number_t meth
 
-  method end_ : int -> float meth
+  method end_ : int -> number_t meth
 end
 
 type networkState =
@@ -1469,9 +1469,9 @@ class type mediaElement = object
 
   method currentSrc : js_string t readonly_prop
 
-  method currentTime : float prop
+  method currentTime : number_t prop
 
-  method duration : float readonly_prop
+  method duration : number_t readonly_prop
 
   method ended : bool t readonly_prop
 
@@ -1487,7 +1487,7 @@ class type mediaElement = object
 
   method paused : bool t readonly_prop
 
-  method playbackRate : float prop
+  method playbackRate : number_t prop
 
   method played : timeRanges t readonly_prop
 
@@ -1503,7 +1503,7 @@ class type mediaElement = object
 
   method src : js_string t prop
 
-  method volume : float prop
+  method volume : number_t prop
 
   method oncanplay : ('self t, mediaEvent t) event_listener writeonly_prop
 
@@ -1569,7 +1569,7 @@ class type canvasElement = object
 
   method toDataURL_type : js_string t -> js_string t meth
 
-  method toDataURL_type_compression : js_string t -> float -> js_string t meth
+  method toDataURL_type_compression : js_string t -> number_t -> js_string t meth
 
   method getContext : context -> canvasRenderingContext2D t meth
 end
@@ -1581,17 +1581,19 @@ and canvasRenderingContext2D = object
 
   method restore : unit meth
 
-  method scale : float -> float -> unit meth
+  method scale : number_t -> number_t -> unit meth
 
-  method rotate : float -> unit meth
+  method rotate : number_t -> unit meth
 
-  method translate : float -> float -> unit meth
+  method translate : number_t -> number_t -> unit meth
 
-  method transform : float -> float -> float -> float -> float -> float -> unit meth
+  method transform :
+    number_t -> number_t -> number_t -> number_t -> number_t -> number_t -> unit meth
 
-  method setTransform : float -> float -> float -> float -> float -> float -> unit meth
+  method setTransform :
+    number_t -> number_t -> number_t -> number_t -> number_t -> number_t -> unit meth
 
-  method globalAlpha : float prop
+  method globalAlpha : number_t prop
 
   method globalCompositeOperation : js_string t prop
 
@@ -1607,10 +1609,17 @@ and canvasRenderingContext2D = object
 
   method fillStyle_pattern : canvasPattern t writeonly_prop
 
-  method createLinearGradient : float -> float -> float -> float -> canvasGradient t meth
+  method createLinearGradient :
+    number_t -> number_t -> number_t -> number_t -> canvasGradient t meth
 
   method createRadialGradient :
-    float -> float -> float -> float -> float -> float -> canvasGradient t meth
+       number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> canvasGradient t meth
 
   method createPattern : imageElement t -> js_string t -> canvasPattern t meth
 
@@ -1618,45 +1627,47 @@ and canvasRenderingContext2D = object
 
   method createPattern_fromVideo : videoElement t -> js_string t -> canvasPattern t meth
 
-  method lineWidth : float prop
+  method lineWidth : number_t prop
 
   method lineCap : js_string t prop
 
   method lineJoin : js_string t prop
 
-  method miterLimit : float prop
+  method miterLimit : number_t prop
 
-  method shadowOffsetX : float prop
+  method shadowOffsetX : number_t prop
 
-  method shadowOffsetY : float prop
+  method shadowOffsetY : number_t prop
 
-  method shadowBlur : float prop
+  method shadowBlur : number_t prop
 
   method shadowColor : js_string t prop
 
-  method clearRect : float -> float -> float -> float -> unit meth
+  method clearRect : number_t -> number_t -> number_t -> number_t -> unit meth
 
-  method fillRect : float -> float -> float -> float -> unit meth
+  method fillRect : number_t -> number_t -> number_t -> number_t -> unit meth
 
-  method strokeRect : float -> float -> float -> float -> unit meth
+  method strokeRect : number_t -> number_t -> number_t -> number_t -> unit meth
 
   method beginPath : unit meth
 
   method closePath : unit meth
 
-  method moveTo : float -> float -> unit meth
+  method moveTo : number_t -> number_t -> unit meth
 
-  method lineTo : float -> float -> unit meth
+  method lineTo : number_t -> number_t -> unit meth
 
-  method quadraticCurveTo : float -> float -> float -> float -> unit meth
+  method quadraticCurveTo : number_t -> number_t -> number_t -> number_t -> unit meth
 
-  method bezierCurveTo : float -> float -> float -> float -> float -> float -> unit meth
+  method bezierCurveTo :
+    number_t -> number_t -> number_t -> number_t -> number_t -> number_t -> unit meth
 
-  method arcTo : float -> float -> float -> float -> float -> unit meth
+  method arcTo : number_t -> number_t -> number_t -> number_t -> number_t -> unit meth
 
-  method rect : float -> float -> float -> float -> unit meth
+  method rect : number_t -> number_t -> number_t -> number_t -> unit meth
 
-  method arc : float -> float -> float -> float -> float -> bool t -> unit meth
+  method arc :
+    number_t -> number_t -> number_t -> number_t -> number_t -> bool t -> unit meth
 
   method fill : unit meth
 
@@ -1664,9 +1675,9 @@ and canvasRenderingContext2D = object
 
   method clip : unit meth
 
-  method isPointInPath : float -> float -> bool t meth
+  method isPointInPath : number_t -> number_t -> bool t meth
 
-  method drawFocusRing : #element t -> float -> float -> bool t -> bool t meth
+  method drawFocusRing : #element t -> number_t -> number_t -> bool t -> bool t meth
 
   method font : js_string t prop
 
@@ -1674,81 +1685,83 @@ and canvasRenderingContext2D = object
 
   method textBaseline : js_string t prop
 
-  method fillText : js_string t -> float -> float -> unit meth
+  method fillText : js_string t -> number_t -> number_t -> unit meth
 
-  method fillText_withWidth : js_string t -> float -> float -> float -> unit meth
+  method fillText_withWidth : js_string t -> number_t -> number_t -> number_t -> unit meth
 
-  method strokeText : js_string t -> float -> float -> unit meth
+  method strokeText : js_string t -> number_t -> number_t -> unit meth
 
-  method strokeText_withWidth : js_string t -> float -> float -> float -> unit meth
+  method strokeText_withWidth :
+    js_string t -> number_t -> number_t -> number_t -> unit meth
 
   method measureText : js_string t -> textMetrics t meth
 
-  method drawImage : imageElement t -> float -> float -> unit meth
+  method drawImage : imageElement t -> number_t -> number_t -> unit meth
 
   method drawImage_withSize :
-    imageElement t -> float -> float -> float -> float -> unit meth
+    imageElement t -> number_t -> number_t -> number_t -> number_t -> unit meth
 
   method drawImage_full :
        imageElement t
-    -> float
-    -> float
-    -> float
-    -> float
-    -> float
-    -> float
-    -> float
-    -> float
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
     -> unit meth
 
-  method drawImage_fromCanvas : canvasElement t -> float -> float -> unit meth
+  method drawImage_fromCanvas : canvasElement t -> number_t -> number_t -> unit meth
 
   method drawImage_fromCanvasWithSize :
-    canvasElement t -> float -> float -> float -> float -> unit meth
+    canvasElement t -> number_t -> number_t -> number_t -> number_t -> unit meth
 
   method drawImage_fullFromCanvas :
        canvasElement t
-    -> float
-    -> float
-    -> float
-    -> float
-    -> float
-    -> float
-    -> float
-    -> float
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
     -> unit meth
 
-  method drawImage_fromVideoWithVideo : videoElement t -> float -> float -> unit meth
+  method drawImage_fromVideoWithVideo :
+    videoElement t -> number_t -> number_t -> unit meth
 
   method drawImage_fromVideoWithSize :
-    videoElement t -> float -> float -> float -> float -> unit meth
+    videoElement t -> number_t -> number_t -> number_t -> number_t -> unit meth
 
   method drawImage_fullFromVideo :
        videoElement t
-    -> float
-    -> float
-    -> float
-    -> float
-    -> float
-    -> float
-    -> float
-    -> float
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
     -> unit meth
 
   (* Method createImageData not available in Opera *)
   method createImageData : int -> int -> imageData t meth
 
-  method getImageData : float -> float -> float -> float -> imageData t meth
+  method getImageData : number_t -> number_t -> number_t -> number_t -> imageData t meth
 
-  method putImageData : imageData t -> float -> float -> unit meth
+  method putImageData : imageData t -> number_t -> number_t -> unit meth
 end
 
 and canvasGradient = object
-  method addColorStop : float -> js_string t -> unit meth
+  method addColorStop : number_t -> js_string t -> unit meth
 end
 
 and textMetrics = object
-  method width : float readonly_prop
+  method width : number_t readonly_prop
 end
 
 and imageData = object
@@ -2125,16 +2138,16 @@ class type window = object
 
   method print : unit meth
 
-  method setInterval : (unit -> unit) Js.callback -> float -> interval_id meth
+  method setInterval : (unit -> unit) Js.callback -> number_t -> interval_id meth
 
   method clearInterval : interval_id -> unit meth
 
-  method setTimeout : (unit -> unit) Js.callback -> float -> timeout_id meth
+  method setTimeout : (unit -> unit) Js.callback -> number_t -> timeout_id meth
 
   method clearTimeout : timeout_id -> unit meth
 
   method requestAnimationFrame :
-    (float -> unit) Js.callback -> animation_frame_request_id meth
+    (number_t -> unit) Js.callback -> animation_frame_request_id meth
 
   method cancelAnimationFrame : animation_frame_request_id -> unit meth
 
@@ -2181,7 +2194,7 @@ class type window = object
 
   method _URL : _URL t readonly_prop
 
-  method devicePixelRatio : float readonly_prop
+  method devicePixelRatio : number_t readonly_prop
 end
 
 val window : window t

--- a/lib/js_of_ocaml/dom_svg.ml
+++ b/lib/js_of_ocaml/dom_svg.ml
@@ -2054,7 +2054,7 @@ module CoerceTo = struct
     if Js.instanceof e svg_element then Js.some (Js.Unsafe.coerce e) else Js.null
 
   let unsafeCoerce (e : #element t) tag =
-    if e##.tagName##toLowerCase == Js.string tag
+    if Js.equals e##.tagName##toLowerCase (Js.string tag)
     then Js.some (Js.Unsafe.coerce e)
     else Js.null
 

--- a/lib/js_of_ocaml/dom_svg.ml
+++ b/lib/js_of_ocaml/dom_svg.ml
@@ -217,7 +217,7 @@ and animatedEnumeration = [int (*short*)] animated
 and animatedInteger = [int] animated
 
 (* interface SVGAnimatedNumber *)
-and animatedNumber = [float] animated
+and animatedNumber = [number_t] animated
 
 (* interface SVGNumberList *)
 and numberList = [number t] list
@@ -229,13 +229,13 @@ and animatedNumberList = [numberList t] animated
 and length = object
   method unitType : lengthUnitType readonly_prop
 
-  method value : float prop
+  method value : number_t prop
 
-  method valueInSpecifiedUnits : float prop
+  method valueInSpecifiedUnits : number_t prop
 
   method valueAsString : js_string t prop
 
-  method newValueSpecifiedUnits : lengthUnitType -> float -> unit meth
+  method newValueSpecifiedUnits : lengthUnitType -> number_t -> unit meth
 
   method convertToSpecifiedUnits : lengthUnitType -> unit meth
 end
@@ -253,13 +253,13 @@ and animatedLengthList = [lengthList t] animated
 and angle = object
   method unitType : angleUnitType readonly_prop
 
-  method value : float prop
+  method value : number_t prop
 
-  method valueInSpecifiedUnits : float prop
+  method valueInSpecifiedUnits : number_t prop
 
   method valueAsString : js_string t prop
 
-  method newValueSpecifiedUnits : angleUnitType -> float -> unit meth
+  method newValueSpecifiedUnits : angleUnitType -> number_t -> unit meth
 
   method convertToSpecifiedUnits : angleUnitType -> unit meth
 end
@@ -295,13 +295,13 @@ end
 
 (* interface SVGRect *)
 and rect = object
-  method x : float prop
+  method x : number_t prop
 
-  method y : float prop
+  method y : number_t prop
 
-  method width : float prop
+  method width : number_t prop
 
-  method height : float prop
+  method height : number_t prop
 end
 
 (* interface SVGAnimatedRect *)
@@ -450,19 +450,19 @@ and svgElement = object
 
   method viewport : rect t readonly_prop
 
-  method pixelUnitToMillimeterX : float readonly_prop
+  method pixelUnitToMillimeterX : number_t readonly_prop
 
-  method pixelUnitToMillimeterY : float readonly_prop
+  method pixelUnitToMillimeterY : number_t readonly_prop
 
-  method screenPixelUnitToMillimeterX : float readonly_prop
+  method screenPixelUnitToMillimeterX : number_t readonly_prop
 
-  method screenPixelUnitToMillimeterY : float readonly_prop
+  method screenPixelUnitToMillimeterY : number_t readonly_prop
 
   method useCurrentView : bool t readonly_prop
 
   method currentView : viewSpec t readonly_prop
 
-  method currentScale : float prop
+  method currentScale : number_t prop
 
   method currentTranslate : point t readonly_prop
 
@@ -480,7 +480,7 @@ and svgElement = object
 
   method animationsPaused : bool t meth
 
-  method getCurrentTime : float meth
+  method getCurrentTime : number_t meth
 
   method setCurrentTime : int -> unit meth
 
@@ -693,9 +693,9 @@ end
 
 (* interface SVGPoint *)
 and point = object
-  method x : float readonly_prop
+  method x : number_t readonly_prop
 
-  method y : float readonly_prop
+  method y : number_t readonly_prop
 
   method matrixTransform : matrix t -> point t meth
 end
@@ -705,39 +705,39 @@ and pointList = [point t] list
 
 (* interface SVGMatrix *)
 and matrix = object
-  method a : float readonly_prop
+  method a : number_t readonly_prop
 
-  method b : float readonly_prop
+  method b : number_t readonly_prop
 
-  method c : float readonly_prop
+  method c : number_t readonly_prop
 
-  method d : float readonly_prop
+  method d : number_t readonly_prop
 
-  method e : float readonly_prop
+  method e : number_t readonly_prop
 
-  method f : float readonly_prop
+  method f : number_t readonly_prop
 
   method multiply : matrix t -> matrix t meth
 
   method inverse : matrix t meth
 
-  method translate : float -> float -> matrix t meth
+  method translate : number_t -> number_t -> matrix t meth
 
-  method scale : float -> matrix t meth
+  method scale : number_t -> matrix t meth
 
-  method scaleNonUniform : float -> float -> matrix t meth
+  method scaleNonUniform : number_t -> number_t -> matrix t meth
 
-  method rotate : float -> matrix t meth
+  method rotate : number_t -> matrix t meth
 
-  method rotateFromVector : float -> float -> matrix t meth
+  method rotateFromVector : number_t -> number_t -> matrix t meth
 
   method flipX : matrix t meth
 
   method flipY : matrix t meth
 
-  method skewX : float -> matrix t meth
+  method skewX : number_t -> matrix t meth
 
-  method skewY : float -> matrix t meth
+  method skewY : number_t -> matrix t meth
 end
 
 (* interface SVGTransform *)
@@ -746,19 +746,19 @@ and transform = object
 
   method matrix : matrix t readonly_prop
 
-  method angle : float readonly_prop
+  method angle : number_t readonly_prop
 
   method setMatrix : matrix t -> unit meth
 
-  method setTranslate : float -> float -> unit meth
+  method setTranslate : number_t -> number_t -> unit meth
 
-  method setScale : float -> float -> unit meth
+  method setScale : number_t -> number_t -> unit meth
 
-  method setRotate : float -> float -> float -> unit meth
+  method setRotate : number_t -> number_t -> number_t -> unit meth
 
-  method setSkewX : float -> unit meth
+  method setSkewX : number_t -> unit meth
 
-  method setSkewY : float -> unit meth
+  method setSkewY : number_t -> unit meth
 end
 
 (* interface SVGTransformList *)
@@ -798,9 +798,9 @@ and pathSegClosePath = pathSeg
 and pathSegMoveto = object
   inherit pathSeg
 
-  method x : float prop
+  method x : number_t prop
 
-  method y : float prop
+  method y : number_t prop
 end
 
 (* interface SVGPathSegLinetoAbs *)
@@ -808,9 +808,9 @@ end
 and pathSegLineto = object
   inherit pathSeg
 
-  method x : float prop
+  method x : number_t prop
 
-  method y : float prop
+  method y : number_t prop
 end
 
 (* interface SVGPathSegCurvetoCubicAbs *)
@@ -818,17 +818,17 @@ end
 and pathSegCurvetoCubic = object
   inherit pathSeg
 
-  method x : float prop
+  method x : number_t prop
 
-  method y : float prop
+  method y : number_t prop
 
-  method x1 : float prop
+  method x1 : number_t prop
 
-  method y1 : float prop
+  method y1 : number_t prop
 
-  method x2 : float prop
+  method x2 : number_t prop
 
-  method y2 : float prop
+  method y2 : number_t prop
 end
 
 (* interface SVGPathSegCurvetoQuadraticAbs *)
@@ -836,13 +836,13 @@ end
 and pathSegCurvetoQuadratic = object
   inherit pathSeg
 
-  method x : float prop
+  method x : number_t prop
 
-  method y : float prop
+  method y : number_t prop
 
-  method x1 : float prop
+  method x1 : number_t prop
 
-  method y1 : float prop
+  method y1 : number_t prop
 end
 
 (* interface SVGPathSegArcAbs *)
@@ -850,13 +850,13 @@ end
 and pathSegArc = object
   inherit pathSeg
 
-  method y : float prop
+  method y : number_t prop
 
-  method r1 : float prop
+  method r1 : number_t prop
 
-  method r2 : float prop
+  method r2 : number_t prop
 
-  method angle : float prop
+  method angle : number_t prop
 
   method largeArcFlag : bool t prop
 
@@ -868,7 +868,7 @@ end
 and pathSegLinetoHorizontal = object
   inherit pathSeg
 
-  method x : float
+  method x : number_t
 end
 
 (* interface SVGPathSegLinetoVerticalAbs *)
@@ -876,19 +876,19 @@ end
 and pathSegLinetoVertical = object
   inherit pathSeg
 
-  method y : float
+  method y : number_t
 end
 
 and pathSegCurvetoCubicSmooth = object
   inherit pathSeg
 
-  method x : float
+  method x : number_t
 
-  method y : float
+  method y : number_t
 
-  method x2 : float
+  method x2 : number_t
 
-  method y2 : float
+  method y2 : number_t
 end
 
 (* interface SVGPathSegCurvetoQuadraticSmoothAbs *)
@@ -896,9 +896,9 @@ end
 and pathSegCurvetoQuadraticSmooth = object
   inherit pathSeg
 
-  method x : float
+  method x : number_t
 
-  method y : float
+  method y : number_t
 end
 
 and pathSegList = [pathSeg t] list
@@ -932,59 +932,85 @@ and pathElement = object
 
   method pathLength : animatedNumber t readonly_prop
 
-  method getTotalLength : float meth
+  method getTotalLength : number_t meth
 
-  method getPointAtLength : float -> point t meth
+  method getPointAtLength : number_t -> point t meth
 
-  method getPathSegAtLength : float -> int
+  method getPathSegAtLength : number_t -> int
 
   method createSVGPathSegClosePath : pathSegClosePath meth
 
-  method createSVGPathSegMovetoAbs : float -> float -> pathSegMoveto meth
+  method createSVGPathSegMovetoAbs : number_t -> number_t -> pathSegMoveto meth
 
-  method createSVGPathSegMovetoRel : float -> float -> pathSegMoveto meth
+  method createSVGPathSegMovetoRel : number_t -> number_t -> pathSegMoveto meth
 
-  method createSVGPathSegLinetoAbs : float -> float -> pathSegLineto meth
+  method createSVGPathSegLinetoAbs : number_t -> number_t -> pathSegLineto meth
 
-  method createSVGPathSegLinetoRel : float -> float -> pathSegLineto meth
+  method createSVGPathSegLinetoRel : number_t -> number_t -> pathSegLineto meth
 
   method createSVGPathSegCurvetoCubicAbs :
-    float -> float -> float -> float -> float -> float -> pathSegCurvetoCubic meth
+       number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> pathSegCurvetoCubic meth
 
   method createSVGPathSegCurvetoCubicRel :
-    float -> float -> float -> float -> float -> float -> pathSegCurvetoCubic meth
+       number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> pathSegCurvetoCubic meth
 
   method createSVGPathSegCurvetoQuadraticAbs :
-    float -> float -> float -> float -> pathSegCurvetoQuadratic meth
+    number_t -> number_t -> number_t -> number_t -> pathSegCurvetoQuadratic meth
 
   method createSVGPathSegCurvetoQuadraticRel :
-    float -> float -> float -> float -> pathSegCurvetoQuadratic meth
+    number_t -> number_t -> number_t -> number_t -> pathSegCurvetoQuadratic meth
 
   method createSVGPathSegArcAbs :
-    float -> float -> float -> float -> float -> bool t -> bool t -> pathSegArc meth
+       number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> bool t
+    -> bool t
+    -> pathSegArc meth
 
   method createSVGPathSegArcRel :
-    float -> float -> float -> float -> float -> bool t -> bool t -> pathSegArc meth
+       number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> bool t
+    -> bool t
+    -> pathSegArc meth
 
-  method createSVGPathSegLinetoHorizontalAbs : float -> pathSegLinetoHorizontal meth
+  method createSVGPathSegLinetoHorizontalAbs : number_t -> pathSegLinetoHorizontal meth
 
-  method createSVGPathSegLinetoHorizontalRel : float -> pathSegLinetoHorizontal meth
+  method createSVGPathSegLinetoHorizontalRel : number_t -> pathSegLinetoHorizontal meth
 
-  method createSVGPathSegLinetoVerticalAbs : float -> pathSegLinetoVertical meth
+  method createSVGPathSegLinetoVerticalAbs : number_t -> pathSegLinetoVertical meth
 
-  method createSVGPathSegLinetoVerticalRel : float -> pathSegLinetoVertical meth
+  method createSVGPathSegLinetoVerticalRel : number_t -> pathSegLinetoVertical meth
 
   method createSVGPathSegCurvetoCubicSmoothAbs :
-    float -> float -> float -> float -> pathSegCurvetoCubicSmooth meth
+    number_t -> number_t -> number_t -> number_t -> pathSegCurvetoCubicSmooth meth
 
   method createSVGPathSegCurvetoCubicSmoothRel :
-    float -> float -> float -> float -> pathSegCurvetoCubicSmooth meth
+    number_t -> number_t -> number_t -> number_t -> pathSegCurvetoCubicSmooth meth
 
   method createSVGPathSegCurvetoQuadraticSmoothAbs :
-    float -> float -> pathSegCurvetoQuadraticSmooth meth
+    number_t -> number_t -> pathSegCurvetoQuadraticSmooth meth
 
   method createSVGPathSegCurvetoQuadraticSmoothRel :
-    float -> float -> pathSegCurvetoQuadraticSmooth meth
+    number_t -> number_t -> pathSegCurvetoQuadraticSmooth meth
 end
 
 (* interface SVGRectElement *)
@@ -1144,9 +1170,9 @@ and textContentElement = object
 
   method getNumberOfChars : int meth
 
-  method getComputedTextLength : float meth
+  method getComputedTextLength : number_t meth
 
-  method getSubStringLength : int -> int -> float meth
+  method getSubStringLength : int -> int -> number_t meth
 
   method getStartPositionOfChar : int -> point t meth
 
@@ -1154,7 +1180,7 @@ and textContentElement = object
 
   method getExtentOfChar : int -> rect t meth
 
-  method getRotationOfChar : int -> float meth
+  method getRotationOfChar : int -> number_t meth
 
   method getCharNumAtPosition : point -> int meth
 
@@ -1237,13 +1263,13 @@ and glyphRefElement = object
 
   method format : js_string t prop
 
-  method x : float prop
+  method x : number_t prop
 
-  method y : float prop
+  method y : number_t prop
 
-  method dx : float prop
+  method dx : number_t prop
 
-  method dy : float prop
+  method dy : number_t prop
 end
 
 (* interface SVGPaint : SVGColor { *)
@@ -1791,11 +1817,11 @@ and animationElement = object
   (* inherit elementTimeControl *)
   method targetElement : element t readonly_prop
 
-  method getStartTime : float meth
+  method getStartTime : number_t meth
 
-  method getCurrentTime : float meth
+  method getCurrentTime : number_t meth
 
-  method getSimpleDuration : float meth
+  method getSimpleDuration : number_t meth
 end
 
 (* interface SVGAnimateElement *)

--- a/lib/js_of_ocaml/dom_svg.mli
+++ b/lib/js_of_ocaml/dom_svg.mli
@@ -220,7 +220,7 @@ and animatedEnumeration = [int (*short*)] animated
 and animatedInteger = [int] animated
 
 (* interface SVGAnimatedNumber *)
-and animatedNumber = [float] animated
+and animatedNumber = [number_t] animated
 
 (* interface SVGNumberList *)
 and numberList = [number t] list
@@ -232,13 +232,13 @@ and animatedNumberList = [numberList t] animated
 and length = object
   method unitType : lengthUnitType readonly_prop
 
-  method value : float prop
+  method value : number_t prop
 
-  method valueInSpecifiedUnits : float prop
+  method valueInSpecifiedUnits : number_t prop
 
   method valueAsString : js_string t prop
 
-  method newValueSpecifiedUnits : lengthUnitType -> float -> unit meth
+  method newValueSpecifiedUnits : lengthUnitType -> number_t -> unit meth
 
   method convertToSpecifiedUnits : lengthUnitType -> unit meth
 end
@@ -256,13 +256,13 @@ and animatedLengthList = [lengthList t] animated
 and angle = object
   method unitType : angleUnitType readonly_prop
 
-  method value : float prop
+  method value : number_t prop
 
-  method valueInSpecifiedUnits : float prop
+  method valueInSpecifiedUnits : number_t prop
 
   method valueAsString : js_string t prop
 
-  method newValueSpecifiedUnits : angleUnitType -> float -> unit meth
+  method newValueSpecifiedUnits : angleUnitType -> number_t -> unit meth
 
   method convertToSpecifiedUnits : angleUnitType -> unit meth
 end
@@ -298,13 +298,13 @@ end
 
 (* interface SVGRect *)
 and rect = object
-  method x : float prop
+  method x : number_t prop
 
-  method y : float prop
+  method y : number_t prop
 
-  method width : float prop
+  method width : number_t prop
 
-  method height : float prop
+  method height : number_t prop
 end
 
 (* interface SVGAnimatedRect *)
@@ -452,19 +452,19 @@ and svgElement = object
 
   method viewport : rect t readonly_prop
 
-  method pixelUnitToMillimeterX : float readonly_prop
+  method pixelUnitToMillimeterX : number_t readonly_prop
 
-  method pixelUnitToMillimeterY : float readonly_prop
+  method pixelUnitToMillimeterY : number_t readonly_prop
 
-  method screenPixelUnitToMillimeterX : float readonly_prop
+  method screenPixelUnitToMillimeterX : number_t readonly_prop
 
-  method screenPixelUnitToMillimeterY : float readonly_prop
+  method screenPixelUnitToMillimeterY : number_t readonly_prop
 
   method useCurrentView : bool t readonly_prop
 
   method currentView : viewSpec t readonly_prop
 
-  method currentScale : float prop
+  method currentScale : number_t prop
 
   method currentTranslate : point t readonly_prop
 
@@ -482,7 +482,7 @@ and svgElement = object
 
   method animationsPaused : bool t meth
 
-  method getCurrentTime : float meth
+  method getCurrentTime : number_t meth
 
   method setCurrentTime : int -> unit meth
 
@@ -695,9 +695,9 @@ end
 
 (* interface SVGPoint *)
 and point = object
-  method x : float readonly_prop
+  method x : number_t readonly_prop
 
-  method y : float readonly_prop
+  method y : number_t readonly_prop
 
   method matrixTransform : matrix t -> point t meth
 end
@@ -707,39 +707,39 @@ and pointList = [point t] list
 
 (* interface SVGMatrix *)
 and matrix = object
-  method a : float readonly_prop
+  method a : number_t readonly_prop
 
-  method b : float readonly_prop
+  method b : number_t readonly_prop
 
-  method c : float readonly_prop
+  method c : number_t readonly_prop
 
-  method d : float readonly_prop
+  method d : number_t readonly_prop
 
-  method e : float readonly_prop
+  method e : number_t readonly_prop
 
-  method f : float readonly_prop
+  method f : number_t readonly_prop
 
   method multiply : matrix t -> matrix t meth
 
   method inverse : matrix t meth
 
-  method translate : float -> float -> matrix t meth
+  method translate : number_t -> number_t -> matrix t meth
 
-  method scale : float -> matrix t meth
+  method scale : number_t -> matrix t meth
 
-  method scaleNonUniform : float -> float -> matrix t meth
+  method scaleNonUniform : number_t -> number_t -> matrix t meth
 
-  method rotate : float -> matrix t meth
+  method rotate : number_t -> matrix t meth
 
-  method rotateFromVector : float -> float -> matrix t meth
+  method rotateFromVector : number_t -> number_t -> matrix t meth
 
   method flipX : matrix t meth
 
   method flipY : matrix t meth
 
-  method skewX : float -> matrix t meth
+  method skewX : number_t -> matrix t meth
 
-  method skewY : float -> matrix t meth
+  method skewY : number_t -> matrix t meth
 end
 
 (* interface SVGTransform *)
@@ -748,19 +748,19 @@ and transform = object
 
   method matrix : matrix t readonly_prop
 
-  method angle : float readonly_prop
+  method angle : number_t readonly_prop
 
   method setMatrix : matrix t -> unit meth
 
-  method setTranslate : float -> float -> unit meth
+  method setTranslate : number_t -> number_t -> unit meth
 
-  method setScale : float -> float -> unit meth
+  method setScale : number_t -> number_t -> unit meth
 
-  method setRotate : float -> float -> float -> unit meth
+  method setRotate : number_t -> number_t -> number_t -> unit meth
 
-  method setSkewX : float -> unit meth
+  method setSkewX : number_t -> unit meth
 
-  method setSkewY : float -> unit meth
+  method setSkewY : number_t -> unit meth
 end
 
 (* interface SVGTransformList *)
@@ -800,9 +800,9 @@ and pathSegClosePath = pathSeg
 and pathSegMoveto = object
   inherit pathSeg
 
-  method x : float prop
+  method x : number_t prop
 
-  method y : float prop
+  method y : number_t prop
 end
 
 (* interface SVGPathSegLinetoAbs *)
@@ -810,9 +810,9 @@ end
 and pathSegLineto = object
   inherit pathSeg
 
-  method x : float prop
+  method x : number_t prop
 
-  method y : float prop
+  method y : number_t prop
 end
 
 (* interface SVGPathSegCurvetoCubicAbs *)
@@ -820,17 +820,17 @@ end
 and pathSegCurvetoCubic = object
   inherit pathSeg
 
-  method x : float prop
+  method x : number_t prop
 
-  method y : float prop
+  method y : number_t prop
 
-  method x1 : float prop
+  method x1 : number_t prop
 
-  method y1 : float prop
+  method y1 : number_t prop
 
-  method x2 : float prop
+  method x2 : number_t prop
 
-  method y2 : float prop
+  method y2 : number_t prop
 end
 
 (* interface SVGPathSegCurvetoQuadraticAbs *)
@@ -838,13 +838,13 @@ end
 and pathSegCurvetoQuadratic = object
   inherit pathSeg
 
-  method x : float prop
+  method x : number_t prop
 
-  method y : float prop
+  method y : number_t prop
 
-  method x1 : float prop
+  method x1 : number_t prop
 
-  method y1 : float prop
+  method y1 : number_t prop
 end
 
 (* interface SVGPathSegArcAbs *)
@@ -852,13 +852,13 @@ end
 and pathSegArc = object
   inherit pathSeg
 
-  method y : float prop
+  method y : number_t prop
 
-  method r1 : float prop
+  method r1 : number_t prop
 
-  method r2 : float prop
+  method r2 : number_t prop
 
-  method angle : float prop
+  method angle : number_t prop
 
   method largeArcFlag : bool t prop
 
@@ -870,7 +870,7 @@ end
 and pathSegLinetoHorizontal = object
   inherit pathSeg
 
-  method x : float
+  method x : number_t
 end
 
 (* interface SVGPathSegLinetoVerticalAbs *)
@@ -878,19 +878,19 @@ end
 and pathSegLinetoVertical = object
   inherit pathSeg
 
-  method y : float
+  method y : number_t
 end
 
 and pathSegCurvetoCubicSmooth = object
   inherit pathSeg
 
-  method x : float
+  method x : number_t
 
-  method y : float
+  method y : number_t
 
-  method x2 : float
+  method x2 : number_t
 
-  method y2 : float
+  method y2 : number_t
 end
 
 (* interface SVGPathSegCurvetoQuadraticSmoothAbs *)
@@ -898,9 +898,9 @@ end
 and pathSegCurvetoQuadraticSmooth = object
   inherit pathSeg
 
-  method x : float
+  method x : number_t
 
-  method y : float
+  method y : number_t
 end
 
 and pathSegList = [pathSeg t] list
@@ -934,59 +934,85 @@ and pathElement = object
 
   method pathLength : animatedNumber t readonly_prop
 
-  method getTotalLength : float meth
+  method getTotalLength : number_t meth
 
-  method getPointAtLength : float -> point t meth
+  method getPointAtLength : number_t -> point t meth
 
-  method getPathSegAtLength : float -> int
+  method getPathSegAtLength : number_t -> int
 
   method createSVGPathSegClosePath : pathSegClosePath meth
 
-  method createSVGPathSegMovetoAbs : float -> float -> pathSegMoveto meth
+  method createSVGPathSegMovetoAbs : number_t -> number_t -> pathSegMoveto meth
 
-  method createSVGPathSegMovetoRel : float -> float -> pathSegMoveto meth
+  method createSVGPathSegMovetoRel : number_t -> number_t -> pathSegMoveto meth
 
-  method createSVGPathSegLinetoAbs : float -> float -> pathSegLineto meth
+  method createSVGPathSegLinetoAbs : number_t -> number_t -> pathSegLineto meth
 
-  method createSVGPathSegLinetoRel : float -> float -> pathSegLineto meth
+  method createSVGPathSegLinetoRel : number_t -> number_t -> pathSegLineto meth
 
   method createSVGPathSegCurvetoCubicAbs :
-    float -> float -> float -> float -> float -> float -> pathSegCurvetoCubic meth
+       number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> pathSegCurvetoCubic meth
 
   method createSVGPathSegCurvetoCubicRel :
-    float -> float -> float -> float -> float -> float -> pathSegCurvetoCubic meth
+       number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> pathSegCurvetoCubic meth
 
   method createSVGPathSegCurvetoQuadraticAbs :
-    float -> float -> float -> float -> pathSegCurvetoQuadratic meth
+    number_t -> number_t -> number_t -> number_t -> pathSegCurvetoQuadratic meth
 
   method createSVGPathSegCurvetoQuadraticRel :
-    float -> float -> float -> float -> pathSegCurvetoQuadratic meth
+    number_t -> number_t -> number_t -> number_t -> pathSegCurvetoQuadratic meth
 
   method createSVGPathSegArcAbs :
-    float -> float -> float -> float -> float -> bool t -> bool t -> pathSegArc meth
+       number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> bool t
+    -> bool t
+    -> pathSegArc meth
 
   method createSVGPathSegArcRel :
-    float -> float -> float -> float -> float -> bool t -> bool t -> pathSegArc meth
+       number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> bool t
+    -> bool t
+    -> pathSegArc meth
 
-  method createSVGPathSegLinetoHorizontalAbs : float -> pathSegLinetoHorizontal meth
+  method createSVGPathSegLinetoHorizontalAbs : number_t -> pathSegLinetoHorizontal meth
 
-  method createSVGPathSegLinetoHorizontalRel : float -> pathSegLinetoHorizontal meth
+  method createSVGPathSegLinetoHorizontalRel : number_t -> pathSegLinetoHorizontal meth
 
-  method createSVGPathSegLinetoVerticalAbs : float -> pathSegLinetoVertical meth
+  method createSVGPathSegLinetoVerticalAbs : number_t -> pathSegLinetoVertical meth
 
-  method createSVGPathSegLinetoVerticalRel : float -> pathSegLinetoVertical meth
+  method createSVGPathSegLinetoVerticalRel : number_t -> pathSegLinetoVertical meth
 
   method createSVGPathSegCurvetoCubicSmoothAbs :
-    float -> float -> float -> float -> pathSegCurvetoCubicSmooth meth
+    number_t -> number_t -> number_t -> number_t -> pathSegCurvetoCubicSmooth meth
 
   method createSVGPathSegCurvetoCubicSmoothRel :
-    float -> float -> float -> float -> pathSegCurvetoCubicSmooth meth
+    number_t -> number_t -> number_t -> number_t -> pathSegCurvetoCubicSmooth meth
 
   method createSVGPathSegCurvetoQuadraticSmoothAbs :
-    float -> float -> pathSegCurvetoQuadraticSmooth meth
+    number_t -> number_t -> pathSegCurvetoQuadraticSmooth meth
 
   method createSVGPathSegCurvetoQuadraticSmoothRel :
-    float -> float -> pathSegCurvetoQuadraticSmooth meth
+    number_t -> number_t -> pathSegCurvetoQuadraticSmooth meth
 end
 
 (* interface SVGRectElement *)
@@ -1146,9 +1172,9 @@ and textContentElement = object
 
   method getNumberOfChars : int meth
 
-  method getComputedTextLength : float meth
+  method getComputedTextLength : number_t meth
 
-  method getSubStringLength : int -> int -> float meth
+  method getSubStringLength : int -> int -> number_t meth
 
   method getStartPositionOfChar : int -> point t meth
 
@@ -1156,7 +1182,7 @@ and textContentElement = object
 
   method getExtentOfChar : int -> rect t meth
 
-  method getRotationOfChar : int -> float meth
+  method getRotationOfChar : int -> number_t meth
 
   method getCharNumAtPosition : point -> int meth
 
@@ -1239,13 +1265,13 @@ and glyphRefElement = object
 
   method format : js_string t prop
 
-  method x : float prop
+  method x : number_t prop
 
-  method y : float prop
+  method y : number_t prop
 
-  method dx : float prop
+  method dx : number_t prop
 
-  method dy : float prop
+  method dy : number_t prop
 end
 
 (* interface SVGPaint : SVGColor { *)
@@ -1793,11 +1819,11 @@ and animationElement = object
   (* inherit elementTimeControl *)
   method targetElement : element t readonly_prop
 
-  method getStartTime : float meth
+  method getStartTime : number_t meth
 
-  method getCurrentTime : float meth
+  method getCurrentTime : number_t meth
 
-  method getSimpleDuration : float meth
+  method getSimpleDuration : number_t meth
 end
 
 (* interface SVGAnimateElement *)

--- a/lib/js_of_ocaml/file.ml
+++ b/lib/js_of_ocaml/file.ml
@@ -123,7 +123,7 @@ module CoerceTo = struct
     if instanceof e blob_constr then Js.some (Unsafe.coerce e : #blob t) else Js.null
 
   let string (e : file_any) =
-    if typeof e == string "string"
+    if Js.equals (typeof e) (string "string")
     then Js.some (Unsafe.coerce e : js_string t)
     else Js.null
 

--- a/lib/js_of_ocaml/geolocation.ml
+++ b/lib/js_of_ocaml/geolocation.ml
@@ -23,19 +23,19 @@ type positionErrorCode
 type watchId
 
 class type coordinates = object
-  method latitude : float Js.readonly_prop
+  method latitude : Js.number_t Js.readonly_prop
 
-  method longitude : float Js.readonly_prop
+  method longitude : Js.number_t Js.readonly_prop
 
-  method altitude : float Js.opt Js.readonly_prop
+  method altitude : Js.number_t Js.opt Js.readonly_prop
 
-  method accuracy : float Js.readonly_prop
+  method accuracy : Js.number_t Js.readonly_prop
 
-  method altitudeAccuracy : float Js.opt Js.readonly_prop
+  method altitudeAccuracy : Js.number_t Js.opt Js.readonly_prop
 
-  method heading : float Js.opt Js.readonly_prop
+  method heading : Js.number_t Js.opt Js.readonly_prop
 
-  method speed : float Js.opt Js.readonly_prop
+  method speed : Js.number_t Js.opt Js.readonly_prop
 end
 
 class type position = object

--- a/lib/js_of_ocaml/geolocation.mli
+++ b/lib/js_of_ocaml/geolocation.mli
@@ -45,19 +45,19 @@ type positionErrorCode
 type watchId
 
 class type coordinates = object
-  method latitude : float Js.readonly_prop
+  method latitude : Js.number_t Js.readonly_prop
 
-  method longitude : float Js.readonly_prop
+  method longitude : Js.number_t Js.readonly_prop
 
-  method altitude : float Js.opt Js.readonly_prop
+  method altitude : Js.number_t Js.opt Js.readonly_prop
 
-  method accuracy : float Js.readonly_prop
+  method accuracy : Js.number_t Js.readonly_prop
 
-  method altitudeAccuracy : float Js.opt Js.readonly_prop
+  method altitudeAccuracy : Js.number_t Js.opt Js.readonly_prop
 
-  method heading : float Js.opt Js.readonly_prop
+  method heading : Js.number_t Js.opt Js.readonly_prop
 
-  method speed : float Js.opt Js.readonly_prop
+  method speed : Js.number_t Js.opt Js.readonly_prop
 end
 
 class type position = object

--- a/lib/js_of_ocaml/intersectionObserver.ml
+++ b/lib/js_of_ocaml/intersectionObserver.ml
@@ -7,11 +7,11 @@ class type intersectionObserverEntry = object
 
   method intersectionRect : Dom_html.clientRect Js.t Js.readonly_prop
 
-  method intersectionRatio : float Js.readonly_prop
+  method intersectionRatio : Js.number_t Js.readonly_prop
 
   method isIntersecting : bool Js.t Js.readonly_prop
 
-  method time : float Js.readonly_prop
+  method time : Js.number_t Js.readonly_prop
 end
 
 class type intersectionObserverOptions = object
@@ -19,7 +19,7 @@ class type intersectionObserverOptions = object
 
   method rootMargin : Js.js_string Js.t Js.writeonly_prop
 
-  method threshold : float Js.js_array Js.t Js.writeonly_prop
+  method threshold : Js.number_t Js.js_array Js.t Js.writeonly_prop
 end
 
 class type intersectionObserver = object
@@ -27,7 +27,7 @@ class type intersectionObserver = object
 
   method rootMargin : Js.js_string Js.t Js.readonly_prop
 
-  method thresholds : float Js.js_array Js.t Js.readonly_prop
+  method thresholds : Js.number_t Js.js_array Js.t Js.readonly_prop
 
   method observe : #Dom.node Js.t -> unit Js.meth
 

--- a/lib/js_of_ocaml/intersectionObserver.mli
+++ b/lib/js_of_ocaml/intersectionObserver.mli
@@ -13,11 +13,11 @@ class type intersectionObserverEntry = object
 
   method intersectionRect : Dom_html.clientRect Js.t Js.readonly_prop
 
-  method intersectionRatio : float Js.readonly_prop
+  method intersectionRatio : Js.number_t Js.readonly_prop
 
   method isIntersecting : bool Js.t Js.readonly_prop
 
-  method time : float Js.readonly_prop
+  method time : Js.number_t Js.readonly_prop
 end
 
 class type intersectionObserverOptions = object
@@ -25,7 +25,7 @@ class type intersectionObserverOptions = object
 
   method rootMargin : Js.js_string Js.t Js.writeonly_prop
 
-  method threshold : float Js.js_array Js.t Js.writeonly_prop
+  method threshold : Js.number_t Js.js_array Js.t Js.writeonly_prop
 end
 
 class type intersectionObserver = object
@@ -33,7 +33,7 @@ class type intersectionObserver = object
 
   method rootMargin : Js.js_string Js.t Js.readonly_prop
 
-  method thresholds : float Js.js_array Js.t Js.readonly_prop
+  method thresholds : Js.number_t Js.js_array Js.t Js.readonly_prop
 
   method observe : #Dom.node Js.t -> unit Js.meth
 

--- a/lib/js_of_ocaml/intl.mli
+++ b/lib/js_of_ocaml/intl.mli
@@ -46,7 +46,7 @@ if (Intl.is_supported()) then (
           let collator = new%js Intl.collator_constr
             (def (array [| lang |])) undefined
           in
-          float_of_int(collator##.compare a b))) ;
+          Js.float (float_of_int(collator##.compare a b)))) ;
       letters
     in
     let a = jas [| "a"; "z"; "ä" |] in
@@ -95,7 +95,8 @@ if (Intl.is_supported()) then (
       (def (jas [| "de-u-co-phonebk" |])) undefined
     in
     let a = a##sort (wrap_callback
-                       (fun v1 v2 -> float_of_int(collator##.compare v1 v2)))
+                       (fun v1 v2 ->
+                          Js.float (float_of_int(collator##.compare v1 v2))))
     in
     fc (a##join (string ", ")) ;
 

--- a/lib/js_of_ocaml/js.ml
+++ b/lib/js_of_ocaml/js.ml
@@ -246,14 +246,32 @@ module Js = struct
 
   type string_array
 
-  class type js_string = object
+  type number_t = float
+
+  class type number = object
+    method toString : js_string t meth
+
+    method toString_radix : int -> js_string t meth
+
+    method toLocaleString : js_string t meth
+
+    method toFixed : int -> js_string t meth
+
+    method toExponential : js_string t meth
+
+    method toExponential_digits : int -> js_string t meth
+
+    method toPrecision : int -> js_string t meth
+  end
+
+  and js_string = object
     method toString : js_string t meth
 
     method valueOf : js_string t meth
 
     method charAt : int -> js_string t meth
 
-    method charCodeAt : int -> float meth
+    method charCodeAt : int -> number_t meth
 
     (* This may return NaN... *)
     method concat : js_string t -> js_string t meth
@@ -273,7 +291,7 @@ module Js = struct
 
     method lastIndexOf_from : js_string t -> int -> int meth
 
-    method localeCompare : js_string t -> float meth
+    method localeCompare : js_string t -> number_t meth
 
     method _match : regExp t -> match_result_handle t opt meth
 
@@ -392,7 +410,7 @@ class type ['a] js_array = object
 
   method slice_end : int -> 'a js_array t meth
 
-  method sort : ('a -> 'a -> float) callback -> 'a js_array t meth
+  method sort : ('a -> 'a -> number_t) callback -> 'a js_array t meth
 
   method sort_asStrings : 'a js_array t meth
 
@@ -470,26 +488,6 @@ let str_array : string_array t -> js_string t js_array t = Unsafe.coerce
 
 let match_result : match_result_handle t -> match_result t = Unsafe.coerce
 
-class type number = object
-  method toString : js_string t meth
-
-  method toString_radix : int -> js_string t meth
-
-  method toLocaleString : js_string t meth
-
-  method toFixed : int -> js_string t meth
-
-  method toExponential : js_string t meth
-
-  method toExponential_digits : int -> js_string t meth
-
-  method toPrecision : int -> js_string t meth
-end
-
-external number_of_float : float -> number t = "caml_js_from_float"
-
-external float_of_number : number t -> float = "caml_js_to_float"
-
 class type date = object
   method toString : js_string t meth
 
@@ -503,9 +501,9 @@ class type date = object
 
   method toLocaleTimeString : js_string t meth
 
-  method valueOf : float meth
+  method valueOf : number_t meth
 
-  method getTime : float meth
+  method getTime : number_t meth
 
   method getFullYear : int meth
 
@@ -541,39 +539,39 @@ class type date = object
 
   method getTimezoneOffset : int meth
 
-  method setTime : float -> float meth
+  method setTime : number_t -> number_t meth
 
-  method setFullYear : int -> float meth
+  method setFullYear : int -> number_t meth
 
-  method setUTCFullYear : int -> float meth
+  method setUTCFullYear : int -> number_t meth
 
-  method setMonth : int -> float meth
+  method setMonth : int -> number_t meth
 
-  method setUTCMonth : int -> float meth
+  method setUTCMonth : int -> number_t meth
 
-  method setDate : int -> float meth
+  method setDate : int -> number_t meth
 
-  method setUTCDate : int -> float meth
+  method setUTCDate : int -> number_t meth
 
-  method setDay : int -> float meth
+  method setDay : int -> number_t meth
 
-  method setUTCDay : int -> float meth
+  method setUTCDay : int -> number_t meth
 
-  method setHours : int -> float meth
+  method setHours : int -> number_t meth
 
-  method setUTCHours : int -> float meth
+  method setUTCHours : int -> number_t meth
 
-  method setMinutes : int -> float meth
+  method setMinutes : int -> number_t meth
 
-  method setUTCMinutes : int -> float meth
+  method setUTCMinutes : int -> number_t meth
 
-  method setSeconds : int -> float meth
+  method setSeconds : int -> number_t meth
 
-  method setUTCSeconds : int -> float meth
+  method setUTCSeconds : int -> number_t meth
 
-  method setMilliseconds : int -> float meth
+  method setMilliseconds : int -> number_t meth
 
-  method setUTCMilliseconds : int -> float meth
+  method setUTCMilliseconds : int -> number_t meth
 
   method toUTCString : js_string t meth
 
@@ -583,21 +581,21 @@ class type date = object
 end
 
 class type date_constr = object
-  method parse : js_string t -> float meth
+  method parse : js_string t -> number_t meth
 
-  method _UTC_month : int -> int -> float meth
+  method _UTC_month : int -> int -> number_t meth
 
-  method _UTC_day : int -> int -> float meth
+  method _UTC_day : int -> int -> number_t meth
 
-  method _UTC_hour : int -> int -> int -> int -> float meth
+  method _UTC_hour : int -> int -> int -> int -> number_t meth
 
-  method _UTC_min : int -> int -> int -> int -> int -> float meth
+  method _UTC_min : int -> int -> int -> int -> int -> number_t meth
 
-  method _UTC_sec : int -> int -> int -> int -> int -> int -> float meth
+  method _UTC_sec : int -> int -> int -> int -> int -> int -> number_t meth
 
-  method _UTC_ms : int -> int -> int -> int -> int -> int -> int -> float meth
+  method _UTC_ms : int -> int -> int -> int -> int -> int -> int -> number_t meth
 
-  method now : float meth
+  method now : number_t meth
 end
 
 let date_constr = Unsafe.global##._Date
@@ -606,7 +604,7 @@ let date : date_constr t = date_constr
 
 let date_now : date t constr = date_constr
 
-let date_fromTimeValue : (float -> date t) constr = date_constr
+let date_fromTimeValue : (number_t -> date t) constr = date_constr
 
 let date_month : (int -> int -> date t) constr = date_constr
 
@@ -622,65 +620,65 @@ let date_ms : (int -> int -> int -> int -> int -> int -> int -> date t) constr =
   date_constr
 
 class type math = object
-  method _E : float readonly_prop
+  method _E : number_t readonly_prop
 
-  method _LN2 : float readonly_prop
+  method _LN2 : number_t readonly_prop
 
-  method _LN10 : float readonly_prop
+  method _LN10 : number_t readonly_prop
 
-  method _LOG2E : float readonly_prop
+  method _LOG2E : number_t readonly_prop
 
-  method _LOG10E : float readonly_prop
+  method _LOG10E : number_t readonly_prop
 
-  method _PI : float readonly_prop
+  method _PI : number_t readonly_prop
 
-  method _SQRT1_2_ : float readonly_prop
+  method _SQRT1_2_ : number_t readonly_prop
 
-  method _SQRT2 : float readonly_prop
+  method _SQRT2 : number_t readonly_prop
 
-  method abs : float -> float meth
+  method abs : number_t -> number_t meth
 
-  method acos : float -> float meth
+  method acos : number_t -> number_t meth
 
-  method asin : float -> float meth
+  method asin : number_t -> number_t meth
 
-  method atan : float -> float meth
+  method atan : number_t -> number_t meth
 
-  method atan2 : float -> float -> float meth
+  method atan2 : number_t -> number_t -> number_t meth
 
-  method ceil : float -> float meth
+  method ceil : number_t -> number_t meth
 
-  method cos : float -> float meth
+  method cos : number_t -> number_t meth
 
-  method exp : float -> float meth
+  method exp : number_t -> number_t meth
 
-  method floor : float -> float meth
+  method floor : number_t -> number_t meth
 
-  method log : float -> float meth
+  method log : number_t -> number_t meth
 
-  method max : float -> float -> float meth
+  method max : number_t -> number_t -> number_t meth
 
-  method max_3 : float -> float -> float -> float meth
+  method max_3 : number_t -> number_t -> number_t -> number_t meth
 
-  method max_4 : float -> float -> float -> float -> float meth
+  method max_4 : number_t -> number_t -> number_t -> number_t -> number_t meth
 
-  method min : float -> float -> float meth
+  method min : number_t -> number_t -> number_t meth
 
-  method min_3 : float -> float -> float -> float meth
+  method min_3 : number_t -> number_t -> number_t -> number_t meth
 
-  method min_4 : float -> float -> float -> float -> float meth
+  method min_4 : number_t -> number_t -> number_t -> number_t -> number_t meth
 
-  method pow : float -> float -> float meth
+  method pow : number_t -> number_t -> number_t meth
 
-  method random : float meth
+  method random : number_t meth
 
-  method round : float -> float meth
+  method round : number_t -> number_t meth
 
-  method sin : float -> float meth
+  method sin : number_t -> number_t meth
 
-  method sqrt : float -> float meth
+  method sqrt : number_t -> number_t meth
 
-  method tan : float -> float meth
+  method tan : number_t -> number_t meth
 end
 
 let math = Unsafe.global##._Math
@@ -783,17 +781,21 @@ external bytestring : string -> js_string t = "caml_jsbytes_of_string"
 
 external to_bytestring : js_string t -> string = "caml_string_of_jsbytes"
 
-external float : float -> float = "caml_js_from_float"
+external float : float -> number_t = "caml_js_from_float"
 
-external to_float : float -> float = "caml_js_to_float"
+external to_float : number_t -> float = "caml_js_to_float"
 
-external int32 : int32 -> float = "caml_js_from_int32"
+external number_of_float : float -> number t = "caml_js_from_float"
 
-external to_int32 : float -> int32 = "caml_js_to_int32"
+external float_of_number : number t -> float = "caml_js_to_float"
 
-external nativeint : nativeint -> float = "caml_js_from_nativeint"
+external int32 : int32 -> number_t = "caml_js_from_int32"
 
-external to_nativeint : float -> nativeint = "caml_js_to_nativeint"
+external to_int32 : number_t -> int32 = "caml_js_to_int32"
+
+external nativeint : nativeint -> number_t = "caml_js_from_nativeint"
+
+external to_nativeint : number_t -> nativeint = "caml_js_to_nativeint"
 
 external typeof : _ t -> js_string t = "caml_js_typeof"
 
@@ -806,7 +808,7 @@ let parseInt (s : js_string t) : int =
   let s = Unsafe.fun_call Unsafe.global##.parseInt [| Unsafe.inject s |] in
   if isNaN s then failwith "parseInt" else s
 
-let parseFloat (s : js_string t) : float =
+let parseFloat (s : js_string t) : number_t =
   let s = Unsafe.fun_call Unsafe.global##.parseFloat [| Unsafe.inject s |] in
   if isNaN s then failwith "parseFloat" else s
 
@@ -841,4 +843,4 @@ let export_all obj =
 
 (* DEPRECATED *)
 
-type float_prop = float prop
+type float_prop = number_t prop

--- a/lib/js_of_ocaml/js.ml
+++ b/lib/js_of_ocaml/js.ml
@@ -763,6 +763,10 @@ external bytestring : string -> js_string t = "caml_jsbytes_of_string"
 
 external to_bytestring : js_string t -> string = "caml_string_of_jsbytes"
 
+external float : float -> float = "caml_js_from_float"
+
+external to_float : float -> float = "caml_js_to_float"
+
 external typeof : _ t -> js_string t = "caml_js_typeof"
 
 external instanceof : _ t -> _ constr -> bool = "caml_js_instanceof"
@@ -810,7 +814,3 @@ let export_all obj =
 (* DEPRECATED *)
 
 type float_prop = float prop
-
-external float : float -> float = "%identity"
-
-external to_float : float -> float = "%identity"

--- a/lib/js_of_ocaml/js.ml
+++ b/lib/js_of_ocaml/js.ml
@@ -56,6 +56,8 @@ module Js = struct
 
     external equals : 'a -> 'b -> bool = "caml_js_equals"
 
+    external strict_equals : 'a -> 'b -> bool = "caml_js_strict_equals"
+
     external pure_expr : (unit -> 'a) -> 'a = "caml_js_pure_expr"
 
     external eval_string : string -> 'a = "caml_js_eval_string"
@@ -128,6 +130,10 @@ module Js = struct
     val option : 'a option -> 'a t
 
     val to_option : 'a t -> 'a option
+
+    external equals : _ t -> _ t -> bool = "caml_js_equals"
+
+    external strict_equals : _ t -> _ t -> bool = "caml_js_strict_equals"
   end
 
   module Opt : OPT with type 'a t = 'a opt = struct
@@ -137,17 +143,21 @@ module Js = struct
 
     let return = some
 
-    let map x f = if Unsafe.equals x null then null else return (f x)
+    external equals : _ t -> _ t -> bool = "caml_js_equals"
 
-    let bind x f = if Unsafe.equals x null then null else f x
+    external strict_equals : _ t -> _ t -> bool = "caml_js_strict_equals"
 
-    let test x = not (Unsafe.equals x null)
+    let map x f = if equals x null then null else return (f x)
 
-    let iter x f = if not (Unsafe.equals x null) then f x
+    let bind x f = if equals x null then null else f x
 
-    let case x f g = if Unsafe.equals x null then f () else g x
+    let test x = not (equals x null)
 
-    let get x f = if Unsafe.equals x null then f () else x
+    let iter x f = if not (equals x null) then f x
+
+    let case x f g = if equals x null then f () else g x
+
+    let get x f = if equals x null then f () else x
 
     let option x =
       match x with
@@ -164,17 +174,21 @@ module Js = struct
 
     let return = def
 
-    let map x f = if x == undefined then undefined else return (f x)
+    external equals : _ t -> _ t -> bool = "caml_js_equals"
 
-    let bind x f = if x == undefined then undefined else f x
+    external strict_equals : _ t -> _ t -> bool = "caml_js_strict_equals"
 
-    let test x = x != undefined
+    let map x f = if strict_equals x undefined then undefined else return (f x)
 
-    let iter x f = if x != undefined then f x
+    let bind x f = if strict_equals x undefined then undefined else f x
 
-    let case x f g = if x == undefined then f () else g x
+    let test x = not (strict_equals x undefined)
 
-    let get x f = if x == undefined then f () else x
+    let iter x f = if not (strict_equals x undefined) then f x
+
+    let case x f g = if strict_equals x undefined then f () else g x
+
+    let get x f = if strict_equals x undefined then f () else x
 
     let option x =
       match x with
@@ -215,6 +229,12 @@ module Js = struct
 
   external wrap_meth_callback : ('a -> 'b) -> ('a, 'b) meth_callback
     = "caml_js_wrap_meth_callback"
+
+  (****)
+
+  external equals : _ t -> _ t -> bool = "caml_js_equals"
+
+  external strict_equals : _ t -> _ t -> bool = "caml_js_strict_equals"
 
   (****)
 

--- a/lib/js_of_ocaml/js.ml
+++ b/lib/js_of_ocaml/js.ml
@@ -767,6 +767,14 @@ external float : float -> float = "caml_js_from_float"
 
 external to_float : float -> float = "caml_js_to_float"
 
+external int32 : int32 -> float = "caml_js_from_int32"
+
+external to_int32 : float -> int32 = "caml_js_to_int32"
+
+external nativeint : nativeint -> float = "caml_js_from_nativeint"
+
+external to_nativeint : float -> nativeint = "caml_js_to_nativeint"
+
 external typeof : _ t -> js_string t = "caml_js_typeof"
 
 external instanceof : _ t -> _ constr -> bool = "caml_js_instanceof"

--- a/lib/js_of_ocaml/js.mli
+++ b/lib/js_of_ocaml/js.mli
@@ -217,15 +217,35 @@ val nfkd : normalization t
 val nfkc : normalization t
 (** Compatibility Decomposition, followed by Canonical Composition *)
 
+(** Specification of Javascript number objects. *)
+
+type number_t = float
+
+class type number = object
+  method toString : js_string t meth
+
+  method toString_radix : int -> js_string t meth
+
+  method toLocaleString : js_string t meth
+
+  method toFixed : int -> js_string t meth
+
+  method toExponential : js_string t meth
+
+  method toExponential_digits : int -> js_string t meth
+
+  method toPrecision : int -> js_string t meth
+end
+
 (** Specification of Javascript string objects. *)
-class type js_string = object
+and js_string = object
   method toString : js_string t meth
 
   method valueOf : js_string t meth
 
   method charAt : int -> js_string t meth
 
-  method charCodeAt : int -> float meth
+  method charCodeAt : int -> number_t meth
 
   (* This may return NaN... *)
   method concat : js_string t -> js_string t meth
@@ -245,7 +265,7 @@ class type js_string = object
 
   method lastIndexOf_from : js_string t -> int -> int meth
 
-  method localeCompare : js_string t -> float meth
+  method localeCompare : js_string t -> number_t meth
 
   method _match : regExp t -> match_result_handle t opt meth
 
@@ -358,7 +378,7 @@ class type ['a] js_array = object
 
   method slice_end : int -> 'a js_array t meth
 
-  method sort : ('a -> 'a -> float) callback -> 'a js_array t meth
+  method sort : ('a -> 'a -> number_t) callback -> 'a js_array t meth
 
   method sort_asStrings : 'a js_array t meth
 
@@ -447,29 +467,6 @@ val match_result : match_result_handle t -> match_result t
       (Used to resolved the mutual dependency between string
       and array type definitions.) *)
 
-(** Specification of Javascript number objects. *)
-class type number = object
-  method toString : js_string t meth
-
-  method toString_radix : int -> js_string t meth
-
-  method toLocaleString : js_string t meth
-
-  method toFixed : int -> js_string t meth
-
-  method toExponential : js_string t meth
-
-  method toExponential_digits : int -> js_string t meth
-
-  method toPrecision : int -> js_string t meth
-end
-
-external number_of_float : float -> number t = "caml_js_from_float"
-(** Conversion of OCaml floats to Javascript number objects. *)
-
-external float_of_number : number t -> float = "caml_js_to_float"
-(** Conversion of Javascript number objects to OCaml floats. *)
-
 (** Specification of Javascript date objects. *)
 class type date = object
   method toString : js_string t meth
@@ -484,9 +481,9 @@ class type date = object
 
   method toLocaleTimeString : js_string t meth
 
-  method valueOf : float meth
+  method valueOf : number_t meth
 
-  method getTime : float meth
+  method getTime : number_t meth
 
   method getFullYear : int meth
 
@@ -522,39 +519,39 @@ class type date = object
 
   method getTimezoneOffset : int meth
 
-  method setTime : float -> float meth
+  method setTime : number_t -> number_t meth
 
-  method setFullYear : int -> float meth
+  method setFullYear : int -> number_t meth
 
-  method setUTCFullYear : int -> float meth
+  method setUTCFullYear : int -> number_t meth
 
-  method setMonth : int -> float meth
+  method setMonth : int -> number_t meth
 
-  method setUTCMonth : int -> float meth
+  method setUTCMonth : int -> number_t meth
 
-  method setDate : int -> float meth
+  method setDate : int -> number_t meth
 
-  method setUTCDate : int -> float meth
+  method setUTCDate : int -> number_t meth
 
-  method setDay : int -> float meth
+  method setDay : int -> number_t meth
 
-  method setUTCDay : int -> float meth
+  method setUTCDay : int -> number_t meth
 
-  method setHours : int -> float meth
+  method setHours : int -> number_t meth
 
-  method setUTCHours : int -> float meth
+  method setUTCHours : int -> number_t meth
 
-  method setMinutes : int -> float meth
+  method setMinutes : int -> number_t meth
 
-  method setUTCMinutes : int -> float meth
+  method setUTCMinutes : int -> number_t meth
 
-  method setSeconds : int -> float meth
+  method setSeconds : int -> number_t meth
 
-  method setUTCSeconds : int -> float meth
+  method setUTCSeconds : int -> number_t meth
 
-  method setMilliseconds : int -> float meth
+  method setMilliseconds : int -> number_t meth
 
-  method setUTCMilliseconds : int -> float meth
+  method setUTCMilliseconds : int -> number_t meth
 
   method toUTCString : js_string t meth
 
@@ -567,7 +564,7 @@ val date_now : date t constr
 (** Constructor of [Date] objects: [new%js date_now] returns a
       [Date] object initialized with the current date. *)
 
-val date_fromTimeValue : (float -> date t) constr
+val date_fromTimeValue : (number_t -> date t) constr
 (** Constructor of [Date] objects: [new%js date_fromTimeValue t] returns a
       [Date] object initialized with the time value [t]. *)
 
@@ -601,21 +598,21 @@ val date_ms : (int -> int -> int -> int -> int -> int -> int -> date t) constr
 
 (** Specification of the date constructor, considered as an object. *)
 class type date_constr = object
-  method parse : js_string t -> float meth
+  method parse : js_string t -> number_t meth
 
-  method _UTC_month : int -> int -> float meth
+  method _UTC_month : int -> int -> number_t meth
 
-  method _UTC_day : int -> int -> float meth
+  method _UTC_day : int -> int -> number_t meth
 
-  method _UTC_hour : int -> int -> int -> int -> float meth
+  method _UTC_hour : int -> int -> int -> int -> number_t meth
 
-  method _UTC_min : int -> int -> int -> int -> int -> float meth
+  method _UTC_min : int -> int -> int -> int -> int -> number_t meth
 
-  method _UTC_sec : int -> int -> int -> int -> int -> int -> float meth
+  method _UTC_sec : int -> int -> int -> int -> int -> int -> number_t meth
 
-  method _UTC_ms : int -> int -> int -> int -> int -> int -> int -> float meth
+  method _UTC_ms : int -> int -> int -> int -> int -> int -> int -> number_t meth
 
-  method now : float meth
+  method now : number_t meth
 end
 
 val date : date_constr t
@@ -623,65 +620,65 @@ val date : date_constr t
 
 (** Specification of Javascript math object. *)
 class type math = object
-  method _E : float readonly_prop
+  method _E : number_t readonly_prop
 
-  method _LN2 : float readonly_prop
+  method _LN2 : number_t readonly_prop
 
-  method _LN10 : float readonly_prop
+  method _LN10 : number_t readonly_prop
 
-  method _LOG2E : float readonly_prop
+  method _LOG2E : number_t readonly_prop
 
-  method _LOG10E : float readonly_prop
+  method _LOG10E : number_t readonly_prop
 
-  method _PI : float readonly_prop
+  method _PI : number_t readonly_prop
 
-  method _SQRT1_2_ : float readonly_prop
+  method _SQRT1_2_ : number_t readonly_prop
 
-  method _SQRT2 : float readonly_prop
+  method _SQRT2 : number_t readonly_prop
 
-  method abs : float -> float meth
+  method abs : number_t -> number_t meth
 
-  method acos : float -> float meth
+  method acos : number_t -> number_t meth
 
-  method asin : float -> float meth
+  method asin : number_t -> number_t meth
 
-  method atan : float -> float meth
+  method atan : number_t -> number_t meth
 
-  method atan2 : float -> float -> float meth
+  method atan2 : number_t -> number_t -> number_t meth
 
-  method ceil : float -> float meth
+  method ceil : number_t -> number_t meth
 
-  method cos : float -> float meth
+  method cos : number_t -> number_t meth
 
-  method exp : float -> float meth
+  method exp : number_t -> number_t meth
 
-  method floor : float -> float meth
+  method floor : number_t -> number_t meth
 
-  method log : float -> float meth
+  method log : number_t -> number_t meth
 
-  method max : float -> float -> float meth
+  method max : number_t -> number_t -> number_t meth
 
-  method max_3 : float -> float -> float -> float meth
+  method max_3 : number_t -> number_t -> number_t -> number_t meth
 
-  method max_4 : float -> float -> float -> float -> float meth
+  method max_4 : number_t -> number_t -> number_t -> number_t -> number_t meth
 
-  method min : float -> float -> float meth
+  method min : number_t -> number_t -> number_t meth
 
-  method min_3 : float -> float -> float -> float meth
+  method min_3 : number_t -> number_t -> number_t -> number_t meth
 
-  method min_4 : float -> float -> float -> float -> float meth
+  method min_4 : number_t -> number_t -> number_t -> number_t -> number_t meth
 
-  method pow : float -> float -> float meth
+  method pow : number_t -> number_t -> number_t meth
 
-  method random : float meth
+  method random : number_t meth
 
-  method round : float -> float meth
+  method round : number_t -> number_t meth
 
-  method sin : float -> float meth
+  method sin : number_t -> number_t meth
 
-  method sqrt : float -> float meth
+  method sqrt : number_t -> number_t meth
 
-  method tan : float -> float meth
+  method tan : number_t -> number_t meth
 end
 
 val math : math t
@@ -782,7 +779,7 @@ val isNaN : 'a -> bool
 
 val parseInt : js_string t -> int
 
-val parseFloat : js_string t -> float
+val parseFloat : js_string t -> number_t
 
 (** {2 Conversion functions between Javascript and OCaml types} *)
 
@@ -815,23 +812,29 @@ external to_bytestring : js_string t -> string = "caml_string_of_jsbytes"
       Javascript string should only contain UTF-16 code points below
       255.) *)
 
-external float : float -> float = "caml_js_from_float"
+external float : float -> number_t = "caml_js_from_float"
 (** Conversion of OCaml floats to Javascript numbers. *)
 
-external to_float : float -> float = "caml_js_to_float"
+external to_float : number_t -> float = "caml_js_to_float"
 (** Conversion of Javascript numbers to OCaml floats. *)
 
-external int32 : int32 -> float = "caml_js_from_int32"
+external number_of_float : float -> number t = "caml_js_from_float"
+(** Conversion of OCaml floats to Javascript number objects. *)
+
+external float_of_number : number t -> float = "caml_js_to_float"
+(** Conversion of Javascript number objects to OCaml floats. *)
+
+external int32 : int32 -> number_t = "caml_js_from_int32"
 (** Conversion of OCaml floats to Javascript numbers. *)
 
-external to_int32 : float -> int32 = "caml_js_to_int32"
+external to_int32 : number_t -> int32 = "caml_js_to_int32"
 (** Conversion of Javascript numbers to OCaml 32-bits. The given
     floating-point number is truncated to an integer. *)
 
-external nativeint : nativeint -> float = "caml_js_from_nativeint"
+external nativeint : nativeint -> number_t = "caml_js_from_nativeint"
 (** Conversion of OCaml 32-bits integers to Javascript numbers. *)
 
-external to_nativeint : float -> nativeint = "caml_js_to_nativeint"
+external to_nativeint : number_t -> nativeint = "caml_js_to_nativeint"
 (** Conversion of Javascript numbers to OCaml native integers. The
     given floating-point number is truncated to an integer. *)
 
@@ -1046,6 +1049,6 @@ exception Error of error t [@ocaml.deprecated "[since 4.0] Use [Js_error.Exn] in
     it will be serialized and wrapped into a [Failure] exception.
   *)
 
-type float_prop = float prop [@@ocaml.deprecated "[since 2.0]."]
+type float_prop = number_t prop [@@ocaml.deprecated "[since 2.0]."]
 
 (** Type of float properties. *)

--- a/lib/js_of_ocaml/js.mli
+++ b/lib/js_of_ocaml/js.mli
@@ -219,7 +219,7 @@ val nfkc : normalization t
 
 (** Specification of Javascript number objects. *)
 
-type number_t = float
+type number_t
 
 class type number = object
   method toString : js_string t meth

--- a/lib/js_of_ocaml/js.mli
+++ b/lib/js_of_ocaml/js.mli
@@ -81,6 +81,12 @@ module type OPT = sig
 
   val to_option : 'a t -> 'a option
   (** Convert to option type. *)
+
+  external equals : _ t -> _ t -> bool = "caml_js_equals"
+  (** Javascript [==] equality operator. *)
+
+  external strict_equals : _ t -> _ t -> bool = "caml_js_strict_equals"
+  (** Javascript [===] equality operator. *)
 end
 
 module Opt : OPT with type 'a t = 'a opt
@@ -167,6 +173,14 @@ external wrap_meth_callback : ('b -> 'a) -> ('b, 'a) meth_callback
 (** Wrap an OCaml function so that it can be invoked from
       Javascript.  The first parameter of the function will be bound
       to the value of the [this] implicit parameter. *)
+
+(** {2 Javascript comparisons} *)
+
+external equals : _ t -> _ t -> bool = "caml_js_equals"
+(** Javascript [==] equality operator. *)
+
+external strict_equals : _ t -> _ t -> bool = "caml_js_strict_equals"
+(** Javascript [===] equality operator. *)
 
 (** {2 Javascript standard objects} *)
 
@@ -988,6 +1002,12 @@ module Unsafe : sig
 
   external meth_callback_with_arity : int -> ('b -> 'a) -> ('b, 'a) meth_callback
     = "caml_js_wrap_meth_callback_strict"
+
+  external equals : _ -> _ -> bool = "caml_js_equals"
+  (** Javascript [==] equality operator. *)
+
+  external strict_equals : _ -> _ -> bool = "caml_js_strict_equals"
+  (** Javascript [===] equality operator. *)
 
   (** {3 Deprecated functions.} *)
 

--- a/lib/js_of_ocaml/js.mli
+++ b/lib/js_of_ocaml/js.mli
@@ -801,6 +801,12 @@ external to_bytestring : js_string t -> string = "caml_string_of_jsbytes"
       Javascript string should only contain UTF-16 code points below
       255.) *)
 
+external float : float -> float = "caml_js_from_float"
+(** Conversion of OCaml floats to Javascript numbers. *)
+
+external to_float : float -> float = "caml_js_to_float"
+(** Conversion of Javascript numbers to OCaml floats. *)
+
 (** {2 Convenience coercion functions} *)
 
 val coerce : 'a -> ('a -> 'b Opt.t) -> ('a -> 'b) -> 'b
@@ -1005,14 +1011,6 @@ exception Error of error t [@ocaml.deprecated "[since 4.0] Use [Js_error.Exn] in
     In case the javascript exception is not an instance of javascript [Error],
     it will be serialized and wrapped into a [Failure] exception.
   *)
-
-external float : float -> float = "%identity" [@@ocaml.deprecated "[since 2.0]."]
-
-(** Conversion of OCaml floats to Javascript numbers. *)
-
-external to_float : float -> float = "%identity" [@@ocaml.deprecated "[since 2.0]."]
-
-(** Conversion of Javascript numbers to OCaml floats. *)
 
 type float_prop = float prop [@@ocaml.deprecated "[since 2.0]."]
 

--- a/lib/js_of_ocaml/js.mli
+++ b/lib/js_of_ocaml/js.mli
@@ -807,6 +807,20 @@ external float : float -> float = "caml_js_from_float"
 external to_float : float -> float = "caml_js_to_float"
 (** Conversion of Javascript numbers to OCaml floats. *)
 
+external int32 : int32 -> float = "caml_js_from_int32"
+(** Conversion of OCaml floats to Javascript numbers. *)
+
+external to_int32 : float -> int32 = "caml_js_to_int32"
+(** Conversion of Javascript numbers to OCaml 32-bits. The given
+    floating-point number is truncated to an integer. *)
+
+external nativeint : nativeint -> float = "caml_js_from_nativeint"
+(** Conversion of OCaml 32-bits integers to Javascript numbers. *)
+
+external to_nativeint : float -> nativeint = "caml_js_to_nativeint"
+(** Conversion of Javascript numbers to OCaml native integers. The
+    given floating-point number is truncated to an integer. *)
+
 (** {2 Convenience coercion functions} *)
 
 val coerce : 'a -> ('a -> 'b Opt.t) -> ('a -> 'b) -> 'b

--- a/lib/js_of_ocaml/json.ml
+++ b/lib/js_of_ocaml/json.ml
@@ -36,7 +36,7 @@ let json : json Js.t = Unsafe.global##._JSON
 
 let input_reviver =
   let reviver _this _key (value : Unsafe.any) : Obj.t =
-    if typeof value == string "string"
+    if Js.equals (typeof value) (string "string")
     then Obj.repr (to_bytestring (Unsafe.coerce value))
     else if instanceof value Js.array_empty
             && (Unsafe.coerce value)##.length == 4

--- a/lib/js_of_ocaml/performanceObserver.ml
+++ b/lib/js_of_ocaml/performanceObserver.ml
@@ -28,9 +28,9 @@ class type performanceEntry = object
 
   method entryType : Js.js_string Js.t Js.readonly_prop
 
-  method startTime : float Js.readonly_prop
+  method startTime : Js.number_t Js.readonly_prop
 
-  method duration : float Js.readonly_prop
+  method duration : Js.number_t Js.readonly_prop
 end
 
 class type performanceObserverEntryList = object

--- a/lib/js_of_ocaml/performanceObserver.mli
+++ b/lib/js_of_ocaml/performanceObserver.mli
@@ -44,9 +44,9 @@ class type performanceEntry = object
 
   method entryType : Js.js_string Js.t Js.readonly_prop
 
-  method startTime : float Js.readonly_prop
+  method startTime : Js.number_t Js.readonly_prop
 
-  method duration : float Js.readonly_prop
+  method duration : Js.number_t Js.readonly_prop
 end
 
 class type performanceObserverEntryList = object

--- a/lib/js_of_ocaml/resizeObserver.ml
+++ b/lib/js_of_ocaml/resizeObserver.ml
@@ -19,9 +19,9 @@
 open! Import
 
 class type resizeObserverSize = object
-  method inlineSize : float Js.readonly_prop
+  method inlineSize : Js.number_t Js.readonly_prop
 
-  method blockSize : float Js.readonly_prop
+  method blockSize : Js.number_t Js.readonly_prop
 end
 
 class type resizeObserverEntry = object

--- a/lib/js_of_ocaml/resizeObserver.mli
+++ b/lib/js_of_ocaml/resizeObserver.mli
@@ -42,9 +42,9 @@
 *)
 
 class type resizeObserverSize = object
-  method inlineSize : float Js.readonly_prop
+  method inlineSize : Js.number_t Js.readonly_prop
 
-  method blockSize : float Js.readonly_prop
+  method blockSize : Js.number_t Js.readonly_prop
 end
 
 class type resizeObserverEntry = object

--- a/lib/js_of_ocaml/typed_array.ml
+++ b/lib/js_of_ocaml/typed_array.ml
@@ -201,13 +201,13 @@ class type dataView = object
 
   method getUint32_ : int -> bool t -> uint32 meth
 
-  method getFloat32 : int -> float meth
+  method getFloat32 : int -> number_t meth
 
-  method getFloat32_ : int -> bool t -> float meth
+  method getFloat32_ : int -> bool t -> number_t meth
 
-  method getFloat64 : int -> float meth
+  method getFloat64 : int -> number_t meth
 
-  method getFloat64_ : int -> bool t -> float meth
+  method getFloat64_ : int -> bool t -> number_t meth
 
   method setInt8 : int -> int -> unit meth
 
@@ -229,13 +229,13 @@ class type dataView = object
 
   method setUint32_ : int -> uint32 -> bool t -> unit meth
 
-  method setFloat32 : int -> float -> unit meth
+  method setFloat32 : int -> number_t -> unit meth
 
-  method setFloat32_ : int -> float -> bool t -> unit meth
+  method setFloat32_ : int -> number_t -> bool t -> unit meth
 
-  method setFloat64 : int -> float -> unit meth
+  method setFloat64 : int -> number_t -> unit meth
 
-  method setFloat64_ : int -> float -> bool t -> unit meth
+  method setFloat64_ : int -> number_t -> bool t -> unit meth
 end
 
 let dataView = Js.Unsafe.global##._DataView

--- a/lib/js_of_ocaml/typed_array.mli
+++ b/lib/js_of_ocaml/typed_array.mli
@@ -196,13 +196,13 @@ class type dataView = object
 
   method getUint32_ : int -> bool t -> uint32 meth
 
-  method getFloat32 : int -> float meth
+  method getFloat32 : int -> number_t meth
 
-  method getFloat32_ : int -> bool t -> float meth
+  method getFloat32_ : int -> bool t -> number_t meth
 
-  method getFloat64 : int -> float meth
+  method getFloat64 : int -> number_t meth
 
-  method getFloat64_ : int -> bool t -> float meth
+  method getFloat64_ : int -> bool t -> number_t meth
 
   method setInt8 : int -> int -> unit meth
 
@@ -224,13 +224,13 @@ class type dataView = object
 
   method setUint32_ : int -> uint32 -> bool t -> unit meth
 
-  method setFloat32 : int -> float -> unit meth
+  method setFloat32 : int -> number_t -> unit meth
 
-  method setFloat32_ : int -> float -> bool t -> unit meth
+  method setFloat32_ : int -> number_t -> bool t -> unit meth
 
-  method setFloat64 : int -> float -> unit meth
+  method setFloat64 : int -> number_t -> unit meth
 
-  method setFloat64_ : int -> float -> bool t -> unit meth
+  method setFloat64_ : int -> number_t -> bool t -> unit meth
 end
 
 val dataView : (arrayBuffer t -> dataView t) constr

--- a/lib/js_of_ocaml/url.ml
+++ b/lib/js_of_ocaml/url.ml
@@ -304,7 +304,7 @@ module Current = struct
 
   let arguments =
     decode_arguments_js_string
-      (if l##.search##charAt 0 == Js.string "?"
+      (if Js.equals (l##.search##charAt 0) (Js.string "?")
        then l##.search##slice_end 1
        else l##.search)
 

--- a/lib/js_of_ocaml/webGL.ml
+++ b/lib/js_of_ocaml/webGL.ml
@@ -31,7 +31,7 @@ type intptr = int
 
 type uint = int
 
-type clampf = float
+type clampf = number_t
 
 type void
 
@@ -239,11 +239,11 @@ class type renderingContext = object
 
   method isEnabled : enableCap -> bool t meth
 
-  method lineWidth : float -> unit meth
+  method lineWidth : number_t -> unit meth
 
   method pixelStorei : 'a. 'a pixelStoreParam -> 'a -> unit meth
 
-  method polygonOffset : float -> float -> unit meth
+  method polygonOffset : number_t -> number_t -> unit meth
 
   method sampleCoverage : clampf -> bool t -> unit meth
 
@@ -437,7 +437,7 @@ class type renderingContext = object
     -> unit meth
 
   (* {[
-      method texParameterf : texTarget -> texParam -> float -> unit meth
+      method texParameterf : texTarget -> texParam -> number_t -> unit meth
      ]}
   *)
   method texParameteri : texTarget -> 'a texParam -> 'a -> unit meth
@@ -559,12 +559,12 @@ class type renderingContext = object
 
   method getVertexAttribOffset : uint -> vertexAttribPointerParam -> sizeiptr meth
 
-  method uniform1f : float uniformLocation t -> float -> unit meth
+  method uniform1f : number_t uniformLocation t -> number_t -> unit meth
 
   method uniform1fv_typed :
-    float uniformLocation t -> Typed_array.float32Array t -> unit meth
+    number_t uniformLocation t -> Typed_array.float32Array t -> unit meth
 
-  method uniform1fv : float uniformLocation t -> float js_array t -> unit meth
+  method uniform1fv : number_t uniformLocation t -> number_t js_array t -> unit meth
 
   method uniform1i : int uniformLocation t -> int -> unit meth
 
@@ -572,12 +572,12 @@ class type renderingContext = object
 
   method uniform1iv : int uniformLocation t -> int js_array t -> unit meth
 
-  method uniform2f : [ `vec2 ] uniformLocation t -> float -> float -> unit meth
+  method uniform2f : [ `vec2 ] uniformLocation t -> number_t -> number_t -> unit meth
 
   method uniform2fv_typed :
     [ `vec2 ] uniformLocation t -> Typed_array.float32Array t -> unit meth
 
-  method uniform2fv : [ `vec2 ] uniformLocation t -> float js_array t -> unit meth
+  method uniform2fv : [ `vec2 ] uniformLocation t -> number_t js_array t -> unit meth
 
   method uniform2i : [ `ivec2 ] uniformLocation t -> int -> int -> unit meth
 
@@ -586,12 +586,13 @@ class type renderingContext = object
   method uniform2iv_typed :
     [ `ivec2 ] uniformLocation t -> Typed_array.int32Array t -> unit meth
 
-  method uniform3f : [ `vec3 ] uniformLocation t -> float -> float -> float -> unit meth
+  method uniform3f :
+    [ `vec3 ] uniformLocation t -> number_t -> number_t -> number_t -> unit meth
 
   method uniform3fv_typed :
     [ `vec3 ] uniformLocation t -> Typed_array.float32Array t -> unit meth
 
-  method uniform3fv : [ `vec3 ] uniformLocation t -> float js_array t -> unit meth
+  method uniform3fv : [ `vec3 ] uniformLocation t -> number_t js_array t -> unit meth
 
   method uniform3i : [ `ivec3 ] uniformLocation t -> int -> int -> int -> unit meth
 
@@ -601,12 +602,17 @@ class type renderingContext = object
     [ `ivec3 ] uniformLocation t -> Typed_array.int32Array t -> unit meth
 
   method uniform4f :
-    [ `vec4 ] uniformLocation t -> float -> float -> float -> float -> unit meth
+       [ `vec4 ] uniformLocation t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> unit meth
 
   method uniform4fv_typed :
     [ `vec4 ] uniformLocation t -> Typed_array.float32Array t -> unit meth
 
-  method uniform4fv : [ `vec4 ] uniformLocation t -> float js_array t -> unit meth
+  method uniform4fv : [ `vec4 ] uniformLocation t -> number_t js_array t -> unit meth
 
   method uniform4i : [ `ivec4 ] uniformLocation t -> int -> int -> int -> int -> unit meth
 
@@ -616,44 +622,45 @@ class type renderingContext = object
     [ `ivec4 ] uniformLocation t -> Typed_array.int32Array t -> unit meth
 
   method uniformMatrix2fv :
-    [ `mat2 ] uniformLocation t -> bool t -> float js_array t -> unit meth
+    [ `mat2 ] uniformLocation t -> bool t -> number_t js_array t -> unit meth
 
   method uniformMatrix2fv_typed :
     [ `mat2 ] uniformLocation t -> bool t -> Typed_array.float32Array t -> unit meth
 
   method uniformMatrix3fv :
-    [ `mat3 ] uniformLocation t -> bool t -> float js_array t -> unit meth
+    [ `mat3 ] uniformLocation t -> bool t -> number_t js_array t -> unit meth
 
   method uniformMatrix3fv_typed :
     [ `mat3 ] uniformLocation t -> bool t -> Typed_array.float32Array t -> unit meth
 
   method uniformMatrix4fv :
-    [ `mat4 ] uniformLocation t -> bool t -> float js_array t -> unit meth
+    [ `mat4 ] uniformLocation t -> bool t -> number_t js_array t -> unit meth
 
   method uniformMatrix4fv_typed :
     [ `mat4 ] uniformLocation t -> bool t -> Typed_array.float32Array t -> unit meth
 
-  method vertexAttrib1f : uint -> float -> unit meth
+  method vertexAttrib1f : uint -> number_t -> unit meth
 
-  method vertexAttrib1fv : uint -> float js_array t -> unit meth
+  method vertexAttrib1fv : uint -> number_t js_array t -> unit meth
 
   method vertexAttrib1fv_typed : uint -> Typed_array.float32Array t -> unit meth
 
-  method vertexAttrib2f : uint -> float -> float -> unit meth
+  method vertexAttrib2f : uint -> number_t -> number_t -> unit meth
 
-  method vertexAttrib2fv : uint -> float js_array t -> unit meth
+  method vertexAttrib2fv : uint -> number_t js_array t -> unit meth
 
   method vertexAttrib2fv_typed : uint -> Typed_array.float32Array t -> unit meth
 
-  method vertexAttrib3f : uint -> float -> float -> float -> unit meth
+  method vertexAttrib3f : uint -> number_t -> number_t -> number_t -> unit meth
 
-  method vertexAttrib3fv : uint -> float js_array t -> unit meth
+  method vertexAttrib3fv : uint -> number_t js_array t -> unit meth
 
   method vertexAttrib3fv_typed : uint -> Typed_array.float32Array t -> unit meth
 
-  method vertexAttrib4f : uint -> float -> float -> float -> float -> unit meth
+  method vertexAttrib4f :
+    uint -> number_t -> number_t -> number_t -> number_t -> unit meth
 
-  method vertexAttrib4fv : uint -> float js_array t -> unit meth
+  method vertexAttrib4fv : uint -> number_t js_array t -> unit meth
 
   method vertexAttrib4fv_typed : uint -> Typed_array.float32Array t -> unit meth
 
@@ -847,7 +854,7 @@ class type renderingContext = object
 
   method _POLYGON_OFFSET_FILL_PARAM : bool t parameter readonly_prop
 
-  method _LINE_WIDTH_ : float parameter readonly_prop
+  method _LINE_WIDTH_ : number_t parameter readonly_prop
 
   method _ALIASED_POINT_SIZE_RANGE_ : Typed_array.float32Array t parameter readonly_prop
 
@@ -861,7 +868,7 @@ class type renderingContext = object
 
   method _DEPTH_WRITEMASK_ : bool t parameter readonly_prop
 
-  method _DEPTH_CLEAR_VALUE_ : float parameter readonly_prop
+  method _DEPTH_CLEAR_VALUE_ : number_t parameter readonly_prop
 
   method _DEPTH_FUNC_ : depthFunction parameter readonly_prop
 
@@ -925,9 +932,9 @@ class type renderingContext = object
 
   method _STENCIL_BITS_ : int parameter readonly_prop
 
-  method _POLYGON_OFFSET_UNITS_ : float parameter readonly_prop
+  method _POLYGON_OFFSET_UNITS_ : number_t parameter readonly_prop
 
-  method _POLYGON_OFFSET_FACTOR_ : float parameter readonly_prop
+  method _POLYGON_OFFSET_FACTOR_ : number_t parameter readonly_prop
 
   method _TEXTURE_BINDING_2D_ : texture t opt parameter readonly_prop
 
@@ -937,7 +944,7 @@ class type renderingContext = object
 
   method _SAMPLES_ : int parameter readonly_prop
 
-  method _SAMPLE_COVERAGE_VALUE_ : float parameter readonly_prop
+  method _SAMPLE_COVERAGE_VALUE_ : number_t parameter readonly_prop
 
   method _SAMPLE_COVERAGE_INVERT_ : bool t parameter readonly_prop
 

--- a/lib/js_of_ocaml/webGL.mli
+++ b/lib/js_of_ocaml/webGL.mli
@@ -32,7 +32,7 @@ type intptr = int
 
 type uint = int
 
-type clampf = float
+type clampf = number_t
 
 type void
 
@@ -229,11 +229,11 @@ class type renderingContext = object
 
   method isEnabled : enableCap -> bool t meth
 
-  method lineWidth : float -> unit meth
+  method lineWidth : number_t -> unit meth
 
   method pixelStorei : 'a. 'a pixelStoreParam -> 'a -> unit meth
 
-  method polygonOffset : float -> float -> unit meth
+  method polygonOffset : number_t -> number_t -> unit meth
 
   method sampleCoverage : clampf -> bool t -> unit meth
 
@@ -427,7 +427,7 @@ class type renderingContext = object
     -> unit meth
 
   (* {[
-       method texParameterf : texTarget -> texParam -> float -> unit meth
+       method texParameterf : texTarget -> texParam -> number_t -> unit meth
      ]}
   *)
   method texParameteri : texTarget -> 'a texParam -> 'a -> unit meth
@@ -549,12 +549,12 @@ class type renderingContext = object
 
   method getVertexAttribOffset : uint -> vertexAttribPointerParam -> sizeiptr meth
 
-  method uniform1f : float uniformLocation t -> float -> unit meth
+  method uniform1f : number_t uniformLocation t -> number_t -> unit meth
 
   method uniform1fv_typed :
-    float uniformLocation t -> Typed_array.float32Array t -> unit meth
+    number_t uniformLocation t -> Typed_array.float32Array t -> unit meth
 
-  method uniform1fv : float uniformLocation t -> float js_array t -> unit meth
+  method uniform1fv : number_t uniformLocation t -> number_t js_array t -> unit meth
 
   method uniform1i : int uniformLocation t -> int -> unit meth
 
@@ -562,12 +562,12 @@ class type renderingContext = object
 
   method uniform1iv : int uniformLocation t -> int js_array t -> unit meth
 
-  method uniform2f : [ `vec2 ] uniformLocation t -> float -> float -> unit meth
+  method uniform2f : [ `vec2 ] uniformLocation t -> number_t -> number_t -> unit meth
 
   method uniform2fv_typed :
     [ `vec2 ] uniformLocation t -> Typed_array.float32Array t -> unit meth
 
-  method uniform2fv : [ `vec2 ] uniformLocation t -> float js_array t -> unit meth
+  method uniform2fv : [ `vec2 ] uniformLocation t -> number_t js_array t -> unit meth
 
   method uniform2i : [ `ivec2 ] uniformLocation t -> int -> int -> unit meth
 
@@ -576,12 +576,13 @@ class type renderingContext = object
   method uniform2iv_typed :
     [ `ivec2 ] uniformLocation t -> Typed_array.int32Array t -> unit meth
 
-  method uniform3f : [ `vec3 ] uniformLocation t -> float -> float -> float -> unit meth
+  method uniform3f :
+    [ `vec3 ] uniformLocation t -> number_t -> number_t -> number_t -> unit meth
 
   method uniform3fv_typed :
     [ `vec3 ] uniformLocation t -> Typed_array.float32Array t -> unit meth
 
-  method uniform3fv : [ `vec3 ] uniformLocation t -> float js_array t -> unit meth
+  method uniform3fv : [ `vec3 ] uniformLocation t -> number_t js_array t -> unit meth
 
   method uniform3i : [ `ivec3 ] uniformLocation t -> int -> int -> int -> unit meth
 
@@ -591,12 +592,17 @@ class type renderingContext = object
     [ `ivec3 ] uniformLocation t -> Typed_array.int32Array t -> unit meth
 
   method uniform4f :
-    [ `vec4 ] uniformLocation t -> float -> float -> float -> float -> unit meth
+       [ `vec4 ] uniformLocation t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> number_t
+    -> unit meth
 
   method uniform4fv_typed :
     [ `vec4 ] uniformLocation t -> Typed_array.float32Array t -> unit meth
 
-  method uniform4fv : [ `vec4 ] uniformLocation t -> float js_array t -> unit meth
+  method uniform4fv : [ `vec4 ] uniformLocation t -> number_t js_array t -> unit meth
 
   method uniform4i : [ `ivec4 ] uniformLocation t -> int -> int -> int -> int -> unit meth
 
@@ -606,44 +612,45 @@ class type renderingContext = object
     [ `ivec4 ] uniformLocation t -> Typed_array.int32Array t -> unit meth
 
   method uniformMatrix2fv :
-    [ `mat2 ] uniformLocation t -> bool t -> float js_array t -> unit meth
+    [ `mat2 ] uniformLocation t -> bool t -> number_t js_array t -> unit meth
 
   method uniformMatrix2fv_typed :
     [ `mat2 ] uniformLocation t -> bool t -> Typed_array.float32Array t -> unit meth
 
   method uniformMatrix3fv :
-    [ `mat3 ] uniformLocation t -> bool t -> float js_array t -> unit meth
+    [ `mat3 ] uniformLocation t -> bool t -> number_t js_array t -> unit meth
 
   method uniformMatrix3fv_typed :
     [ `mat3 ] uniformLocation t -> bool t -> Typed_array.float32Array t -> unit meth
 
   method uniformMatrix4fv :
-    [ `mat4 ] uniformLocation t -> bool t -> float js_array t -> unit meth
+    [ `mat4 ] uniformLocation t -> bool t -> number_t js_array t -> unit meth
 
   method uniformMatrix4fv_typed :
     [ `mat4 ] uniformLocation t -> bool t -> Typed_array.float32Array t -> unit meth
 
-  method vertexAttrib1f : uint -> float -> unit meth
+  method vertexAttrib1f : uint -> number_t -> unit meth
 
-  method vertexAttrib1fv : uint -> float js_array t -> unit meth
+  method vertexAttrib1fv : uint -> number_t js_array t -> unit meth
 
   method vertexAttrib1fv_typed : uint -> Typed_array.float32Array t -> unit meth
 
-  method vertexAttrib2f : uint -> float -> float -> unit meth
+  method vertexAttrib2f : uint -> number_t -> number_t -> unit meth
 
-  method vertexAttrib2fv : uint -> float js_array t -> unit meth
+  method vertexAttrib2fv : uint -> number_t js_array t -> unit meth
 
   method vertexAttrib2fv_typed : uint -> Typed_array.float32Array t -> unit meth
 
-  method vertexAttrib3f : uint -> float -> float -> float -> unit meth
+  method vertexAttrib3f : uint -> number_t -> number_t -> number_t -> unit meth
 
-  method vertexAttrib3fv : uint -> float js_array t -> unit meth
+  method vertexAttrib3fv : uint -> number_t js_array t -> unit meth
 
   method vertexAttrib3fv_typed : uint -> Typed_array.float32Array t -> unit meth
 
-  method vertexAttrib4f : uint -> float -> float -> float -> float -> unit meth
+  method vertexAttrib4f :
+    uint -> number_t -> number_t -> number_t -> number_t -> unit meth
 
-  method vertexAttrib4fv : uint -> float js_array t -> unit meth
+  method vertexAttrib4fv : uint -> number_t js_array t -> unit meth
 
   method vertexAttrib4fv_typed : uint -> Typed_array.float32Array t -> unit meth
 
@@ -837,7 +844,7 @@ class type renderingContext = object
 
   method _POLYGON_OFFSET_FILL_PARAM : bool t parameter readonly_prop
 
-  method _LINE_WIDTH_ : float parameter readonly_prop
+  method _LINE_WIDTH_ : number_t parameter readonly_prop
 
   method _ALIASED_POINT_SIZE_RANGE_ : Typed_array.float32Array t parameter readonly_prop
 
@@ -851,7 +858,7 @@ class type renderingContext = object
 
   method _DEPTH_WRITEMASK_ : bool t parameter readonly_prop
 
-  method _DEPTH_CLEAR_VALUE_ : float parameter readonly_prop
+  method _DEPTH_CLEAR_VALUE_ : number_t parameter readonly_prop
 
   method _DEPTH_FUNC_ : depthFunction parameter readonly_prop
 
@@ -915,9 +922,9 @@ class type renderingContext = object
 
   method _STENCIL_BITS_ : int parameter readonly_prop
 
-  method _POLYGON_OFFSET_UNITS_ : float parameter readonly_prop
+  method _POLYGON_OFFSET_UNITS_ : number_t parameter readonly_prop
 
-  method _POLYGON_OFFSET_FACTOR_ : float parameter readonly_prop
+  method _POLYGON_OFFSET_FACTOR_ : number_t parameter readonly_prop
 
   method _TEXTURE_BINDING_2D_ : texture t opt parameter readonly_prop
 
@@ -927,7 +934,7 @@ class type renderingContext = object
 
   method _SAMPLES_ : int parameter readonly_prop
 
-  method _SAMPLE_COVERAGE_VALUE_ : float parameter readonly_prop
+  method _SAMPLE_COVERAGE_VALUE_ : number_t parameter readonly_prop
 
   method _SAMPLE_COVERAGE_INVERT_ : bool t parameter readonly_prop
 

--- a/lib/js_of_ocaml/worker.ml
+++ b/lib/js_of_ocaml/worker.ml
@@ -58,19 +58,19 @@ let worker = Unsafe.global##._Worker
 let create script = new%js worker (string script)
 
 let import_scripts scripts : unit =
-  if Unsafe.global##.importScripts == undefined
+  if not (Js.Optdef.test Unsafe.global##.importScripts)
   then invalid_arg "Worker.import_scripts is undefined";
   Unsafe.fun_call
     Unsafe.global##.importScripts
     (Array.map (fun s -> Unsafe.inject (string s)) (Array.of_list scripts))
 
 let set_onmessage handler =
-  if Unsafe.global##.onmessage == undefined
+  if not (Js.Optdef.test Unsafe.global##.onmessage)
   then invalid_arg "Worker.onmessage is undefined";
   let js_handler (ev : 'a messageEvent Js.t) = handler ev##.data in
   Unsafe.global##.onmessage := wrap_callback js_handler
 
 let post_message msg =
-  if Unsafe.global##.postMessage == undefined
+  if not (Js.Optdef.test Unsafe.global##.postMessage)
   then invalid_arg "Worker.onmessage is undefined";
   Unsafe.global##postMessage msg

--- a/lib/lwt/graphics/graphics_js.ml
+++ b/lib/lwt/graphics/graphics_js.ml
@@ -48,13 +48,13 @@ let open_canvas x =
 let compute_real_pos (elt : #Dom_html.element Js.t) ev =
   let r = elt##getBoundingClientRect in
   let x =
-    (float_of_int ev##.clientX -. r##.left)
-    /. (r##.right -. r##.left)
+    (float_of_int ev##.clientX -. Js.to_float r##.left)
+    /. (Js.to_float r##.right -. Js.to_float r##.left)
     *. float_of_int elt##.width
   in
   let y =
-    (float_of_int ev##.clientY -. r##.top)
-    /. (r##.bottom -. r##.top)
+    (float_of_int ev##.clientY -. Js.to_float r##.top)
+    /. (Js.to_float r##.bottom -. Js.to_float r##.top)
     *. float_of_int elt##.height
   in
   truncate x, elt##.height - truncate y

--- a/lib/lwt/lwt_js.ml
+++ b/lib/lwt/lwt_js.ml
@@ -30,7 +30,9 @@ let sleep d =
 let yield () = sleep 0.
 
 let wakeup = function
-  | 1 -> ignore (Dom_html.window##setTimeout (Js.wrap_callback Lwt.wakeup_paused) 0.)
+  | 1 ->
+      ignore
+        (Dom_html.window##setTimeout (Js.wrap_callback Lwt.wakeup_paused) (Js.float 0.))
   | _ -> ()
 
 let () = Lwt.register_pause_notifier wakeup

--- a/lib/lwt/lwt_js_events.ml
+++ b/lib/lwt/lwt_js_events.ml
@@ -610,7 +610,7 @@ let request_animation_frame () =
   let t, s = Lwt.wait () in
   let (_ : Dom_html.animation_frame_request_id) =
     Dom_html.window##requestAnimationFrame
-      (Js.wrap_callback (fun (_ : float) -> Lwt.wakeup s ()))
+      (Js.wrap_callback (fun (_ : Js.number_t) -> Lwt.wakeup s ()))
   in
   t
 

--- a/lib/runtime/js_of_ocaml_runtime_stubs.c
+++ b/lib/runtime/js_of_ocaml_runtime_stubs.c
@@ -120,6 +120,10 @@ void caml_js_set () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_set!\n");
   exit(1);
 }
+void caml_js_strict_equals () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_js_strict_equals!\n");
+  exit(1);
+}
 void caml_js_to_array () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_to_array!\n");
   exit(1);

--- a/lib/runtime/js_of_ocaml_runtime_stubs.c
+++ b/lib/runtime/js_of_ocaml_runtime_stubs.c
@@ -76,6 +76,14 @@ void caml_js_from_float () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_from_float!\n");
   exit(1);
 }
+void caml_js_from_int32 () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_js_from_int32!\n");
+  exit(1);
+}
+void caml_js_from_nativeint () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_js_from_nativeint!\n");
+  exit(1);
+}
 void caml_js_from_string () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_from_string!\n");
   exit(1);
@@ -126,6 +134,14 @@ void caml_js_to_byte_string () {
 }
 void caml_js_to_float () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_to_float!\n");
+  exit(1);
+}
+void caml_js_to_int32 () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_js_to_int32!\n");
+  exit(1);
+}
+void caml_js_to_nativeint () {
+  fprintf(stderr, "Unimplemented Javascript primitive caml_js_to_nativeint!\n");
   exit(1);
 }
 void caml_js_to_string () {

--- a/lib/runtime/jsoo_runtime.ml
+++ b/lib/runtime/jsoo_runtime.ml
@@ -25,6 +25,14 @@ module Js = struct
 
   external float_of_number : t -> float = "caml_js_to_float"
 
+  external number_of_int32 : int32 -> t = "caml_js_from_int32"
+
+  external int32_of_number : t -> int32 = "caml_js_to_int32"
+
+  external number_of_nativeint : nativeint -> t = "caml_js_from_nativeint"
+
+  external nativeint_of_number : t -> nativeint = "caml_js_to_nativeint"
+
   external typeof : t -> t = "caml_js_typeof"
 
   external instanceof : t -> t -> bool = "caml_js_instanceof"

--- a/lib/runtime/jsoo_runtime.ml
+++ b/lib/runtime/jsoo_runtime.ml
@@ -59,6 +59,8 @@ module Js = struct
 
   external equals : t -> t -> bool = "caml_js_equals"
 
+  external strict_equals : t -> t -> bool = "caml_js_strict_equals"
+
   external pure_expr : (unit -> 'a) -> 'a = "caml_js_pure_expr"
 
   external eval_string : string -> 'a = "caml_js_eval_string"

--- a/runtime/jslib.js
+++ b/runtime/jslib.js
@@ -408,6 +408,9 @@ function caml_js_function_arity(f) {
 //Provides: caml_js_equals mutable (const, const)
 function caml_js_equals (x, y) { return +(x == y); }
 
+//Provides: caml_js_strict_equals mutable (const, const)
+function caml_js_strict_equals (x, y) { return +(x === y); }
+
 //Provides: caml_js_eval_string (const)
 //Requires: caml_jsstring_of_string
 function caml_js_eval_string (s) {return eval(caml_jsstring_of_string(s));}

--- a/runtime/jslib.js
+++ b/runtime/jslib.js
@@ -191,9 +191,14 @@ function caml_js_from_bool(x) { return !!x; }
 //Provides: caml_js_to_bool const (const)
 function caml_js_to_bool(x) { return +x; }
 //Provides: caml_js_from_float const (const)
+//Alias: caml_js_from_int32
+//Alias: caml_js_from_nativeint
 function caml_js_from_float(x) { return x; }
 //Provides: caml_js_to_float const (const)
 function caml_js_to_float(x) { return x; }
+//Provides: caml_js_to_int32 const (const)
+//Alias: caml_js_to_nativeint
+function caml_js_to_int32(x) { return x|0; }
 
 //Provides: caml_js_from_array mutable (shallow)
 function caml_js_from_array(a) {


### PR DESCRIPTION
[Wasm_of_ocaml](https://github.com/ocaml-wasm/wasm_of_ocaml) needs additional bindings:
- float conversions are no longer deprecated
- add conversion between OCaml int32 and nativeint and JavaScript numbers
- add binding for JavaScript strict equality (and better expose the regular equality)
