### PR TITLE
Download attribute

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Features/Changes
 * Compiler: change control-flow compilation strategy (#1496)
+* Lib: add download attribute to anchor element
 
 ## Bug fixes
 * Runtime: fix Dom_html.onIE (#1493)

--- a/lib/js_of_ocaml/dom_html.ml
+++ b/lib/js_of_ocaml/dom_html.ml
@@ -1324,6 +1324,8 @@ class type anchorElement = object
 
   method coords : js_string t prop
 
+  method download : js_string t prop
+
   method href : js_string t prop
 
   method hreflang : js_string t prop

--- a/lib/js_of_ocaml/dom_html.mli
+++ b/lib/js_of_ocaml/dom_html.mli
@@ -1149,6 +1149,8 @@ class type anchorElement = object
 
   method coords : js_string t prop
 
+  method download : js_string t prop
+
   method href : js_string t prop
 
   method hreflang : js_string t prop


### PR DESCRIPTION
Hi,

Tiny patch to add `download` attribute in `<a>`:

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-download
https://caniuse.com/download