### PR TITLE
Remove spurious newline when outputing uncaught exception

### DIFF
--- a/compiler/tests-compiler/error.ml
+++ b/compiler/tests-compiler/error.ml
@@ -32,7 +32,6 @@ let%expect_test "uncaugh error" =
     {|
     Fatal error: exception Not_found
 
-
     process exited with error code 2
      %{NODE} test.js |}];
   compile_and_run_bytecode prog;
@@ -57,7 +56,6 @@ let _ = raise C |}
     {|
     Fatal error: exception Test.C
 
-
     process exited with error code 2
      %{NODE} test.js |}];
   let prog =
@@ -74,7 +72,6 @@ let _ = raise (D(2,"test",43L))
     {|
     Fatal error: exception Test.D(2, "test", _)
 
-
     process exited with error code 2
      %{NODE} test.js |}];
   let prog =
@@ -89,7 +86,6 @@ let _ = assert false |}
     {|
     Fatal error: exception Assert_failure("test.ml", 4, 8)
 
-
     process exited with error code 2
      %{NODE} test.js |}];
   let prog =
@@ -103,7 +99,6 @@ let () = Callback.register "Printexc.handle_uncaught_exception" null
   [%expect
     {|
     Fatal error: exception Match_failure("test.ml", 4, 33)
-
 
     process exited with error code 2
      %{NODE} test.js |}];

--- a/compiler/tests-jsoo/bin/error1-unregister.expected
+++ b/compiler/tests-jsoo/bin/error1-unregister.expected
@@ -1,2 +1,1 @@
 Fatal error: exception Dune__exe__Error1.D(2, "test", _)
-

--- a/compiler/tests-jsoo/bin/error2-unregister.expected
+++ b/compiler/tests-jsoo/bin/error2-unregister.expected
@@ -1,2 +1,1 @@
 Fatal error: exception Match_failure("compiler/tests-jsoo/bin/error2.ml", 13, 2)
-

--- a/compiler/tests-ocaml/lib-effects/unhandled_unlinked.reference
+++ b/compiler/tests-ocaml/lib-effects/unhandled_unlinked.reference
@@ -1,2 +1,1 @@
 Fatal error: exception Effect.Unhandled
-

--- a/runtime/sys.js
+++ b/runtime/sys.js
@@ -90,7 +90,7 @@ function caml_fatal_uncaught_exception(err){
       var msg = caml_format_exception(err);
       var at_exit = caml_named_value("Pervasives.do_at_exit");
       if(at_exit) caml_callback(at_exit, [0]);
-      console.error("Fatal error: exception " + msg + "\n");
+      console.error("Fatal error: exception " + msg);
       if(err.js_error) throw err.js_error;
     }
   }


### PR DESCRIPTION
A newline is already added by `console.error`.