### PR TITLE
Fix global flow analysis

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Dev (2023-??-??) - ??
 
 * Runtime: fix Dom_html.onIE (#1493)
+* Compiler: fix global flow analysis (#1494)
 
 # 5.4.0 (2023-07-06) - Lille
 

--- a/compiler/tests-compiler/dune.inc
+++ b/compiler/tests-compiler/dune.inc
@@ -360,6 +360,21 @@
   (pps ppx_expect)))
 
 (library
+ ;; compiler/tests-compiler/gh1494.ml
+ (name gh1494_15)
+ (enabled_if true)
+ (modules gh1494)
+ (libraries js_of_ocaml_compiler unix str jsoo_compiler_expect_tests_helper)
+ (inline_tests
+  (enabled_if true)
+  (deps
+   (file %{project_root}/compiler/bin-js_of_ocaml/js_of_ocaml.exe)
+   (file %{project_root}/compiler/bin-jsoo_minify/jsoo_minify.exe)))
+ (flags (:standard -open Jsoo_compiler_expect_tests_helper))
+ (preprocess
+  (pps ppx_expect)))
+
+(library
  ;; compiler/tests-compiler/gh747.ml
  (name gh747_15)
  (enabled_if true)

--- a/compiler/tests-compiler/gh1494.ml
+++ b/compiler/tests-compiler/gh1494.ml
@@ -32,13 +32,14 @@ let () =
   in
   Util.compile_and_run prog;
   [%expect {|
-    undefined
-    undefined |}];
+    7
+    7 |}];
   let program = Util.compile_and_parse prog in
   Util.print_fun_decl program (Some "bug");
-  [%expect {|
+  [%expect
+    {|
     function bug(param){
      var g = [0, function(x){return function(_c_){return _c_;};}];
-     return [0, function(param){return g[1].call(null, 1);}, g];
+     return [0, function(param){return caml_call1(g[1], 1);}, g];
     }
     //end |}]

--- a/compiler/tests-compiler/gh1494.ml
+++ b/compiler/tests-compiler/gh1494.ml
@@ -1,0 +1,44 @@
+(* Js_of_ocaml tests
+ * http://www.ocsigen.org/js_of_ocaml/
+ * Copyright (C) 2020 Hugo Heuzard
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+
+(* https://github.com/ocsigen/js_of_ocaml/issues/1007 *)
+
+(* Small bug in the global flow analysis in fast mode *)
+let%expect_test _ =
+  let prog =
+    {|
+let () =
+  let bug () = let g = ref (fun x -> Fun.id) in (fun () -> !g 1), g in
+  let h f =
+    let (h, g) = f() in g := (fun x y -> y); Printf.printf "%d\n" (h () 7) in
+  h bug; h bug
+|}
+  in
+  Util.compile_and_run prog;
+  [%expect {|
+    undefined
+    undefined |}];
+  let program = Util.compile_and_parse prog in
+  Util.print_fun_decl program (Some "bug");
+  [%expect {|
+    function bug(param){
+     var g = [0, function(x){return function(_c_){return _c_;};}];
+     return [0, function(param){return g[1].call(null, 1);}, g];
+    }
+    //end |}]


### PR DESCRIPTION
In fast mode, we don't track function arguments, so we should consider them as escaping.