### PR TITLE
Compiler: fix toplevel with globaldeacode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,9 @@
 * Compiler: no longer rely on IIFE for scoping variable inside loops
 * Lib: add ellipse to canvasRenderingContext2D (@FayCarsons, #1555)
 
+## Bug fixes
+* Compiler: fix global dead code elimination in a toplevel context
+
 # 5.6.0 (2024-01-02) - Lille
 
 ## Features/Changes

--- a/compiler/lib/global_deadcode.ml
+++ b/compiler/lib/global_deadcode.ml
@@ -246,6 +246,15 @@ let liveness prog pure_funs (global_info : Global_flow.info) =
     | Stop | Branch _ | Poptrap _ | Pushtrap _ -> ()
   in
   Addr.Map.iter (fun _ block -> live_block block) prog.blocks;
+  Code.traverse
+    { Code.fold = Code.fold_children }
+    (fun pc () ->
+      match Addr.Map.find pc prog.blocks with
+      | { branch = Return x, _; _ } -> add_top x
+      | _ -> ())
+    prog.start
+    prog.blocks
+    ();
   live_vars
 
 (* Returns the set of variables given a table of variables. *)

--- a/compiler/tests-toplevel/test_toplevel.ml
+++ b/compiler/tests-toplevel/test_toplevel.ml
@@ -1,6 +1,7 @@
 let () =
   let content = {|
 let () = print_endline "hello";;
+1+1;;
 1+;;
 Missing_module.f;;
 |} in
@@ -12,10 +13,10 @@ Missing_module.f;;
     try
       Location.reset ();
       let phr = !Toploop.parse_toplevel_phrase lexbuf in
-      if not (Toploop.execute_phrase true Format.std_formatter phr) then raise Exit
+      let res = Toploop.execute_phrase true Format.std_formatter phr in
+      flush_all ();
+      if not res then raise Exit
     with
-    | End_of_file ->
-        flush_all ();
-        exit 0
+    | End_of_file -> exit 0
     | x -> Location.report_exception Format.std_formatter x
   done

--- a/compiler/tests-toplevel/test_toplevel.reference
+++ b/compiler/tests-toplevel/test_toplevel.reference
@@ -1,4 +1,5 @@
 hello
+- : int = 2
 Line 4, characters 2-4:
 Error: Syntax error
 Line 5, characters 0-16:

--- a/compiler/tests-toplevel/test_toplevel.reference
+++ b/compiler/tests-toplevel/test_toplevel.reference
@@ -1,5 +1,5 @@
 hello
-Line 3, characters 2-4:
+Line 4, characters 2-4:
 Error: Syntax error
-Line 4, characters 0-16:
+Line 5, characters 0-16:
 Error: Unbound module Missing_module


### PR DESCRIPTION
Bug introduced in https://github.com/ocsigen/js_of_ocaml/pull/1503

When using the toplevel and evaluating an expression. The corresponding bytecode received by jsoo look like a function body. In particular, it contains `Return` instructions returning the evaluated expression. The global DCE think that these returned values are unused and removes them. The PR marks all values returned at "toplevel" as escaping.

cc @micahcantor @OlivierNicole 