### PR TITLE
Make it possible to link runtime JavaScript file together with OCaml libraries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 * Compiler: codegen: more specialization for %int_add, %int_sub
 * Compiler: recognize and optimize String.concat
 * Compiler: more inlining - duplicate small function.
+* Compiler: Make it possible to link runtime JavaScript file
+  together with OCaml libraries #1509
 * Runtime: abort instead of exit when calling unimplemented
   js primitives in bytecode/native. It should help if one tries
   to understand the source of the call with gdb (see #677)

--- a/compiler/bin-js_of_ocaml/compile.ml
+++ b/compiler/bin-js_of_ocaml/compile.ml
@@ -119,7 +119,7 @@ let run
         Some (Hashtbl.fold (fun cmi () acc -> cmi :: acc) t [])
   in
   let runtime_files =
-    if toplevel || dynlink
+    if (not no_runtime) && (toplevel || dynlink)
     then
       let add_if_absent x l = if List.mem x ~set:l then l else x :: l in
       runtime_files |> add_if_absent "+toplevel.js" |> add_if_absent "+dynlink.js"
@@ -246,9 +246,22 @@ let run
     Pretty_print.string fmt (Unit_info.to_string uinfo);
     output code ~source_map ~standalone ~linkall:false output_file
   in
+  let output_runtime ~standalone ~source_map ((_, fmt) as output_file) =
+    assert (not standalone);
+    let uinfo = Unit_info.of_primitives (Linker.list_all () |> StringSet.elements) in
+    Pretty_print.string fmt "\n";
+    Pretty_print.string fmt (Unit_info.to_string uinfo);
+    let code =
+      { Parse_bytecode.code = Code.empty
+      ; cmis = StringSet.empty
+      ; debug = Parse_bytecode.Debug.create ~include_cmis:false false
+      }
+    in
+    output code ~source_map ~standalone ~linkall:true output_file
+  in
   (if runtime_only
    then (
-     let prims = Primitive.get_external () |> StringSet.elements in
+     let prims = Linker.list_all () |> StringSet.elements in
      assert (List.length prims > 0);
      let code, uinfo = Parse_bytecode.predefined_exceptions () in
      let uinfo = { uinfo with primitives = uinfo.primitives @ prims } in
@@ -328,6 +341,7 @@ let run
              cmo
              ic
          in
+         let linkall = linkall || toplevel || dynlink in
          if times () then Format.eprintf "  parsing: %a@." Timer.print t1;
          output_gen
            ~standalone:false
@@ -335,7 +349,13 @@ let run
            ~build_info:(Build_info.create `Cmo)
            ~source_map
            output_file
-           (output_partial cmo code)
+           (fun ~standalone ~source_map output ->
+             let source_map =
+               if linkall
+               then output_runtime ~standalone ~source_map output
+               else source_map
+             in
+             output_partial cmo code ~standalone ~source_map output)
      | `Cma cma when keep_unit_names ->
          List.iter cma.lib_units ~f:(fun cmo ->
              let output_file =
@@ -372,7 +392,11 @@ let run
                (`Name output_file)
                (output_partial cmo code))
      | `Cma cma ->
+         let linkall = linkall || toplevel || dynlink in
          let f ~standalone ~source_map output =
+           let source_map =
+             if linkall then output_runtime ~standalone ~source_map output else source_map
+           in
            List.fold_left cma.lib_units ~init:source_map ~f:(fun source_map cmo ->
                let t1 = Timer.make () in
                let code =

--- a/compiler/lib/driver.ml
+++ b/compiler/lib/driver.ml
@@ -291,7 +291,7 @@ let gen_missing js missing =
 let mark_start_of_generated_code = Debug.find ~even_if_quiet:true "mark-runtime-gen"
 
 let link ~standalone ~linkall (js : Javascript.statement_list) : Linker.output =
-  if not standalone
+  if not (linkall || standalone)
   then { runtime_code = js; always_required_codes = [] }
   else
     let t = Timer.make () in
@@ -328,7 +328,7 @@ let link ~standalone ~linkall (js : Javascript.statement_list) : Linker.output =
     let all_external = StringSet.union prim prov in
     let used = StringSet.inter free all_external in
     let linkinfos = Linker.init () in
-    let linkinfos, missing = Linker.resolve_deps ~linkall linkinfos used in
+    let linkinfos, missing = Linker.resolve_deps ~standalone ~linkall linkinfos used in
     (* gen_missing may use caml_failwith *)
     let linkinfos, missing =
       if (not (StringSet.is_empty missing)) && Config.Flag.genprim ()
@@ -351,18 +351,60 @@ let link ~standalone ~linkall (js : Javascript.statement_list) : Linker.output =
               let name = Utf8_string.of_string_exn name in
               Property (PNI name, EVar (ident name)))
         in
-        ( Expression_statement
-            (EBin
-               ( Eq
-               , dot
-                   (EVar (ident Constant.global_object_))
-                   (Utf8_string.of_string_exn "jsoo_runtime")
-               , EObj all ))
-        , N )
+        (if standalone
+         then
+           ( Expression_statement
+               (EBin
+                  ( Eq
+                  , dot
+                      (EVar (ident Constant.global_object_))
+                      (Utf8_string.of_string_exn "jsoo_runtime")
+                  , EObj all ))
+           , N )
+         else
+           ( Expression_statement
+               (call
+                  (dot
+                     (EVar (ident (Utf8_string.of_string_exn "Object")))
+                     (Utf8_string.of_string_exn "assign"))
+                  [ dot
+                      (EVar (ident Constant.global_object_))
+                      (Utf8_string.of_string_exn "jsoo_runtime")
+                  ; EObj all
+                  ]
+                  N)
+           , N ))
         :: js
       else js
     in
-    Linker.link js linkinfos
+    let missing = Linker.missing linkinfos in
+    let output = Linker.link ~standalone js linkinfos in
+    if not (List.is_empty missing)
+    then
+      { output with
+        runtime_code =
+          (let open Javascript in
+           ( Variable_statement
+               ( Var
+               , [ DeclPattern
+                     ( ObjectBinding
+                         { list =
+                             List.map
+                               ~f:(fun name ->
+                                 let name = Utf8_string.of_string_exn name in
+                                 Prop_ident (Prop_and_ident (ident name), None))
+                               missing
+                         ; rest = None
+                         }
+                     , ( dot
+                           (EVar (ident Constant.global_object_))
+                           (Utf8_string.of_string_exn "jsoo_runtime")
+                       , N ) )
+                 ] )
+           , N )
+           :: output.runtime_code)
+      }
+    else output
 
 let check_js js =
   let t = Timer.make () in

--- a/compiler/lib/linker.ml
+++ b/compiler/lib/linker.ml
@@ -393,6 +393,7 @@ type state =
   { ids : IntSet.t
   ; always_required_codes : always_required list
   ; codes : (Javascript.program pack * bool) list
+  ; missing : StringSet.t
   }
 
 type output =
@@ -589,10 +590,9 @@ let load_files ~target_env l =
 
 (* resolve *)
 let rec resolve_dep_name_rev visited path nm =
-  let x =
-    try Hashtbl.find provided nm with Not_found -> error "missing dependency '%s'@." nm
-  in
-  resolve_dep_id_rev visited path x.id
+  match Hashtbl.find provided nm with
+  | x -> resolve_dep_id_rev visited path x.id
+  | exception Not_found -> { visited with missing = StringSet.add nm visited.missing }
 
 and resolve_dep_id_rev visited path id =
   if IntSet.mem id visited.ids
@@ -623,9 +623,17 @@ let init () =
   { ids = IntSet.empty
   ; always_required_codes = List.rev_map !always_included ~f:proj_always_required
   ; codes = []
+  ; missing = StringSet.empty
   }
 
-let resolve_deps ?(linkall = false) visited_rev used =
+let list_all () =
+  Hashtbl.fold (fun nm _ set -> StringSet.add nm set) provided StringSet.empty
+
+let check_missing state =
+  if not (StringSet.is_empty state.missing)
+  then error "missing dependency '%s'@." (StringSet.choose state.missing)
+
+let resolve_deps ?(standalone = true) ?(linkall = false) visited_rev used =
   (* link the special files *)
   let missing, visited_rev =
     if linkall
@@ -650,9 +658,10 @@ let resolve_deps ?(linkall = false) visited_rev used =
         used
         (StringSet.empty, visited_rev)
   in
+  if standalone then check_missing visited_rev;
   visited_rev, missing
 
-let link program (state : state) =
+let link ?(standalone = true) program (state : state) =
   let always, always_required =
     List.partition
       ~f:(function
@@ -669,6 +678,7 @@ let link program (state : state) =
         in
         { state with codes = (Ok always.program, false) :: state.codes })
   in
+  if standalone then check_missing state;
   let codes =
     List.map state.codes ~f:(fun (x, has_macro) ->
         let c = unpack x in
@@ -690,6 +700,8 @@ let all state =
       with Not_found -> acc)
     state.ids
     []
+
+let missing state = StringSet.elements state.missing
 
 let origin ~name =
   try

--- a/compiler/lib/linker.mli
+++ b/compiler/lib/linker.mli
@@ -55,14 +55,19 @@ type output =
   ; always_required_codes : always_required list
   }
 
+val list_all : unit -> StringSet.t
+
 val init : unit -> state
 
-val resolve_deps : ?linkall:bool -> state -> StringSet.t -> state * StringSet.t
+val resolve_deps :
+  ?standalone:bool -> ?linkall:bool -> state -> StringSet.t -> state * StringSet.t
 
-val link : Javascript.program -> state -> output
+val link : ?standalone:bool -> Javascript.program -> state -> output
 
 val get_provided : unit -> StringSet.t
 
 val all : state -> string list
+
+val missing : state -> string list
 
 val origin : name:string -> string option

--- a/compiler/lib/unit_info.ml
+++ b/compiler/lib/unit_info.ml
@@ -37,6 +37,15 @@ let empty =
   ; effects_without_cps = false
   }
 
+let of_primitives l =
+  { provides = StringSet.empty
+  ; requires = StringSet.empty
+  ; primitives = l
+  ; crcs = StringMap.empty
+  ; force_link = true
+  ; effects_without_cps = false
+  }
+
 let of_cmo (cmo : Cmo_format.compilation_unit) =
   let open Ocaml_compiler in
   let provides = StringSet.singleton (Cmo_format.name cmo) in

--- a/compiler/lib/unit_info.mli
+++ b/compiler/lib/unit_info.mli
@@ -30,6 +30,8 @@ type t =
 
 val of_cmo : Cmo_format.compilation_unit -> t
 
+val of_primitives : string list -> t
+
 val union : t -> t -> t
 
 val empty : t

--- a/toplevel/examples/lwt_toplevel/dune
+++ b/toplevel/examples/lwt_toplevel/dune
@@ -49,7 +49,9 @@
     --file
     %{dep:test_dynlink.cmo}
     --file
-    %{dep:test_dynlink.js}))
+    %{dep:test_dynlink.js}
+    --file
+    %{dep:test_lib_jsoo.js}))
   (flags
    (:standard
     --toplevel
@@ -67,7 +69,12 @@
 (rule
  (targets test_dynlink.js)
  (action
-  (run %{bin:js_of_ocaml} --pretty --toplevel %{dep:test_dynlink.cmo})))
+  (run %{bin:js_of_ocaml} --pretty --toplevel %{read-strings:effects_flags.txt} %{dep:test_dynlink.cmo})))
+
+(rule
+ (target test_lib_jsoo.js)
+ (action
+  (run %{bin:js_of_ocaml} --pretty --toplevel %{read-strings:effects_flags.txt} %{dep:test_lib/stubs.js} %{dep:test_lib/test_lib_jsoo.cma} -o %{target})))
 
 (rule
  (targets export.txt)
@@ -136,6 +143,8 @@
    %{dep:test_dynlink.cmo}
    --file
    %{dep:test_dynlink.js}
+   --file
+   %{dep:test_lib_jsoo.js}
    --export
    %{dep:export.txt}
    --toplevel

--- a/toplevel/examples/lwt_toplevel/dune
+++ b/toplevel/examples/lwt_toplevel/dune
@@ -69,12 +69,26 @@
 (rule
  (targets test_dynlink.js)
  (action
-  (run %{bin:js_of_ocaml} --pretty --toplevel %{read-strings:effects_flags.txt} %{dep:test_dynlink.cmo})))
+  (run
+   %{bin:js_of_ocaml}
+   --pretty
+   --toplevel
+   %{read-strings:effects_flags.txt}
+   %{dep:test_dynlink.cmo})))
 
 (rule
  (target test_lib_jsoo.js)
  (action
-  (run %{bin:js_of_ocaml} --pretty --toplevel %{read-strings:effects_flags.txt} %{dep:test_lib/stubs.js} %{dep:test_lib/test_lib_jsoo.cma} -o %{target})))
+  (run
+   %{bin:js_of_ocaml}
+   --pretty
+   --no-runtime
+   --toplevel
+   %{read-strings:effects_flags.txt}
+   %{dep:test_lib/stubs.js}
+   %{dep:test_lib/test_lib_jsoo.cma}
+   -o
+   %{target})))
 
 (rule
  (targets export.txt)

--- a/toplevel/examples/lwt_toplevel/test_lib/a.ml
+++ b/toplevel/examples/lwt_toplevel/test_lib/a.ml
@@ -1,0 +1,3 @@
+external test_stubs : unit -> unit = "test_lib_jsoo_a"
+
+let () = print_endline "This is A"

--- a/toplevel/examples/lwt_toplevel/test_lib/a.ml
+++ b/toplevel/examples/lwt_toplevel/test_lib/a.ml
@@ -1,3 +1,8 @@
-external test_stubs : unit -> unit = "test_lib_jsoo_a"
+external test_stubs : unit -> int = "test_lib_jsoo_a"
 
 let () = print_endline "This is A"
+
+let test () =
+  let i = test_stubs () in
+  flush_all ();
+  Printf.printf "returned %d\n" i

--- a/toplevel/examples/lwt_toplevel/test_lib/b.ml
+++ b/toplevel/examples/lwt_toplevel/test_lib/b.ml
@@ -1,0 +1,1 @@
+let () = print_endline "This is B"

--- a/toplevel/examples/lwt_toplevel/test_lib/dune
+++ b/toplevel/examples/lwt_toplevel/test_lib/dune
@@ -1,0 +1,5 @@
+(library
+  (name test_lib_jsoo)
+  (modes byte)
+  (js_of_ocaml
+     (javascript_files stubs.js)))

--- a/toplevel/examples/lwt_toplevel/test_lib/dune
+++ b/toplevel/examples/lwt_toplevel/test_lib/dune
@@ -1,5 +1,5 @@
 (library
-  (name test_lib_jsoo)
-  (modes byte)
-  (js_of_ocaml
-     (javascript_files stubs.js)))
+ (name test_lib_jsoo)
+ (modes byte)
+ (js_of_ocaml
+  (javascript_files stubs.js)))

