### PR TITLE
Fix caml_js_on_ie

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# Dev (2023-??-??) - ??
+
+* Runtime: fix Dom_html.onIE (#1493)
+
 # 5.4.0 (2023-07-06) - Lille
 
 ## Bug fixes

--- a/runtime/jslib_js_of_ocaml.js
+++ b/runtime/jslib_js_of_ocaml.js
@@ -22,7 +22,8 @@
 //Provides: caml_js_on_ie const
 function caml_js_on_ie () {
   var ua =
-      globalThis.navigator?globalThis.navigator.userAgent:"";
+      (globalThis.navigator&&globalThis.navigator.userAgent)
+      ?globalThis.navigator.userAgent:"";
   return ua.indexOf("MSIE") != -1 && ua.indexOf("Opera") != 0;
 }
 


### PR DESCRIPTION
Recent versions of node define `navigator` but not `navigator.userAgent`.