### PR TITLE
fix: add missing return for `stat` Unix functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 * Runtime: fix Dom_html.onIE (#1493)
 * Runtime: add conversion functions + strict equality for compatibility with Wasm_of_ocaml (#1492)
 * Runtime: Dynlink should be able to find symbols in jsoo_runtime #1517
+* Runtime: fix Unix.lstat, Unix.LargeFile.lstat (#1519)
 * Compiler: fix global flow analysis (#1494)
 * Compiler: fix js parser/printer wrt async functions (#1515)
 

--- a/runtime/unix.js
+++ b/runtime/unix.js
@@ -135,6 +135,7 @@ function caml_unix_stat(name) {
 function caml_unix_stat_64(name) {
   var r = caml_unix_stat(name);
   r[9] = caml_int64_of_int32(r[9]);
+  return r;
 }
 
 //Provides: caml_unix_lstat

--- a/runtime/unix.js
+++ b/runtime/unix.js
@@ -154,6 +154,7 @@ function caml_unix_lstat(name) {
 function caml_unix_lstat_64(name) {
   var r = caml_unix_lstat(name);
   r[9] = caml_int64_of_int32(r[9]);
+  return r;
 }
 
 //Provides: caml_unix_mkdir


### PR DESCRIPTION
## What:
This PR fixes the JS implementation of the `caml_unix_lstat_64`and `caml_unix_stat_64` calls.

## Why:
Per the OCaml documentation (https://github.com/ocaml/ocaml/blob/f9371a2ea294f75da793451ef7be5dc69aad6b53/otherlibs/unix/unix_unix.ml#L388), the `caml_unix_lstat_64` external function has type signature `string -> stats`. In particular, it is meant to return a value of type `stats`.

In the Js_of_ocaml implementation of that external function, however, it returns nothing at all. This results in an `undefined`, which will then proceed to wreak havoc.

`caml_unix_stat_64` is similar.

## How:
Added back the `return` for the `r` object.