--- a/toplevel/examples/lwt_toplevel/test_lib/stubs.js
+++ b/toplevel/examples/lwt_toplevel/test_lib/stubs.js
@@ -1,0 +1,5 @@
+//Provides: test_lib_jsoo_a
+function test_lib_jsoo_a (unit) {
+  console.log("hello");
+  return 0
+}

--- a/toplevel/examples/lwt_toplevel/test_lib/stubs.js
+++ b/toplevel/examples/lwt_toplevel/test_lib/stubs.js
@@ -1,5 +1,11 @@
 //Provides: test_lib_jsoo_a
+//Requires: caml_string_of_jsbytes
+//Requires: caml_ml_output
+//Requires: caml_ml_string_length
 function test_lib_jsoo_a (unit) {
-  console.log("hello");
-  return 0
+  var s = caml_string_of_jsbytes("test_lib_jsoo_a: ok\n");
+  caml_ml_output(2, s, 0, caml_ml_string_length(s));
+  return 42
 }
+
+


### PR DESCRIPTION
Quick hack to make it possible to include some JavaScript files when compiling an OCaml library.

For now, one has to pass the `--linkall` and `--no-runtime` flags:
```
js_of_ocaml --linkall --no-runtime runtime.js library.cma
```

At the moment, the generated code uses some ECMAScript 6 features.


Trying to address https://github.com/ocsigen/js_of_ocaml/issues/1508