### PR TITLE
Some more fix to the js parser.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,16 @@
 # 5.5.2 (2023-12-01) - Lille
 
 ## Features/Changes
+* Compiler: try to preserve clorures ordering between ml and js
+
+## Bug fixes
+* Compiler: js-parser now accept all the line terminators defined in the spec
+* Compiler: js-parser: fix support for LHS assignment target
+* Compiler: js-parser: fix parser of default export
+
+# 5.5.2 (2023-12-01) - Lille
+
+## Features/Changes
 * Compiler: global dead code elimination (Micah Cantor, #1503)
 * Compiler: change control-flow compilation strategy (#1496)
 * Compiler: loop no longer absorb the whole continuation

--- a/compiler/lib/javascript.mli
+++ b/compiler/lib/javascript.mli
@@ -185,7 +185,7 @@ and property_name =
 and expression =
   | ESeq of expression * expression
   | ECond of expression * expression * expression
-  | EAssignTarget of binding_pattern
+  | EAssignTarget of assignment_target
   (* EAssignTarget is used on the LHS of assignment and in for-loops.
      for({name} in o);
      for([fst] in o);
@@ -334,6 +334,22 @@ and binding_pattern =
   | ObjectBinding of (binding_property, binding_ident) list_with_rest
   | ArrayBinding of (binding_element option, binding) list_with_rest
 
+and object_target_elt =
+  | TargetPropertyId of ident * initialiser option
+  | TargetProperty of property_name * expression
+  | TargetPropertySpread of expression
+  | TargetPropertyMethod of property_name * method_
+
+and array_target_elt =
+  | TargetElementId of ident * initialiser option
+  | TargetElementHole
+  | TargetElement of expression
+  | TargetElementSpread of expression
+
+and assignment_target =
+  | ObjectTarget of object_target_elt list
+  | ArrayTarget of array_target_elt list
+
 and binding_ident = ident
 
 and binding_property =
@@ -424,4 +440,4 @@ val early_error : ?reason:string -> Parse_info.t -> early_error
 
 val fun_ : ident list -> statement_list -> location -> function_declaration
 
-val assignment_pattern_of_expr : binop option -> expression -> binding_pattern option
+val assignment_target_of_expr : binop option -> expression -> expression

--- a/compiler/lib/js_output.ml
+++ b/compiler/lib/js_output.ml
@@ -303,8 +303,8 @@ struct
       | ESeq (e, _) -> Prec.(l <= Expression) && traverse Expression e
       | ECond (e, _, _) ->
           Prec.(l <= ConditionalExpression) && traverse ShortCircuitExpression e
-      | EAssignTarget (ObjectBinding _) -> obj
-      | EAssignTarget (ArrayBinding _) -> false
+      | EAssignTarget (ObjectTarget _) -> obj
+      | EAssignTarget (ArrayTarget _) -> false
       | EBin (op, e, _) ->
           let out, lft, _rght = op_prec op in
           Prec.(l <= out) && traverse lft e
@@ -697,7 +697,56 @@ struct
         if Prec.(l > out) then PP.string f ")";
         PP.end_group f;
         PP.end_group f
-    | EAssignTarget p -> pattern f p
+    | EAssignTarget t -> (
+        let property f p =
+          match p with
+          | TargetPropertyId (id, None) -> ident f id
+          | TargetPropertyId (id, Some (e, _)) ->
+              ident f id;
+              PP.space f;
+              PP.string f "=";
+              PP.space f;
+              expression AssignementExpression f e
+          | TargetProperty (pn, e) ->
+              PP.start_group f 0;
+              property_name f pn;
+              PP.string f ":";
+              PP.space f;
+              expression AssignementExpression f e;
+              PP.end_group f
+          | TargetPropertySpread e ->
+              PP.string f "...";
+              expression AssignementExpression f e
+          | TargetPropertyMethod (n, m) -> method_ f property_name n m
+        in
+        let element f p =
+          match p with
+          | TargetElementHole -> ()
+          | TargetElementId (id, None) -> ident f id
+          | TargetElementId (id, Some (e, _)) ->
+              ident f id;
+              PP.space f;
+              PP.string f "=";
+              PP.space f;
+              expression AssignementExpression f e
+          | TargetElement e -> expression AssignementExpression f e
+          | TargetElementSpread e ->
+              PP.string f "...";
+              expression AssignementExpression f e
+        in
+        match t with
+        | ObjectTarget list ->
+            PP.start_group f 1;
+            PP.string f "{";
+            comma_list f property list;
+            PP.string f "}";
+            PP.end_group f
+        | ArrayTarget list ->
+            PP.start_group f 1;
+            PP.string f "[";
+            comma_list f element list;
+            PP.string f "]";
+            PP.end_group f)
     | EArr el ->
         PP.start_group f 1;
         PP.string f "[";

--- a/compiler/lib/js_parser.mly
+++ b/compiler/lib/js_parser.mly
@@ -329,6 +329,16 @@ module_specifier:
 (* export *)
 (*----------------------------*)
 
+export_fun_class:
+ | function_expr       { $1 }
+ | class_expr          { $1 }
+ (* es6: *)
+ | generator_expr      { $1 }
+ (* es7: *)
+ | async_function_expr { $1 }
+ | async_generator_expr{ $1 }
+
+
 export_decl:
   | T_EXPORT names=export_clause sc {
     let exception Invalid of Lexing.position in
@@ -364,8 +374,17 @@ export_decl:
       in
       let pos = $symbolstartpos in
       Export (k,pi pos), p pos }
- (* in theory just func/gen/class, no lexical_decl *)
- | T_EXPORT T_DEFAULT e=assignment_expr sc
+ | T_EXPORT T_DEFAULT e=assignment_expr_no_stmt sc
+    {
+      let k = ExportDefaultExpression e in
+      let pos = $symbolstartpos in
+      Export (k,pi pos), p pos }
+ | T_EXPORT T_DEFAULT e=object_literal sc
+    {
+      let k = ExportDefaultExpression e in
+      let pos = $symbolstartpos in
+      Export (k,pi pos), p pos }
+ | T_EXPORT T_DEFAULT e=export_fun_class
     {
       let k = match e with
       | EFun (Some id, decl) ->

--- a/compiler/lib/js_parser.mly
+++ b/compiler/lib/js_parser.mly
@@ -319,8 +319,8 @@ import_specifier:
 
 %inline string_or_ident:
  | T_STRING { `String, fst $1, $symbolstartpos }
- | T_DEFAULT { `Ident, Stdlib.Utf8_string.of_string_exn "default", $symbolstartpos }
  | id { `Ident, $1, $symbolstartpos }
+ | ident_keyword { `Ident, $1, $symbolstartpos }
 
 module_specifier:
   | T_STRING { (fst $1) }

--- a/compiler/lib/js_parser.mly
+++ b/compiler/lib/js_parser.mly
@@ -687,16 +687,14 @@ iteration_stmt:
    { For_statement (Right l, c, incr, st) }
 
  | T_FOR "(" left=left_hand_side_expr T_IN right=expr ")" body=stmt
-   { match assignment_pattern_of_expr None left with
-      | None -> ForIn_statement (Left left, right, body)
-      | Some b -> ForIn_statement (Left (EAssignTarget b), right, body) }
+   { let left = assignment_target_of_expr None left in
+     ForIn_statement (Left left, right, body) }
  | T_FOR "(" left=for_single_variable_decl T_IN right=expr ")" body=stmt
    { ForIn_statement (Right left, right, body) }
 
  | T_FOR "(" left=left_hand_side_expr T_OF right=assignment_expr ")" body=stmt
-    { match assignment_pattern_of_expr None left with
-      | None -> ForOf_statement (Left left, right, body)
-      | Some b -> ForOf_statement (Left (EAssignTarget b), right, body) }
+    { let left = assignment_target_of_expr None left in
+      ForOf_statement (Left left, right, body) }
  | T_FOR "(" left=for_single_variable_decl T_OF right=assignment_expr ")" body=stmt
    { ForOf_statement (Right left, right, body) }
 
@@ -765,9 +763,8 @@ assignment_expr:
  | conditional_expr(d1) { $1 }
  | e1=left_hand_side_expr_(d1) op=assignment_operator e2=assignment_expr
     {
-      match assignment_pattern_of_expr (Some op) e1 with
-        | None -> EBin (op, e1, e2)
-        | Some pat -> EBin (op, EAssignTarget pat, e2)
+      let e1 = assignment_target_of_expr (Some op) e1 in
+      EBin (op, e1, e2)
     }
  | arrow_function { $1 }
  | async_arrow_function { $1 }
@@ -1076,9 +1073,8 @@ assignment_expr_no_in:
  | conditional_expr_no_in { $1 }
  | e1=left_hand_side_expr_(d1) op=assignment_operator e2=assignment_expr_no_in
     {
-      match assignment_pattern_of_expr (Some op) e1 with
-        | None -> EBin (op, e1, e2)
-        | Some pat -> EBin (op, EAssignTarget pat, e2)
+      let e1 = assignment_target_of_expr (Some op) e1 in
+      EBin (op, e1, e2)
     }
 
 conditional_expr_no_in:
@@ -1119,9 +1115,8 @@ assignment_expr_no_stmt:
  | conditional_expr(primary_no_stmt) { $1 }
  | e1=left_hand_side_expr_(primary_no_stmt) op=assignment_operator e2=assignment_expr
     {
-      match assignment_pattern_of_expr (Some op) e1 with
-      | None -> EBin (op, e1, e2)
-      | Some pat -> EBin (op, EAssignTarget pat, e2)
+      let e1 = assignment_target_of_expr (Some op) e1 in
+      EBin (op, e1, e2)
     }
  (* es6: *)
  | arrow_function { $1 }
@@ -1145,9 +1140,8 @@ assignment_expr_for_consise_body:
  | conditional_expr(primary_for_consise_body) { $1 }
  | e1=left_hand_side_expr_(primary_for_consise_body) op=assignment_operator e2=assignment_expr
     {
-      match assignment_pattern_of_expr (Some op) e1 with
-      | None -> EBin (op, e1, e2)
-      | Some pat -> EBin (op, EAssignTarget pat, e2)
+      let e1 = assignment_target_of_expr (Some op) e1 in
+      EBin (op, e1, e2)
     }
  (* es6: *)
  | arrow_function { $1 }

--- a/compiler/lib/js_parser.mly
+++ b/compiler/lib/js_parser.mly
@@ -468,10 +468,7 @@ object_binding_pattern:
     { ObjectBinding {list=l;rest= Some r} }
 
 binding_property:
-  | i=ident e=initializer_? { let id = match i with
-                                   | S { name; _ } -> name
-                                   | _ -> assert false in
-                           Prop_binding (PNI id, (BindingIdent i, e)) }
+  | i=ident e=initializer_? { Prop_ident (i, e) }
   | pn=property_name ":" e=binding_element { Prop_binding (pn, e) }
 
 binding_property_rest:

--- a/compiler/tests-compiler/js_parser_printer.ml
+++ b/compiler/tests-compiler/js_parser_printer.ml
@@ -437,22 +437,19 @@ let%expect_test "assignment pattern" =
 
   [%expect
     {|
-     /*<<fake:2:4>>*/ var x, y, rest;
-     /*<<fake:3:4>>*/  /*<<fake:3:14>>*/ var [x, y] = [1, 2];
-     /*<<fake:4:4>>*/  /*<<fake:4:22>>*/ var [x, y, ...rest] = [1, 2, ...o];
-     /*<<fake:6:4>>*/  /*<<fake:6:14>>*/ var {x: x, y: y} = {x: 1, y: 2};
-     /*<<fake:7:4>>*/  /*<<fake:7:22>>*/ var
-     {x: x, y: y, ...rest} = {x: 1, y: 2, ...o};
-     /*<<fake:9:4>>*/ [x, y] = [1, 2];
-     /*<<fake:10:4>>*/ [x, y, ...rest] = [1, 2];
-     /*<<fake:12:4>>*/ ({x, y} = {x: 1, y: 2});
-     /*<<fake:13:4>>*/ ({x, y, ...rest} = {x: 1, y: 2});
-     /*<<fake:15:4>>*/ for
-    ([a, b, {c, d =  /*<<fake:15:17>>*/ e, [f]: [g, h, a, i, j]}] in 3)
-      /*<<fake:15:43>>*/ ;
-     /*<<fake:17:4>>*/ for
-    ([a, b, {c, d =  /*<<fake:17:17>>*/ e, [f]: [g, h, a, i, j]}] of 3)
-      /*<<fake:17:43>>*/ ; |}]
+    /*<<fake:2:4>>*/ var x, y, rest;
+    /*<<fake:3:4>>*/  /*<<fake:3:14>>*/ var [x, y] = [1, 2];
+    /*<<fake:4:4>>*/  /*<<fake:4:22>>*/ var [x, y, ...rest] = [1, 2, ...o];
+    /*<<fake:6:4>>*/  /*<<fake:6:14>>*/ var {x, y} = {x: 1, y: 2};
+    /*<<fake:7:4>>*/  /*<<fake:7:22>>*/ var {x, y, ...rest} = {x: 1, y: 2, ...o};
+    /*<<fake:9:4>>*/ [x, y] = [1, 2];
+    /*<<fake:10:4>>*/ [x, y, ...rest] = [1, 2];
+    /*<<fake:12:4>>*/ ({x, y} = {x: 1, y: 2});
+    /*<<fake:13:4>>*/ ({x, y, ...rest} = {x: 1, y: 2});
+    /*<<fake:15:4>>*/ for([a, b, {c, d = e, [f]: [g, h, a, i, j]}] in 3)
+     /*<<fake:15:43>>*/ ;
+    /*<<fake:17:4>>*/ for([a, b, {c, d = e, [f]: [g, h, a, i, j]}] of 3)
+     /*<<fake:17:43>>*/ ; |}]
 
 let%expect_test "string template" =
   (* GH#1017 *)
@@ -662,6 +659,22 @@ var e = new (class f {})
   [%expect
     {|
     var e = new f; var e = new f(); var e = new class f{}; var e = new class f{}; |}]
+
+let%expect_test "assignment targets" =
+  print
+    ~debuginfo:false
+    ~compact:false
+    ~report:true
+    {|
+ [a,b,c, {a,b}] = [];
+ [[[x = 5]], {a,b}, ...rest] = [];
+ ({a: [a,b] = f(), b = 3, ...rest} = {});
+|};
+  [%expect
+    {|
+    [a, b, c, {a, b}] = [];
+    [[[x = 5]], {a, b}, ...rest] = [];
+    ({a: [a, b] = f(), b = 3, ...rest} = {}); |}]
 
 let%expect_test "error reporting" =
   (try

--- a/compiler/tests-compiler/scopes.ml
+++ b/compiler/tests-compiler/scopes.ml
@@ -541,10 +541,9 @@ export default function* () { /* … */ }
     $ cat "test.min.js"
       1: export function* generatorFunctionName(){} |}];
   t {| export const { name1, name2: bar } = o; |};
-  [%expect
-    {|
+  [%expect {|
     $ cat "test.min.js"
-      1: export const {name1: name1, name2: bar} = o; |}];
+      1: export const {name1, name2: bar} = o; |}];
   t {| export const [ name1, name2 ] = array; |};
   [%expect {|
     $ cat "test.min.js"

--- a/runtime/zstd.js
+++ b/runtime/zstd.js
@@ -669,11 +669,3 @@ function caml_zstd_initialize(unit) {
 //Version: < 5.1.1
 //Requires: zstd_decompress
 var caml_decompress_input = zstd_decompress;
-
-
-//Provides: caml_compression_available
-//Requires: caml_decompress_input
-//Version: >= 5.1.1
-function caml_compression_available() {
-  return caml_decompress_input ? 1 : 0;
-}


### PR DESCRIPTION
Using tests available in https://github.com/tc39/test262-parser-tests
We now check that we can parse as much as `node` in strict mode.

- Accept more line separator as it affect automatic semi-colon insertion
- Fix assignment target on the LHS
- Fix default export of function and class declaration  

```
$ dune runtest compiler/tests-js-parser/
Summary:                                 
  skip : 90
  fail : 0
  pass : 1893
```