### PR TITLE
fix(url.ml): set_fragment need not any urlencode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@
 * Compiler: fix free variables pass wrt parameters' default value (#1521)
 * Compiler: fix free variables for classes
 * Compiler: fix internal invariant (continuation)
+* Lib: Url.Current.set_fragment need not any urlencode (#1497)
 
 # 5.4.0 (2023-07-06) - Lille
 

--- a/lib/js_of_ocaml/url.ml
+++ b/lib/js_of_ocaml/url.ml
@@ -322,7 +322,7 @@ module Current = struct
         let res = Js.match_result res in
         Js.to_string (Js.Unsafe.get res 1))
 
-  let set_fragment s = l##.hash := Js.bytestring (urlencode s)
+  let set_fragment s = l##.hash := Js.bytestring s
 
   let get () = url_of_js_string l##.href
 

--- a/lib/js_of_ocaml/url.ml
+++ b/lib/js_of_ocaml/url.ml
@@ -309,18 +309,10 @@ module Current = struct
        else l##.search)
 
   let get_fragment () =
-    (* location.hash doesn't have the same behavior depending on the browser
-       Firefox bug : https://bugzilla.mozilla.org/show_bug.cgi?id=483304 *)
-    (* let s = Js.to_bytestring (l##hash) in *)
-    (* if String.length s > 0 && s.[0] = '#' *)
-    (* then String.sub s 1 (String.length s - 1) *)
-    (* else s; *)
-    Js.Opt.case
-      (l##.href##_match (new%js Js.regExp (Js.string "#(.*)")))
-      (fun () -> "")
-      (fun res ->
-        let res = Js.match_result res in
-        Js.to_string (Js.Unsafe.get res 1))
+    let s = Js.to_bytestring l##.hash in
+    if String.length s > 0 && Char.equal s.[0] '#'
+    then String.sub s 1 (String.length s - 1)
+    else s
 
   let set_fragment s = l##.hash := Js.bytestring s
 


### PR DESCRIPTION
Dear js_of_ocaml maintainers,

This patch comes from an issue spotted in learn-ocaml (which heavily relies on js_of_ocaml), namely:

* https://github.com/ocaml-sf/learn-ocaml/issues/539

Note: I didn't recompile js_of_ocaml itself yet to test it, but I'm confident of the fix; to summarize what I understood:

1. learn-ocaml handles local urls of the form `http://localhost:8080/exercises/tp1/#tab=report`;
2. it contains some (js_of_)ocaml code such as **`Url.Current.set_fragment "tab=report"`** to this aim;
3. unfortunately the browser URL was always `http://localhost:8080/exercises/tp1/#tab%3Dreport`, which is not that legible!;
4. replacing the line of point 2. above with `Dom_html.window##.location##.hash := Js.bytestring "tab=report"` solves the issue.

* FTR, the `document.location.hash` is documented at https://developer.mozilla.org/en-US/docs/Web/API/Location/hash
* I noticed there was an old bug in Firefox w.r.t. encoding/decoding only for the getter:
  * see https://stackoverflow.com/questions/1703552/encoding-of-window-location-hash
  * and https://bugzilla.mozilla.org/show_bug.cgi?id=483304
* But this bug was fixed 8 years ago and anyway, this bug only dealt with the *getter* of the fragment.
* So there was no need for manually url-encoding the fragment for the *setter* as well!

Hence this small patch; WDYT?