### PR TITLE
Explicitly void unused c variable

### DIFF
--- a/compiler/tests-jsoo/flush_stubs.c
+++ b/compiler/tests-jsoo/flush_stubs.c
@@ -4,6 +4,7 @@
 #include "caml/memory.h"
 
 CAMLprim value flush_stdout_stderr (value unit) {
+  (void)unit;
   CAMLparam0 ();   /* v is ignored */
   fflush(stderr);
   fflush(stdout);


### PR DESCRIPTION
When importing jsoo into a project where the c compiler errors on warnings, this becomes problematic. Since void is a noop, this seems like a reasonable addition to upstream and make this file more portable.