### PR TITLE
Compiler: only flush the necessary env for closure 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# ?? (2024-??) - ??
+
+## Features/Changes
+* Compiler: only flush the necessary env for closures (#1568)
+
 # 5.7.0 (2024-02-16) - Lille
 
 ## Features/Changes

--- a/compiler/lib/generate.ml
+++ b/compiler/lib/generate.ml
@@ -1397,7 +1397,7 @@ and translate_instrs_rev (ctx : Ctx.t) expr_queue instrs acc_rev muts_map : _ * 
                  | Some x' -> x' ))
       in
       let muts_map =
-        List.fold_left muts_map_l ~init:Var.Map.empty ~f:(fun acc (x, x') ->
+        List.fold_left muts_map_l ~init:old_muts_map ~f:(fun acc (x, x') ->
             Var.Map.add x x' acc)
       in
       let fvs =

--- a/compiler/lib/structure.mli
+++ b/compiler/lib/structure.mli
@@ -11,7 +11,7 @@ val is_backward : t -> Addr.t -> Addr.t -> bool
 
 val is_forward : t -> Addr.t -> Addr.t -> bool
 
-val build_graph : block Addr.Map.t -> Code.Var.Set.t Code.Addr.Map.t -> Addr.t -> t
+val build_graph : block Addr.Map.t -> Addr.t -> t
 
 val dominator_tree : t -> graph
 

--- a/compiler/tests-compiler/direct_calls.ml
+++ b/compiler/tests-compiler/direct_calls.ml
@@ -58,17 +58,14 @@ let%expect_test "direct calls without --enable effects" =
     {|
     function test1(param){
      function f(g, x){return caml_call1(g, x);}
-     var _d_ = 7;
-     f(function(x){return x + 1 | 0;}, _d_);
-     var _e_ = 4.;
-     f(function(x){return x * 2.;}, _e_);
+     f(function(x){return x + 1 | 0;}, 7);
+     f(function(x){return x * 2.;}, 4.);
      return 0;
     }
     //end
     function test2(param){
      function f(g, x){return caml_call1(g, x);}
-     var _c_ = 7;
-     f(function(x){return x + 1 | 0;}, _c_);
+     f(function(x){return x + 1 | 0;}, 7);
      f(function(x){return caml_call2(Stdlib[28], x, cst_a$0);}, cst_a);
      return 0;
     }
@@ -138,26 +135,25 @@ let%expect_test "direct calls with --enable effects" =
     //end
     function test2(param, cont){
      function f(g, x, cont){return caml_cps_exact_call2(g, x, cont);}
-     var _f_ = 7;
      return caml_cps_exact_call3
              (f,
               function(x, cont){return cont(undef);},
-              _f_,
-              function(_g_){
+              7,
+              function(_d_){
                return caml_cps_exact_call3
                        (f,
                         function(x, cont){
                          return caml_cps_call3(Stdlib[28], x, cst_a$0, cont);
                         },
                         cst_a,
-                        function(_h_){return cont(0);});
+                        function(_e_){return cont(0);});
               });
     }
     //end
     function test3(x, cont){
      function F(symbol){function f(x){return x + 1 | 0;} return [0, f];}
-     var M1 = F(undef), M2 = F(undef), _e_ = M2[1].call(null, 2);
-     return cont([0, M1[1].call(null, 1), _e_]);
+     var M1 = F(undef), M2 = F(undef), _c_ = M2[1].call(null, 2);
+     return cont([0, M1[1].call(null, 1), _c_]);
     }
     //end
     function test4(x, cont){
@@ -165,10 +161,10 @@ let%expect_test "direct calls with --enable effects" =
       function f(x, cont){return caml_cps_call3(Stdlib_Printf[2], _a_, x, cont);}
       return [0, f];
      }
-     var M1 = F(undef), M2 = F(undef), _b_ = 1, _c_ = M1[1];
+     var M1 = F(undef), M2 = F(undef);
      return caml_cps_exact_call2
-             (_c_,
-              _b_,
-              function(_d_){return caml_cps_exact_call2(M2[1], 2, cont);});
+             (M1[1],
+              1,
+              function(_b_){return caml_cps_exact_call2(M2[1], 2, cont);});
     }
     //end |}]

--- a/compiler/tests-compiler/effects.ml
+++ b/compiler/tests-compiler/effects.ml
@@ -43,28 +43,21 @@ let fff () =
   [%expect
     {|
     function fff(param, cont){
-     var
-      _b_ =
-        [0,
-         function(e, cont){
-          return e === E
-                  ? cont([0, function(k, cont){return cont(11);}])
-                  : cont(0);
-         }],
-      _c_ = 10;
-     function _d_(x, cont){return cont(x);}
-     var _e_ = Stdlib_Effect[3][5];
      return caml_cps_call4
-             (_e_,
-              _d_,
-              _c_,
-              _b_,
-              function(_f_){
-               var _g_ = Stdlib_Printf[2];
+             (Stdlib_Effect[3][5],
+              function(x, cont){return cont(x);},
+              10,
+              [0,
+               function(e, cont){
+                return e === E
+                        ? cont([0, function(k, cont){return cont(11);}])
+                        : cont(0);
+               }],
+              function(_b_){
                return caml_cps_call2
-                       (_g_,
+                       (Stdlib_Printf[2],
                         _a_,
-                        function(_h_){return caml_cps_call2(_h_, _f_, cont);});
+                        function(_c_){return caml_cps_call2(_c_, _b_, cont);});
               });
     }
     //end |}]

--- a/compiler/tests-compiler/effects_continuations.ml
+++ b/compiler/tests-compiler/effects_continuations.ml
@@ -103,103 +103,96 @@ let%expect_test "test-compiler/lib-effects/test1.ml" =
     {|
 
     function exceptions(s, cont){
-     try{var _z_ = runtime.caml_int_of_string(s), n = _z_;}
-     catch(_D_){
-      var _u_ = caml_wrap_exception(_D_);
-      if(_u_[1] !== Stdlib[7]){
+     try{var _t_ = runtime.caml_int_of_string(s), n = _t_;}
+     catch(_x_){
+      var _p_ = caml_wrap_exception(_x_);
+      if(_p_[1] !== Stdlib[7]){
        var raise$1 = caml_pop_trap();
-       return raise$1(caml_maybe_attach_backtrace(_u_, 0));
+       return raise$1(caml_maybe_attach_backtrace(_p_, 0));
       }
       var n = 0;
      }
      try{
       if(caml_string_equal(s, cst$0))
        throw caml_maybe_attach_backtrace(Stdlib[8], 1);
-      var _y_ = 7, m = _y_;
+      var _s_ = 7, m = _s_;
      }
-     catch(_C_){
-      var _v_ = caml_wrap_exception(_C_);
-      if(_v_ !== Stdlib[8]){
+     catch(_w_){
+      var _q_ = caml_wrap_exception(_w_);
+      if(_q_ !== Stdlib[8]){
        var raise$0 = caml_pop_trap();
-       return raise$0(caml_maybe_attach_backtrace(_v_, 0));
+       return raise$0(caml_maybe_attach_backtrace(_q_, 0));
       }
       var m = 0;
      }
      runtime.caml_push_trap
-      (function(_B_){
-        if(_B_ === Stdlib[8]) return cont(0);
+      (function(_v_){
+        if(_v_ === Stdlib[8]) return cont(0);
         var raise = caml_pop_trap();
-        return raise(caml_maybe_attach_backtrace(_B_, 0));
+        return raise(caml_maybe_attach_backtrace(_v_, 0));
        });
-     if(caml_string_equal(s, cst)){
-      var _w_ = Stdlib[8], raise = caml_pop_trap();
-      return raise(caml_maybe_attach_backtrace(_w_, 1));
-     }
-     var _x_ = Stdlib[79];
-     return caml_cps_call2
-             (_x_,
-              cst_toto,
-              function(_A_){caml_pop_trap(); return cont([0, [0, _A_, n, m]]);});
+     if(! caml_string_equal(s, cst))
+      return caml_cps_call2
+              (Stdlib[79],
+               cst_toto,
+               function(_u_){caml_pop_trap(); return cont([0, [0, _u_, n, m]]);});
+     var _r_ = Stdlib[8], raise = caml_pop_trap();
+     return raise(caml_maybe_attach_backtrace(_r_, 1));
     }
     //end
     function cond1(b, cont){
-     function _t_(ic){return cont([0, ic, 7]);}
+     function _o_(ic){return cont([0, ic, 7]);}
      return b
-             ? caml_cps_call2(Stdlib[79], cst_toto$0, _t_)
-             : caml_cps_call2(Stdlib[79], cst_titi, _t_);
+             ? caml_cps_call2(Stdlib[79], cst_toto$0, _o_)
+             : caml_cps_call2(Stdlib[79], cst_titi, _o_);
     }
     //end
     function cond2(b, cont){
-     function _r_(_s_){return cont(7);}
+     function _m_(_n_){return cont(7);}
      return b
-             ? caml_cps_call2(Stdlib_Printf[3], _a_, _r_)
-             : caml_cps_call2(Stdlib_Printf[3], _b_, _r_);
+             ? caml_cps_call2(Stdlib_Printf[3], _a_, _m_)
+             : caml_cps_call2(Stdlib_Printf[3], _b_, _m_);
     }
     //end
     function cond3(b, cont){
      var x = [0, 0];
-     function _p_(_q_){return cont(x[1]);}
-     return b ? (x[1] = 1, _p_(0)) : caml_cps_call2(Stdlib_Printf[3], _c_, _p_);
+     function _k_(_l_){return cont(x[1]);}
+     return b ? (x[1] = 1, _k_(0)) : caml_cps_call2(Stdlib_Printf[3], _c_, _k_);
     }
     //end
     function loop1(b, cont){
-     var _l_ = Stdlib[79];
      return caml_cps_call2
-             (_l_,
+             (Stdlib[79],
               cst_static_examples_ml,
               function(ic){
-               function _m_(_o_){
-                var _n_ = Stdlib[83];
+               function _i_(_j_){
                 return caml_cps_call2
-                        (_n_,
+                        (Stdlib[83],
                          ic,
                          function(line){
                           return b
-                                  ? caml_cps_call2(Stdlib[53], line, _m_)
-                                  : caml_cps_exact_call1(_m_, 0);
+                                  ? caml_cps_call2(Stdlib[53], line, _i_)
+                                  : caml_cps_exact_call1(_i_, 0);
                          });
                }
-               return _m_(0);
+               return _i_(0);
               });
     }
     //end
     function loop2(param, cont){
-     var _g_ = Stdlib[79];
      return caml_cps_call2
-             (_g_,
+             (Stdlib[79],
               cst_static_examples_ml$0,
               function(ic){
-               var _h_ = Stdlib_Printf[3];
-               function _i_(_k_){
-                var _j_ = Stdlib[83];
+               function _g_(_h_){
                 return caml_cps_call2
-                        (_j_,
+                        (Stdlib[83],
                          ic,
                          function(line){
-                          return caml_cps_call2(Stdlib[53], line, _i_);
+                          return caml_cps_call2(Stdlib[53], line, _g_);
                          });
                }
-               return caml_cps_call2(_h_, _d_, _i_);
+               return caml_cps_call2(Stdlib_Printf[3], _d_, _g_);
               });
     }
     //end

--- a/compiler/tests-compiler/effects_exceptions.ml
+++ b/compiler/tests-compiler/effects_exceptions.ml
@@ -57,43 +57,41 @@ let%expect_test "test-compiler/lib-effects/test1.ml" =
     {|
 
     function exceptions(s, cont){
-     try{var _n_ = runtime.caml_int_of_string(s), n = _n_;}
-     catch(_r_){
-      var _i_ = caml_wrap_exception(_r_);
-      if(_i_[1] !== Stdlib[7]){
+     try{var _k_ = runtime.caml_int_of_string(s), n = _k_;}
+     catch(_o_){
+      var _g_ = caml_wrap_exception(_o_);
+      if(_g_[1] !== Stdlib[7]){
        var raise$1 = caml_pop_trap();
-       return raise$1(caml_maybe_attach_backtrace(_i_, 0));
+       return raise$1(caml_maybe_attach_backtrace(_g_, 0));
       }
       var n = 0;
      }
      try{
       if(caml_string_equal(s, cst$0))
        throw caml_maybe_attach_backtrace(Stdlib[8], 1);
-      var _m_ = 7, m = _m_;
+      var _j_ = 7, m = _j_;
      }
-     catch(_q_){
-      var _j_ = caml_wrap_exception(_q_);
-      if(_j_ !== Stdlib[8]){
+     catch(_n_){
+      var _h_ = caml_wrap_exception(_n_);
+      if(_h_ !== Stdlib[8]){
        var raise$0 = caml_pop_trap();
-       return raise$0(caml_maybe_attach_backtrace(_j_, 0));
+       return raise$0(caml_maybe_attach_backtrace(_h_, 0));
       }
       var m = 0;
      }
      caml_push_trap
-      (function(_p_){
-        if(_p_ === Stdlib[8]) return cont(0);
+      (function(_m_){
+        if(_m_ === Stdlib[8]) return cont(0);
         var raise = caml_pop_trap();
-        return raise(caml_maybe_attach_backtrace(_p_, 0));
+        return raise(caml_maybe_attach_backtrace(_m_, 0));
        });
-     if(caml_string_equal(s, cst)){
-      var _k_ = Stdlib[8], raise = caml_pop_trap();
-      return raise(caml_maybe_attach_backtrace(_k_, 1));
-     }
-     var _l_ = Stdlib[79];
-     return caml_cps_call2
-             (_l_,
-              cst_toto,
-              function(_o_){caml_pop_trap(); return cont([0, [0, _o_, n, m]]);});
+     if(! caml_string_equal(s, cst))
+      return caml_cps_call2
+              (Stdlib[79],
+               cst_toto,
+               function(_l_){caml_pop_trap(); return cont([0, [0, _l_, n, m]]);});
+     var _i_ = Stdlib[8], raise = caml_pop_trap();
+     return raise(caml_maybe_attach_backtrace(_i_, 1));
     }
     //end |}];
   print_fun_decl code (Some "handler_is_loop");
@@ -101,15 +99,15 @@ let%expect_test "test-compiler/lib-effects/test1.ml" =
     {|
     function handler_is_loop(f, g, l, cont){
      caml_push_trap
-      (function(_g_){
-        function _h_(l){
+      (function(_e_){
+        function _f_(l){
          return caml_cps_call2
                  (g,
                   l,
                   function(match){
                    if(72330306 <= match[1]){
                     var l = match[2];
-                    return caml_cps_exact_call1(_h_, l);
+                    return caml_cps_exact_call1(_f_, l);
                    }
                    var
                     exn = match[2],
@@ -118,21 +116,18 @@ let%expect_test "test-compiler/lib-effects/test1.ml" =
                    return raise(exn$0);
                   });
         }
-        return _h_(l);
+        return _f_(l);
        });
-     var _e_ = 0;
      return caml_cps_call2
-             (f, _e_, function(_f_){caml_pop_trap(); return cont(_f_);});
+             (f, 0, function(_d_){caml_pop_trap(); return cont(_d_);});
     }
     //end |}];
   print_fun_decl code (Some "handler_is_merge_node");
   [%expect
     {|
     function handler_is_merge_node(g, cont){
-     function _b_(s){return caml_cps_call3(Stdlib[28], s, cst_aaa, cont);}
-     caml_push_trap(function(_d_){return _b_(cst$1);});
-     var _a_ = 0;
-     return caml_cps_call2
-             (g, _a_, function(_c_){caml_pop_trap(); return _b_(_c_);});
+     function _a_(s){return caml_cps_call3(Stdlib[28], s, cst_aaa, cont);}
+     caml_push_trap(function(_c_){return _a_(cst$1);});
+     return caml_cps_call2(g, 0, function(_b_){caml_pop_trap(); return _a_(_b_);});
     }
     //end |}]

--- a/compiler/tests-compiler/effects_toplevel.ml
+++ b/compiler/tests-compiler/effects_toplevel.ml
@@ -76,21 +76,20 @@ let%expect_test "test-compiler/lib-effects/test1.ml" =
                   return caml_cps_call2(Stdlib_Printf[2], _a_, cont);
                  }
                  caml_callback(g, [undef]);
-                 var _b_ = 1;
-                 function _c_(i){
+                 function _b_(i){
                   return caml_cps_exact_call2
                           (g,
                            undef,
-                           function(_d_){
-                            var _e_ = i + 1 | 0;
-                            if(5 !== i) return caml_cps_exact_call1(_c_, _e_);
+                           function(_c_){
+                            var _d_ = i + 1 | 0;
+                            if(5 !== i) return caml_cps_exact_call1(_b_, _d_);
                             caml_callback(g, [undef]);
                             var Test = [0];
                             runtime.caml_register_global(2, Test, "Test");
                             return;
                            });
                  }
-                 return _c_(_b_);
+                 return _b_(1);
                 },
                 []);
       }

--- a/compiler/tests-compiler/gh1007.ml
+++ b/compiler/tests-compiler/gh1007.ml
@@ -459,7 +459,7 @@ let ()  = M.run ()
        if(2 < n >>> 0) return 1 - (1 - even(n - 1 | 0));
        switch(n){
          case 0:
-          var f = function(param){return caml_call2(Stdlib_Printf[2], _b_, i$0);};
+          var f = function(param){return caml_call2(Stdlib_Printf[2], _a_, i$0);};
           delayed[1] = [0, f, delayed[1]];
           f(0);
           return 0;
@@ -472,7 +472,7 @@ let ()  = M.run ()
        if(2 < n >>> 0) return 1 - (1 - odd(n - 1 | 0));
        switch(n){
          case 0:
-          var f = function(param){return caml_call2(Stdlib_Printf[2], _c_, i$0);};
+          var f = function(param){return caml_call2(Stdlib_Printf[2], _b_, i$0);};
           delayed[1] = [0, f, delayed[1]];
           f(0);
           return 1;
@@ -482,12 +482,14 @@ let ()  = M.run ()
        }
       }
       if(even(i)) caml_call1(Stdlib[42], cst);
-      var _e_ = i + 1 | 0;
+      var _c_ = i + 1 | 0;
       if(4 === i) break;
-      var i = _e_;
+      var i = _c_;
      }
-     var _d_ = caml_call1(list_rev, delayed[1]);
-     return caml_call2(list_iter, function(f){return caml_call1(f, 0);}, _d_);
+     return caml_call2
+             (list_iter,
+              function(f){return caml_call1(f, 0);},
+              caml_call1(list_rev, delayed[1]));
     }
     //end |}]
 
@@ -570,11 +572,11 @@ let ()  = M.run ()
                   748545554,
                   function(param){
                    function f(param){
-                    return caml_call2(Stdlib_Printf[2], _b_, i$0);
+                    return caml_call2(Stdlib_Printf[2], _a_, i$0);
                    }
                    delayed[1] = [0, f, delayed[1]];
                    f(0);
-                   return _c_;
+                   return _b_;
                   }];
          case 1:
           return [0, 748545554, function(param){return even(0);}];
@@ -590,11 +592,11 @@ let ()  = M.run ()
                   748545554,
                   function(param){
                    function f(param){
-                    return caml_call2(Stdlib_Printf[2], _d_, i$0);
+                    return caml_call2(Stdlib_Printf[2], _c_, i$0);
                    }
                    delayed[1] = [0, f, delayed[1]];
                    f(0);
-                   return _e_;
+                   return _d_;
                   }];
          case 1:
           return [0, 748545554, function(param){return odd(0);}];
@@ -606,11 +608,13 @@ let ()  = M.run ()
        if(759635106 <= param$0[1]) break;
        var f = param$0[2], param$0 = f(0);
       }
-      var _g_ = i + 1 | 0;
+      var _e_ = i + 1 | 0;
       if(4 === i) break;
-      var i = _g_;
+      var i = _e_;
      }
-     var _f_ = caml_call1(list_rev, delayed[1]);
-     return caml_call2(list_iter, function(f){return caml_call1(f, 0);}, _f_);
+     return caml_call2
+             (list_iter,
+              function(f){return caml_call1(f, 0);},
+              caml_call1(list_rev, delayed[1]));
     }
     //end |}]

--- a/compiler/tests-compiler/gh1007.ml
+++ b/compiler/tests-compiler/gh1007.ml
@@ -158,161 +158,167 @@ let ()  = M.myfun M.x
      var x$0 = x;
      for(;;){
       if(! x$0) return 0;
-      var next = x$0[1];
-      function sort(n, l){
-       if(2 === n){
-        if(l){
-         var match = l[2];
-         if(match){
-          var
-           tl = match[2],
-           x2 = match[1],
-           x1 = l[1],
-           s =
-             0 < caml_int_compare(x1, x2)
-              ? [0, x2, [0, x1, 0]]
-              : [0, x1, [0, x2, 0]];
-          return [0, s, tl];
-         }
-        }
-       }
-       else if(3 === n && l){
-        var _d_ = l[2];
-        if(_d_){
-         var match$2 = _d_[2];
-         if(match$2){
-          var
-           tl$1 = match$2[2],
-           x3 = match$2[1],
-           x2$0 = _d_[1],
-           x1$0 = l[1],
-           s$0 =
-             0 < caml_int_compare(x1$0, x2$0)
-              ? 0
-                < caml_int_compare(x1$0, x3)
-                ? 0
-                  < caml_int_compare(x2$0, x3)
-                  ? [0, x3, [0, x2$0, [0, x1$0, 0]]]
-                  : [0, x2$0, [0, x3, [0, x1$0, 0]]]
-                : [0, x2$0, [0, x1$0, [0, x3, 0]]]
-              : 0
-                < caml_int_compare(x2$0, x3)
-                ? 0
-                  < caml_int_compare(x1$0, x3)
-                  ? [0, x3, [0, x1$0, [0, x2$0, 0]]]
-                  : [0, x1$0, [0, x3, [0, x2$0, 0]]]
-                : [0, x1$0, [0, x2$0, [0, x3, 0]]];
-          return [0, s$0, tl$1];
-         }
-        }
-       }
-       var
-        n1 = n >> 1,
-        n2 = n - n1 | 0,
-        match$0 = rev_sort(n1, l),
-        l2$0 = match$0[2],
-        s1 = match$0[1],
-        match$1 = rev_sort(n2, l2$0),
-        tl$0 = match$1[2],
-        s2 = match$1[1],
-        l1 = s1,
-        l2 = s2,
-        accu = 0;
-       for(;;){
-        if(l1){
-         if(l2){
-          var t2 = l2[2], h2 = l2[1], t1 = l1[2], h1 = l1[1];
-          if(0 < caml_int_compare(h1, h2)){
-           var accu$0 = [0, h1, accu], l1 = t1, accu = accu$0;
-           continue;
+      var
+       next = x$0[1],
+       sort =
+         function(n, l){
+          if(2 === n){
+           if(l){
+            var match = l[2];
+            if(match){
+             var
+              tl = match[2],
+              x2 = match[1],
+              x1 = l[1],
+              s =
+                0 < caml_int_compare(x1, x2)
+                 ? [0, x2, [0, x1, 0]]
+                 : [0, x1, [0, x2, 0]];
+             return [0, s, tl];
+            }
+           }
           }
-          var accu$1 = [0, h2, accu], l2 = t2, accu = accu$1;
-          continue;
-         }
-         var _c_ = rev_append(l1, accu);
-        }
-        else
-         var _c_ = rev_append(l2, accu);
-        return [0, _c_, tl$0];
-       }
-      }
-      function rev_sort(n, l){
-       if(2 === n){
-        if(l){
-         var match = l[2];
-         if(match){
-          var
-           tl = match[2],
-           x2 = match[1],
-           x1 = l[1],
-           s =
-             0 < caml_int_compare(x1, x2)
-              ? [0, x1, [0, x2, 0]]
-              : [0, x2, [0, x1, 0]];
-          return [0, s, tl];
-         }
-        }
-       }
-       else if(3 === n && l){
-        var _b_ = l[2];
-        if(_b_){
-         var match$2 = _b_[2];
-         if(match$2){
-          var
-           tl$1 = match$2[2],
-           x3 = match$2[1],
-           x2$0 = _b_[1],
-           x1$0 = l[1],
-           s$0 =
-             0 < caml_int_compare(x1$0, x2$0)
-              ? 0
-                < caml_int_compare(x2$0, x3)
-                ? [0, x1$0, [0, x2$0, [0, x3, 0]]]
-                : 0
-                  < caml_int_compare(x1$0, x3)
-                  ? [0, x1$0, [0, x3, [0, x2$0, 0]]]
-                  : [0, x3, [0, x1$0, [0, x2$0, 0]]]
-              : 0
-                < caml_int_compare(x1$0, x3)
-                ? [0, x2$0, [0, x1$0, [0, x3, 0]]]
-                : 0
-                  < caml_int_compare(x2$0, x3)
-                  ? [0, x2$0, [0, x3, [0, x1$0, 0]]]
-                  : [0, x3, [0, x2$0, [0, x1$0, 0]]];
-          return [0, s$0, tl$1];
-         }
-        }
-       }
-       var
-        n1 = n >> 1,
-        n2 = n - n1 | 0,
-        match$0 = sort(n1, l),
-        l2$0 = match$0[2],
-        s1 = match$0[1],
-        match$1 = sort(n2, l2$0),
-        tl$0 = match$1[2],
-        s2 = match$1[1],
-        l1 = s1,
-        l2 = s2,
-        accu = 0;
-       for(;;){
-        if(l1){
-         if(l2){
-          var t2 = l2[2], h2 = l2[1], t1 = l1[2], h1 = l1[1];
-          if(0 < caml_int_compare(h1, h2)){
-           var accu$0 = [0, h2, accu], l2 = t2, accu = accu$0;
-           continue;
+          else if(3 === n && l){
+           var _d_ = l[2];
+           if(_d_){
+            var match$2 = _d_[2];
+            if(match$2){
+             var
+              tl$1 = match$2[2],
+              x3 = match$2[1],
+              x2$0 = _d_[1],
+              x1$0 = l[1],
+              s$0 =
+                0 < caml_int_compare(x1$0, x2$0)
+                 ? 0
+                   < caml_int_compare(x1$0, x3)
+                   ? 0
+                     < caml_int_compare(x2$0, x3)
+                     ? [0, x3, [0, x2$0, [0, x1$0, 0]]]
+                     : [0, x2$0, [0, x3, [0, x1$0, 0]]]
+                   : [0, x2$0, [0, x1$0, [0, x3, 0]]]
+                 : 0
+                   < caml_int_compare(x2$0, x3)
+                   ? 0
+                     < caml_int_compare(x1$0, x3)
+                     ? [0, x3, [0, x1$0, [0, x2$0, 0]]]
+                     : [0, x1$0, [0, x3, [0, x2$0, 0]]]
+                   : [0, x1$0, [0, x2$0, [0, x3, 0]]];
+             return [0, s$0, tl$1];
+            }
+           }
           }
-          var accu$1 = [0, h1, accu], l1 = t1, accu = accu$1;
-          continue;
-         }
-         var _a_ = rev_append(l1, accu);
-        }
-        else
-         var _a_ = rev_append(l2, accu);
-        return [0, _a_, tl$0];
-       }
-      }
+          var
+           n1 = n >> 1,
+           n2 = n - n1 | 0,
+           match$0 = rev_sort$0(n1, l),
+           l2$0 = match$0[2],
+           s1 = match$0[1],
+           match$1 = rev_sort$0(n2, l2$0),
+           tl$0 = match$1[2],
+           s2 = match$1[1],
+           l1 = s1,
+           l2 = s2,
+           accu = 0;
+          for(;;){
+           if(l1){
+            if(l2){
+             var t2 = l2[2], h2 = l2[1], t1 = l1[2], h1 = l1[1];
+             if(0 < caml_int_compare(h1, h2)){
+              var accu$0 = [0, h1, accu], l1 = t1, accu = accu$0;
+              continue;
+             }
+             var accu$1 = [0, h2, accu], l2 = t2, accu = accu$1;
+             continue;
+            }
+            var _c_ = rev_append(l1, accu);
+           }
+           else
+            var _c_ = rev_append(l2, accu);
+           return [0, _c_, tl$0];
+          }
+         };
+      let sort$0 = sort;
+      var
+       rev_sort =
+         function(n, l){
+          if(2 === n){
+           if(l){
+            var match = l[2];
+            if(match){
+             var
+              tl = match[2],
+              x2 = match[1],
+              x1 = l[1],
+              s =
+                0 < caml_int_compare(x1, x2)
+                 ? [0, x1, [0, x2, 0]]
+                 : [0, x2, [0, x1, 0]];
+             return [0, s, tl];
+            }
+           }
+          }
+          else if(3 === n && l){
+           var _b_ = l[2];
+           if(_b_){
+            var match$2 = _b_[2];
+            if(match$2){
+             var
+              tl$1 = match$2[2],
+              x3 = match$2[1],
+              x2$0 = _b_[1],
+              x1$0 = l[1],
+              s$0 =
+                0 < caml_int_compare(x1$0, x2$0)
+                 ? 0
+                   < caml_int_compare(x2$0, x3)
+                   ? [0, x1$0, [0, x2$0, [0, x3, 0]]]
+                   : 0
+                     < caml_int_compare(x1$0, x3)
+                     ? [0, x1$0, [0, x3, [0, x2$0, 0]]]
+                     : [0, x3, [0, x1$0, [0, x2$0, 0]]]
+                 : 0
+                   < caml_int_compare(x1$0, x3)
+                   ? [0, x2$0, [0, x1$0, [0, x3, 0]]]
+                   : 0
+                     < caml_int_compare(x2$0, x3)
+                     ? [0, x2$0, [0, x3, [0, x1$0, 0]]]
+                     : [0, x3, [0, x2$0, [0, x1$0, 0]]];
+             return [0, s$0, tl$1];
+            }
+           }
+          }
+          var
+           n1 = n >> 1,
+           n2 = n - n1 | 0,
+           match$0 = sort$0(n1, l),
+           l2$0 = match$0[2],
+           s1 = match$0[1],
+           match$1 = sort$0(n2, l2$0),
+           tl$0 = match$1[2],
+           s2 = match$1[1],
+           l1 = s1,
+           l2 = s2,
+           accu = 0;
+          for(;;){
+           if(l1){
+            if(l2){
+             var t2 = l2[2], h2 = l2[1], t1 = l1[2], h1 = l1[1];
+             if(0 < caml_int_compare(h1, h2)){
+              var accu$0 = [0, h2, accu], l2 = t2, accu = accu$0;
+              continue;
+             }
+             var accu$1 = [0, h1, accu], l1 = t1, accu = accu$1;
+             continue;
+            }
+            var _a_ = rev_append(l1, accu);
+           }
+           else
+            var _a_ = rev_append(l2, accu);
+           return [0, _a_, tl$0];
+          }
+         };
+      let rev_sort$0 = rev_sort;
       var len = 0, param = l;
       for(;;){
        if(! param) break;
@@ -361,26 +367,32 @@ let ()  = M.run ()
     function run(param){
      var i = 0;
      for(;;){
-      function odd(n){
-       if(2 < n >>> 0) return 1 - (1 - even(n - 1 | 0));
-       switch(n){
-         case 0:
-          return 0;
-         case 1:
-          return 1 - (1 - even(0));
-         default: return 1 - (1 - even(1));
-       }
-      }
-      function even(n){
-       if(2 < n >>> 0) return 1 - (1 - odd(n - 1 | 0));
-       switch(n){
-         case 0:
-          return 1;
-         case 1:
-          return 1 - (1 - odd(0));
-         default: return 1 - (1 - odd(1));
-       }
-      }
+      var
+       odd =
+         function(n){
+          if(2 < n >>> 0) return 1 - (1 - even$0(n - 1 | 0));
+          switch(n){
+            case 0:
+             return 0;
+            case 1:
+             return 1 - (1 - even$0(0));
+            default: return 1 - (1 - even$0(1));
+          }
+         };
+      let odd$0 = odd;
+      var
+       even =
+         function(n){
+          if(2 < n >>> 0) return 1 - (1 - odd$0(n - 1 | 0));
+          switch(n){
+            case 0:
+             return 1;
+            case 1:
+             return 1 - (1 - odd$0(0));
+            default: return 1 - (1 - odd$0(1));
+          }
+         };
+      let even$0 = even;
       if(even(i)) caml_call1(Stdlib[42], cst);
       var _a_ = i + 1 | 0;
       if(4 === i) return 0;
@@ -455,32 +467,40 @@ let ()  = M.run ()
      var i = 0;
      for(;;){
       let i$0 = i;
-      function odd(n){
-       if(2 < n >>> 0) return 1 - (1 - even(n - 1 | 0));
-       switch(n){
-         case 0:
-          var f = function(param){return caml_call2(Stdlib_Printf[2], _a_, i$0);};
-          delayed[1] = [0, f, delayed[1]];
-          f(0);
-          return 0;
-         case 1:
-          return 1 - (1 - even(0));
-         default: return 1 - (1 - even(1));
-       }
-      }
-      function even(n){
-       if(2 < n >>> 0) return 1 - (1 - odd(n - 1 | 0));
-       switch(n){
-         case 0:
-          var f = function(param){return caml_call2(Stdlib_Printf[2], _b_, i$0);};
-          delayed[1] = [0, f, delayed[1]];
-          f(0);
-          return 1;
-         case 1:
-          return 1 - (1 - odd(0));
-         default: return 1 - (1 - odd(1));
-       }
-      }
+      var
+       odd =
+         function(n){
+          if(2 < n >>> 0) return 1 - (1 - even$0(n - 1 | 0));
+          switch(n){
+            case 0:
+             var
+              f = function(param){return caml_call2(Stdlib_Printf[2], _a_, i$0);};
+             delayed[1] = [0, f, delayed[1]];
+             f(0);
+             return 0;
+            case 1:
+             return 1 - (1 - even$0(0));
+            default: return 1 - (1 - even$0(1));
+          }
+         };
+      let odd$0 = odd;
+      var
+       even =
+         function(n){
+          if(2 < n >>> 0) return 1 - (1 - odd$0(n - 1 | 0));
+          switch(n){
+            case 0:
+             var
+              f = function(param){return caml_call2(Stdlib_Printf[2], _b_, i$0);};
+             delayed[1] = [0, f, delayed[1]];
+             f(0);
+             return 1;
+            case 1:
+             return 1 - (1 - odd$0(0));
+            default: return 1 - (1 - odd$0(1));
+          }
+         };
+      let even$0 = even;
       if(even(i)) caml_call1(Stdlib[42], cst);
       var _c_ = i + 1 | 0;
       if(4 === i) break;
@@ -563,46 +583,52 @@ let ()  = M.run ()
      var i = 0;
      for(;;){
       let i$0 = i;
-      function odd(n){
-       if(2 < n >>> 0)
-        return [0, 748545554, function(param){return even(n - 1 | 0);}];
-       switch(n){
-         case 0:
-          return [0,
-                  748545554,
-                  function(param){
-                   function f(param){
-                    return caml_call2(Stdlib_Printf[2], _a_, i$0);
-                   }
-                   delayed[1] = [0, f, delayed[1]];
-                   f(0);
-                   return _b_;
-                  }];
-         case 1:
-          return [0, 748545554, function(param){return even(0);}];
-         default: return [0, 748545554, function(param){return even(1);}];
-       }
-      }
-      function even(n){
-       if(2 < n >>> 0)
-        return [0, 748545554, function(param){return odd(n - 1 | 0);}];
-       switch(n){
-         case 0:
-          return [0,
-                  748545554,
-                  function(param){
-                   function f(param){
-                    return caml_call2(Stdlib_Printf[2], _c_, i$0);
-                   }
-                   delayed[1] = [0, f, delayed[1]];
-                   f(0);
-                   return _d_;
-                  }];
-         case 1:
-          return [0, 748545554, function(param){return odd(0);}];
-         default: return [0, 748545554, function(param){return odd(1);}];
-       }
-      }
+      var
+       odd =
+         function(n){
+          if(2 < n >>> 0)
+           return [0, 748545554, function(param){return even$0(n - 1 | 0);}];
+          switch(n){
+            case 0:
+             return [0,
+                     748545554,
+                     function(param){
+                      function f(param){
+                       return caml_call2(Stdlib_Printf[2], _a_, i$0);
+                      }
+                      delayed[1] = [0, f, delayed[1]];
+                      f(0);
+                      return _b_;
+                     }];
+            case 1:
+             return [0, 748545554, function(param){return even$0(0);}];
+            default: return [0, 748545554, function(param){return even$0(1);}];
+          }
+         };
+      let odd$0 = odd;
+      var
+       even =
+         function(n){
+          if(2 < n >>> 0)
+           return [0, 748545554, function(param){return odd$0(n - 1 | 0);}];
+          switch(n){
+            case 0:
+             return [0,
+                     748545554,
+                     function(param){
+                      function f(param){
+                       return caml_call2(Stdlib_Printf[2], _c_, i$0);
+                      }
+                      delayed[1] = [0, f, delayed[1]];
+                      f(0);
+                      return _d_;
+                     }];
+            case 1:
+             return [0, 748545554, function(param){return odd$0(0);}];
+            default: return [0, 748545554, function(param){return odd$0(1);}];
+          }
+         };
+      let even$0 = even;
       var param$0 = even(i);
       for(;;){
        if(759635106 <= param$0[1]) break;

--- a/compiler/tests-compiler/gh1007.ml
+++ b/compiler/tests-compiler/gh1007.ml
@@ -237,9 +237,7 @@ let ()  = M.myfun M.x
             var _c_ = rev_append(l2, accu);
            return [0, _c_, tl$0];
           }
-         };
-      let sort$0 = sort;
-      var
+         },
        rev_sort =
          function(n, l){
           if(2 === n){
@@ -318,7 +316,7 @@ let ()  = M.myfun M.x
            return [0, _a_, tl$0];
           }
          };
-      let rev_sort$0 = rev_sort;
+      let sort$0 = sort, rev_sort$0 = rev_sort;
       var len = 0, param = l;
       for(;;){
        if(! param) break;
@@ -378,9 +376,7 @@ let ()  = M.run ()
              return 1 - (1 - even$0(0));
             default: return 1 - (1 - even$0(1));
           }
-         };
-      let odd$0 = odd;
-      var
+         },
        even =
          function(n){
           if(2 < n >>> 0) return 1 - (1 - odd$0(n - 1 | 0));
@@ -392,7 +388,7 @@ let ()  = M.run ()
             default: return 1 - (1 - odd$0(1));
           }
          };
-      let even$0 = even;
+      let odd$0 = odd, even$0 = even;
       if(even(i)) caml_call1(Stdlib[42], cst);
       var _a_ = i + 1 | 0;
       if(4 === i) return 0;
@@ -466,7 +462,6 @@ let ()  = M.run ()
     function run(param){
      var i = 0;
      for(;;){
-      let i$0 = i;
       var
        odd =
          function(n){
@@ -482,9 +477,7 @@ let ()  = M.run ()
              return 1 - (1 - even$0(0));
             default: return 1 - (1 - even$0(1));
           }
-         };
-      let odd$0 = odd;
-      var
+         },
        even =
          function(n){
           if(2 < n >>> 0) return 1 - (1 - odd$0(n - 1 | 0));
@@ -500,7 +493,7 @@ let ()  = M.run ()
             default: return 1 - (1 - odd$0(1));
           }
          };
-      let even$0 = even;
+      let odd$0 = odd, even$0 = even, i$0 = i;
       if(even(i)) caml_call1(Stdlib[42], cst);
       var _c_ = i + 1 | 0;
       if(4 === i) break;
@@ -582,7 +575,6 @@ let ()  = M.run ()
     function run(param){
      var i = 0;
      for(;;){
-      let i$0 = i;
       var
        odd =
          function(n){
@@ -604,9 +596,7 @@ let ()  = M.run ()
              return [0, 748545554, function(param){return even$0(0);}];
             default: return [0, 748545554, function(param){return even$0(1);}];
           }
-         };
-      let odd$0 = odd;
-      var
+         },
        even =
          function(n){
           if(2 < n >>> 0)
@@ -628,7 +618,7 @@ let ()  = M.run ()
             default: return [0, 748545554, function(param){return odd$0(1);}];
           }
          };
-      let even$0 = even;
+      let odd$0 = odd, even$0 = even, i$0 = i;
       var param$0 = even(i);
       for(;;){
        if(759635106 <= param$0[1]) break;

--- a/compiler/tests-compiler/gh1007.ml
+++ b/compiler/tests-compiler/gh1007.ml
@@ -462,6 +462,7 @@ let ()  = M.run ()
     function run(param){
      var i = 0;
      for(;;){
+      let i$0 = i;
       var
        odd =
          function(n){
@@ -493,7 +494,7 @@ let ()  = M.run ()
             default: return 1 - (1 - odd$0(1));
           }
          };
-      let odd$0 = odd, even$0 = even, i$0 = i;
+      let odd$0 = odd, even$0 = even;
       if(even(i)) caml_call1(Stdlib[42], cst);
       var _c_ = i + 1 | 0;
       if(4 === i) break;
@@ -575,6 +576,7 @@ let ()  = M.run ()
     function run(param){
      var i = 0;
      for(;;){
+      let i$0 = i;
       var
        odd =
          function(n){
@@ -618,7 +620,7 @@ let ()  = M.run ()
             default: return [0, 748545554, function(param){return odd$0(1);}];
           }
          };
-      let odd$0 = odd, even$0 = even, i$0 = i;
+      let odd$0 = odd, even$0 = even;
       var param$0 = even(i);
       for(;;){
        if(759635106 <= param$0[1]) break;

--- a/compiler/tests-compiler/gh1320.ml
+++ b/compiler/tests-compiler/gh1320.ml
@@ -47,10 +47,14 @@ let () = myfun ()
      var i = 1;
      for(;;){
       let i$0 = i;
-      function f(x){
-       return 0 === x ? 1 : runtime.caml_mul(i$0, app(g, x - 1 | 0));
-      }
-      function g(x){return app(f, x);}
+      var
+       f =
+         function(x){
+          return 0 === x ? 1 : runtime.caml_mul(i$0, app(g$0, x - 1 | 0));
+         };
+      let f$0 = f;
+      var g = function(x){return app(f$0, x);};
+      let g$0 = g;
       var _b_ = g(i);
       caml_call2(Stdlib_Printf[3], _a_, _b_);
       var _c_ = i + 1 | 0;

--- a/compiler/tests-compiler/gh1320.ml
+++ b/compiler/tests-compiler/gh1320.ml
@@ -46,15 +46,13 @@ let () = myfun ()
     function myfun(param){
      var i = 1;
      for(;;){
-      let i$0 = i;
       var
        f =
          function(x){
           return 0 === x ? 1 : runtime.caml_mul(i$0, app(g$0, x - 1 | 0));
-         };
-      let f$0 = f;
-      var g = function(x){return app(f$0, x);};
-      let g$0 = g;
+         },
+       g = function(x){return app(f$0, x);};
+      let i$0 = i, f$0 = f, g$0 = g;
       var _b_ = g(i);
       caml_call2(Stdlib_Printf[3], _a_, _b_);
       var _c_ = i + 1 | 0;

--- a/compiler/tests-compiler/gh1320.ml
+++ b/compiler/tests-compiler/gh1320.ml
@@ -46,13 +46,14 @@ let () = myfun ()
     function myfun(param){
      var i = 1;
      for(;;){
+      let i$0 = i;
       var
        f =
          function(x){
           return 0 === x ? 1 : runtime.caml_mul(i$0, app(g$0, x - 1 | 0));
          },
        g = function(x){return app(f$0, x);};
-      let i$0 = i, f$0 = f, g$0 = g;
+      let f$0 = f, g$0 = g;
       var _b_ = g(i);
       caml_call2(Stdlib_Printf[3], _a_, _b_);
       var _c_ = i + 1 | 0;

--- a/compiler/tests-compiler/gh1559.ml
+++ b/compiler/tests-compiler/gh1559.ml
@@ -91,11 +91,11 @@ let () = my_ref := 2
        {
         var t = init;
         for(;;){
-         let t$1 = t;
          var
           this_will_be_undefined =
-            function(param){var _c_ = 1 === t$1[1] ? 1 : 0; return _c_ ? 1 : 2;},
-          i = t[1];
+            function(param){var _c_ = 1 === t$1[1] ? 1 : 0; return _c_ ? 1 : 2;};
+         let t$1 = t;
+         var i = t[1];
          if(0 === i){var _a_ = this_will_be_undefined(0); break a;}
          if(1 === i) break;
          var t = t$0;
@@ -198,11 +198,11 @@ let () = my_ref := 2
         {
          var t = init;
          for(;;){
-          let t$1 = t;
           var
            this_will_be_undefined =
-             function(param){var _e_ = 1 === t$1[1] ? 1 : 0; return _e_ ? 1 : 2;},
-           i = t[1];
+             function(param){var _e_ = 1 === t$1[1] ? 1 : 0; return _e_ ? 1 : 2;};
+          let t$1 = t;
+          var i = t[1];
           if(0 === i) break;
           if(1 === i) break b;
           var t = t$0;

--- a/compiler/tests-compiler/gh1559.ml
+++ b/compiler/tests-compiler/gh1559.ml
@@ -86,31 +86,32 @@ let () = my_ref := 2
         Stdlib_Int = global_data.Stdlib__Int,
         Stdlib = global_data.Stdlib,
         my_ref = [0, 1],
-        nesting = 1,
-        t = init;
-       for(;;){
-        let t$1 = t;
-        var
-         this_will_be_undefined =
-           function(param){var _c_ = 1 === t$1[1] ? 1 : 0; return _c_ ? 1 : 2;},
-         i = t[1];
-        if(0 === i)
-         var _a_ = this_will_be_undefined(0);
-        else{
-         if(1 !== i){var t = t$0; continue;}
+        nesting = 1;
+       a:
+       {
+        var t = init;
+        for(;;){
+         let t$1 = t;
          var
-          _a_ =
-            caml_call2(Stdlib_Int[8], nesting, 0)
-             ? nesting
-             : this_will_be_undefined(0);
+          this_will_be_undefined =
+            function(param){var _c_ = 1 === t$1[1] ? 1 : 0; return _c_ ? 1 : 2;},
+          i = t[1];
+         if(0 === i){var _a_ = this_will_be_undefined(0); break a;}
+         if(1 === i) break;
+         var t = t$0;
         }
-        var _b_ = caml_call1(Stdlib_Int[12], _a_);
-        caml_call1(Stdlib[46], _b_);
-        my_ref[1] = 2;
-        var Test = [0, my_ref];
-        runtime.caml_register_global(4, Test, "Test");
-        return;
+        var
+         _a_ =
+           caml_call2(Stdlib_Int[8], nesting, 0)
+            ? nesting
+            : this_will_be_undefined(0);
        }
+       var _b_ = caml_call1(Stdlib_Int[12], _a_);
+       caml_call1(Stdlib[46], _b_);
+       my_ref[1] = 2;
+       var Test = [0, my_ref];
+       runtime.caml_register_global(4, Test, "Test");
+       return;
       }
       (globalThis));
     //end |}]
@@ -190,41 +191,47 @@ let () = my_ref := 2
         Stdlib_Int = global_data.Stdlib__Int,
         Stdlib = global_data.Stdlib,
         my_ref = [0, 1],
-        nesting = 1,
-        t = init;
-       for(;;){
-        let t$1 = t;
-        var
-         this_will_be_undefined =
-           function(param){var _e_ = 1 === t$1[1] ? 1 : 0; return _e_ ? 1 : 2;},
-         i = t[1];
-        if(0 === i)
+        nesting = 1;
+       a:
+       {
+        b:
+        {
+         var t = init;
+         for(;;){
+          let t$1 = t;
+          var
+           this_will_be_undefined =
+             function(param){var _e_ = 1 === t$1[1] ? 1 : 0; return _e_ ? 1 : 2;},
+           i = t[1];
+          if(0 === i) break;
+          if(1 === i) break b;
+          var t = t$0;
+         }
          var
           g = function(param){return 2 + this_will_be_undefined(0) | 0;},
           _a_ = g(0),
           _c_ = g(0) + _a_ | 0;
-        else{
-         if(1 !== i){var t = t$0; continue;}
-         if(caml_call2(Stdlib_Int[8], nesting, 0))
-          var _c_ = nesting;
-         else
-          var
-           g$0 =
-             function(param){
-              return 1 < caml_call1(Stdlib_Random[5], 3)
-                      ? 2 + this_will_be_undefined(0) | 0
-                      : 1;
-             },
-           _b_ = g$0(0),
-           _c_ = g$0(0) + _b_ | 0;
+         break a;
         }
-        var _d_ = caml_call1(Stdlib_Int[12], _c_);
-        caml_call1(Stdlib[46], _d_);
-        my_ref[1] = 2;
-        var Test = [0, my_ref];
-        runtime.caml_register_global(5, Test, "Test");
-        return;
+        if(caml_call2(Stdlib_Int[8], nesting, 0))
+         var _c_ = nesting;
+        else
+         var
+          g$0 =
+            function(param){
+             return 1 < caml_call1(Stdlib_Random[5], 3)
+                     ? 2 + this_will_be_undefined(0) | 0
+                     : 1;
+            },
+          _b_ = g$0(0),
+          _c_ = g$0(0) + _b_ | 0;
        }
+       var _d_ = caml_call1(Stdlib_Int[12], _c_);
+       caml_call1(Stdlib[46], _d_);
+       my_ref[1] = 2;
+       var Test = [0, my_ref];
+       runtime.caml_register_global(5, Test, "Test");
+       return;
       }
       (globalThis));
     //end |}]

--- a/compiler/tests-compiler/gh1559.ml
+++ b/compiler/tests-compiler/gh1559.ml
@@ -90,11 +90,10 @@ let () = my_ref := 2
         t = init;
        for(;;){
         let t$1 = t;
-        function this_will_be_undefined(param){
-         var _c_ = 1 === t$1[1] ? 1 : 0;
-         return _c_ ? 1 : 2;
-        }
-        var i = t[1];
+        var
+         this_will_be_undefined =
+           function(param){var _c_ = 1 === t$1[1] ? 1 : 0; return _c_ ? 1 : 2;},
+         i = t[1];
         if(0 === i)
          var _a_ = this_will_be_undefined(0);
         else{
@@ -195,11 +194,10 @@ let () = my_ref := 2
         t = init;
        for(;;){
         let t$1 = t;
-        function this_will_be_undefined(param){
-         var _e_ = 1 === t$1[1] ? 1 : 0;
-         return _e_ ? 1 : 2;
-        }
-        var i = t[1];
+        var
+         this_will_be_undefined =
+           function(param){var _e_ = 1 === t$1[1] ? 1 : 0; return _e_ ? 1 : 2;},
+         i = t[1];
         if(0 === i)
          var
           g = function(param){return 2 + this_will_be_undefined(0) | 0;},

--- a/compiler/tests-compiler/gh1559.ml
+++ b/compiler/tests-compiler/gh1559.ml
@@ -91,11 +91,11 @@ let () = my_ref := 2
        {
         var t = init;
         for(;;){
+         let t$1 = t;
          var
           this_will_be_undefined =
-            function(param){var _c_ = 1 === t$1[1] ? 1 : 0; return _c_ ? 1 : 2;};
-         let t$1 = t;
-         var i = t[1];
+            function(param){var _c_ = 1 === t$1[1] ? 1 : 0; return _c_ ? 1 : 2;},
+          i = t[1];
          if(0 === i){var _a_ = this_will_be_undefined(0); break a;}
          if(1 === i) break;
          var t = t$0;
@@ -198,11 +198,11 @@ let () = my_ref := 2
         {
          var t = init;
          for(;;){
+          let t$1 = t;
           var
            this_will_be_undefined =
-             function(param){var _e_ = 1 === t$1[1] ? 1 : 0; return _e_ ? 1 : 2;};
-          let t$1 = t;
-          var i = t[1];
+             function(param){var _e_ = 1 === t$1[1] ? 1 : 0; return _e_ ? 1 : 2;},
+           i = t[1];
           if(0 === i) break;
           if(1 === i) break b;
           var t = t$0;

--- a/compiler/tests-compiler/gh747.ml
+++ b/compiler/tests-compiler/gh747.ml
@@ -266,136 +266,133 @@ end
      41:       [248,
      42:        caml_string_of_jsbytes("Test.Unhandled"),
      43:        runtime.caml_fresh_oo_id(0)],
-     44:     _c_ = [0, [2, 0, [12, 10, 0]], caml_string_of_jsbytes("%s\n")],
-     45:     _d_ =
-     46:       [0,
-     47:        [11,
-     48:         caml_string_of_jsbytes
-     49:          ("(Program not linked with -g, cannot print stack backtrace)\n"),
-     50:         0],
-     51:        caml_string_of_jsbytes
-     52:         ("(Program not linked with -g, cannot print stack backtrace)\n")],
-     53:     cst_Raised_at = caml_string_of_jsbytes("Raised at"),
-     54:     cst_Re_raised_at = caml_string_of_jsbytes("Re-raised at"),
-     55:     cst_Raised_by_primitive_operat =
-     56:       caml_string_of_jsbytes("Raised by primitive operation at"),
-     57:     cst_Called_from = caml_string_of_jsbytes("Called from"),
-     58:     cst_inlined = caml_string_of_jsbytes(" (inlined)"),
-     59:     _a_ =
-     60:       [0,
-     61:        [2,
-     62:         0,
-     63:         [12,
-     64:          32,
-     65:          [2,
-     66:           0,
-     67:           [11,
-     68:            caml_string_of_jsbytes(' in file "'),
-     69:            [2,
-     70:             0,
-     71:             [12,
-     72:              34,
-     73:              [2,
-     74:               0,
-     75:               [11,
-     76:                caml_string_of_jsbytes(", line "),
-     77:                [4,
-     78:                 0,
-     79:                 0,
-     80:                 0,
-     81:                 [11, caml_string_of_jsbytes(", characters "), partial]]]]]]]]]],
-     82:        caml_string_of_jsbytes
-     83:         ('%s %s in file "%s"%s, line %d, characters %d-%d')],
-     84:     _b_ =
-     85:       [0,
-     86:        [2, 0, [11, caml_string_of_jsbytes(" unknown location"), 0]],
-     87:        caml_string_of_jsbytes("%s unknown location")],
-     88:     big_endian = 0,
-     89:     word_size = 32,
-     90:     int_size = 32;
-     91:    function format_backtrace_slot(pos, slot){
-     92:     function info(is_raise){
-     93:       /*<<test.ml:46:4>>*/ return is_raise
-     94:              ? 0 === pos ? cst_Raised_at : cst_Re_raised_at
-     95:              : 0 === pos ? cst_Raised_by_primitive_operat : cst_Called_from;
-     96:      /*<<test.ml:49:75>>*/ }
-     97:      /*<<test.ml:51:2>>*/ if(0 === slot[0]){
-     98:       /*<<test.ml:59:14>>*/ var
-     99:       _h_ = slot[5],
-    100:       _i_ = slot[4],
-    101:       _j_ = slot[3],
-    102:       _k_ = slot[6] ? cst_inlined : cst,
-    103:       _l_ = slot[2],
-    104:       _m_ = slot[7],
-    105:        /*<<test.ml:59:14>>*/ _n_ = info(slot[1]);
-    106:       /*<<test.ml:58:6>>*/ return [0,
-    107:               /*<<test.ml:58:11>>*/ caml_call8
-    108:               (Stdlib_Printf[4], _a_, _n_, _m_, _l_, _k_, _j_, _i_, _h_)];
-    109:     }
-    110:     if(slot[1])  /*<<test.ml:54:50>>*/ return 0;
-    111:      /*<<test.ml:56:51>>*/  /*<<test.ml:56:51>>*/ var _o_ = info(0);
-    112:      /*<<test.ml:56:8>>*/ return [0,
-    113:              /*<<test.ml:56:13>>*/ caml_call2(Stdlib_Printf[4], _b_, _o_)];
-    114:     /*<<test.ml:61:52>>*/ }
-    115:    function print_exception_backtrace(outchan, backtrace){
-    116:      /*<<test.ml:64:2>>*/ if(! backtrace)
-    117:       /*<<test.ml:66:6>>*/ return  /*<<test.ml:66:6>>*/ caml_call2
-    118:              (Stdlib_Printf[1], outchan, _d_);
-    119:     var a = backtrace[1], _f_ = a.length - 1 - 1 | 0, _e_ = 0;
-    120:     if(_f_ >= 0){
-    121:      var i = _e_;
-    122:      for(;;){
-    123:        /*<<test.ml:70:14>>*/  /*<<test.ml:70:14>>*/ var
-    124:        match = format_backtrace_slot(i, runtime.caml_check_bound(a, i)[1 + i]);
-    125:       if(match){
-    126:        var str = match[1];
-    127:         /*<<test.ml:72:24>>*/  /*<<test.ml:72:24>>*/ caml_call3
-    128:         (Stdlib_Printf[1], outchan, _c_, str);
-    129:       }
-    130:        /*<<test.ml:69:6>>*/  /*<<test.ml:69:6>>*/ var _g_ = i + 1 | 0;
-    131:       if(_f_ === i) break;
-    132:       var i = _g_;
-    133:      }
-    134:     }
-    135:     return 0;
-    136:     /*<<test.ml:73:10>>*/ }
-    137:    function compare(left, right, e1, e2){
-    138:      /*<<test.ml:77:35>>*/ if(0 === e1[0]){
-    139:      var v1 = e1[1];
-    140:      if(0 !== e2[0])  /*<<test.ml:80:23>>*/ return -1;
-    141:      var v2 = e2[1];
-    142:       /*<<test.ml:78:24>>*/ return  /*<<test.ml:78:24>>*/ caml_call2
-    143:              (left, v1, v2);
-    144:     }
-    145:     var v1$0 = e1[1];
-    146:     if(0 === e2[0])  /*<<test.ml:81:23>>*/ return 1;
-    147:     var v2$0 = e2[1];
-    148:      /*<<test.ml:79:26>>*/ return  /*<<test.ml:79:26>>*/ caml_call2
-    149:             (right, v1$0, v2$0);
-    150:     /*<<test.ml:81:24>>*/ }
-    151:     /*<<test.ml:75:16>>*/ var
-    152:      /*<<test.ml:75:16>>*/ Either = [0, compare],
-    153:     Test =
-    154:       [0,
-    155:        executable_name,
-    156:        os_type,
-    157:        backend_type,
-    158:        big_endian,
-    159:        word_size,
-    160:        int_size,
-    161:        unix,
-    162:        win32,
-    163:        cygwin,
-    164:        max_array_length,
-    165:        max_floatarray_length,
-    166:        max_string_length,
-    167:        Unhandled,
-    168:        format_backtrace_slot,
-    169:        print_exception_backtrace,
-    170:        Either];
-    171:    runtime.caml_register_global(12, Test, "Test");
-    172:    return;
-    173:    /*<<?>>*/ }
-    174:   (globalThis));
-    175:
-    176: //# sourceMappingURL=test.map |}]
+     44:     cst_Raised_at = caml_string_of_jsbytes("Raised at"),
+     45:     cst_Re_raised_at = caml_string_of_jsbytes("Re-raised at"),
+     46:     cst_Raised_by_primitive_operat =
+     47:       caml_string_of_jsbytes("Raised by primitive operation at"),
+     48:     cst_Called_from = caml_string_of_jsbytes("Called from"),
+     49:     cst_inlined = caml_string_of_jsbytes(" (inlined)"),
+     50:     _a_ =
+     51:       [0,
+     52:        [2,
+     53:         0,
+     54:         [12,
+     55:          32,
+     56:          [2,
+     57:           0,
+     58:           [11,
+     59:            caml_string_of_jsbytes(' in file "'),
+     60:            [2,
+     61:             0,
+     62:             [12,
+     63:              34,
+     64:              [2,
+     65:               0,
+     66:               [11,
+     67:                caml_string_of_jsbytes(", line "),
+     68:                [4,
+     69:                 0,
+     70:                 0,
+     71:                 0,
+     72:                 [11, caml_string_of_jsbytes(", characters "), partial]]]]]]]]]],
+     73:        caml_string_of_jsbytes
+     74:         ('%s %s in file "%s"%s, line %d, characters %d-%d')],
+     75:     _b_ =
+     76:       [0,
+     77:        [2, 0, [11, caml_string_of_jsbytes(" unknown location"), 0]],
+     78:        caml_string_of_jsbytes("%s unknown location")],
+     79:     _c_ = [0, [2, 0, [12, 10, 0]], caml_string_of_jsbytes("%s\n")],
+     80:     _d_ =
+     81:       [0,
+     82:        [11,
+     83:         caml_string_of_jsbytes
+     84:          ("(Program not linked with -g, cannot print stack backtrace)\n"),
+     85:         0],
+     86:        caml_string_of_jsbytes
+     87:         ("(Program not linked with -g, cannot print stack backtrace)\n")];
+     88:    function format_backtrace_slot(pos, slot){
+     89:     function info(is_raise){
+     90:       /*<<test.ml:46:4>>*/ return is_raise
+     91:              ? 0 === pos ? cst_Raised_at : cst_Re_raised_at
+     92:              : 0 === pos ? cst_Raised_by_primitive_operat : cst_Called_from;
+     93:      /*<<test.ml:49:75>>*/ }
+     94:      /*<<test.ml:51:2>>*/ if(0 === slot[0]){
+     95:       /*<<test.ml:59:14>>*/ var
+     96:       _h_ = slot[5],
+     97:       _i_ = slot[4],
+     98:       _j_ = slot[3],
+     99:       _k_ = slot[6] ? cst_inlined : cst,
+    100:       _l_ = slot[2],
+    101:       _m_ = slot[7],
+    102:        /*<<test.ml:59:14>>*/ _n_ = info(slot[1]);
+    103:       /*<<test.ml:58:6>>*/ return [0,
+    104:               /*<<test.ml:58:11>>*/ caml_call8
+    105:               (Stdlib_Printf[4], _a_, _n_, _m_, _l_, _k_, _j_, _i_, _h_)];
+    106:     }
+    107:     if(slot[1])  /*<<test.ml:54:50>>*/ return 0;
+    108:      /*<<test.ml:56:51>>*/  /*<<test.ml:56:51>>*/ var _o_ = info(0);
+    109:      /*<<test.ml:56:8>>*/ return [0,
+    110:              /*<<test.ml:56:13>>*/ caml_call2(Stdlib_Printf[4], _b_, _o_)];
+    111:     /*<<test.ml:61:52>>*/ }
+    112:    function print_exception_backtrace(outchan, backtrace){
+    113:      /*<<test.ml:64:2>>*/ if(! backtrace)
+    114:       /*<<test.ml:66:6>>*/ return  /*<<test.ml:66:6>>*/ caml_call2
+    115:              (Stdlib_Printf[1], outchan, _d_);
+    116:     var a = backtrace[1], _f_ = a.length - 1 - 1 | 0, _e_ = 0;
+    117:     if(_f_ >= 0){
+    118:      var i = _e_;
+    119:      for(;;){
+    120:        /*<<test.ml:70:14>>*/  /*<<test.ml:70:14>>*/ var
+    121:        match = format_backtrace_slot(i, runtime.caml_check_bound(a, i)[1 + i]);
+    122:       if(match){
+    123:        var str = match[1];
+    124:         /*<<test.ml:72:24>>*/  /*<<test.ml:72:24>>*/ caml_call3
+    125:         (Stdlib_Printf[1], outchan, _c_, str);
+    126:       }
+    127:        /*<<test.ml:69:6>>*/  /*<<test.ml:69:6>>*/ var _g_ = i + 1 | 0;
+    128:       if(_f_ === i) break;
+    129:       var i = _g_;
+    130:      }
+    131:     }
+    132:     return 0;
+    133:     /*<<test.ml:73:10>>*/ }
+    134:    function compare(left, right, e1, e2){
+    135:      /*<<test.ml:77:35>>*/ if(0 === e1[0]){
+    136:      var v1 = e1[1];
+    137:      if(0 !== e2[0])  /*<<test.ml:80:23>>*/ return -1;
+    138:      var v2 = e2[1];
+    139:       /*<<test.ml:78:24>>*/ return  /*<<test.ml:78:24>>*/ caml_call2
+    140:              (left, v1, v2);
+    141:     }
+    142:     var v1$0 = e1[1];
+    143:     if(0 === e2[0])  /*<<test.ml:81:23>>*/ return 1;
+    144:     var v2$0 = e2[1];
+    145:      /*<<test.ml:79:26>>*/ return  /*<<test.ml:79:26>>*/ caml_call2
+    146:             (right, v1$0, v2$0);
+    147:     /*<<test.ml:81:24>>*/ }
+    148:     /*<<test.ml:75:16>>*/ var
+    149:      /*<<test.ml:75:16>>*/ Either = [0, compare],
+    150:     Test =
+    151:       [0,
+    152:        executable_name,
+    153:        os_type,
+    154:        backend_type,
+    155:        0,
+    156:        32,
+    157:        32,
+    158:        unix,
+    159:        win32,
+    160:        cygwin,
+    161:        max_array_length,
+    162:        max_floatarray_length,
+    163:        max_string_length,
+    164:        Unhandled,
+    165:        format_backtrace_slot,
+    166:        print_exception_backtrace,
+    167:        Either];
+    168:    runtime.caml_register_global(12, Test, "Test");
+    169:    return;
+    170:    /*<<?>>*/ }
+    171:   (globalThis));
+    172:
+    173: //# sourceMappingURL=test.map |}]

--- a/compiler/tests-compiler/global_deadcode.ml
+++ b/compiler/tests-compiler/global_deadcode.ml
@@ -40,30 +40,30 @@ let%expect_test "Eliminates unused functions from functor" =
     function create(l, v, r){
      if(l) var h = l[4], hl = h; else var hl = 0;
      if(r) var h$0 = r[4], hr = h$0; else var hr = 0;
-     var _m_ = hr <= hl ? hl + 1 | 0 : hr + 1 | 0;
-     return [0, l, v, r, _m_];
+     var _k_ = hr <= hl ? hl + 1 | 0 : hr + 1 | 0;
+     return [0, l, v, r, _k_];
     }
     function bal(l, v, r){
      if(l) var h = l[4], hl = h; else var hl = 0;
      if(r) var h$0 = r[4], hr = h$0; else var hr = 0;
      if((hr + 2 | 0) < hl){
       if(! l) return invalid_arg(_b_);
-      var lr = l[3], lv = l[2], ll = l[1], _h_ = height(lr);
-      if(_h_ <= height(ll)) return create(ll, lv, create(lr, v, r));
+      var lr = l[3], lv = l[2], ll = l[1], _f_ = height(lr);
+      if(_f_ <= height(ll)) return create(ll, lv, create(lr, v, r));
       if(! lr) return invalid_arg(_a_);
-      var lrr = lr[3], lrv = lr[2], lrl = lr[1], _i_ = create(lrr, v, r);
-      return create(create(ll, lv, lrl), lrv, _i_);
+      var lrr = lr[3], lrv = lr[2], lrl = lr[1], _g_ = create(lrr, v, r);
+      return create(create(ll, lv, lrl), lrv, _g_);
      }
      if((hl + 2 | 0) >= hr){
-      var _l_ = hr <= hl ? hl + 1 | 0 : hr + 1 | 0;
-      return [0, l, v, r, _l_];
+      var _j_ = hr <= hl ? hl + 1 | 0 : hr + 1 | 0;
+      return [0, l, v, r, _j_];
      }
      if(! r) return invalid_arg(_d_);
-     var rr = r[3], rv = r[2], rl = r[1], _j_ = height(rl);
-     if(_j_ <= height(rr)) return create(create(l, v, rl), rv, rr);
+     var rr = r[3], rv = r[2], rl = r[1], _h_ = height(rl);
+     if(_h_ <= height(rr)) return create(create(l, v, rl), rv, rr);
      if(! rl) return invalid_arg(_c_);
-     var rlr = rl[3], rlv = rl[2], rll = rl[1], _k_ = create(rlr, rv, rr);
-     return create(create(l, v, rll), rlv, _k_);
+     var rlr = rl[3], rlv = rl[2], rll = rl[1], _i_ = create(rlr, rv, rr);
+     return create(create(l, v, rll), rlv, _i_);
     }
     function add(x, t){
      if(! t) return [0, 0, x, 0, 1];
@@ -74,7 +74,6 @@ let%expect_test "Eliminates unused functions from functor" =
      return l === ll ? t : bal(ll, v, r);
     }
     function singleton(x){return [0, 0, x, 0, 1];}
-    var empty = 0;
     function find(x, param){
      var param$0 = param;
      for(;;){
@@ -88,7 +87,7 @@ let%expect_test "Eliminates unused functions from functor" =
       var r$0 = 0 <= c ? r : l, param$0 = r$0;
      }
     }
-    return [0, empty, add, singleton, find];
+    return [0, 0, add, singleton, find];
     //end |}]
 
 let%expect_test "Omit unused fields" =

--- a/compiler/tests-compiler/mutable_closure.ml
+++ b/compiler/tests-compiler/mutable_closure.ml
@@ -153,8 +153,8 @@ let%expect_test _ =
       let i$0 = i, g$0 = g, f$1 = f$0;
       var _b_ = direct[1];
       direct[1] = [0, f(i), _b_];
-      let i$1 = i, f$2 = f;
-      indirect[1] = [0, function(param){return f$2(i$1);}, indirect[1]];
+      let f$2 = f;
+      indirect[1] = [0, function(param){return f$2(i$0);}, indirect[1]];
       var _c_ = i + 1 | 0;
       if(3 === i) break;
       var i = _c_;

--- a/compiler/tests-compiler/mutable_closure.ml
+++ b/compiler/tests-compiler/mutable_closure.ml
@@ -123,46 +123,66 @@ let%expect_test _ =
       let i$0 = i;
       function f$0(counter, n){
        if(- 1 === n){
-        var _j_ = - 2;
-        if(counter >= 50) return caml_trampoline_return(g, [0, _j_]);
+        var _f_ = - 2;
+        if(counter >= 50) return caml_trampoline_return(g, [0, _f_]);
         var counter$1 = counter + 1 | 0;
-        return g(counter$1, _j_);
+        return g(counter$1, _f_);
        }
        if(0 === n) return i$0;
-       var _k_ = n - 1 | 0;
-       if(counter >= 50) return caml_trampoline_return(g, [0, _k_]);
+       var _g_ = n - 1 | 0;
+       if(counter >= 50) return caml_trampoline_return(g, [0, _g_]);
        var counter$0 = counter + 1 | 0;
-       return g(counter$0, _k_);
+       return g(counter$0, _g_);
       }
-      function f(n){return caml_trampoline(f$0(0, n));}
+      var f = function(n){return caml_trampoline(f$0(0, n));};
       function g(counter, n){
        if(- 1 === n){
-        var _h_ = - 2;
-        if(counter >= 50) return caml_trampoline_return(f$0, [0, _h_]);
+        var _d_ = - 2;
+        if(counter >= 50) return caml_trampoline_return(f$0, [0, _d_]);
         var counter$1 = counter + 1 | 0;
-        return f$0(counter$1, _h_);
+        return f$0(counter$1, _d_);
        }
        if(0 === n) return i$0;
-       var _i_ = n - 1 | 0;
-       if(counter >= 50) return caml_trampoline_return(f$0, [0, _i_]);
+       var _e_ = n - 1 | 0;
+       if(counter >= 50) return caml_trampoline_return(f$0, [0, _e_]);
        var counter$0 = counter + 1 | 0;
-       return f$0(counter$0, _i_);
+       return f$0(counter$0, _e_);
       }
-      var _e_ = direct[1];
-      direct[1] = [0, f(i), _e_];
+      var _b_ = direct[1];
+      direct[1] = [0, f(i), _b_];
       let i$1 = i, f$1 = f;
-      var _f_ = indirect[1];
-      indirect[1] = [0, function(param){return f$1(i$1);}, _f_];
-      var _g_ = i + 1 | 0;
+      indirect[1] = [0, function(param){return f$1(i$1);}, indirect[1]];
+      var _c_ = i + 1 | 0;
       if(3 === i) break;
-      var i = _g_;
+      var i = _c_;
      }
      var
-      _d_ = indirect[1],
       indirect$0 =
-        caml_call2(list_map, function(f){return caml_call1(f, 0);}, _d_),
+        caml_call2(list_map, function(f){return caml_call1(f, 0);}, indirect[1]),
       direct$0 = direct[1];
      if(runtime.caml_equal(indirect$0, direct$0)) return 0;
-     throw caml_maybe_attach_backtrace([0, Assert_failure, _c_], 1);
+     throw caml_maybe_attach_backtrace([0, Assert_failure, _a_], 1);
     }
     //end|}]
+
+let%expect_test _ =
+  let prog = {|
+
+let f =
+  let my_ref = ref 1 in
+  fun () -> incr my_ref; !my_ref
+|} in
+  let program = Util.compile_and_parse prog in
+  Util.print_program program;
+  [%expect
+    {|
+    (function(globalThis){
+       "use strict";
+       var runtime = globalThis.jsoo_runtime, my_ref = [0, 1];
+       function f(param){my_ref[1]++; return my_ref[1];}
+       var Test = [0, f];
+       runtime.caml_register_global(0, Test, "Test");
+       return;
+      }
+      (globalThis));
+    //end |}]

--- a/compiler/tests-compiler/mutable_closure.ml
+++ b/compiler/tests-compiler/mutable_closure.ml
@@ -121,37 +121,43 @@ let%expect_test _ =
      var i = 0;
      for(;;){
       let i$0 = i;
-      function f$0(counter, n){
-       if(- 1 === n){
-        var _f_ = - 2;
-        if(counter >= 50) return caml_trampoline_return(g, [0, _f_]);
-        var counter$1 = counter + 1 | 0;
-        return g(counter$1, _f_);
-       }
-       if(0 === n) return i$0;
-       var _g_ = n - 1 | 0;
-       if(counter >= 50) return caml_trampoline_return(g, [0, _g_]);
-       var counter$0 = counter + 1 | 0;
-       return g(counter$0, _g_);
-      }
-      var f = function(n){return caml_trampoline(f$0(0, n));};
-      function g(counter, n){
-       if(- 1 === n){
-        var _d_ = - 2;
-        if(counter >= 50) return caml_trampoline_return(f$0, [0, _d_]);
-        var counter$1 = counter + 1 | 0;
-        return f$0(counter$1, _d_);
-       }
-       if(0 === n) return i$0;
-       var _e_ = n - 1 | 0;
-       if(counter >= 50) return caml_trampoline_return(f$0, [0, _e_]);
-       var counter$0 = counter + 1 | 0;
-       return f$0(counter$0, _e_);
-      }
+      var
+       f$0 =
+         function(counter, n){
+          if(- 1 === n){
+           var _f_ = - 2;
+           if(counter >= 50) return caml_trampoline_return(g$0, [0, _f_]);
+           var counter$1 = counter + 1 | 0;
+           return g$0(counter$1, _f_);
+          }
+          if(0 === n) return i$0;
+          var _g_ = n - 1 | 0;
+          if(counter >= 50) return caml_trampoline_return(g$0, [0, _g_]);
+          var counter$0 = counter + 1 | 0;
+          return g$0(counter$0, _g_);
+         };
+      let f$1 = f$0;
+      var
+       f = function(n){return caml_trampoline(f$1(0, n));},
+       g =
+         function(counter, n){
+          if(- 1 === n){
+           var _d_ = - 2;
+           if(counter >= 50) return caml_trampoline_return(f$1, [0, _d_]);
+           var counter$1 = counter + 1 | 0;
+           return f$1(counter$1, _d_);
+          }
+          if(0 === n) return i$0;
+          var _e_ = n - 1 | 0;
+          if(counter >= 50) return caml_trampoline_return(f$1, [0, _e_]);
+          var counter$0 = counter + 1 | 0;
+          return f$1(counter$0, _e_);
+         };
+      let g$0 = g;
       var _b_ = direct[1];
       direct[1] = [0, f(i), _b_];
-      let i$1 = i, f$1 = f;
-      indirect[1] = [0, function(param){return f$1(i$1);}, indirect[1]];
+      let i$1 = i, f$2 = f;
+      indirect[1] = [0, function(param){return f$2(i$1);}, indirect[1]];
       var _c_ = i + 1 | 0;
       if(3 === i) break;
       var i = _c_;

--- a/compiler/tests-compiler/mutable_closure.ml
+++ b/compiler/tests-compiler/mutable_closure.ml
@@ -120,6 +120,7 @@ let%expect_test _ =
     function fun1(param){
      var i = 0;
      for(;;){
+      let i$0 = i;
       var
        f$0 =
          function(counter, n){
@@ -150,7 +151,7 @@ let%expect_test _ =
           var counter$0 = counter + 1 | 0;
           return f$1(counter$0, _e_);
          };
-      let i$0 = i, g$0 = g, f$1 = f$0;
+      let f$1 = f$0, g$0 = g;
       var _b_ = direct[1];
       direct[1] = [0, f(i), _b_];
       let f$2 = f;

--- a/compiler/tests-compiler/mutable_closure.ml
+++ b/compiler/tests-compiler/mutable_closure.ml
@@ -120,7 +120,6 @@ let%expect_test _ =
     function fun1(param){
      var i = 0;
      for(;;){
-      let i$0 = i;
       var
        f$0 =
          function(counter, n){
@@ -135,9 +134,7 @@ let%expect_test _ =
           if(counter >= 50) return caml_trampoline_return(g$0, [0, _g_]);
           var counter$0 = counter + 1 | 0;
           return g$0(counter$0, _g_);
-         };
-      let f$1 = f$0;
-      var
+         },
        f = function(n){return caml_trampoline(f$1(0, n));},
        g =
          function(counter, n){
@@ -153,7 +150,7 @@ let%expect_test _ =
           var counter$0 = counter + 1 | 0;
           return f$1(counter$0, _e_);
          };
-      let g$0 = g;
+      let i$0 = i, g$0 = g, f$1 = f$0;
       var _b_ = direct[1];
       direct[1] = [0, f(i), _b_];
       let i$1 = i, f$2 = f;

--- a/compiler/tests-compiler/tailcall.ml
+++ b/compiler/tests-compiler/tailcall.ml
@@ -47,25 +47,25 @@ let%expect_test _ =
     function fun1(param){
      function odd$0(counter, x){
       if(0 === x) return 0;
-      var _g_ = x - 1 | 0;
-      if(counter >= 50) return caml_trampoline_return(even$0, [0, _g_]);
+      var _f_ = x - 1 | 0;
+      if(counter >= 50) return caml_trampoline_return(even$0, [0, _f_]);
       var counter$0 = counter + 1 | 0;
-      return even$0(counter$0, _g_);
+      return even$0(counter$0, _f_);
      }
      function odd(x){return caml_trampoline(odd$0(0, x));}
      function even$0(counter, x){
       if(0 === x) return 1;
-      var _f_ = x - 1 | 0;
-      if(counter >= 50) return caml_trampoline_return(odd$0, [0, _f_]);
+      var _e_ = x - 1 | 0;
+      if(counter >= 50) return caml_trampoline_return(odd$0, [0, _e_]);
       var counter$0 = counter + 1 | 0;
-      return odd$0(counter$0, _f_);
+      return odd$0(counter$0, _e_);
      }
      function even(x){return caml_trampoline(even$0(0, x));}
-     var _c_ = even(1);
-     if(odd(1) === _c_)
-      throw caml_maybe_attach_backtrace([0, Assert_failure, _b_], 1);
-     try{odd(5000); var _d_ = log_success(0); return _d_;}
-     catch(_e_){return caml_call1(log_failure, cst_too_much_recursion);}
+     var _b_ = even(1);
+     if(odd(1) === _b_)
+      throw caml_maybe_attach_backtrace([0, Assert_failure, _a_], 1);
+     try{odd(5000); var _c_ = log_success(0); return _c_;}
+     catch(_d_){return caml_call1(log_failure, cst_too_much_recursion);}
     }
     //end |}]
 
@@ -102,10 +102,10 @@ let%expect_test _ =
       return 0 === x ? 1 : caml_trampoline_return(odd$0, [0, x - 1 | 0]);
      }
      function even(x){return caml_trampoline(even$0(x));}
-     var _c_ = even(1);
-     if(odd(1) === _c_)
-      throw caml_maybe_attach_backtrace([0, Assert_failure, _b_], 1);
-     try{odd(5000); var _d_ = log_success(0); return _d_;}
-     catch(_e_){return caml_call1(log_failure, cst_too_much_recursion);}
+     var _b_ = even(1);
+     if(odd(1) === _b_)
+      throw caml_maybe_attach_backtrace([0, Assert_failure, _a_], 1);
+     try{odd(5000); var _c_ = log_success(0); return _c_;}
+     catch(_d_){return caml_call1(log_failure, cst_too_much_recursion);}
     }
     //end |}]

--- a/compiler/tests-full/stdlib.cma.expected.js
+++ b/compiler/tests-full/stdlib.cma.expected.js
@@ -2130,7 +2130,7 @@
      /*<<seq.ml:324:2>>*/  /*<<seq.ml:324:8>>*/ var
      match =  /*<<seq.ml:324:8>>*/ caml_call1(xs, 0);
     if(! match)  /*<<seq.ml:326:6>>*/ return 0;
-    var xs$0 = match[2], x = match[1], _Z_ = i + 1 | 0;
+    var xs$0 = match[2], x = match[1],  /*<<seq.ml:328:6>>*/ _Z_ = i + 1 | 0;
      /*<<seq.ml:328:6>>*/ return [0,
              /*<<seq.ml:328:12>>*/ caml_call2(f, i, x),
             function(___){ /*<<?>>*/ return mapi_aux(f, _Z_, xs$0, ___);}];
@@ -2230,11 +2230,11 @@
     var
      xs$0 = match[2],
      x = match[1],
-     _K_ =  /*<<seq.ml:413:64>>*/ caml_call1(eq, x),
-     _M_ =  /*<<seq.ml:413:31>>*/ caml_call1(eq, x);
+      /*<<seq.ml:413:64>>*/ _K_ =  /*<<seq.ml:413:64>>*/ caml_call1(eq, x);
      /*<<seq.ml:413:52>>*/ function _L_(_R_){
       /*<<?>>*/ return drop_while(_K_, xs$0, _R_);
     }
+     /*<<seq.ml:413:31>>*/ var _M_ =  /*<<seq.ml:413:31>>*/ caml_call1(eq, x);
      /*<<seq.ml:413:19>>*/ function _N_(_Q_){
       /*<<?>>*/ return take_while(_M_, xs$0, _Q_);
     }
@@ -2486,17 +2486,19 @@
             function(_m_){ /*<<?>>*/ return _b_(tails$0, xss$0, _m_);}];
     /*<<seq.ml:649:29>>*/ }
    function map_product(f, xs, ys){
-     /*<<seq.ml:668:20>>*/ function xss(_k_){
-      /*<<?>>*/ return map(_f_, xs, _k_);
-    }
-    function _e_(_j_){ /*<<?>>*/ return _b_(empty, xss, _j_);}
     function _f_(x){
-     function _h_(y){
+     function _j_(y){
        /*<<seq.ml:671:8>>*/ return  /*<<seq.ml:671:8>>*/ caml_call2(f, x, y);
       /*<<seq.ml:671:13>>*/ }
-      /*<<seq.ml:670:10>>*/ return function(_i_){
-       /*<<?>>*/ return map(_h_, ys, _i_);};
+      /*<<seq.ml:670:10>>*/ return function(_k_){
+       /*<<?>>*/ return map(_j_, ys, _k_);};
      /*<<seq.ml:672:10>>*/ }
+     /*<<seq.ml:668:20>>*/ function xss(_i_){
+      /*<<?>>*/ return map(_f_, xs, _i_);
+    }
+     /*<<seq.ml:665:2>>*/ function _e_(_h_){
+      /*<<?>>*/ return _b_(empty, xss, _h_);
+    }
      /*<<seq.ml:668:9>>*/ return function(_g_){
       /*<<?>>*/ return concat(_e_, _g_);};
     /*<<seq.ml:674:4>>*/ }
@@ -2529,7 +2531,7 @@
       /*<<seq.ml:697:8>>*/ return [0, x]; /*<<seq.ml:697:14>>*/ };
     /*<<seq.ml:697:14>>*/ }
    function ints(i, param){
-     /*<<seq.ml:702:2>>*/ var _c_ = i + 1 | 0;
+     /*<<seq.ml:702:2>>*/  /*<<seq.ml:702:2>>*/ var _c_ = i + 1 | 0;
      /*<<seq.ml:702:2>>*/ return [0,
             i,
             function(_d_){ /*<<?>>*/ return ints(_c_, _d_);}];
@@ -3851,7 +3853,7 @@
     }
    }
    function find_index(p){
-     /*<<list.ml:240:2>>*/ var i = 0;
+     /*<<list.ml:240:2>>*/  /*<<list.ml:243:2>>*/ var i = 0;
      /*<<list.ml:243:2>>*/ return function(param$0){
      var i$0 = i, param = param$0;
      for(;;){
@@ -3876,7 +3878,7 @@
     }
    }
    function find_mapi(f){
-     /*<<list.ml:254:2>>*/ var i = 0;
+     /*<<list.ml:254:2>>*/  /*<<list.ml:261:2>>*/ var i = 0;
      /*<<list.ml:261:2>>*/ return function(param$0){
      var i$0 = i, param = param$0;
      for(;;){
@@ -5555,12 +5557,12 @@
       /*<<bytes.ml:414:14>>*/ var
        /*<<bytes.ml:414:14>>*/ x =
          /*<<bytes.ml:414:14>>*/ caml_bytes_get(s, i),
-      _A_ = i + 1 | 0;
+       /*<<bytes.ml:414:14>>*/ _A_ = i + 1 | 0;
       /*<<bytes.ml:415:6>>*/ return [0,
              x,
              function(_B_){ /*<<?>>*/ return aux(_A_, _B_);}];
      /*<<bytes.ml:415:29>>*/ }
-    var _y_ = 0;
+     /*<<bytes.ml:417:2>>*/ var _y_ = 0;
      /*<<bytes.ml:417:2>>*/ return function(_z_){
       /*<<?>>*/ return aux(_y_, _z_);};
     /*<<bytes.ml:417:7>>*/ }
@@ -5571,12 +5573,12 @@
       /*<<bytes.ml:423:14>>*/ var
        /*<<bytes.ml:423:14>>*/ x =
          /*<<bytes.ml:423:14>>*/ caml_bytes_get(s, i),
-      _w_ = i + 1 | 0;
+       /*<<bytes.ml:423:14>>*/ _w_ = i + 1 | 0;
       /*<<bytes.ml:424:6>>*/ return [0,
              [0, i, x],
              function(_x_){ /*<<?>>*/ return aux(_w_, _x_);}];
      /*<<bytes.ml:424:33>>*/ }
-    var _u_ = 0;
+     /*<<bytes.ml:426:2>>*/ var _u_ = 0;
      /*<<bytes.ml:426:2>>*/ return function(_v_){
       /*<<?>>*/ return aux(_u_, _v_);};
     /*<<bytes.ml:426:7>>*/ }
@@ -7963,12 +7965,12 @@
        /*<<array.ml:429:9>>*/ return 0;
       /*<<array.ml:427:14>>*/ var
        /*<<array.ml:427:14>>*/ x = a[1 + i],
-      _h_ = i + 1 | 0;
+       /*<<array.ml:427:14>>*/ _h_ = i + 1 | 0;
       /*<<array.ml:428:6>>*/ return [0,
              x,
              function(_i_){ /*<<?>>*/ return aux(_h_, _i_);}];
      /*<<array.ml:429:16>>*/ }
-    var _f_ = 0;
+     /*<<array.ml:431:2>>*/ var _f_ = 0;
      /*<<array.ml:431:2>>*/ return function(_g_){
       /*<<?>>*/ return aux(_f_, _g_);};
     /*<<array.ml:431:7>>*/ }
@@ -7978,12 +7980,12 @@
        /*<<array.ml:439:9>>*/ return 0;
       /*<<array.ml:437:14>>*/ var
        /*<<array.ml:437:14>>*/ x = a[1 + i],
-      _d_ = i + 1 | 0;
+       /*<<array.ml:437:14>>*/ _d_ = i + 1 | 0;
       /*<<array.ml:438:6>>*/ return [0,
              [0, i, x],
              function(_e_){ /*<<?>>*/ return aux(_d_, _e_);}];
      /*<<array.ml:439:16>>*/ }
-    var _b_ = 0;
+     /*<<array.ml:441:2>>*/ var _b_ = 0;
      /*<<array.ml:441:2>>*/ return function(_c_){
       /*<<?>>*/ return aux(_b_, _c_);};
     /*<<array.ml:441:7>>*/ }
@@ -8913,12 +8915,12 @@
        /*<<float.ml:537:11>>*/ return 0;
       /*<<float.ml:535:16>>*/ var
        /*<<float.ml:535:16>>*/ x = a[1 + i],
-      _q_ = i + 1 | 0;
+       /*<<float.ml:535:16>>*/ _q_ = i + 1 | 0;
       /*<<float.ml:536:8>>*/ return [0,
              x,
              function(_r_){ /*<<?>>*/ return aux(_q_, _r_);}];
      /*<<float.ml:537:18>>*/ }
-    var _o_ = 0;
+     /*<<float.ml:539:4>>*/ var _o_ = 0;
      /*<<float.ml:539:4>>*/ return function(_p_){
       /*<<?>>*/ return aux(_o_, _p_);};
     /*<<float.ml:539:9>>*/ }
@@ -8928,12 +8930,12 @@
        /*<<float.ml:548:11>>*/ return 0;
       /*<<float.ml:546:16>>*/ var
        /*<<float.ml:546:16>>*/ x = a[1 + i],
-      _m_ = i + 1 | 0;
+       /*<<float.ml:546:16>>*/ _m_ = i + 1 | 0;
       /*<<float.ml:547:8>>*/ return [0,
              [0, i, x],
              function(_n_){ /*<<?>>*/ return aux(_m_, _n_);}];
      /*<<float.ml:548:18>>*/ }
-    var _k_ = 0;
+     /*<<float.ml:550:4>>*/ var _k_ = 0;
      /*<<float.ml:550:4>>*/ return function(_l_){
       /*<<?>>*/ return aux(_k_, _l_);};
     /*<<float.ml:550:9>>*/ }
@@ -11021,13 +11023,18 @@
          /*<<set.ml:593:34>>*/ }
         function seq_of_enum(c, param){
           /*<<set.ml:595:32>>*/ if(! c)  /*<<set.ml:596:15>>*/ return 0;
-         var rest = c[3], t = c[2], x = c[1], _l_ = cons_enum(t, rest);
+         var
+          rest = c[3],
+          t = c[2],
+          x = c[1],
+           /*<<set.ml:597:55>>*/ _l_ = cons_enum(t, rest);
           /*<<set.ml:597:29>>*/ return [0,
                  x,
                  function(_m_){ /*<<?>>*/ return seq_of_enum(_l_, _m_);}];
          /*<<set.ml:597:74>>*/ }
         function to_seq(c){
-          /*<<set.ml:599:19>>*/ var _j_ = cons_enum(c, 0);
+          /*<<set.ml:599:19>>*/  /*<<set.ml:599:32>>*/ var
+          _j_ = cons_enum(c, 0);
           /*<<set.ml:599:32>>*/ return function(_k_){
            /*<<?>>*/ return seq_of_enum(_j_, _k_);};
          /*<<set.ml:599:49>>*/ }
@@ -11046,13 +11053,18 @@
          /*<<set.ml:604:52>>*/ }
         function rev_seq_of_enum(c, param){
           /*<<set.ml:606:36>>*/ if(! c)  /*<<set.ml:607:15>>*/ return 0;
-         var rest = c[3], t = c[2], x = c[1], _h_ = snoc_enum(t, rest);
+         var
+          rest = c[3],
+          t = c[2],
+          x = c[1],
+           /*<<set.ml:608:59>>*/ _h_ = snoc_enum(t, rest);
           /*<<set.ml:608:29>>*/ return [0,
                  x,
                  function(_i_){ /*<<?>>*/ return rev_seq_of_enum(_h_, _i_);}];
          /*<<set.ml:608:78>>*/ }
         function to_rev_seq(c){
-          /*<<set.ml:610:23>>*/ var _f_ = snoc_enum(c, 0);
+          /*<<set.ml:610:23>>*/  /*<<set.ml:610:40>>*/ var
+          _f_ = snoc_enum(c, 0);
           /*<<set.ml:610:40>>*/ return function(_g_){
            /*<<?>>*/ return rev_seq_of_enum(_f_, _g_);};
          /*<<set.ml:610:57>>*/ }
@@ -12016,13 +12028,14 @@
           t = c[3],
           v = c[2],
           k = c[1],
-          _m_ = cons_enum(t, rest);
+           /*<<map.ml:518:59>>*/ _m_ = cons_enum(t, rest);
           /*<<map.ml:518:29>>*/ return [0,
                  [0, k, v],
                  function(_n_){ /*<<?>>*/ return seq_of_enum(_m_, _n_);}];
          /*<<map.ml:518:78>>*/ }
         function to_seq(m){
-          /*<<map.ml:521:6>>*/ var _k_ = cons_enum(m, 0);
+          /*<<map.ml:521:6>>*/  /*<<map.ml:521:19>>*/ var
+          _k_ = cons_enum(m, 0);
           /*<<map.ml:521:19>>*/ return function(_l_){
            /*<<?>>*/ return seq_of_enum(_k_, _l_);};
          /*<<map.ml:521:36>>*/ }
@@ -12047,13 +12060,14 @@
           t = c[3],
           v = c[2],
           k = c[1],
-          _i_ = snoc_enum(t, rest);
+           /*<<map.ml:531:44>>*/ _i_ = snoc_enum(t, rest);
           /*<<map.ml:531:10>>*/ return [0,
                  [0, k, v],
                  function(_j_){ /*<<?>>*/ return rev_seq_of_enum(_i_, _j_);}];
          /*<<map.ml:531:63>>*/ }
         function to_rev_seq(c){
-          /*<<map.ml:534:6>>*/ var _g_ = snoc_enum(c, 0);
+          /*<<map.ml:534:6>>*/  /*<<map.ml:534:23>>*/ var
+          _g_ = snoc_enum(c, 0);
           /*<<map.ml:534:23>>*/ return function(_h_){
            /*<<?>>*/ return rev_seq_of_enum(_g_, _h_);};
          /*<<map.ml:534:40>>*/ }
@@ -12928,12 +12942,12 @@
       /*<<buffer.ml:298:14>>*/ var
        /*<<buffer.ml:298:14>>*/ x =
          /*<<buffer.ml:298:14>>*/ caml_bytes_get(b[1][1], i),
-      _l_ = i + 1 | 0;
+       /*<<buffer.ml:298:14>>*/ _l_ = i + 1 | 0;
       /*<<buffer.ml:299:6>>*/ return [0,
              x,
              function(_m_){ /*<<?>>*/ return aux(_l_, _m_);}];
      /*<<buffer.ml:299:29>>*/ }
-    var _j_ = 0;
+     /*<<buffer.ml:301:2>>*/ var _j_ = 0;
      /*<<buffer.ml:301:2>>*/ return function(_k_){
       /*<<?>>*/ return aux(_j_, _k_);};
     /*<<buffer.ml:301:7>>*/ }
@@ -12944,12 +12958,12 @@
       /*<<buffer.ml:308:14>>*/ var
        /*<<buffer.ml:308:14>>*/ x =
          /*<<buffer.ml:308:14>>*/ caml_bytes_get(b[1][1], i),
-      _h_ = i + 1 | 0;
+       /*<<buffer.ml:308:14>>*/ _h_ = i + 1 | 0;
       /*<<buffer.ml:309:6>>*/ return [0,
              [0, i, x],
              function(_i_){ /*<<?>>*/ return aux(_h_, _i_);}];
      /*<<buffer.ml:309:33>>*/ }
-    var _f_ = 0;
+     /*<<buffer.ml:311:2>>*/ var _f_ = 0;
      /*<<buffer.ml:311:2>>*/ return function(_g_){
       /*<<?>>*/ return aux(_f_, _g_);};
     /*<<buffer.ml:311:7>>*/ }
@@ -17901,28 +17915,41 @@
               (k$0, o);
      switch(fmt$0[0]){
        case 0:
-        var rest = fmt$0[1], _b2_ = make_iprintf(k$0, o, rest);
+        var
+         rest = fmt$0[1],
+          /*<<camlinternalFormat.ml:1790:14>>*/ _b2_ =
+           make_iprintf(k$0, o, rest);
          /*<<camlinternalFormat.ml:1790:14>>*/ return function(_cK_){
           /*<<?>>*/ return _b2_;};
        case 1:
-        var rest$0 = fmt$0[1], _b3_ = make_iprintf(k$0, o, rest$0);
+        var
+         rest$0 = fmt$0[1],
+          /*<<camlinternalFormat.ml:1792:14>>*/ _b3_ =
+           make_iprintf(k$0, o, rest$0);
          /*<<camlinternalFormat.ml:1792:14>>*/ return function(_cJ_){
           /*<<?>>*/ return _b3_;};
        case 2:
         var _b4_ = fmt$0[1];
         if(typeof _b4_ === "number"){
-         var rest$1 = fmt$0[2], _b5_ = make_iprintf(k$0, o, rest$1);
+         var
+          rest$1 = fmt$0[2],
+           /*<<camlinternalFormat.ml:1794:14>>*/ _b5_ =
+            make_iprintf(k$0, o, rest$1);
           /*<<camlinternalFormat.ml:1794:14>>*/ return function(_cI_){
            /*<<?>>*/ return _b5_;};
         }
         if(0 === _b4_[0]){
-         var rest$2 = fmt$0[2], _b6_ = make_iprintf(k$0, o, rest$2);
+         var
+          rest$2 = fmt$0[2],
+           /*<<camlinternalFormat.ml:1796:14>>*/ _b6_ =
+            make_iprintf(k$0, o, rest$2);
           /*<<camlinternalFormat.ml:1796:14>>*/ return function(_cH_){
            /*<<?>>*/ return _b6_;};
         }
          /*<<camlinternalFormat.ml:1798:14>>*/ var
          rest$3 = fmt$0[2],
-         _b7_ = make_iprintf(k$0, o, rest$3),
+          /*<<camlinternalFormat.ml:1798:21>>*/ _b7_ =
+           make_iprintf(k$0, o, rest$3),
           /*<<camlinternalFormat.ml:1798:14>>*/ _b8_ =
            function(_cG_){ /*<<?>>*/ return _b7_;};
          /*<<camlinternalFormat.ml:1798:14>>*/ return function(_cF_){
@@ -17930,18 +17957,25 @@
        case 3:
         var _b9_ = fmt$0[1];
         if(typeof _b9_ === "number"){
-         var rest$4 = fmt$0[2], _b__ = make_iprintf(k$0, o, rest$4);
+         var
+          rest$4 = fmt$0[2],
+           /*<<camlinternalFormat.ml:1800:14>>*/ _b__ =
+            make_iprintf(k$0, o, rest$4);
           /*<<camlinternalFormat.ml:1800:14>>*/ return function(_cE_){
            /*<<?>>*/ return _b__;};
         }
         if(0 === _b9_[0]){
-         var rest$5 = fmt$0[2], _b$_ = make_iprintf(k$0, o, rest$5);
+         var
+          rest$5 = fmt$0[2],
+           /*<<camlinternalFormat.ml:1802:14>>*/ _b$_ =
+            make_iprintf(k$0, o, rest$5);
           /*<<camlinternalFormat.ml:1802:14>>*/ return function(_cD_){
            /*<<?>>*/ return _b$_;};
         }
          /*<<camlinternalFormat.ml:1804:14>>*/ var
          rest$6 = fmt$0[2],
-         _ca_ = make_iprintf(k$0, o, rest$6),
+          /*<<camlinternalFormat.ml:1804:21>>*/ _ca_ =
+           make_iprintf(k$0, o, rest$6),
           /*<<camlinternalFormat.ml:1804:14>>*/ _cb_ =
            function(_cC_){ /*<<?>>*/ return _ca_;};
          /*<<camlinternalFormat.ml:1804:14>>*/ return function(_cB_){
@@ -17969,18 +18003,25 @@
        case 9:
         var _cc_ = fmt$0[1];
         if(typeof _cc_ === "number"){
-         var rest$12 = fmt$0[2], _cd_ = make_iprintf(k$0, o, rest$12);
+         var
+          rest$12 = fmt$0[2],
+           /*<<camlinternalFormat.ml:1816:14>>*/ _cd_ =
+            make_iprintf(k$0, o, rest$12);
           /*<<camlinternalFormat.ml:1816:14>>*/ return function(_cA_){
            /*<<?>>*/ return _cd_;};
         }
         if(0 === _cc_[0]){
-         var rest$13 = fmt$0[2], _ce_ = make_iprintf(k$0, o, rest$13);
+         var
+          rest$13 = fmt$0[2],
+           /*<<camlinternalFormat.ml:1818:14>>*/ _ce_ =
+            make_iprintf(k$0, o, rest$13);
           /*<<camlinternalFormat.ml:1818:14>>*/ return function(_cz_){
            /*<<?>>*/ return _ce_;};
         }
          /*<<camlinternalFormat.ml:1820:14>>*/ var
          rest$14 = fmt$0[2],
-         _cf_ = make_iprintf(k$0, o, rest$14),
+          /*<<camlinternalFormat.ml:1820:21>>*/ _cf_ =
+           make_iprintf(k$0, o, rest$14),
           /*<<camlinternalFormat.ml:1820:14>>*/ _cg_ =
            function(_cy_){ /*<<?>>*/ return _cf_;};
          /*<<camlinternalFormat.ml:1820:14>>*/ return function(_cx_){
@@ -17992,7 +18033,10 @@
        case 12:
         var rest$17 = fmt$0[2], fmt$0 = rest$17; break;
        case 13:
-        var rest$18 = fmt$0[3], _ch_ = make_iprintf(k$0, o, rest$18);
+        var
+         rest$18 = fmt$0[3],
+          /*<<camlinternalFormat.ml:1838:14>>*/ _ch_ =
+           make_iprintf(k$0, o, rest$18);
          /*<<camlinternalFormat.ml:1838:14>>*/ return function(_cw_){
           /*<<?>>*/ return _ch_;};
        case 14:
@@ -18009,13 +18053,17 @@
        case 15:
          /*<<camlinternalFormat.ml:1822:14>>*/ var
          rest$20 = fmt$0[1],
-         _ci_ = make_iprintf(k$0, o, rest$20),
+          /*<<camlinternalFormat.ml:1822:21>>*/ _ci_ =
+           make_iprintf(k$0, o, rest$20),
           /*<<camlinternalFormat.ml:1822:14>>*/ _cj_ =
            function(_cu_){ /*<<?>>*/ return _ci_;};
          /*<<camlinternalFormat.ml:1822:14>>*/ return function(_ct_){
           /*<<?>>*/ return _cj_;};
        case 16:
-        var rest$21 = fmt$0[1], _ck_ = make_iprintf(k$0, o, rest$21);
+        var
+         rest$21 = fmt$0[1],
+          /*<<camlinternalFormat.ml:1824:14>>*/ _ck_ =
+           make_iprintf(k$0, o, rest$21);
          /*<<camlinternalFormat.ml:1824:14>>*/ return function(_cs_){
           /*<<?>>*/ return _ck_;};
        case 17:
@@ -18051,15 +18099,24 @@
          /*<<camlinternalFormat.ml:1830:8>>*/ throw  /*<<camlinternalFormat.ml:1830:8>>*/ caml_maybe_attach_backtrace
                ([0, Assert_failure, _w_], 1);
        case 20:
-        var rest$25 = fmt$0[3], _cm_ = make_iprintf(k$0, o, rest$25);
+        var
+         rest$25 = fmt$0[3],
+          /*<<camlinternalFormat.ml:1844:14>>*/ _cm_ =
+           make_iprintf(k$0, o, rest$25);
          /*<<camlinternalFormat.ml:1844:14>>*/ return function(_cr_){
           /*<<?>>*/ return _cm_;};
        case 21:
-        var rest$26 = fmt$0[2], _cn_ = make_iprintf(k$0, o, rest$26);
+        var
+         rest$26 = fmt$0[2],
+          /*<<camlinternalFormat.ml:1846:14>>*/ _cn_ =
+           make_iprintf(k$0, o, rest$26);
          /*<<camlinternalFormat.ml:1846:14>>*/ return function(_cq_){
           /*<<?>>*/ return _cn_;};
        case 22:
-        var rest$27 = fmt$0[1], _co_ = make_iprintf(k$0, o, rest$27);
+        var
+         rest$27 = fmt$0[1],
+          /*<<camlinternalFormat.ml:1848:14>>*/ _co_ =
+           make_iprintf(k$0, o, rest$27);
          /*<<camlinternalFormat.ml:1848:14>>*/ return function(_cp_){
           /*<<?>>*/ return _co_;};
        case 23:
@@ -18089,43 +18146,47 @@
    function fn_of_padding_precision(k, o, fmt, pad, prec){
      /*<<camlinternalFormat.ml:1863:26>>*/ if(typeof pad === "number"){
      if(typeof prec !== "number"){
-      var _bB_ = make_iprintf(k, o, fmt);
+       /*<<camlinternalFormat.ml:1867:14>>*/ var
+       _bB_ = make_iprintf(k, o, fmt);
        /*<<camlinternalFormat.ml:1867:14>>*/ return function(_b1_){
         /*<<?>>*/ return _bB_;};
      }
      if(prec){
        /*<<camlinternalFormat.ml:1869:14>>*/ var
-       _by_ = make_iprintf(k, o, fmt),
+        /*<<camlinternalFormat.ml:1869:21>>*/ _by_ = make_iprintf(k, o, fmt),
         /*<<camlinternalFormat.ml:1869:14>>*/ _bz_ =
          function(_b0_){ /*<<?>>*/ return _by_;};
        /*<<camlinternalFormat.ml:1869:14>>*/ return function(_bZ_){
         /*<<?>>*/ return _bz_;};
      }
-     var _bA_ = make_iprintf(k, o, fmt);
+      /*<<camlinternalFormat.ml:1865:14>>*/ var
+      _bA_ = make_iprintf(k, o, fmt);
       /*<<camlinternalFormat.ml:1865:14>>*/ return function(_bY_){
        /*<<?>>*/ return _bA_;};
     }
     if(0 === pad[0]){
      if(typeof prec !== "number"){
-      var _bF_ = make_iprintf(k, o, fmt);
+       /*<<camlinternalFormat.ml:1873:14>>*/ var
+       _bF_ = make_iprintf(k, o, fmt);
        /*<<camlinternalFormat.ml:1873:14>>*/ return function(_bX_){
         /*<<?>>*/ return _bF_;};
      }
      if(prec){
        /*<<camlinternalFormat.ml:1875:14>>*/ var
-       _bC_ = make_iprintf(k, o, fmt),
+        /*<<camlinternalFormat.ml:1875:21>>*/ _bC_ = make_iprintf(k, o, fmt),
         /*<<camlinternalFormat.ml:1875:14>>*/ _bD_ =
          function(_bW_){ /*<<?>>*/ return _bC_;};
        /*<<camlinternalFormat.ml:1875:14>>*/ return function(_bV_){
         /*<<?>>*/ return _bD_;};
      }
-     var _bE_ = make_iprintf(k, o, fmt);
+      /*<<camlinternalFormat.ml:1871:14>>*/ var
+      _bE_ = make_iprintf(k, o, fmt);
       /*<<camlinternalFormat.ml:1871:14>>*/ return function(_bU_){
        /*<<?>>*/ return _bE_;};
     }
     if(typeof prec !== "number"){
       /*<<camlinternalFormat.ml:1879:14>>*/ var
-      _bL_ = make_iprintf(k, o, fmt),
+       /*<<camlinternalFormat.ml:1879:21>>*/ _bL_ = make_iprintf(k, o, fmt),
        /*<<camlinternalFormat.ml:1879:14>>*/ _bM_ =
         function(_bT_){ /*<<?>>*/ return _bL_;};
       /*<<camlinternalFormat.ml:1879:14>>*/ return function(_bS_){
@@ -18133,7 +18194,7 @@
     }
     if(prec){
       /*<<camlinternalFormat.ml:1881:21>>*/ var
-      _bG_ = make_iprintf(k, o, fmt),
+       /*<<camlinternalFormat.ml:1881:28>>*/ _bG_ = make_iprintf(k, o, fmt),
        /*<<camlinternalFormat.ml:1881:21>>*/ _bH_ =
         function(_bR_){ /*<<?>>*/ return _bG_;},
        /*<<camlinternalFormat.ml:1881:14>>*/ _bI_ =
@@ -18141,7 +18202,7 @@
       /*<<camlinternalFormat.ml:1881:14>>*/ return function(_bP_){
        /*<<?>>*/ return _bI_;};
     }
-    var _bJ_ = make_iprintf(k, o, fmt);
+     /*<<camlinternalFormat.ml:1877:21>>*/ var _bJ_ = make_iprintf(k, o, fmt);
      /*<<camlinternalFormat.ml:1877:14>>*/ function _bK_(_bO_){
       /*<<?>>*/ return _bJ_;
     }
@@ -18150,7 +18211,10 @@
     /*<<camlinternalFormat.ml:1881:52>>*/ }
    function fn_of_custom_arity$0(counter, k, o, fmt, param){
      /*<<?>>*/ if(param){
-     var arity = param[1], _bw_ = fn_of_custom_arity(k, o, fmt, arity);
+     var
+      arity = param[1],
+       /*<<camlinternalFormat.ml:1889:14>>*/ _bw_ =
+        fn_of_custom_arity(k, o, fmt, arity);
       /*<<camlinternalFormat.ml:1889:14>>*/ return function(_bx_){
        /*<<?>>*/ return _bw_;};
     }
@@ -20782,199 +20846,214 @@
         }
        }
        let s$0 = s, follow$2 = follow$0;
-       function no_arg(param){
-         /*<<arg.ml:178:10>>*/ if(! follow$2)  /*<<arg.ml:179:20>>*/ return;
-        var arg = follow$2[1];
-         /*<<arg.ml:180:24>>*/ throw  /*<<arg.ml:180:24>>*/ caml_maybe_attach_backtrace
-               ([0, Stop, [1, s$0, arg, cst_no_argument]], 1);
-        /*<<arg.ml:180:68>>*/ }
-       function get_arg(param){
-         /*<<arg.ml:182:10>>*/ if(follow$2){
-         var arg = follow$2[1];
-          /*<<arg.ml:186:24>>*/ return arg;
-        }
-        if((current[1] + 1 | 0) >= argv[1].length - 1)
-          /*<<arg.ml:185:19>>*/ throw  /*<<arg.ml:185:19>>*/ caml_maybe_attach_backtrace
-                ([0, Stop, [2, s$0]], 1);
-        var _af_ = current[1] + 1 | 0;
-         /*<<arg.ml:184:58>>*/ return caml_check_bound(argv[1], _af_)
-                [1 + _af_];
-        /*<<arg.ml:186:27>>*/ }
-       function consume_arg(param){
-         /*<<arg.ml:189:10>>*/ return follow$2 ? 0 : (current[1]++, 0);
-        /*<<arg.ml:191:24>>*/ }
-       function treat_action(param){
-         /*<<arg.ml:193:31>>*/ switch(param[0]){
-          case 0:
-           var f = param[1];
-            /*<<arg.ml:194:20>>*/ no_arg(0);
-            /*<<arg.ml:194:20>>*/ return  /*<<arg.ml:194:20>>*/ caml_call1
-                   (f, 0);
-          case 1:
-            /*<<arg.ml:196:22>>*/ var
-            f$0 = param[1],
-             /*<<arg.ml:196:22>>*/ arg = get_arg(0);
-            /*<<arg.ml:124:2>>*/ try{
-             /*<<arg.ml:124:6>>*/ var
-              /*<<arg.ml:124:6>>*/ _$_ =
-               [0,  /*<<arg.ml:124:11>>*/ caml_call1(Stdlib[32], arg)],
-             match = _$_;
+       var
+        no_arg =
+          function(param){
+            /*<<arg.ml:178:10>>*/ if(! follow$2)
+             /*<<arg.ml:179:20>>*/ return;
+           var arg = follow$2[1];
+            /*<<arg.ml:180:24>>*/ throw  /*<<arg.ml:180:24>>*/ caml_maybe_attach_backtrace
+                  ([0, Stop, [1, s$0, arg, cst_no_argument]], 1);
+           /*<<arg.ml:180:68>>*/ };
+       let no_arg$0 = no_arg;
+       var
+        get_arg =
+          function(param){
+            /*<<arg.ml:182:10>>*/ if(follow$2){
+            var arg = follow$2[1];
+             /*<<arg.ml:186:24>>*/ return arg;
            }
-           catch(_ae_){
-            var ___ = caml_wrap_exception(_ae_);
-            if(___[1] !== Stdlib[6])
-             throw caml_maybe_attach_backtrace(___, 0);
-            var match = 0;
+           if((current[1] + 1 | 0) >= argv[1].length - 1)
+             /*<<arg.ml:185:19>>*/ throw  /*<<arg.ml:185:19>>*/ caml_maybe_attach_backtrace
+                   ([0, Stop, [2, s$0]], 1);
+           var _af_ = current[1] + 1 | 0;
+            /*<<arg.ml:184:58>>*/ return caml_check_bound(argv[1], _af_)
+                   [1 + _af_];
+           /*<<arg.ml:186:27>>*/ };
+       let get_arg$0 = get_arg;
+       var
+        consume_arg =
+          function(param){
+            /*<<arg.ml:189:10>>*/ return follow$2 ? 0 : (current[1]++, 0);
+           /*<<arg.ml:191:24>>*/ };
+       let consume_arg$0 = consume_arg;
+       var
+        treat_action =
+          function(param){
+            /*<<arg.ml:193:31>>*/ switch(param[0]){
+             case 0:
+              var f = param[1];
+               /*<<arg.ml:194:20>>*/ no_arg$0(0);
+               /*<<arg.ml:194:20>>*/ return  /*<<arg.ml:194:20>>*/ caml_call1
+                      (f, 0);
+             case 1:
+               /*<<arg.ml:196:22>>*/ var
+               f$0 = param[1],
+                /*<<arg.ml:196:22>>*/ arg = get_arg$0(0);
+               /*<<arg.ml:124:2>>*/ try{
+                /*<<arg.ml:124:6>>*/ var
+                 /*<<arg.ml:124:6>>*/ _$_ =
+                  [0,  /*<<arg.ml:124:11>>*/ caml_call1(Stdlib[32], arg)],
+                match = _$_;
+              }
+              catch(_ae_){
+               var ___ = caml_wrap_exception(_ae_);
+               if(___[1] !== Stdlib[6])
+                throw caml_maybe_attach_backtrace(___, 0);
+               var match = 0;
+              }
+              if(! match)
+                /*<<arg.ml:198:22>>*/ throw  /*<<arg.ml:198:22>>*/ caml_maybe_attach_backtrace
+                      ([0, Stop, [1, s$0, arg, cst_a_boolean]], 1);
+              var s = match[1];
+               /*<<arg.ml:199:24>>*/  /*<<arg.ml:199:24>>*/ caml_call1(f$0, s);
+               /*<<arg.ml:201:12>>*/ return consume_arg$0(0);
+             case 2:
+              var r = param[1];
+               /*<<arg.ml:202:19>>*/ no_arg$0(0);
+              r[1] = 1;
+              return 0;
+             case 3:
+              var r$0 = param[1];
+               /*<<arg.ml:203:21>>*/ no_arg$0(0);
+              r$0[1] = 0;
+              return 0;
+             case 4:
+               /*<<arg.ml:205:22>>*/ var
+               f$1 = param[1],
+                /*<<arg.ml:205:22>>*/ arg$0 = get_arg$0(0);
+               /*<<arg.ml:206:12>>*/  /*<<arg.ml:206:12>>*/ caml_call1
+               (f$1, arg$0);
+               /*<<arg.ml:206:12>>*/ return consume_arg$0(0);
+             case 5:
+              var r$1 = param[1];
+              r$1[1] = get_arg$0(0);
+               /*<<arg.ml:219:12>>*/ return consume_arg$0(0);
+             case 6:
+               /*<<arg.ml:221:22>>*/ var
+               f$2 = param[1],
+                /*<<arg.ml:221:22>>*/ arg$1 = get_arg$0(0),
+                /*<<arg.ml:222:24>>*/ match$0 = int_of_string_opt(arg$1);
+              if(! match$0)
+                /*<<arg.ml:223:22>>*/ throw  /*<<arg.ml:223:22>>*/ caml_maybe_attach_backtrace
+                      ([0, Stop, [1, s$0, arg$1, cst_an_integer]], 1);
+              var x = match$0[1];
+               /*<<arg.ml:224:24>>*/  /*<<arg.ml:224:24>>*/ caml_call1(f$2, x);
+               /*<<arg.ml:226:12>>*/ return consume_arg$0(0);
+             case 7:
+               /*<<arg.ml:228:22>>*/ var
+               r$2 = param[1],
+                /*<<arg.ml:228:22>>*/ arg$2 = get_arg$0(0),
+                /*<<arg.ml:229:24>>*/ match$1 = int_of_string_opt(arg$2);
+              if(! match$1)
+                /*<<arg.ml:230:22>>*/ throw  /*<<arg.ml:230:22>>*/ caml_maybe_attach_backtrace
+                      ([0, Stop, [1, s$0, arg$2, cst_an_integer$0]], 1);
+              var x$0 = match$1[1];
+              r$2[1] = x$0;
+               /*<<arg.ml:233:12>>*/ return consume_arg$0(0);
+             case 8:
+               /*<<arg.ml:235:22>>*/ var
+               f$3 = param[1],
+                /*<<arg.ml:235:22>>*/ arg$3 = get_arg$0(0),
+                /*<<arg.ml:236:24>>*/ match$2 = float_of_string_opt(arg$3);
+              if(! match$2)
+                /*<<arg.ml:237:22>>*/ throw  /*<<arg.ml:237:22>>*/ caml_maybe_attach_backtrace
+                      ([0, Stop, [1, s$0, arg$3, cst_a_float]], 1);
+              var x$1 = match$2[1];
+               /*<<arg.ml:238:24>>*/  /*<<arg.ml:238:24>>*/ caml_call1
+               (f$3, x$1);
+               /*<<arg.ml:240:12>>*/ return consume_arg$0(0);
+             case 9:
+               /*<<arg.ml:242:22>>*/ var
+               r$3 = param[1],
+                /*<<arg.ml:242:22>>*/ arg$4 = get_arg$0(0),
+                /*<<arg.ml:243:24>>*/ match$3 = float_of_string_opt(arg$4);
+              if(! match$3)
+                /*<<arg.ml:244:22>>*/ throw  /*<<arg.ml:244:22>>*/ caml_maybe_attach_backtrace
+                      ([0, Stop, [1, s$0, arg$4, cst_a_float$0]], 1);
+              var x$2 = match$3[1];
+              r$3[1] = x$2;
+               /*<<arg.ml:247:12>>*/ return consume_arg$0(0);
+             case 10:
+              var specs = param[1];
+               /*<<arg.ml:249:12>>*/ no_arg$0(0);
+               /*<<arg.ml:249:12>>*/ return  /*<<arg.ml:249:12>>*/ caml_call2
+                      (Stdlib_List[18], treat_action$0, specs);
+             case 11:
+               /*<<arg.ml:209:22>>*/ var
+               f$4 = param[2],
+               symb = param[1],
+                /*<<arg.ml:209:22>>*/ arg$5 = get_arg$0(0);
+               /*<<arg.ml:210:15>>*/ if
+               ( /*<<arg.ml:210:15>>*/ caml_call2
+                 (Stdlib_List[37], arg$5, symb)){
+                /*<<arg.ml:211:14>>*/  /*<<arg.ml:211:14>>*/ caml_call1
+                (f$4, arg$5);
+                /*<<arg.ml:211:14>>*/ return consume_arg$0(0);
+              }
+               /*<<arg.ml:215:44>>*/  /*<<arg.ml:215:44>>*/ var
+               _aa_ = make_symlist(cst$6, cst$5, cst$4, symb);
+               /*<<arg.ml:213:21>>*/ throw  /*<<arg.ml:213:21>>*/ caml_maybe_attach_backtrace
+                     ([0,
+                       Stop,
+                       [1,
+                        s$0,
+                        arg$5,
+                         /*<<arg.ml:214:42>>*/ caml_call2
+                         (Stdlib[28], cst_one_of, _aa_)]],
+                      1);
+             case 12:
+              var f$5 = param[1];
+               /*<<arg.ml:252:12>>*/ no_arg$0(0);
+               /*<<arg.ml:255:14>>*/ for(;;){
+               if(current[1] >= (argv[1].length - 1 - 1 | 0)) return 0;
+               var _ab_ = current[1] + 1 | 0;
+                /*<<arg.ml:254:14>>*/  /*<<arg.ml:254:14>>*/ caml_call1
+                (f$5, caml_check_bound(argv[1], _ab_)[1 + _ab_]);
+                /*<<arg.ml:255:14>>*/ consume_arg$0(0);
+              }
+              break;
+             case 13:
+              var f$6 = param[1];
+               /*<<arg.ml:258:12>>*/ no_arg$0(0);
+               /*<<arg.ml:259:22>>*/  /*<<arg.ml:259:22>>*/ var acc = [0, 0];
+               /*<<arg.ml:262:14>>*/ for(;;){
+               if(current[1] >= (argv[1].length - 1 - 1 | 0))
+                 /*<<arg.ml:264:14>>*/ return  /*<<arg.ml:264:14>>*/ caml_call1
+                        (f$6,
+                          /*<<arg.ml:264:14>>*/ caml_call1(Stdlib_List[10], acc[1]));
+               var _ad_ = current[1] + 1 | 0, _ac_ = acc[1];
+               acc[1] = [0, caml_check_bound(argv[1], _ad_)[1 + _ad_], _ac_];
+                /*<<arg.ml:262:14>>*/ consume_arg$0(0);
+              }
+              break;
+             default:
+              var f$7 = param[1];
+              if(1 - allow_expand)
+                /*<<arg.ml:267:14>>*/ throw  /*<<arg.ml:267:14>>*/ caml_maybe_attach_backtrace
+                      ([0, Stdlib[6], cst_Arg_Expand_is_is_only_allo], 1);
+               /*<<arg.ml:269:22>>*/ var
+                /*<<arg.ml:269:22>>*/ arg$6 = get_arg$0(0),
+                /*<<arg.ml:270:25>>*/ newarg =
+                  /*<<arg.ml:270:25>>*/ caml_call1(f$7, arg$6);
+               /*<<arg.ml:271:12>>*/ consume_arg$0(0);
+               /*<<arg.ml:272:25>>*/ var
+                /*<<arg.ml:272:25>>*/ before =
+                  /*<<arg.ml:272:25>>*/ caml_call3
+                  (Stdlib_Array[5], argv[1], 0, current[1] + 1 | 0),
+                /*<<arg.ml:274:14>>*/ after =
+                  /*<<arg.ml:274:14>>*/ caml_call3
+                  (Stdlib_Array[5],
+                   argv[1],
+                   current[1] + 1 | 0,
+                   (argv[1].length - 1 - current[1] | 0) - 1 | 0);
+              argv[1] =
+                /*<<arg.ml:276:19>>*/ caml_call1
+                (Stdlib_Array[4], [0, before, [0, newarg, [0, after, 0]]]);
+              return 0;
            }
-           if(! match)
-             /*<<arg.ml:198:22>>*/ throw  /*<<arg.ml:198:22>>*/ caml_maybe_attach_backtrace
-                   ([0, Stop, [1, s$0, arg, cst_a_boolean]], 1);
-           var s = match[1];
-            /*<<arg.ml:199:24>>*/  /*<<arg.ml:199:24>>*/ caml_call1(f$0, s);
-            /*<<arg.ml:201:12>>*/ return consume_arg(0);
-          case 2:
-           var r = param[1];
-            /*<<arg.ml:202:19>>*/ no_arg(0);
-           r[1] = 1;
-           return 0;
-          case 3:
-           var r$0 = param[1];
-            /*<<arg.ml:203:21>>*/ no_arg(0);
-           r$0[1] = 0;
-           return 0;
-          case 4:
-            /*<<arg.ml:205:22>>*/ var
-            f$1 = param[1],
-             /*<<arg.ml:205:22>>*/ arg$0 = get_arg(0);
-            /*<<arg.ml:206:12>>*/  /*<<arg.ml:206:12>>*/ caml_call1
-            (f$1, arg$0);
-            /*<<arg.ml:206:12>>*/ return consume_arg(0);
-          case 5:
-           var r$1 = param[1];
-           r$1[1] = get_arg(0);
-            /*<<arg.ml:219:12>>*/ return consume_arg(0);
-          case 6:
-            /*<<arg.ml:221:22>>*/ var
-            f$2 = param[1],
-             /*<<arg.ml:221:22>>*/ arg$1 = get_arg(0),
-             /*<<arg.ml:222:24>>*/ match$0 = int_of_string_opt(arg$1);
-           if(! match$0)
-             /*<<arg.ml:223:22>>*/ throw  /*<<arg.ml:223:22>>*/ caml_maybe_attach_backtrace
-                   ([0, Stop, [1, s$0, arg$1, cst_an_integer]], 1);
-           var x = match$0[1];
-            /*<<arg.ml:224:24>>*/  /*<<arg.ml:224:24>>*/ caml_call1(f$2, x);
-            /*<<arg.ml:226:12>>*/ return consume_arg(0);
-          case 7:
-            /*<<arg.ml:228:22>>*/ var
-            r$2 = param[1],
-             /*<<arg.ml:228:22>>*/ arg$2 = get_arg(0),
-             /*<<arg.ml:229:24>>*/ match$1 = int_of_string_opt(arg$2);
-           if(! match$1)
-             /*<<arg.ml:230:22>>*/ throw  /*<<arg.ml:230:22>>*/ caml_maybe_attach_backtrace
-                   ([0, Stop, [1, s$0, arg$2, cst_an_integer$0]], 1);
-           var x$0 = match$1[1];
-           r$2[1] = x$0;
-            /*<<arg.ml:233:12>>*/ return consume_arg(0);
-          case 8:
-            /*<<arg.ml:235:22>>*/ var
-            f$3 = param[1],
-             /*<<arg.ml:235:22>>*/ arg$3 = get_arg(0),
-             /*<<arg.ml:236:24>>*/ match$2 = float_of_string_opt(arg$3);
-           if(! match$2)
-             /*<<arg.ml:237:22>>*/ throw  /*<<arg.ml:237:22>>*/ caml_maybe_attach_backtrace
-                   ([0, Stop, [1, s$0, arg$3, cst_a_float]], 1);
-           var x$1 = match$2[1];
-            /*<<arg.ml:238:24>>*/  /*<<arg.ml:238:24>>*/ caml_call1(f$3, x$1);
-            /*<<arg.ml:240:12>>*/ return consume_arg(0);
-          case 9:
-            /*<<arg.ml:242:22>>*/ var
-            r$3 = param[1],
-             /*<<arg.ml:242:22>>*/ arg$4 = get_arg(0),
-             /*<<arg.ml:243:24>>*/ match$3 = float_of_string_opt(arg$4);
-           if(! match$3)
-             /*<<arg.ml:244:22>>*/ throw  /*<<arg.ml:244:22>>*/ caml_maybe_attach_backtrace
-                   ([0, Stop, [1, s$0, arg$4, cst_a_float$0]], 1);
-           var x$2 = match$3[1];
-           r$3[1] = x$2;
-            /*<<arg.ml:247:12>>*/ return consume_arg(0);
-          case 10:
-           var specs = param[1];
-            /*<<arg.ml:249:12>>*/ no_arg(0);
-            /*<<arg.ml:249:12>>*/ return  /*<<arg.ml:249:12>>*/ caml_call2
-                   (Stdlib_List[18], treat_action, specs);
-          case 11:
-            /*<<arg.ml:209:22>>*/ var
-            f$4 = param[2],
-            symb = param[1],
-             /*<<arg.ml:209:22>>*/ arg$5 = get_arg(0);
-            /*<<arg.ml:210:15>>*/ if
-            ( /*<<arg.ml:210:15>>*/ caml_call2(Stdlib_List[37], arg$5, symb)){
-             /*<<arg.ml:211:14>>*/  /*<<arg.ml:211:14>>*/ caml_call1
-             (f$4, arg$5);
-             /*<<arg.ml:211:14>>*/ return consume_arg(0);
-           }
-            /*<<arg.ml:215:44>>*/  /*<<arg.ml:215:44>>*/ var
-            _aa_ = make_symlist(cst$6, cst$5, cst$4, symb);
-            /*<<arg.ml:213:21>>*/ throw  /*<<arg.ml:213:21>>*/ caml_maybe_attach_backtrace
-                  ([0,
-                    Stop,
-                    [1,
-                     s$0,
-                     arg$5,
-                      /*<<arg.ml:214:42>>*/ caml_call2
-                      (Stdlib[28], cst_one_of, _aa_)]],
-                   1);
-          case 12:
-           var f$5 = param[1];
-            /*<<arg.ml:252:12>>*/ no_arg(0);
-            /*<<arg.ml:255:14>>*/ for(;;){
-            if(current[1] >= (argv[1].length - 1 - 1 | 0)) return 0;
-            var _ab_ = current[1] + 1 | 0;
-             /*<<arg.ml:254:14>>*/  /*<<arg.ml:254:14>>*/ caml_call1
-             (f$5, caml_check_bound(argv[1], _ab_)[1 + _ab_]);
-             /*<<arg.ml:255:14>>*/ consume_arg(0);
-           }
-           break;
-          case 13:
-           var f$6 = param[1];
-            /*<<arg.ml:258:12>>*/ no_arg(0);
-            /*<<arg.ml:259:22>>*/  /*<<arg.ml:259:22>>*/ var acc = [0, 0];
-            /*<<arg.ml:262:14>>*/ for(;;){
-            if(current[1] >= (argv[1].length - 1 - 1 | 0))
-              /*<<arg.ml:264:14>>*/ return  /*<<arg.ml:264:14>>*/ caml_call1
-                     (f$6,
-                       /*<<arg.ml:264:14>>*/ caml_call1(Stdlib_List[10], acc[1]));
-            var _ad_ = current[1] + 1 | 0, _ac_ = acc[1];
-            acc[1] = [0, caml_check_bound(argv[1], _ad_)[1 + _ad_], _ac_];
-             /*<<arg.ml:262:14>>*/ consume_arg(0);
-           }
-           break;
-          default:
-           var f$7 = param[1];
-           if(1 - allow_expand)
-             /*<<arg.ml:267:14>>*/ throw  /*<<arg.ml:267:14>>*/ caml_maybe_attach_backtrace
-                   ([0, Stdlib[6], cst_Arg_Expand_is_is_only_allo], 1);
-            /*<<arg.ml:269:22>>*/ var
-             /*<<arg.ml:269:22>>*/ arg$6 = get_arg(0),
-             /*<<arg.ml:270:25>>*/ newarg =
-               /*<<arg.ml:270:25>>*/ caml_call1(f$7, arg$6);
-            /*<<arg.ml:271:12>>*/ consume_arg(0);
-            /*<<arg.ml:272:25>>*/ var
-             /*<<arg.ml:272:25>>*/ before =
-               /*<<arg.ml:272:25>>*/ caml_call3
-               (Stdlib_Array[5], argv[1], 0, current[1] + 1 | 0),
-             /*<<arg.ml:274:14>>*/ after =
-               /*<<arg.ml:274:14>>*/ caml_call3
-               (Stdlib_Array[5],
-                argv[1],
-                current[1] + 1 | 0,
-                (argv[1].length - 1 - current[1] | 0) - 1 | 0);
-           argv[1] =
-             /*<<arg.ml:276:19>>*/ caml_call1
-             (Stdlib_Array[4], [0, before, [0, newarg, [0, after, 0]]]);
-           return 0;
-        }
-        /*<<arg.ml:276:54>>*/ }
+           /*<<arg.ml:276:54>>*/ };
+       let treat_action$0 = treat_action;
         /*<<arg.ml:278:8>>*/ treat_action(action);
       }
       else
@@ -21274,7 +21353,10 @@
     /*<<arg.ml:407:15>>*/ function read_arg(_D_){
      /*<<?>>*/ return read_aux(_s_, _r_, _D_);
    }
-   var _t_ = 0, _u_ = 0, _v_ = [0, [2, 0, [0, 0]], "%s%c"];
+   var
+     /*<<arg.ml:407:15>>*/ _t_ = 0,
+    _u_ = 0,
+    _v_ = [0, [2, 0, [0, 0]], "%s%c"];
     /*<<arg.ml:409:16>>*/ function read_arg0(_C_){
      /*<<?>>*/ return read_aux(_u_, _t_, _C_);
    }
@@ -21295,7 +21377,7 @@
     /*<<arg.ml:416:16>>*/ function write_arg(_A_, _B_){
      /*<<?>>*/ return write_aux(_w_, _A_, _B_);
    }
-   var _x_ = 0;
+    /*<<arg.ml:416:16>>*/ var _x_ = 0;
     /*<<arg.ml:418:17>>*/ function write_arg0(_y_, _z_){
      /*<<?>>*/ return write_aux(_x_, _y_, _z_);
    }
@@ -22594,7 +22676,7 @@
             (arr, [0]);
     /*<<bigarray.ml:158:37>>*/ }
    function set(arr){
-     /*<<bigarray.ml:159:16>>*/ var _aa_ = [0];
+     /*<<bigarray.ml:159:16>>*/  /*<<bigarray.ml:159:16>>*/ var _aa_ = [0];
      /*<<bigarray.ml:159:33>>*/ return function(_ab_){
       /*<<?>>*/ return caml_ba_set_generic(arr, _aa_, _ab_);};
     /*<<bigarray.ml:159:37>>*/ }
@@ -24029,7 +24111,7 @@
        buck$0 = buck$1;
      }
      /*<<hashtbl.ml:266:42>>*/ }
-    var _H_ = 0, _I_ = 0;
+    var  /*<<hashtbl.ml:268:2>>*/ _H_ = 0, _I_ = 0;
      /*<<hashtbl.ml:268:2>>*/ return function(_J_){
       /*<<?>>*/ return aux(_I_, _H_, _J_);};
     /*<<hashtbl.ml:268:13>>*/ }
@@ -27513,7 +27595,7 @@
     /*<<scanf.ml:274:22>>*/ function from_function(_a6_){
      /*<<?>>*/ return create(_a_, _a6_);
    }
-   var len = 1024;
+    /*<<scanf.ml:274:22>>*/ var len = 1024;
    function scan_close_at_end(ic){
      /*<<scanf.ml:320:29>>*/  /*<<scanf.ml:320:29>>*/ caml_call1
      (Stdlib[93], ic);
@@ -27561,7 +27643,7 @@
     /*<<scanf.ml:374:16>>*/ function open_in(_a5_){
      /*<<?>>*/ return open_in_file(_b_, _a5_);
    }
-   var _c_ = Stdlib[80];
+    /*<<scanf.ml:374:16>>*/ var _c_ = Stdlib[80];
     /*<<scanf.ml:375:20>>*/ function open_in_bin(_a4_){
      /*<<?>>*/ return open_in_file(_c_, _a4_);
    }
@@ -29639,7 +29721,7 @@
      /*<<camlinternalOO.ml:116:18>>*/ table_count = [0, 0],
      /*<<camlinternalOO.ml:119:31>>*/ dummy_met =
        /*<<camlinternalOO.ml:119:31>>*/ caml_obj_block(0, 0),
-    initial_object_size = 2;
+     /*<<camlinternalOO.ml:36:13>>*/ initial_object_size = 2;
    function fit_size(n){
      /*<<camlinternalOO.ml:124:2>>*/ return 2 < n
             ? fit_size((n + 1 | 0) / 2 | 0) * 2 | 0
@@ -30689,15 +30771,18 @@
        switch(shape){
          case 0:
           let i$1 = i;
-          function fn(x){
-            /*<<camlinternalMod.ml:28:9>>*/  /*<<camlinternalMod.ml:28:38>>*/ var
-            fn$0 = modu[1 + i$1];
-           if(fn === fn$0)
-             /*<<camlinternalMod.ml:30:11>>*/ throw  /*<<camlinternalMod.ml:30:11>>*/ caml_maybe_attach_backtrace
-                   ([0, Stdlib[15], loc], 1);
-            /*<<camlinternalMod.ml:32:11>>*/ return  /*<<camlinternalMod.ml:32:11>>*/ caml_call1
-                   (fn$0, x);
-           /*<<camlinternalMod.ml:32:16>>*/ }
+          var
+           fn =
+             function(x){
+               /*<<camlinternalMod.ml:28:9>>*/  /*<<camlinternalMod.ml:28:38>>*/ var
+               fn = modu[1 + i$1];
+              if(fn$0 === fn)
+                /*<<camlinternalMod.ml:30:11>>*/ throw  /*<<camlinternalMod.ml:30:11>>*/ caml_maybe_attach_backtrace
+                      ([0, Stdlib[15], loc], 1);
+               /*<<camlinternalMod.ml:32:11>>*/ return  /*<<camlinternalMod.ml:32:11>>*/ caml_call1
+                      (fn, x);
+              /*<<camlinternalMod.ml:32:16>>*/ };
+          let fn$0 = fn;
           var init = fn;
           break;
          case 1:

--- a/compiler/tests-full/stdlib.cma.expected.js
+++ b/compiler/tests-full/stdlib.cma.expected.js
@@ -364,28 +364,7 @@
     End_of_file = global_data.End_of_file,
     Division_by_zero = global_data.Division_by_zero,
     Sys_blocked_io = global_data.Sys_blocked_io,
-    Undefined_recursive_module = global_data.Undefined_recursive_module,
-    cst_really_input = "really_input",
-    cst_input = "input",
-    _l_ = [0, 0, [0, 6, 0]],
-    _k_ = [0, 0, [0, 7, 0]],
-    cst_output_substring = "output_substring",
-    cst_output = "output",
-    _j_ = [0, 1, [0, 3, [0, 4, [0, 6, 0]]]],
-    _i_ = [0, 1, [0, 3, [0, 4, [0, 7, 0]]]],
-    _g_ = [0, 1],
-    _h_ = [0, 0],
-    cst_bool_of_string = "bool_of_string",
-    cst_true = cst_true$0,
-    cst_false = cst_false$0,
-    cst_char_of_int = "char_of_int",
-    cst_Stdlib_Exit = "Stdlib.Exit",
-    _a_ = runtime.caml_int64_create_lo_mi_hi(0, 0, 32752),
-    _b_ = runtime.caml_int64_create_lo_mi_hi(0, 0, 65520),
-    _c_ = runtime.caml_int64_create_lo_mi_hi(1, 0, 32760),
-    _d_ = runtime.caml_int64_create_lo_mi_hi(16777215, 16777215, 32751),
-    _e_ = runtime.caml_int64_create_lo_mi_hi(0, 0, 16),
-    _f_ = runtime.caml_int64_create_lo_mi_hi(0, 0, 15536);
+    Undefined_recursive_module = global_data.Undefined_recursive_module;
    function failwith(s){
      /*<<stdlib.ml:29:17>>*/ throw  /*<<stdlib.ml:29:17>>*/ caml_maybe_attach_backtrace
            ([0, Failure, s], 1);
@@ -395,7 +374,7 @@
            ([0, Invalid_argument, s], 1);
     /*<<stdlib.ml:30:45>>*/ }
     /*<<stdlib.ml:32:0>>*/  /*<<stdlib.ml:32:0>>*/ var
-    Exit = [248, cst_Stdlib_Exit, runtime.caml_fresh_oo_id(0)];
+    Exit = [248, "Stdlib.Exit", runtime.caml_fresh_oo_id(0)];
    function min(x, y){
      /*<<stdlib.ml:74:14>>*/ return  /*<<stdlib.ml:74:17>>*/ runtime.caml_lessequal
              (x, y)
@@ -416,19 +395,29 @@
     /*<<stdlib.ml:104:24>>*/ }
     /*<<stdlib.ml:180:2>>*/ var
      /*<<stdlib.ml:180:2>>*/ infinity =
-       /*<<stdlib.ml:180:2>>*/ caml_int64_float_of_bits(_a_),
+       /*<<stdlib.ml:180:2>>*/ caml_int64_float_of_bits
+       (runtime.caml_int64_create_lo_mi_hi(0, 0, 32752)),
      /*<<stdlib.ml:182:2>>*/ neg_infinity =
-       /*<<stdlib.ml:182:2>>*/ caml_int64_float_of_bits(_b_),
+       /*<<stdlib.ml:182:2>>*/ caml_int64_float_of_bits
+       (runtime.caml_int64_create_lo_mi_hi(0, 0, 65520)),
      /*<<stdlib.ml:184:2>>*/ nan =
-       /*<<stdlib.ml:184:2>>*/ caml_int64_float_of_bits(_c_),
+       /*<<stdlib.ml:184:2>>*/ caml_int64_float_of_bits
+       (runtime.caml_int64_create_lo_mi_hi(1, 0, 32760)),
      /*<<stdlib.ml:186:2>>*/ max_float =
-       /*<<stdlib.ml:186:2>>*/ caml_int64_float_of_bits(_d_),
+       /*<<stdlib.ml:186:2>>*/ caml_int64_float_of_bits
+       (runtime.caml_int64_create_lo_mi_hi(16777215, 16777215, 32751)),
      /*<<stdlib.ml:188:2>>*/ min_float =
-       /*<<stdlib.ml:188:2>>*/ caml_int64_float_of_bits(_e_),
+       /*<<stdlib.ml:188:2>>*/ caml_int64_float_of_bits
+       (runtime.caml_int64_create_lo_mi_hi(0, 0, 16)),
      /*<<stdlib.ml:190:2>>*/ epsilon_float =
-       /*<<stdlib.ml:190:2>>*/ caml_int64_float_of_bits(_f_),
-    max_int = 2147483647,
-    min_int = -2147483648;
+       /*<<stdlib.ml:190:2>>*/ caml_int64_float_of_bits
+       (runtime.caml_int64_create_lo_mi_hi(0, 0, 15536)),
+    cst_char_of_int = "char_of_int",
+    cst_true = cst_true$0,
+    cst_false = cst_false$0,
+    cst_bool_of_string = "bool_of_string",
+    _a_ = [0, 1],
+    _b_ = [0, 0];
    function symbol(s1, s2){
      /*<<stdlib.ml:213:2>>*/ var
      l1 = caml_ml_string_length(s1),
@@ -459,8 +448,8 @@
     /*<<stdlib.ml:258:37>>*/ }
    function bool_of_string_opt(param){
      /*<<stdlib.ml:260:25>>*/ return caml_string_notequal(param, cst_false$0)
-            ? caml_string_notequal(param, cst_true$0) ? 0 : _g_
-            : _h_;
+            ? caml_string_notequal(param, cst_true$0) ? 0 : _a_
+            : _b_;
     /*<<stdlib.ml:263:13>>*/ }
    function string_of_int(n){
      /*<<stdlib.ml:266:2>>*/ return "" + n;
@@ -468,13 +457,13 @@
    function int_of_string_opt(s){
      /*<<stdlib.ml:272:2>>*/ try{
       /*<<stdlib.ml:272:6>>*/  /*<<stdlib.ml:272:6>>*/ var
-      _D_ = [0,  /*<<stdlib.ml:272:11>>*/ caml_int_of_string(s)];
-      /*<<stdlib.ml:272:6>>*/ return _D_;
+      _x_ = [0,  /*<<stdlib.ml:272:11>>*/ caml_int_of_string(s)];
+      /*<<stdlib.ml:272:6>>*/ return _x_;
     }
-    catch(_E_){
-     var _C_ = caml_wrap_exception(_E_);
-     if(_C_[1] === Failure)  /*<<stdlib.ml:273:20>>*/ return 0;
-     throw caml_maybe_attach_backtrace(_C_, 0);
+    catch(_y_){
+     var _w_ = caml_wrap_exception(_y_);
+     if(_w_[1] === Failure)  /*<<stdlib.ml:273:20>>*/ return 0;
+     throw caml_maybe_attach_backtrace(_w_, 0);
     }
     /*<<stdlib.ml:273:24>>*/ }
    function valid_float_lexem(s){
@@ -500,20 +489,20 @@
    function float_of_string_opt(s){
      /*<<stdlib.ml:293:2>>*/ try{
       /*<<stdlib.ml:293:6>>*/  /*<<stdlib.ml:293:6>>*/ var
-      _A_ = [0,  /*<<stdlib.ml:293:11>>*/ caml_float_of_string(s)];
-      /*<<stdlib.ml:293:6>>*/ return _A_;
+      _u_ = [0,  /*<<stdlib.ml:293:11>>*/ caml_float_of_string(s)];
+      /*<<stdlib.ml:293:6>>*/ return _u_;
     }
-    catch(_B_){
-     var _z_ = caml_wrap_exception(_B_);
-     if(_z_[1] === Failure)  /*<<stdlib.ml:294:20>>*/ return 0;
-     throw caml_maybe_attach_backtrace(_z_, 0);
+    catch(_v_){
+     var _t_ = caml_wrap_exception(_v_);
+     if(_t_[1] === Failure)  /*<<stdlib.ml:294:20>>*/ return 0;
+     throw caml_maybe_attach_backtrace(_t_, 0);
     }
     /*<<stdlib.ml:294:24>>*/ }
    function symbol$0(l1, l2){
      /*<<stdlib.ml:299:2>>*/ if(! l1)  /*<<stdlib.ml:300:10>>*/ return l2;
-    var _x_ = l1[2], h1 = l1[1];
-    if(! _x_)  /*<<stdlib.ml:301:16>>*/ return [0, h1, l2];
-    var match = _x_[2], h2 = _x_[1];
+    var _r_ = l1[2], h1 = l1[1];
+    if(! _r_)  /*<<stdlib.ml:301:16>>*/ return [0, h1, l2];
+    var match = _r_[2], h2 = _r_[1];
     if(! match)  /*<<stdlib.ml:302:22>>*/ return [0, h1, [0, h2, l2]];
      /*<<stdlib.ml:303:40>>*/ var
      tl = match[2],
@@ -524,9 +513,9 @@
      l1$0 = tl;
      /*<<stdlib.ml:299:2>>*/ for(;;){
      if(l1$0){
-      var _y_ = l1$0[2], h1$0 = l1$0[1];
-      if(_y_){
-       var match$0 = _y_[2], h2$0 = _y_[1];
+      var _s_ = l1$0[2], h1$0 = l1$0[1];
+      if(_s_){
+       var match$0 = _s_[2], h2$0 = _s_[1];
        if(match$0){
          /*<<stdlib.ml:303:40>>*/ var
          tl$0 = match$0[2],
@@ -552,7 +541,15 @@
      /*<<stdlib.ml:315:13>>*/ stdout =
        /*<<stdlib.ml:315:13>>*/ caml_ml_open_descriptor_out(1),
      /*<<stdlib.ml:316:13>>*/ stderr =
-       /*<<stdlib.ml:316:13>>*/ caml_ml_open_descriptor_out(2);
+       /*<<stdlib.ml:316:13>>*/ caml_ml_open_descriptor_out(2),
+    _c_ = [0, 1, [0, 3, [0, 4, [0, 7, 0]]]],
+    _d_ = [0, 1, [0, 3, [0, 4, [0, 6, 0]]]],
+    cst_output = "output",
+    cst_output_substring = "output_substring",
+    _e_ = [0, 0, [0, 7, 0]],
+    _f_ = [0, 0, [0, 6, 0]],
+    cst_input = "input",
+    cst_really_input = "really_input";
    function open_out_gen(mode, perm, name){
      /*<<stdlib.ml:331:2>>*/  /*<<stdlib.ml:331:10>>*/ var
      c =
@@ -563,10 +560,10 @@
      /*<<stdlib.ml:332:2>>*/ return c;
     /*<<stdlib.ml:333:3>>*/ }
    function open_out(name){
-     /*<<stdlib.ml:336:2>>*/ return open_out_gen(_i_, 438, name);
+     /*<<stdlib.ml:336:2>>*/ return open_out_gen(_c_, 438, name);
     /*<<stdlib.ml:336:74>>*/ }
    function open_out_bin(name){
-     /*<<stdlib.ml:339:2>>*/ return open_out_gen(_j_, 438, name);
+     /*<<stdlib.ml:339:2>>*/ return open_out_gen(_d_, 438, name);
     /*<<stdlib.ml:339:76>>*/ }
    function flush_all(param){
      /*<<stdlib.ml:347:2>>*/ var
@@ -577,9 +574,9 @@
       /*<<stdlib.ml:350:8>>*/ try{
        /*<<stdlib.ml:351:12>>*/  /*<<stdlib.ml:351:12>>*/ caml_ml_flush(a);
      }
-     catch(_w_){
-      var _v_ = caml_wrap_exception(_w_);
-      if(_v_[1] !== Sys_error) throw caml_maybe_attach_backtrace(_v_, 0);
+     catch(_q_){
+      var _p_ = caml_wrap_exception(_q_);
+      if(_p_[1] !== Sys_error) throw caml_maybe_attach_backtrace(_p_, 0);
      }
      var param$0 = l;
     }
@@ -619,13 +616,13 @@
      /*<<stdlib.ml:394:2>>*/ try{
       /*<<stdlib.ml:394:7>>*/  /*<<stdlib.ml:394:7>>*/ caml_ml_flush(oc);
     }
-    catch(_u_){}
+    catch(_o_){}
      /*<<stdlib.ml:395:2>>*/ try{
       /*<<stdlib.ml:395:7>>*/  /*<<stdlib.ml:395:7>>*/ var
-      _s_ =  /*<<stdlib.ml:395:7>>*/ caml_ml_close_channel(oc);
-      /*<<stdlib.ml:395:7>>*/ return _s_;
+      _m_ =  /*<<stdlib.ml:395:7>>*/ caml_ml_close_channel(oc);
+      /*<<stdlib.ml:395:7>>*/ return _m_;
     }
-    catch(_t_){ /*<<stdlib.ml:395:38>>*/ return 0;}
+    catch(_n_){ /*<<stdlib.ml:395:38>>*/ return 0;}
     /*<<stdlib.ml:395:41>>*/ }
    function open_in_gen(mode, perm, name){
      /*<<stdlib.ml:405:2>>*/  /*<<stdlib.ml:405:10>>*/ var
@@ -637,10 +634,10 @@
      /*<<stdlib.ml:406:2>>*/ return c;
     /*<<stdlib.ml:407:3>>*/ }
    function open_in(name){
-     /*<<stdlib.ml:410:2>>*/ return open_in_gen(_k_, 0, name);
+     /*<<stdlib.ml:410:2>>*/ return open_in_gen(_e_, 0, name);
     /*<<stdlib.ml:410:45>>*/ }
    function open_in_bin(name){
-     /*<<stdlib.ml:413:2>>*/ return open_in_gen(_l_, 0, name);
+     /*<<stdlib.ml:413:2>>*/ return open_in_gen(_f_, 0, name);
     /*<<stdlib.ml:413:47>>*/ }
    function input(ic, s, ofs, len){
      /*<<stdlib.ml:421:2>>*/ if
@@ -701,7 +698,7 @@
         /*<<stdlib.ml:456:14>>*/ throw  /*<<stdlib.ml:456:14>>*/ caml_maybe_attach_backtrace
               (End_of_file, 1);
       var
-       _r_ =
+       _l_ =
          build_result
           ( /*<<stdlib.ml:457:27>>*/ caml_create_bytes(len), len, accu);
      }
@@ -727,25 +724,25 @@
       if(accu)
        var
         len$0 = (len + n | 0) - 1 | 0,
-        _r_ =
+        _l_ =
           build_result
            ( /*<<stdlib.ml:465:27>>*/ caml_create_bytes(len$0),
             len$0,
             [0, res, accu]);
       else
-       var _r_ = res;
+       var _l_ = res;
      }
       /*<<stdlib.ml:471:28>>*/ return  /*<<stdlib.ml:471:28>>*/ caml_string_of_bytes
-             (_r_);
+             (_l_);
     }
     /*<<stdlib.ml:471:39>>*/ }
    function close_in_noerr(ic){
      /*<<stdlib.ml:480:24>>*/ try{
       /*<<stdlib.ml:480:29>>*/  /*<<stdlib.ml:480:29>>*/ var
-      _p_ =  /*<<stdlib.ml:480:29>>*/ caml_ml_close_channel(ic);
-      /*<<stdlib.ml:480:29>>*/ return _p_;
+      _j_ =  /*<<stdlib.ml:480:29>>*/ caml_ml_close_channel(ic);
+      /*<<stdlib.ml:480:29>>*/ return _j_;
     }
-    catch(_q_){ /*<<stdlib.ml:480:51>>*/ return 0;}
+    catch(_k_){ /*<<stdlib.ml:480:51>>*/ return 0;}
     /*<<stdlib.ml:480:54>>*/ }
    function print_char(c){
      /*<<stdlib.ml:486:19>>*/ return  /*<<stdlib.ml:486:19>>*/ caml_ml_output_char
@@ -827,17 +824,17 @@
     var str = param[2];
      /*<<stdlib.ml:538:44>>*/ return str;
    }
-   function symbol$1(param, _n_){
+   function symbol$1(param, _h_){
      /*<<stdlib.ml:546:10>>*/ var
-     str2 = _n_[2],
-     fmt2 = _n_[1],
+     str2 = _h_[2],
+     fmt2 = _h_[1],
      str1 = param[2],
      fmt1 = param[1],
-      /*<<stdlib.ml:546:10>>*/ _o_ = symbol(str1, symbol(cst$0, str2));
+      /*<<stdlib.ml:546:10>>*/ _i_ = symbol(str1, symbol(cst$0, str2));
      /*<<stdlib.ml:545:2>>*/ return [0,
              /*<<stdlib.ml:545:10>>*/ caml_call2
              (CamlinternalFormatBasics[3], fmt1, fmt2),
-            _o_];
+            _i_];
    }
     /*<<stdlib.ml:559:20>>*/  /*<<stdlib.ml:559:20>>*/ var
     exit_function = [0, flush_all];
@@ -848,16 +845,17 @@
        /*<<stdlib.ml:564:2>>*/ old_exit =
          /*<<stdlib.ml:564:2>>*/ caml_atomic_load(exit_function);
      let f_yet_to_run$0 = f_yet_to_run, old_exit$0 = old_exit;
-     function new_exit(param){
-       /*<<stdlib.ml:566:4>>*/ if(caml_atomic_cas(f_yet_to_run$0, 1, 0))
-        /*<<stdlib.ml:566:59>>*/  /*<<stdlib.ml:566:59>>*/ caml_call1(f, 0);
-       /*<<stdlib.ml:566:59>>*/ return  /*<<stdlib.ml:566:59>>*/ caml_call1
-              (old_exit$0, 0);
-      /*<<stdlib.ml:567:15>>*/ }
       /*<<stdlib.ml:570:2>>*/ var
+      new_exit =
+        function(param){
+          /*<<stdlib.ml:566:4>>*/ if(caml_atomic_cas(f_yet_to_run$0, 1, 0))
+           /*<<stdlib.ml:566:59>>*/  /*<<stdlib.ml:566:59>>*/ caml_call1(f, 0);
+          /*<<stdlib.ml:566:59>>*/ return  /*<<stdlib.ml:566:59>>*/ caml_call1
+                 (old_exit$0, 0);
+         /*<<stdlib.ml:567:15>>*/ },
       success = caml_atomic_cas(exit_function, old_exit, new_exit),
-       /*<<stdlib.ml:570:2>>*/ _m_ = 1 - success;
-     if(! _m_)  /*<<stdlib.ml:570:2>>*/ return _m_;
+       /*<<stdlib.ml:570:2>>*/ _g_ = 1 - success;
+     if(! _g_)  /*<<stdlib.ml:570:2>>*/ return _g_;
     }
     /*<<stdlib.ml:570:31>>*/ }
     /*<<stdlib.ml:572:30>>*/  /*<<stdlib.ml:572:30>>*/ var
@@ -900,8 +898,8 @@
        min,
        max,
        abs,
-       max_int,
-       min_int,
+       2147483647,
+       -2147483648,
        lnot,
        infinity,
        neg_infinity,
@@ -1144,11 +1142,7 @@
     cygwin = runtime.caml_sys_const_ostype_cygwin(0),
     max_array_length = runtime.caml_sys_const_max_wosize(0),
     max_floatarray_length = max_array_length / 2 | 0,
-    max_string_length = (4 * max_array_length | 0) - 1 | 0,
-    cst_Stdlib_Sys_Break = "Stdlib.Sys.Break",
-    big_endian = 0,
-    word_size = 32,
-    int_size = 32;
+    max_string_length = (4 * max_array_length | 0) - 1 | 0;
    function getenv_opt(s){
      /*<<sys.ml.in:60:2>>*/ try{
       /*<<sys.ml.in:60:6>>*/  /*<<sys.ml.in:60:6>>*/ var
@@ -1164,41 +1158,11 @@
     /*<<sys.ml.in:72:18>>*/  /*<<sys.ml.in:72:18>>*/ var interactive = [0, 0];
    function set_signal(sig_num, sig_beh){ /*<<sys.ml.in:82:33>>*/ return 0;
     /*<<sys.ml.in:82:63>>*/ }
-    /*<<sys.ml.in:113:0>>*/ var
-     /*<<sys.ml.in:113:0>>*/ Break =
-      [248, cst_Stdlib_Sys_Break, runtime.caml_fresh_oo_id(0)],
-    sigabrt = -1,
-    sigalrm = -2,
-    sigfpe = -3,
-    sighup = -4,
-    sigill = -5,
-    sigint = -6,
-    sigkill = -7,
-    sigpipe = -8,
-    sigquit = -9,
-    sigsegv = -10,
-    sigterm = -11,
-    sigusr1 = -12,
-    sigusr2 = -13,
-    sigchld = -14,
-    sigcont = -15,
-    sigstop = -16,
-    sigtstp = -17,
-    sigttin = -18,
-    sigttou = -19,
-    sigvtalrm = -20,
-    sigprof = -21,
-    sigbus = -22,
-    sigpoll = -23,
-    sigsys = -24,
-    sigtrap = -25,
-    sigurg = -26,
-    sigxcpu = -27,
-    sigxfsz = -28;
+    /*<<sys.ml.in:113:0>>*/  /*<<sys.ml.in:113:0>>*/ var
+    Break = [248, "Stdlib.Sys.Break", runtime.caml_fresh_oo_id(0)];
    function catch_break(on){
      /*<<sys.ml.in:116:2>>*/ return on ? 0 : 0;
     /*<<sys.ml.in:119:36>>*/ }
-   var development_version = 0;
    function Make(_b_, _a_){ /*<<sys.ml.in:163:70>>*/ return [0, 1];}
     /*<<sys.ml.in:155:21>>*/ var
      /*<<sys.ml.in:155:21>>*/ Immediate64 = [0, Make],
@@ -1212,45 +1176,45 @@
        unix,
        win32,
        cygwin,
-       word_size,
-       int_size,
-       big_endian,
+       32,
+       32,
+       0,
        max_string_length,
        max_array_length,
        max_floatarray_length,
        set_signal,
-       sigabrt,
-       sigalrm,
-       sigfpe,
-       sighup,
-       sigill,
-       sigint,
-       sigkill,
-       sigpipe,
-       sigquit,
-       sigsegv,
-       sigterm,
-       sigusr1,
-       sigusr2,
-       sigchld,
-       sigcont,
-       sigstop,
-       sigtstp,
-       sigttin,
-       sigttou,
-       sigvtalrm,
-       sigprof,
-       sigbus,
-       sigpoll,
-       sigsys,
-       sigtrap,
-       sigurg,
-       sigxcpu,
-       sigxfsz,
+       -1,
+       -2,
+       -3,
+       -4,
+       -5,
+       -6,
+       -7,
+       -8,
+       -9,
+       -10,
+       -11,
+       -12,
+       -13,
+       -14,
+       -15,
+       -16,
+       -17,
+       -18,
+       -19,
+       -20,
+       -21,
+       -22,
+       -23,
+       -24,
+       -25,
+       -26,
+       -27,
+       -28,
        Break,
        catch_break,
        ocaml_version,
-       development_version,
+       0,
        ocaml_release,
        runtime.caml_ml_enable_runtime_warnings,
        runtime.caml_ml_runtime_warnings_enabled,
@@ -1279,41 +1243,16 @@
     global_data = runtime.caml_get_global_data(),
     Stdlib = global_data.Stdlib,
     Assert_failure = global_data.Assert_failure,
-    Stdlib_Sys = global_data.Stdlib__Sys,
-    cst_Obj_Ephemeron_blit_key = "Obj.Ephemeron.blit_key",
-    cst_Obj_Ephemeron_check_key = "Obj.Ephemeron.check_key",
-    cst_Obj_Ephemeron_unset_key = "Obj.Ephemeron.unset_key",
-    cst_Obj_Ephemeron_set_key = "Obj.Ephemeron.set_key",
-    cst_Obj_Ephemeron_get_key_copy = "Obj.Ephemeron.get_key_copy",
-    cst_Obj_Ephemeron_get_key = "Obj.Ephemeron.get_key",
-    cst_Obj_Ephemeron_create = "Obj.Ephemeron.create",
-    cst_Obj_extension_constructor$0 = cst_Obj_extension_constructor$1,
-    cst_Obj_extension_constructor = cst_Obj_extension_constructor$1,
-    _a_ = [0, "obj.ml", 94, 4];
+    Stdlib_Sys = global_data.Stdlib__Sys;
    function is_block(a){
      /*<<obj.ml:26:34>>*/ return 1 - (typeof a === "number" ? 1 : 0);
     /*<<obj.ml:26:48>>*/ }
    var
     double_field = runtime.caml_array_get,
     set_double_field = runtime.caml_array_set,
-    first_non_constant_constructor = 0,
-    last_non_constant_constructor_ = 243,
-    forcing_tag = 244,
-    cont_tag = 245,
-    lazy_tag = 246,
-    closure_tag = 247,
-    object_tag = 248,
-    infix_tag = 249,
-    forward_tag = 250,
-    no_scan_tag = 251,
-    abstract_tag = 251,
-    string_tag = 252,
-    double_tag = 253,
-    double_array_tag = 254,
-    custom_tag = 255,
-    int_tag = 1000,
-    out_of_heap_tag = 1001,
-    unaligned_tag = 1002;
+    _a_ = [0, "obj.ml", 94, 4],
+    cst_Obj_extension_constructor = cst_Obj_extension_constructor$1,
+    cst_Obj_extension_constructor$0 = cst_Obj_extension_constructor$1;
    function info(obj){
      /*<<obj.ml:94:4>>*/ if( /*<<obj.ml:94:12>>*/ caml_obj_tag(obj) !== 247)
       /*<<obj.ml:94:4>>*/ throw  /*<<obj.ml:94:4>>*/ caml_maybe_attach_backtrace
@@ -1354,7 +1293,14 @@
     /*<<obj.ml:118:30>>*/ }
     /*<<obj.ml:99:0>>*/ var
      /*<<obj.ml:99:0>>*/ Extension_constructor = [0, of_val, name, id],
-    max_ephe_length = Stdlib_Sys[13] - 2 | 0;
+    max_ephe_length = Stdlib_Sys[13] - 2 | 0,
+    cst_Obj_Ephemeron_create = "Obj.Ephemeron.create",
+    cst_Obj_Ephemeron_get_key = "Obj.Ephemeron.get_key",
+    cst_Obj_Ephemeron_get_key_copy = "Obj.Ephemeron.get_key_copy",
+    cst_Obj_Ephemeron_set_key = "Obj.Ephemeron.set_key",
+    cst_Obj_Ephemeron_unset_key = "Obj.Ephemeron.unset_key",
+    cst_Obj_Ephemeron_check_key = "Obj.Ephemeron.check_key",
+    cst_Obj_Ephemeron_blit_key = "Obj.Ephemeron.blit_key";
    function create(l){
      /*<<obj.ml:132:4>>*/ var
      _g_ = 0 <= l ? 1 : 0,
@@ -1429,24 +1375,24 @@
        is_block,
        double_field,
        set_double_field,
-       first_non_constant_constructor,
-       last_non_constant_constructor_,
-       forcing_tag,
-       cont_tag,
-       lazy_tag,
-       closure_tag,
-       object_tag,
-       infix_tag,
-       forward_tag,
-       no_scan_tag,
-       abstract_tag,
-       string_tag,
-       double_tag,
-       double_array_tag,
-       custom_tag,
-       int_tag,
-       out_of_heap_tag,
-       unaligned_tag,
+       0,
+       243,
+       244,
+       245,
+       246,
+       247,
+       248,
+       249,
+       250,
+       251,
+       251,
+       252,
+       253,
+       254,
+       255,
+       1000,
+       1001,
+       1002,
        [0, info],
        Extension_constructor,
        [0,
@@ -1484,8 +1430,8 @@
    var
     global_data = runtime.caml_get_global_data(),
     Stdlib_Obj = global_data.Stdlib__Obj,
-    _a_ = [0, 0],
-    cst_Id = "Id";
+    cst_Id = "Id",
+    _a_ = [0, 0];
    function make(param){
      /*<<type.ml:32:4>>*/  /*<<type.ml:32:43>>*/ var
      Id = [248, cst_Id, runtime.caml_fresh_oo_id(0)];
@@ -1528,18 +1474,14 @@
     return 0;
     /*<<atomic.ml:26:42>>*/ }
    var
-    _a_ = caml_atomic_fetch_add,
-    _b_ = runtime.caml_atomic_cas,
-    _c_ = caml_atomic_exchange,
-    _d_ = runtime.caml_atomic_load,
     Stdlib_Atomic =
       [0,
-       function(_e_){ /*<<atomic.ml:17:0>>*/ return [0, _e_];},
-       _d_,
+       function(_a_){ /*<<atomic.ml:17:0>>*/ return [0, _a_];},
+       runtime.caml_atomic_load,
        set,
-       _c_,
-       _b_,
-       _a_,
+       caml_atomic_exchange,
+       runtime.caml_atomic_cas,
+       caml_atomic_fetch_add,
        incr,
        decr];
    runtime.caml_register_global(0, Stdlib_Atomic, "Stdlib__Atomic");
@@ -1756,11 +1698,9 @@
     CamlinternalLazy = global_data.CamlinternalLazy,
     Stdlib = global_data.Stdlib,
     Stdlib_Lazy = global_data.Stdlib__Lazy,
-    _a_ = [0, "seq.ml", 616, 4],
-    cst_Seq_drop = "Seq.drop",
-    cst_Seq_take = "Seq.take",
     cst_Seq_init = "Seq.init",
-    cst_Stdlib_Seq_Forced_twice = "Stdlib.Seq.Forced_twice";
+    cst_Seq_take = "Seq.take",
+    cst_Seq_drop = "Seq.drop";
    function empty(param){
      /*<<seq.ml:24:15>>*/ return 0;
     /*<<seq.ml:24:18>>*/ }
@@ -1778,19 +1718,16 @@
     var next = match[2], x = match[1];
      /*<<seq.ml:33:22>>*/ return [0,
             x,
-            function(_aI_){ /*<<?>>*/ return append(next, seq2, _aI_);}];
+            function(_ay_){ /*<<?>>*/ return append(next, seq2, _ay_);}];
     /*<<seq.ml:33:48>>*/ }
    function map(f, seq, param){
      /*<<seq.ml:35:23>>*/  /*<<seq.ml:35:29>>*/ var
      match =  /*<<seq.ml:35:29>>*/ caml_call1(seq, 0);
     if(! match)  /*<<seq.ml:36:11>>*/ return 0;
     var next = match[2], x = match[1];
-     /*<<seq.ml:37:33>>*/ function _aG_(_aH_){
-      /*<<?>>*/ return map(f, next, _aH_);
-    }
      /*<<seq.ml:37:22>>*/ return [0,
              /*<<seq.ml:37:28>>*/ caml_call1(f, x),
-            _aG_];
+            function(_ax_){ /*<<?>>*/ return map(f, next, _ax_);}];
     /*<<seq.ml:37:44>>*/ }
    function filter_map(f, seq, param){
      /*<<seq.ml:39:30>>*/ var seq$0 = seq;
@@ -1806,7 +1743,7 @@
       var y = match$0[1];
        /*<<seq.ml:44:20>>*/ return [0,
               y,
-              function(_aF_){ /*<<?>>*/ return filter_map(f, next, _aF_);}];
+              function(_aw_){ /*<<?>>*/ return filter_map(f, next, _aw_);}];
      }
      var seq$0 = next;
     }
@@ -1821,7 +1758,7 @@
       /*<<seq.ml:49:9>>*/ if( /*<<seq.ml:49:9>>*/ caml_call1(f, x))
        /*<<seq.ml:50:11>>*/ return [0,
               x,
-              function(_aE_){ /*<<?>>*/ return filter(f, next, _aE_);}];
+              function(_av_){ /*<<?>>*/ return filter(f, next, _av_);}];
      var seq$0 = next;
     }
     /*<<seq.ml:51:27>>*/ }
@@ -1829,20 +1766,19 @@
      /*<<seq.ml:53:24>>*/  /*<<seq.ml:53:30>>*/ var
      match =  /*<<seq.ml:53:30>>*/ caml_call1(seq, 0);
     if(! match)  /*<<seq.ml:54:11>>*/ return 0;
-    var next = match[2], x = match[1], _aC_ = 0;
+    var next = match[2], x = match[1];
      /*<<seq.ml:56:5>>*/ return append
-            (x, function(_aD_){ /*<<?>>*/ return concat(next, _aD_);}, _aC_);
+            (x, function(_au_){ /*<<?>>*/ return concat(next, _au_);}, 0);
     /*<<seq.ml:56:30>>*/ }
    function flat_map(f, seq, param){
      /*<<seq.ml:58:28>>*/  /*<<seq.ml:58:34>>*/ var
      match =  /*<<seq.ml:58:34>>*/ caml_call1(seq, 0);
     if(! match)  /*<<seq.ml:59:11>>*/ return 0;
-    var next = match[2], x = match[1], _az_ = 0;
-     /*<<seq.ml:61:17>>*/ function _aA_(_aB_){
-      /*<<?>>*/ return flat_map(f, next, _aB_);
-    }
+    var next = match[2], x = match[1];
      /*<<seq.ml:61:4>>*/ return append
-            ( /*<<seq.ml:61:11>>*/ caml_call1(f, x), _aA_, _az_);
+            ( /*<<seq.ml:61:11>>*/ caml_call1(f, x),
+             function(_at_){ /*<<?>>*/ return flat_map(f, next, _at_);},
+             0);
     /*<<seq.ml:61:37>>*/ }
    function fold_left(f, acc, seq){
      /*<<seq.ml:66:2>>*/ var acc$0 = acc, seq$0 = seq;
@@ -1877,7 +1813,7 @@
     var match$0 = match[1], u$0 = match$0[2], x = match$0[1];
      /*<<seq.ml:82:20>>*/ return [0,
             x,
-            function(_ay_){ /*<<?>>*/ return unfold(f, u$0, _ay_);}];
+            function(_as_){ /*<<?>>*/ return unfold(f, u$0, _as_);}];
     /*<<seq.ml:82:41>>*/ }
    function is_empty(xs){
      /*<<seq.ml:85:2>>*/ return  /*<<seq.ml:85:8>>*/ caml_call1(xs, 0) ? 0 : 1;
@@ -1939,8 +1875,8 @@
       /*<<seq.ml:137:6>>*/ var
       xs$1 = match[2],
       x = match[1],
-       /*<<seq.ml:137:6>>*/ _ax_ =  /*<<seq.ml:137:6>>*/ caml_call1(p, x);
-      /*<<seq.ml:137:6>>*/ if(! _ax_)  /*<<seq.ml:137:6>>*/ return _ax_;
+       /*<<seq.ml:137:6>>*/ _ar_ =  /*<<seq.ml:137:6>>*/ caml_call1(p, x);
+      /*<<seq.ml:137:6>>*/ if(! _ar_)  /*<<seq.ml:137:6>>*/ return _ar_;
      var xs$0 = xs$1;
     }
     /*<<seq.ml:137:25>>*/ }
@@ -1953,8 +1889,8 @@
       /*<<seq.ml:144:6>>*/ var
       xs$1 = match[2],
       x = match[1],
-       /*<<seq.ml:144:6>>*/ _aw_ =  /*<<seq.ml:144:6>>*/ caml_call1(p, x);
-      /*<<seq.ml:144:6>>*/ if(_aw_)  /*<<seq.ml:144:6>>*/ return _aw_;
+       /*<<seq.ml:144:6>>*/ _aq_ =  /*<<seq.ml:144:6>>*/ caml_call1(p, x);
+      /*<<seq.ml:144:6>>*/ if(_aq_)  /*<<seq.ml:144:6>>*/ return _aq_;
      var xs$0 = xs$1;
     }
     /*<<seq.ml:144:24>>*/ }
@@ -2065,8 +2001,8 @@
       /*<<seq.ml:224:10>>*/ var
       ys$1 = match$0[2],
       y = match$0[1],
-       /*<<seq.ml:224:10>>*/ _av_ =  /*<<seq.ml:224:10>>*/ caml_call2(f, x, y);
-      /*<<seq.ml:224:10>>*/ if(! _av_)  /*<<seq.ml:224:10>>*/ return _av_;
+       /*<<seq.ml:224:10>>*/ _ap_ =  /*<<seq.ml:224:10>>*/ caml_call2(f, x, y);
+      /*<<seq.ml:224:10>>*/ if(! _ap_)  /*<<seq.ml:224:10>>*/ return _ap_;
      var xs$0 = xs$1, ys$0 = ys$1;
     }
     /*<<seq.ml:224:35>>*/ }
@@ -2085,8 +2021,8 @@
       /*<<seq.ml:235:10>>*/ var
       ys$1 = match$0[2],
       y = match$0[1],
-       /*<<seq.ml:235:10>>*/ _au_ =  /*<<seq.ml:235:10>>*/ caml_call2(f, x, y);
-      /*<<seq.ml:235:10>>*/ if(_au_)  /*<<seq.ml:235:10>>*/ return _au_;
+       /*<<seq.ml:235:10>>*/ _ao_ =  /*<<seq.ml:235:10>>*/ caml_call2(f, x, y);
+      /*<<seq.ml:235:10>>*/ if(_ao_)  /*<<seq.ml:235:10>>*/ return _ao_;
      var xs$0 = xs$1, ys$0 = ys$1;
     }
     /*<<seq.ml:235:34>>*/ }
@@ -2104,9 +2040,9 @@
         y = match$0[1],
         xs$1 = match[2],
         x = match[1],
-         /*<<seq.ml:242:6>>*/ _at_ =
+         /*<<seq.ml:242:6>>*/ _an_ =
            /*<<seq.ml:242:6>>*/ caml_call2(eq, x, y);
-        /*<<seq.ml:242:6>>*/ if(! _at_)  /*<<seq.ml:242:6>>*/ return _at_;
+        /*<<seq.ml:242:6>>*/ if(! _an_)  /*<<seq.ml:242:6>>*/ return _an_;
        var xs$0 = xs$1, ys$0 = ys$1;
        continue;
       }
@@ -2135,87 +2071,74 @@
     /*<<seq.ml:257:8>>*/ }
    function init_aux(f, i, j, param){
      /*<<seq.ml:264:2>>*/ if(i >= j)  /*<<seq.ml:268:4>>*/ return 0;
-    var _aq_ = i + 1 | 0;
-     /*<<seq.ml:265:15>>*/ function _ar_(_as_){
-      /*<<?>>*/ return init_aux(f, _aq_, j, _as_);
-    }
+    var _al_ = i + 1 | 0;
      /*<<seq.ml:264:16>>*/ return [0,
              /*<<seq.ml:265:10>>*/ caml_call1(f, i),
-            _ar_];
+            function(_am_){ /*<<?>>*/ return init_aux(f, _al_, j, _am_);}];
     /*<<seq.ml:268:7>>*/ }
    function init(n, f){
      /*<<seq.ml:271:2>>*/ if(0 > n)
       /*<<seq.ml:272:4>>*/ return  /*<<seq.ml:272:4>>*/ caml_call1
              (Stdlib[1], cst_Seq_init);
-    var _ao_ = 0;
-     /*<<seq.ml:274:4>>*/ return function(_ap_){
-      /*<<?>>*/ return init_aux(f, _ao_, n, _ap_);};
+    var _aj_ = 0;
+     /*<<seq.ml:274:4>>*/ return function(_ak_){
+      /*<<?>>*/ return init_aux(f, _aj_, n, _ak_);};
     /*<<seq.ml:274:18>>*/ }
    function repeat(x, param){
      /*<<seq.ml:277:2>>*/ return [0,
             x,
-            function(_an_){ /*<<?>>*/ return repeat(x, _an_);}];
+            function(_ai_){ /*<<?>>*/ return repeat(x, _ai_);}];
     /*<<seq.ml:277:20>>*/ }
    function forever(f, param){
-     /*<<seq.ml:280:13>>*/ function _al_(_am_){
-      /*<<?>>*/ return forever(f, _am_);
-    }
      /*<<seq.ml:280:2>>*/ return [0,
              /*<<seq.ml:280:8>>*/ caml_call1(f, 0),
-            _al_];
+            function(_ah_){ /*<<?>>*/ return forever(f, _ah_);}];
     /*<<seq.ml:280:23>>*/ }
    function cycle_nonempty(xs, param){
-     /*<<seq.ml:287:2>>*/  /*<<seq.ml:287:2>>*/ var _aj_ = 0;
      /*<<seq.ml:287:2>>*/ return append
             (xs,
-             function(_ak_){ /*<<?>>*/ return cycle_nonempty(xs, _ak_);},
-             _aj_);
+             function(_ag_){ /*<<?>>*/ return cycle_nonempty(xs, _ag_);},
+             0);
     /*<<seq.ml:287:34>>*/ }
    function cycle(xs, param){
      /*<<seq.ml:295:2>>*/  /*<<seq.ml:295:8>>*/ var
      match =  /*<<seq.ml:295:8>>*/ caml_call1(xs, 0);
     if(! match)  /*<<seq.ml:297:6>>*/ return 0;
     var xs$0 = match[2], x = match[1];
-     /*<<seq.ml:299:26>>*/ function _ag_(_ai_){
-      /*<<?>>*/ return cycle_nonempty(xs, _ai_);
+     /*<<seq.ml:299:26>>*/ function _ad_(_af_){
+      /*<<?>>*/ return cycle_nonempty(xs, _af_);
     }
      /*<<seq.ml:299:6>>*/ return [0,
             x,
-            function(_ah_){ /*<<?>>*/ return append(xs$0, _ag_, _ah_);}];
+            function(_ae_){ /*<<?>>*/ return append(xs$0, _ad_, _ae_);}];
     /*<<seq.ml:299:46>>*/ }
    function iterate1(f, x, param){
      /*<<seq.ml:306:2>>*/  /*<<seq.ml:306:10>>*/ var
      y =  /*<<seq.ml:306:10>>*/ caml_call1(f, x);
      /*<<seq.ml:307:2>>*/ return [0,
             y,
-            function(_af_){ /*<<?>>*/ return iterate1(f, y, _af_);}];
+            function(_ac_){ /*<<?>>*/ return iterate1(f, y, _ac_);}];
     /*<<seq.ml:307:24>>*/ }
    function iterate(f, x){
-     /*<<seq.ml:319:9>>*/ function _ac_(_ae_){
-      /*<<?>>*/ return iterate1(f, x, _ae_);
+     /*<<seq.ml:319:9>>*/ function _$_(_ab_){
+      /*<<?>>*/ return iterate1(f, x, _ab_);
     }
-     /*<<seq.ml:319:9>>*/ return function(_ad_){
-      /*<<?>>*/ return [0, x, _ac_];};
+     /*<<seq.ml:319:9>>*/ return function(_aa_){
+      /*<<?>>*/ return [0, x, _$_];};
     /*<<seq.ml:319:23>>*/ }
    function mapi_aux(f, i, xs, param){
      /*<<seq.ml:324:2>>*/  /*<<seq.ml:324:8>>*/ var
      match =  /*<<seq.ml:324:8>>*/ caml_call1(xs, 0);
     if(! match)  /*<<seq.ml:326:6>>*/ return 0;
-     /*<<seq.ml:328:6>>*/ var
-     xs$0 = match[2],
-     x = match[1],
-      /*<<seq.ml:328:6>>*/ _$_ = i + 1 | 0;
-     /*<<seq.ml:328:19>>*/ function _aa_(_ab_){
-      /*<<?>>*/ return mapi_aux(f, _$_, xs$0, _ab_);
-    }
+    var xs$0 = match[2], x = match[1], _Z_ = i + 1 | 0;
      /*<<seq.ml:328:6>>*/ return [0,
              /*<<seq.ml:328:12>>*/ caml_call2(f, i, x),
-            _aa_];
+            function(___){ /*<<?>>*/ return mapi_aux(f, _Z_, xs$0, ___);}];
     /*<<seq.ml:328:39>>*/ }
    function mapi(f, xs){
-     /*<<seq.ml:331:2>>*/ var _Z_ = 0;
-     /*<<seq.ml:331:2>>*/ return function(___){
-      /*<<?>>*/ return mapi_aux(f, _Z_, xs, ___);};
+     /*<<seq.ml:331:2>>*/ var _X_ = 0;
+     /*<<seq.ml:331:2>>*/ return function(_Y_){
+      /*<<?>>*/ return mapi_aux(f, _X_, xs, _Y_);};
     /*<<seq.ml:331:17>>*/ }
    function tail_scan(f, s, xs, param){
      /*<<seq.ml:340:2>>*/  /*<<seq.ml:340:8>>*/ var
@@ -2227,14 +2150,14 @@
       /*<<seq.ml:344:14>>*/ s$0 =  /*<<seq.ml:344:14>>*/ caml_call2(f, s, x);
      /*<<seq.ml:345:6>>*/ return [0,
             s$0,
-            function(_Y_){ /*<<?>>*/ return tail_scan(f, s$0, xs$0, _Y_);}];
+            function(_W_){ /*<<?>>*/ return tail_scan(f, s$0, xs$0, _W_);}];
     /*<<seq.ml:345:32>>*/ }
    function scan(f, s, xs){
-     /*<<seq.ml:348:9>>*/ function _V_(_X_){
-      /*<<?>>*/ return tail_scan(f, s, xs, _X_);
+     /*<<seq.ml:348:9>>*/ function _T_(_V_){
+      /*<<?>>*/ return tail_scan(f, s, xs, _V_);
     }
-     /*<<seq.ml:348:9>>*/ return function(_W_){
-      /*<<?>>*/ return [0, s, _V_];};
+     /*<<seq.ml:348:9>>*/ return function(_U_){
+      /*<<?>>*/ return [0, s, _T_];};
     /*<<seq.ml:348:27>>*/ }
    function take_aux(n, xs){
      /*<<seq.ml:354:2>>*/ return 0 === n
@@ -2285,7 +2208,7 @@
      /*<<seq.ml:399:9>>*/ return  /*<<seq.ml:399:9>>*/ caml_call1(p, x)
             ? [0,
               x,
-              function(_U_){ /*<<?>>*/ return take_while(p, xs$0, _U_);}]
+              function(_S_){ /*<<?>>*/ return take_while(p, xs$0, _S_);}]
             : 0;
     /*<<seq.ml:399:52>>*/ }
    function drop_while(p, xs, param){
@@ -2304,29 +2227,26 @@
      /*<<seq.ml:409:2>>*/  /*<<seq.ml:409:8>>*/ var
      match =  /*<<seq.ml:409:8>>*/ caml_call1(xs, 0);
     if(! match)  /*<<seq.ml:411:6>>*/ return 0;
-     /*<<seq.ml:413:64>>*/ var
+    var
      xs$0 = match[2],
      x = match[1],
-      /*<<seq.ml:413:64>>*/ _L_ =  /*<<seq.ml:413:64>>*/ caml_call1(eq, x);
-     /*<<seq.ml:413:52>>*/ function _M_(_T_){
-      /*<<?>>*/ return drop_while(_L_, xs$0, _T_);
+     _K_ =  /*<<seq.ml:413:64>>*/ caml_call1(eq, x),
+     _M_ =  /*<<seq.ml:413:31>>*/ caml_call1(eq, x);
+     /*<<seq.ml:413:52>>*/ function _L_(_R_){
+      /*<<?>>*/ return drop_while(_K_, xs$0, _R_);
     }
-     /*<<seq.ml:413:43>>*/ function _N_(_S_){
-      /*<<?>>*/ return group(eq, _M_, _S_);
-    }
-     /*<<seq.ml:413:31>>*/  /*<<seq.ml:413:31>>*/ var
-     _O_ =  /*<<seq.ml:413:31>>*/ caml_call1(eq, x);
-     /*<<seq.ml:413:19>>*/ function _P_(_R_){
-      /*<<?>>*/ return take_while(_O_, xs$0, _R_);
+     /*<<seq.ml:413:19>>*/ function _N_(_Q_){
+      /*<<?>>*/ return take_while(_M_, xs$0, _Q_);
     }
      /*<<seq.ml:413:6>>*/ return [0,
-            function(_Q_){ /*<<?>>*/ return [0, x, _P_];},
-            _N_];
+            function(_P_){ /*<<?>>*/ return [0, x, _N_];},
+            function(_O_){ /*<<?>>*/ return group(eq, _L_, _O_);}];
     /*<<seq.ml:413:75>>*/ }
     /*<<seq.ml:415:0>>*/ var
      /*<<seq.ml:415:0>>*/ Forced_twice =
-      [248, cst_Stdlib_Seq_Forced_twice, runtime.caml_fresh_oo_id(0)],
-     /*<<seq.ml:415:0>>*/ to_lazy = Stdlib_Lazy[6];
+      [248, "Stdlib.Seq.Forced_twice", runtime.caml_fresh_oo_id(0)],
+     /*<<seq.ml:415:0>>*/ to_lazy = Stdlib_Lazy[6],
+    _a_ = [0, "seq.ml", 616, 4];
    function failure(param){
      /*<<seq.ml:441:6>>*/ throw  /*<<seq.ml:441:6>>*/ caml_maybe_attach_backtrace
            (Forced_twice, 1);
@@ -2341,10 +2261,10 @@
      /*<<seq.ml:464:28>>*/ }
      /*<<seq.ml:434:14>>*/  /*<<seq.ml:434:14>>*/ var
      s =  /*<<seq.ml:434:14>>*/ caml_call1(to_lazy, s$0);
-     /*<<seq.ml:434:14>>*/ return function(_K_){
-     var _J_ = runtime.caml_obj_tag(s);
-     if(250 === _J_) return s[1];
-     if(246 !== _J_ && 244 !== _J_)  /*<<seq.ml:429:14>>*/ return s;
+     /*<<seq.ml:434:14>>*/ return function(_J_){
+     var _I_ = runtime.caml_obj_tag(s);
+     if(250 === _I_) return s[1];
+     if(246 !== _I_ && 244 !== _I_)  /*<<seq.ml:429:14>>*/ return s;
       /*<<seq.ml:429:14>>*/ return  /*<<seq.ml:429:14>>*/ caml_call1
              (CamlinternalLazy[2], s);};
     /*<<seq.ml:465:3>>*/ }
@@ -2375,7 +2295,7 @@
     var ys$0 = match$0[2], y = match$0[1];
      /*<<seq.ml:486:10>>*/ return [0,
             [0, x, y],
-            function(_I_){ /*<<?>>*/ return zip(xs$0, ys$0, _I_);}];
+            function(_H_){ /*<<?>>*/ return zip(xs$0, ys$0, _H_);}];
     /*<<seq.ml:486:34>>*/ }
    function map2(f, xs, ys, param){
      /*<<seq.ml:489:2>>*/  /*<<seq.ml:489:8>>*/ var
@@ -2387,12 +2307,9 @@
       /*<<seq.ml:493:12>>*/ match$0 =  /*<<seq.ml:493:12>>*/ caml_call1(ys, 0);
     if(! match$0)  /*<<seq.ml:495:10>>*/ return 0;
     var ys$0 = match$0[2], y = match$0[1];
-     /*<<seq.ml:497:23>>*/ function _G_(_H_){
-      /*<<?>>*/ return map2(f, xs$0, ys$0, _H_);
-    }
      /*<<seq.ml:497:10>>*/ return [0,
              /*<<seq.ml:497:16>>*/ caml_call2(f, x, y),
-            _G_];
+            function(_G_){ /*<<?>>*/ return map2(f, xs$0, ys$0, _G_);}];
     /*<<seq.ml:497:36>>*/ }
    function interleave(xs, ys, param){
      /*<<seq.ml:500:2>>*/  /*<<seq.ml:500:8>>*/ var
@@ -2572,16 +2489,14 @@
      /*<<seq.ml:668:20>>*/ function xss(_k_){
       /*<<?>>*/ return map(_f_, xs, _k_);
     }
+    function _e_(_j_){ /*<<?>>*/ return _b_(empty, xss, _j_);}
     function _f_(x){
-     function _i_(y){
+     function _h_(y){
        /*<<seq.ml:671:8>>*/ return  /*<<seq.ml:671:8>>*/ caml_call2(f, x, y);
       /*<<seq.ml:671:13>>*/ }
-      /*<<seq.ml:670:10>>*/ return function(_j_){
-       /*<<?>>*/ return map(_i_, ys, _j_);};
+      /*<<seq.ml:670:10>>*/ return function(_i_){
+       /*<<?>>*/ return map(_h_, ys, _i_);};
      /*<<seq.ml:672:10>>*/ }
-     /*<<seq.ml:665:2>>*/ function _e_(_h_){
-      /*<<?>>*/ return _b_(empty, xss, _h_);
-    }
      /*<<seq.ml:668:9>>*/ return function(_g_){
       /*<<?>>*/ return concat(_e_, _g_);};
     /*<<seq.ml:674:4>>*/ }
@@ -2614,7 +2529,7 @@
       /*<<seq.ml:697:8>>*/ return [0, x]; /*<<seq.ml:697:14>>*/ };
     /*<<seq.ml:697:14>>*/ }
    function ints(i, param){
-     /*<<seq.ml:702:2>>*/  /*<<seq.ml:702:2>>*/ var _c_ = i + 1 | 0;
+     /*<<seq.ml:702:2>>*/ var _c_ = i + 1 | 0;
      /*<<seq.ml:702:2>>*/ return [0,
             i,
             function(_d_){ /*<<?>>*/ return ints(_c_, _d_);}];
@@ -2706,8 +2621,7 @@
     global_data = runtime.caml_get_global_data(),
     Stdlib_Seq = global_data.Stdlib__Seq,
     Stdlib = global_data.Stdlib,
-    cst_option_is_None = "option is None",
-    none = 0;
+    cst_option_is_None = "option is None";
    function some(v){
      /*<<option.ml:19:13>>*/ return [0, v];
     /*<<option.ml:19:19>>*/ }
@@ -2796,7 +2710,7 @@
    var
     Stdlib_Option =
       [0,
-       none,
+       0,
        some,
        value,
        get,
@@ -2837,8 +2751,8 @@
     global_data = runtime.caml_get_global_data(),
     Stdlib_Seq = global_data.Stdlib__Seq,
     Stdlib = global_data.Stdlib,
-    cst_result_is_Ok = "result is Ok _",
-    cst_result_is_Error = "result is Error _";
+    cst_result_is_Error = "result is Error _",
+    cst_result_is_Ok = "result is Ok _";
    function ok(v){
      /*<<result.ml:18:11>>*/ return [0, v];
     /*<<result.ml:18:15>>*/ }
@@ -2995,13 +2909,12 @@
 //# unitInfo: Provides: Stdlib__Bool
 (function(globalThis){
    "use strict";
+   var runtime = globalThis.jsoo_runtime, caml_hash = runtime.caml_hash;
+   function equal(_d_, _c_){ /*<<?>>*/ return _d_ === _c_ ? 1 : 0;}
    var
-    runtime = globalThis.jsoo_runtime,
-    caml_hash = runtime.caml_hash,
+    compare = runtime.caml_int_compare,
     cst_true = "true",
     cst_false = "false";
-   function equal(_d_, _c_){ /*<<?>>*/ return _d_ === _c_ ? 1 : 0;}
-   var compare = runtime.caml_int_compare;
    function to_float(param){
      /*<<bool.ml:24:15>>*/ return param ? 1. : 0.;
     /*<<bool.ml:24:48>>*/ }
@@ -3053,11 +2966,11 @@
     cst = "\\\\",
     cst$0 = "\\'",
     Stdlib = global_data.Stdlib,
+    cst_Char_chr = "Char.chr",
     cst_b = "\\b",
     cst_t = "\\t",
     cst_n = "\\n",
-    cst_r = "\\r",
-    cst_Char_chr = "Char.chr";
+    cst_r = "\\r";
    function chr(n){
      /*<<char.ml:22:2>>*/ if(0 <= n && 255 >= n)
       /*<<char.ml:22:55>>*/ return n;
@@ -3160,19 +3073,11 @@
     err_no_succ = "U+10FFFF has no successor",
     Assert_failure = global_data.Assert_failure,
     Stdlib = global_data.Stdlib,
-    _d_ = [0, cst_uchar_ml, 88, 18],
-    _c_ = [0, cst_uchar_ml, 91, 7],
-    _b_ = [0, cst_uchar_ml, 80, 18],
-    _a_ = [0, cst_uchar_ml, 85, 7],
+    cst_is_not_an_Unicode_scalar_v = " is not an Unicode scalar value",
     cst_is_not_a_latin1_character = " is not a latin1 character",
     cst_U = "U+",
-    cst_is_not_an_Unicode_scalar_v = " is not an Unicode scalar value",
-    min = 0,
-    max = 1114111,
     lo_bound = 55295,
-    hi_bound = 57344,
-    bom = 65279,
-    rep = 65533;
+    hi_bound = 57344;
    function succ(u){
      /*<<uchar.ml:34:2>>*/ return u === 55295
             ? hi_bound
@@ -3225,7 +3130,12 @@
     /*<<uchar.ml:52:19>>*/ }
    function unsafe_to_char(_j_){ /*<<?>>*/ return _j_;}
    function equal(_i_, _h_){ /*<<?>>*/ return _i_ === _h_ ? 1 : 0;}
-   var compare = runtime.caml_int_compare;
+   var
+    compare = runtime.caml_int_compare,
+    _a_ = [0, cst_uchar_ml, 85, 7],
+    _b_ = [0, cst_uchar_ml, 80, 18],
+    _c_ = [0, cst_uchar_ml, 91, 7],
+    _d_ = [0, cst_uchar_ml, 88, 18];
    function hash(_g_){ /*<<?>>*/ return _g_;}
    function utf_decode_is_valid(d){
      /*<<uchar.ml:73:37>>*/ return 1 === (d >>> 27 | 0) ? 1 : 0;
@@ -3267,10 +3177,10 @@
    var
     Stdlib_Uchar =
       [0,
-       min,
-       max,
-       bom,
-       rep,
+       0,
+       1114111,
+       65279,
+       65533,
        succ,
        pred,
        is_valid,
@@ -3325,22 +3235,11 @@
    var
     global_data = runtime.caml_get_global_data(),
     Stdlib = global_data.Stdlib,
-    cst_List_map2 = cst_List_map2$1,
-    cst_List_map2$0 = cst_List_map2$1,
-    cst_List_iter2 = "List.iter2",
-    cst_List_fold_left2 = "List.fold_left2",
-    cst_List_fold_right2 = "List.fold_right2",
-    cst_List_for_all2 = "List.for_all2",
-    cst_List_exists2 = "List.exists2",
-    _a_ = [0, 0, 0],
-    cst_List_combine = "List.combine",
-    cst_List_rev_map2 = "List.rev_map2",
-    cst_List_init = "List.init",
-    cst_List_nth$0 = cst_List_nth$1,
+    cst_hd = "hd",
+    cst_tl = "tl",
     cst_nth = "nth",
     cst_List_nth = cst_List_nth$1,
-    cst_tl = "tl",
-    cst_hd = "hd";
+    cst_List_nth$0 = cst_List_nth$1;
    function length(l$0){
      /*<<list.ml:25:15>>*/ var len = 0, param = l$0;
     for(;;){
@@ -3402,7 +3301,19 @@
       n$0 = n$1;
     }
     /*<<list.ml:51:16>>*/ }
-   var append = Stdlib[37];
+   var
+    append = Stdlib[37],
+    cst_List_init = "List.init",
+    cst_List_map2 = cst_List_map2$1,
+    cst_List_map2$0 = cst_List_map2$1,
+    cst_List_rev_map2 = "List.rev_map2",
+    cst_List_iter2 = "List.iter2",
+    cst_List_fold_left2 = "List.fold_left2",
+    cst_List_fold_right2 = "List.fold_right2",
+    cst_List_for_all2 = "List.for_all2",
+    cst_List_exists2 = "List.exists2",
+    _a_ = [0, 0, 0],
+    cst_List_combine = "List.combine";
    function rev_append(l1, l2){
      /*<<list.ml:56:2>>*/ var l1$0 = l1, l2$0 = l2;
      /*<<list.ml:56:2>>*/ for(;;){
@@ -3940,7 +3851,7 @@
     }
    }
    function find_index(p){
-     /*<<list.ml:240:2>>*/  /*<<list.ml:243:2>>*/ var i = 0;
+     /*<<list.ml:240:2>>*/ var i = 0;
      /*<<list.ml:243:2>>*/ return function(param$0){
      var i$0 = i, param = param$0;
      for(;;){
@@ -3965,7 +3876,7 @@
     }
    }
    function find_mapi(f){
-     /*<<list.ml:254:2>>*/  /*<<list.ml:261:2>>*/ var i = 0;
+     /*<<list.ml:254:2>>*/ var i = 0;
      /*<<list.ml:261:2>>*/ return function(param$0){
      var i$0 = i, param = param$0;
      for(;;){
@@ -4855,16 +4766,10 @@
 //# unitInfo: Provides: Stdlib__Int
 (function(globalThis){
    "use strict";
-   var
-    runtime = globalThis.jsoo_runtime,
-    caml_hash = runtime.caml_hash,
-    zero = 0,
-    one = 1,
-    minus_one = -1;
+   var runtime = globalThis.jsoo_runtime, caml_hash = runtime.caml_hash;
    function abs(x){
      /*<<int.ml:29:12>>*/ return 0 <= x ? x : - x | 0;
     /*<<int.ml:29:36>>*/ }
-   var max_int = 2147483647, min_int = -2147483648;
    function lognot(x){
      /*<<int.ml:35:15>>*/ return x ^ -1;
     /*<<int.ml:35:28>>*/ }
@@ -4890,12 +4795,12 @@
    var
     Stdlib_Int =
       [0,
-       zero,
-       one,
-       minus_one,
+       0,
+       1,
+       -1,
        abs,
-       max_int,
-       min_int,
+       2147483647,
+       -2147483648,
        lognot,
        equal,
        compare,
@@ -4958,34 +4863,7 @@
     Stdlib_Sys = global_data.Stdlib__Sys,
     Stdlib_Int = global_data.Stdlib__Int,
     Stdlib_Seq = global_data.Stdlib__Seq,
-    Stdlib_Char = global_data.Stdlib__Char,
-    cst_index_out_of_bounds$2 = cst_index_out_of_bounds$3,
-    _f_ = [0, cst_bytes_ml, 820, 20],
-    _e_ = [0, cst_bytes_ml, 831, 9],
-    cst_index_out_of_bounds$1 = cst_index_out_of_bounds$3,
-    cst_index_out_of_bounds$0 = cst_index_out_of_bounds$3,
-    _d_ = [0, cst_bytes_ml, 766, 20],
-    _c_ = [0, cst_bytes_ml, 777, 9],
-    cst_index_out_of_bounds = cst_index_out_of_bounds$3,
-    _b_ = [0, cst_bytes_ml, 654, 20],
-    _a_ = [0, cst_bytes_ml, 679, 9],
-    cst_Bytes_of_seq_cannot_grow_b = "Bytes.of_seq: cannot grow bytes",
-    cst_String_rcontains_from_Byte =
-      "String.rcontains_from / Bytes.rcontains_from",
-    cst_String_contains_from_Bytes =
-      "String.contains_from / Bytes.contains_from",
-    cst_String_rindex_from_opt_Byt =
-      "String.rindex_from_opt / Bytes.rindex_from_opt",
-    cst_String_rindex_from_Bytes_r = "String.rindex_from / Bytes.rindex_from",
-    cst_String_index_from_opt_Byte =
-      "String.index_from_opt / Bytes.index_from_opt",
-    cst_String_index_from_Bytes_in = "String.index_from / Bytes.index_from",
-    cst_Bytes_concat = "Bytes.concat",
-    cst_String_blit_Bytes_blit_str = "String.blit / Bytes.blit_string",
-    cst_Bytes_blit = "Bytes.blit",
-    cst_String_fill_Bytes_fill = "String.fill / Bytes.fill",
-    cst_Bytes_extend = "Bytes.extend",
-    cst_String_sub_Bytes_sub = "String.sub / Bytes.sub";
+    Stdlib_Char = global_data.Stdlib__Char;
    function make(n, c){
      /*<<bytes.ml:42:2>>*/  /*<<bytes.ml:42:10>>*/ var
      s =  /*<<bytes.ml:42:10>>*/ caml_create_bytes(n);
@@ -4995,21 +4873,38 @@
    function init(n, f){
      /*<<bytes.ml:47:2>>*/ var
       /*<<bytes.ml:47:10>>*/ s =  /*<<bytes.ml:47:10>>*/ caml_create_bytes(n),
-      /*<<bytes.ml:48:2>>*/ _aq_ = n - 1 | 0,
-      /*<<bytes.ml:47:10>>*/ _ap_ = 0;
-    if(_aq_ >= 0){
-     var i = _ap_;
+      /*<<bytes.ml:48:2>>*/ _ap_ = n - 1 | 0,
+      /*<<bytes.ml:47:10>>*/ _ao_ = 0;
+    if(_ap_ >= 0){
+     var i = _ao_;
      for(;;){
       caml_bytes_unsafe_set(s, i,  /*<<bytes.ml:49:19>>*/ caml_call1(f, i));
-       /*<<bytes.ml:48:2>>*/  /*<<bytes.ml:48:2>>*/ var _ar_ = i + 1 | 0;
-      if(_aq_ === i) break;
-      var i = _ar_;
+       /*<<bytes.ml:48:2>>*/  /*<<bytes.ml:48:2>>*/ var _aq_ = i + 1 | 0;
+      if(_ap_ === i) break;
+      var i = _aq_;
      }
     }
      /*<<bytes.ml:51:2>>*/ return s;
     /*<<bytes.ml:51:3>>*/ }
-    /*<<bytes.ml:53:12>>*/  /*<<bytes.ml:53:12>>*/ var
-    empty =  /*<<bytes.ml:53:12>>*/ caml_create_bytes(0);
+    /*<<bytes.ml:53:12>>*/ var
+     /*<<bytes.ml:53:12>>*/ empty =
+       /*<<bytes.ml:53:12>>*/ caml_create_bytes(0),
+    cst_String_sub_Bytes_sub = "String.sub / Bytes.sub",
+    cst_Bytes_extend = "Bytes.extend",
+    cst_String_fill_Bytes_fill = "String.fill / Bytes.fill",
+    cst_Bytes_blit = "Bytes.blit",
+    cst_String_blit_Bytes_blit_str = "String.blit / Bytes.blit_string",
+    cst_Bytes_concat = "Bytes.concat",
+    cst_String_index_from_Bytes_in = "String.index_from / Bytes.index_from",
+    cst_String_index_from_opt_Byte =
+      "String.index_from_opt / Bytes.index_from_opt",
+    cst_String_rindex_from_Bytes_r = "String.rindex_from / Bytes.rindex_from",
+    cst_String_rindex_from_opt_Byt =
+      "String.rindex_from_opt / Bytes.rindex_from_opt",
+    cst_String_contains_from_Bytes =
+      "String.contains_from / Bytes.contains_from",
+    cst_String_rcontains_from_Byte =
+      "String.rcontains_from / Bytes.rcontains_from";
    function copy(s){
      /*<<bytes.ml:56:2>>*/ var
      len = caml_ml_bytes_length(s),
@@ -5045,11 +4940,11 @@
    function symbol(a, b){
      /*<<bytes.ml:77:2>>*/ var
      c = a + b | 0,
-     _ao_ = b < 0 ? 1 : 0,
+     _an_ = b < 0 ? 1 : 0,
      match = c < 0 ? 1 : 0;
     a:
     {
-     if(a < 0){if(_ao_ && ! match) break a;} else if(! _ao_ && match) break a;
+     if(a < 0){if(_an_ && ! match) break a;} else if(! _an_ && match) break a;
       /*<<bytes.ml:81:9>>*/ return c;
     }
      /*<<bytes.ml:80:27>>*/ return  /*<<bytes.ml:80:27>>*/ caml_call1
@@ -5112,32 +5007,32 @@
     /*<<bytes.ml:106:45>>*/ }
    function iter(f, a){
      /*<<bytes.ml:110:2>>*/ var
-     _am_ = caml_ml_bytes_length(a) - 1 | 0,
-      /*<<bytes.ml:110:2>>*/ _al_ = 0;
-    if(_am_ >= 0){
-     var i = _al_;
+     _al_ = caml_ml_bytes_length(a) - 1 | 0,
+      /*<<bytes.ml:110:2>>*/ _ak_ = 0;
+    if(_al_ >= 0){
+     var i = _ak_;
      for(;;){
        /*<<bytes.ml:110:31>>*/  /*<<bytes.ml:110:31>>*/ caml_call1
        (f, caml_bytes_unsafe_get(a, i));
-       /*<<bytes.ml:110:31>>*/  /*<<bytes.ml:110:31>>*/ var _an_ = i + 1 | 0;
-      if(_am_ === i) break;
-      var i = _an_;
+       /*<<bytes.ml:110:31>>*/  /*<<bytes.ml:110:31>>*/ var _am_ = i + 1 | 0;
+      if(_al_ === i) break;
+      var i = _am_;
      }
     }
     return 0;
     /*<<bytes.ml:110:53>>*/ }
    function iteri(f, a){
      /*<<bytes.ml:114:2>>*/ var
-     _aj_ = caml_ml_bytes_length(a) - 1 | 0,
-      /*<<bytes.ml:114:2>>*/ _ai_ = 0;
-    if(_aj_ >= 0){
-     var i = _ai_;
+     _ai_ = caml_ml_bytes_length(a) - 1 | 0,
+      /*<<bytes.ml:114:2>>*/ _ah_ = 0;
+    if(_ai_ >= 0){
+     var i = _ah_;
      for(;;){
        /*<<bytes.ml:114:31>>*/  /*<<bytes.ml:114:31>>*/ caml_call2
        (f, i, caml_bytes_unsafe_get(a, i));
-       /*<<bytes.ml:114:31>>*/  /*<<bytes.ml:114:31>>*/ var _ak_ = i + 1 | 0;
-      if(_aj_ === i) break;
-      var i = _ak_;
+       /*<<bytes.ml:114:31>>*/  /*<<bytes.ml:114:31>>*/ var _aj_ = i + 1 | 0;
+      if(_ai_ === i) break;
+      var i = _aj_;
      }
     }
     return 0;
@@ -5164,14 +5059,14 @@
         acc = acc$0,
         param = tl;
       }
-      var _ah_ = acc;
+      var _ag_ = acc;
       break a;
      }
-     var _ah_ = caml_ml_bytes_length(hd) + acc | 0;
+     var _ag_ = caml_ml_bytes_length(hd) + acc | 0;
     }
      /*<<bytes.ml:136:12>>*/ var
       /*<<bytes.ml:136:12>>*/ dst =
-        /*<<bytes.ml:136:12>>*/ caml_create_bytes(_ah_),
+        /*<<bytes.ml:136:12>>*/ caml_create_bytes(_ag_),
      pos = pos$1,
      param$0 = l;
     for(;;){
@@ -5208,10 +5103,10 @@
     /*<<bytes.ml:145:3>>*/ }
    function is_space(param){
      /*<<bytes.ml:151:15>>*/  /*<<bytes.ml:151:15>>*/ var
-     _ag_ = param - 9 | 0;
+     _af_ = param - 9 | 0;
     a:
     {
-     if(4 < _ag_ >>> 0){if(23 !== _ag_) break a;} else if(2 === _ag_) break a;
+     if(4 < _af_ >>> 0){if(23 !== _af_) break a;} else if(2 === _af_) break a;
       /*<<bytes.ml:152:41>>*/ return 1;
     }
      /*<<bytes.ml:153:9>>*/ return 0;
@@ -5237,10 +5132,10 @@
    function unsafe_escape(s){
      /*<<bytes.ml:184:2>>*/ var
       /*<<bytes.ml:184:10>>*/ n = [0, 0],
-     _$_ = caml_ml_bytes_length(s) - 1 | 0,
-      /*<<bytes.ml:184:10>>*/ ___ = 0;
-    if(_$_ >= 0){
-     var i$0 = ___;
+     ___ = caml_ml_bytes_length(s) - 1 | 0,
+      /*<<bytes.ml:184:10>>*/ _Z_ = 0;
+    if(___ >= 0){
+     var i$0 = _Z_;
      for(;;){
       var match = caml_bytes_unsafe_get(s, i$0);
       a:
@@ -5250,12 +5145,12 @@
         c:
         {
          if(32 <= match){
-          var _ad_ = match - 34 | 0;
-          if(58 < _ad_ >>> 0){
-           if(93 <= _ad_) break c;
+          var _ac_ = match - 34 | 0;
+          if(58 < _ac_ >>> 0){
+           if(93 <= _ac_) break c;
           }
-          else if(56 < _ad_ - 1 >>> 0) break b;
-          var _ae_ = 1;
+          else if(56 < _ac_ - 1 >>> 0) break b;
+          var _ad_ = 1;
           break a;
          }
          if(11 <= match){
@@ -5263,15 +5158,15 @@
          }
          else if(8 <= match) break b;
         }
-        var _ae_ = 4;
+        var _ad_ = 4;
         break a;
        }
-       var _ae_ = 2;
+       var _ad_ = 2;
       }
-      n[1] = n[1] + _ae_ | 0;
-       /*<<bytes.ml:185:2>>*/  /*<<bytes.ml:185:2>>*/ var _af_ = i$0 + 1 | 0;
-      if(_$_ === i$0) break;
-      var i$0 = _af_;
+      n[1] = n[1] + _ad_ | 0;
+       /*<<bytes.ml:185:2>>*/  /*<<bytes.ml:185:2>>*/ var _ae_ = i$0 + 1 | 0;
+      if(___ === i$0) break;
+      var i$0 = _ae_;
      }
     }
     if(n[1] === caml_ml_bytes_length(s))  /*<<bytes.ml:192:24>>*/ return s;
@@ -5279,10 +5174,10 @@
      s$0 =  /*<<bytes.ml:194:13>>*/ caml_create_bytes(n[1]);
     n[1] = 0;
      /*<<bytes.ml:196:4>>*/ var
-     _ab_ = caml_ml_bytes_length(s) - 1 | 0,
-      /*<<bytes.ml:196:4>>*/ _aa_ = 0;
-    if(_ab_ >= 0){
-     var i = _aa_;
+     _aa_ = caml_ml_bytes_length(s) - 1 | 0,
+      /*<<bytes.ml:196:4>>*/ _$_ = 0;
+    if(_aa_ >= 0){
+     var i = _$_;
      for(;;){
       var c = caml_bytes_unsafe_get(s, i);
       a:
@@ -5340,9 +5235,9 @@
        caml_bytes_unsafe_set(s$0, n[1], c);
       }
       n[1]++;
-       /*<<bytes.ml:196:4>>*/  /*<<bytes.ml:196:4>>*/ var _ac_ = i + 1 | 0;
-      if(_ab_ === i) break;
-      var i = _ac_;
+       /*<<bytes.ml:196:4>>*/  /*<<bytes.ml:196:4>>*/ var _ab_ = i + 1 | 0;
+      if(_aa_ === i) break;
+      var i = _ab_;
      }
     }
      /*<<bytes.ml:221:4>>*/ return s$0;
@@ -5357,18 +5252,18 @@
      /*<<bytes.ml:233:12>>*/ var
       /*<<bytes.ml:233:12>>*/ r =
         /*<<bytes.ml:233:12>>*/ caml_create_bytes(l),
-      /*<<bytes.ml:234:4>>*/ _Y_ = l - 1 | 0,
-      /*<<bytes.ml:233:12>>*/ _X_ = 0;
-    if(_Y_ >= 0){
-     var i = _X_;
+      /*<<bytes.ml:234:4>>*/ _X_ = l - 1 | 0,
+      /*<<bytes.ml:233:12>>*/ _W_ = 0;
+    if(_X_ >= 0){
+     var i = _W_;
      for(;;){
       caml_bytes_unsafe_set
        (r,
         i,
          /*<<bytes.ml:234:41>>*/ caml_call1(f, caml_bytes_unsafe_get(s, i)));
-       /*<<bytes.ml:234:4>>*/  /*<<bytes.ml:234:4>>*/ var _Z_ = i + 1 | 0;
-      if(_Y_ === i) break;
-      var i = _Z_;
+       /*<<bytes.ml:234:4>>*/  /*<<bytes.ml:234:4>>*/ var _Y_ = i + 1 | 0;
+      if(_X_ === i) break;
+      var i = _Y_;
      }
     }
      /*<<bytes.ml:235:4>>*/ return r;
@@ -5379,18 +5274,18 @@
      /*<<bytes.ml:241:12>>*/ var
       /*<<bytes.ml:241:12>>*/ r =
         /*<<bytes.ml:241:12>>*/ caml_create_bytes(l),
-      /*<<bytes.ml:242:4>>*/ _V_ = l - 1 | 0,
-      /*<<bytes.ml:241:12>>*/ _U_ = 0;
-    if(_V_ >= 0){
-     var i = _U_;
+      /*<<bytes.ml:242:4>>*/ _U_ = l - 1 | 0,
+      /*<<bytes.ml:241:12>>*/ _T_ = 0;
+    if(_U_ >= 0){
+     var i = _T_;
      for(;;){
       caml_bytes_unsafe_set
        (r,
         i,
          /*<<bytes.ml:242:41>>*/ caml_call2(f, i, caml_bytes_unsafe_get(s, i)));
-       /*<<bytes.ml:242:4>>*/  /*<<bytes.ml:242:4>>*/ var _W_ = i + 1 | 0;
-      if(_V_ === i) break;
-      var i = _W_;
+       /*<<bytes.ml:242:4>>*/  /*<<bytes.ml:242:4>>*/ var _V_ = i + 1 | 0;
+      if(_U_ === i) break;
+      var i = _V_;
      }
     }
      /*<<bytes.ml:243:4>>*/ return r;
@@ -5398,17 +5293,17 @@
    function fold_left(f, x, a){
      /*<<bytes.ml:247:2>>*/ var
       /*<<bytes.ml:247:10>>*/ r = [0, x],
-     _S_ = caml_ml_bytes_length(a) - 1 | 0,
-      /*<<bytes.ml:247:10>>*/ _R_ = 0;
-    if(_S_ >= 0){
-     var i = _R_;
+     _R_ = caml_ml_bytes_length(a) - 1 | 0,
+      /*<<bytes.ml:247:10>>*/ _Q_ = 0;
+    if(_R_ >= 0){
+     var i = _Q_;
      for(;;){
       r[1] =
         /*<<bytes.ml:249:9>>*/ caml_call2
         (f, r[1], caml_bytes_unsafe_get(a, i));
-       /*<<bytes.ml:248:2>>*/  /*<<bytes.ml:248:2>>*/ var _T_ = i + 1 | 0;
-      if(_S_ === i) break;
-      var i = _T_;
+       /*<<bytes.ml:248:2>>*/  /*<<bytes.ml:248:2>>*/ var _S_ = i + 1 | 0;
+      if(_R_ === i) break;
+      var i = _S_;
      }
     }
     return r[1];
@@ -5416,17 +5311,17 @@
    function fold_right(f, a, x){
      /*<<bytes.ml:254:2>>*/ var
       /*<<bytes.ml:254:10>>*/ r = [0, x],
-      /*<<bytes.ml:255:2>>*/ _P_ =
+      /*<<bytes.ml:255:2>>*/ _O_ =
         /*<<bytes.ml:255:2>>*/ caml_ml_bytes_length(a) - 1 | 0;
-    if(_P_ >= 0){
-     var i = _P_;
+    if(_O_ >= 0){
+     var i = _O_;
      for(;;){
       r[1] =
         /*<<bytes.ml:256:9>>*/ caml_call2
         (f, caml_bytes_unsafe_get(a, i), r[1]);
-       /*<<bytes.ml:255:2>>*/  /*<<bytes.ml:255:2>>*/ var _Q_ = i - 1 | 0;
+       /*<<bytes.ml:255:2>>*/  /*<<bytes.ml:255:2>>*/ var _P_ = i - 1 | 0;
       if(0 === i) break;
-      var i = _Q_;
+      var i = _P_;
      }
     }
     return r[1];
@@ -5481,8 +5376,8 @@
      /*<<bytes.ml:291:2>>*/ var
      len_s = caml_ml_bytes_length(s),
      len_pre = caml_ml_bytes_length(prefix),
-     _O_ = len_pre <= len_s ? 1 : 0;
-    if(! _O_) return _O_;
+     _N_ = len_pre <= len_s ? 1 : 0;
+    if(! _N_) return _N_;
     var i = 0;
      /*<<bytes.ml:294:4>>*/ for(;;){
      if(i === len_pre)  /*<<bytes.ml:294:24>>*/ return 1;
@@ -5498,8 +5393,8 @@
      len_s = caml_ml_bytes_length(s),
      len_suf = caml_ml_bytes_length(suffix),
      diff = len_s - len_suf | 0,
-     _N_ = 0 <= diff ? 1 : 0;
-    if(! _N_) return _N_;
+     _M_ = 0 <= diff ? 1 : 0;
+    if(! _M_) return _M_;
     var i = 0;
      /*<<bytes.ml:305:4>>*/ for(;;){
      if(i === len_suf)  /*<<bytes.ml:305:24>>*/ return 1;
@@ -5598,13 +5493,13 @@
     if(0 <= i && l >= i)
       /*<<bytes.ml:377:4>>*/ try{
        /*<<bytes.ml:377:15>>*/ index_rec(s, l, i, c);
-       /*<<bytes.ml:377:36>>*/  /*<<bytes.ml:377:36>>*/ var _L_ = 1;
-       /*<<bytes.ml:377:36>>*/ return _L_;
+       /*<<bytes.ml:377:36>>*/  /*<<bytes.ml:377:36>>*/ var _K_ = 1;
+       /*<<bytes.ml:377:36>>*/ return _K_;
      }
-     catch(_M_){
-      var _K_ = caml_wrap_exception(_M_);
-      if(_K_ === Stdlib[8])  /*<<bytes.ml:377:59>>*/ return 0;
-      throw caml_maybe_attach_backtrace(_K_, 0);
+     catch(_L_){
+      var _J_ = caml_wrap_exception(_L_);
+      if(_J_ === Stdlib[8])  /*<<bytes.ml:377:59>>*/ return 0;
+      throw caml_maybe_attach_backtrace(_J_, 0);
      }
      /*<<bytes.ml:375:4>>*/ return  /*<<bytes.ml:375:4>>*/ caml_call1
             (Stdlib[1], cst_String_contains_from_Bytes);
@@ -5616,40 +5511,42 @@
      /*<<bytes.ml:385:2>>*/ if(0 <= i && caml_ml_bytes_length(s) > i)
       /*<<bytes.ml:388:4>>*/ try{
        /*<<bytes.ml:388:15>>*/ rindex_rec(s, i, c);
-       /*<<bytes.ml:388:35>>*/  /*<<bytes.ml:388:35>>*/ var _I_ = 1;
-       /*<<bytes.ml:388:35>>*/ return _I_;
+       /*<<bytes.ml:388:35>>*/  /*<<bytes.ml:388:35>>*/ var _H_ = 1;
+       /*<<bytes.ml:388:35>>*/ return _H_;
      }
-     catch(_J_){
-      var _H_ = caml_wrap_exception(_J_);
-      if(_H_ === Stdlib[8])  /*<<bytes.ml:388:58>>*/ return 0;
-      throw caml_maybe_attach_backtrace(_H_, 0);
+     catch(_I_){
+      var _G_ = caml_wrap_exception(_I_);
+      if(_G_ === Stdlib[8])  /*<<bytes.ml:388:58>>*/ return 0;
+      throw caml_maybe_attach_backtrace(_G_, 0);
      }
      /*<<bytes.ml:386:4>>*/ return  /*<<bytes.ml:386:4>>*/ caml_call1
             (Stdlib[1], cst_String_rcontains_from_Byte);
     /*<<bytes.ml:388:63>>*/ }
-   var compare = runtime.caml_bytes_compare;
+   var
+    compare = runtime.caml_bytes_compare,
+    cst_Bytes_of_seq_cannot_grow_b = "Bytes.of_seq: cannot grow bytes";
    function split_on_char(sep, s){
      /*<<bytes.ml:398:2>>*/ var
       /*<<bytes.ml:398:10>>*/ r = [0, 0],
       /*<<bytes.ml:399:10>>*/ j =
        [0,  /*<<bytes.ml:399:2>>*/ caml_ml_bytes_length(s)],
-      /*<<bytes.ml:400:2>>*/ _D_ =
+      /*<<bytes.ml:400:2>>*/ _C_ =
         /*<<bytes.ml:400:2>>*/ caml_ml_bytes_length(s) - 1 | 0;
-    if(_D_ >= 0){
-     var i = _D_;
+    if(_C_ >= 0){
+     var i = _C_;
      for(;;){
       if(caml_bytes_unsafe_get(s, i) === sep){
-       var _F_ = r[1];
-       r[1] = [0, sub(s, i + 1 | 0, (j[1] - i | 0) - 1 | 0), _F_];
+       var _E_ = r[1];
+       r[1] = [0, sub(s, i + 1 | 0, (j[1] - i | 0) - 1 | 0), _E_];
        j[1] = i;
       }
-       /*<<bytes.ml:400:2>>*/  /*<<bytes.ml:400:2>>*/ var _G_ = i - 1 | 0;
+       /*<<bytes.ml:400:2>>*/  /*<<bytes.ml:400:2>>*/ var _F_ = i - 1 | 0;
       if(0 === i) break;
-      var i = _G_;
+      var i = _F_;
      }
     }
-    var _E_ = r[1];
-     /*<<bytes.ml:406:2>>*/ return [0, sub(s, 0, j[1]), _E_];
+    var _D_ = r[1];
+     /*<<bytes.ml:406:2>>*/ return [0, sub(s, 0, j[1]), _D_];
     /*<<bytes.ml:406:18>>*/ }
    function to_seq(s){
     function aux(i, param){
@@ -5658,14 +5555,14 @@
       /*<<bytes.ml:414:14>>*/ var
        /*<<bytes.ml:414:14>>*/ x =
          /*<<bytes.ml:414:14>>*/ caml_bytes_get(s, i),
-       /*<<bytes.ml:414:14>>*/ _B_ = i + 1 | 0;
+      _A_ = i + 1 | 0;
       /*<<bytes.ml:415:6>>*/ return [0,
              x,
-             function(_C_){ /*<<?>>*/ return aux(_B_, _C_);}];
+             function(_B_){ /*<<?>>*/ return aux(_A_, _B_);}];
      /*<<bytes.ml:415:29>>*/ }
-     /*<<bytes.ml:417:2>>*/  /*<<bytes.ml:417:2>>*/ var _z_ = 0;
-     /*<<bytes.ml:417:2>>*/ return function(_A_){
-      /*<<?>>*/ return aux(_z_, _A_);};
+    var _y_ = 0;
+     /*<<bytes.ml:417:2>>*/ return function(_z_){
+      /*<<?>>*/ return aux(_y_, _z_);};
     /*<<bytes.ml:417:7>>*/ }
    function to_seqi(s){
     function aux(i, param){
@@ -5674,42 +5571,43 @@
       /*<<bytes.ml:423:14>>*/ var
        /*<<bytes.ml:423:14>>*/ x =
          /*<<bytes.ml:423:14>>*/ caml_bytes_get(s, i),
-       /*<<bytes.ml:423:14>>*/ _x_ = i + 1 | 0;
+      _w_ = i + 1 | 0;
       /*<<bytes.ml:424:6>>*/ return [0,
              [0, i, x],
-             function(_y_){ /*<<?>>*/ return aux(_x_, _y_);}];
+             function(_x_){ /*<<?>>*/ return aux(_w_, _x_);}];
      /*<<bytes.ml:424:33>>*/ }
-     /*<<bytes.ml:426:2>>*/  /*<<bytes.ml:426:2>>*/ var _v_ = 0;
-     /*<<bytes.ml:426:2>>*/ return function(_w_){
-      /*<<?>>*/ return aux(_v_, _w_);};
+    var _u_ = 0;
+     /*<<bytes.ml:426:2>>*/ return function(_v_){
+      /*<<?>>*/ return aux(_u_, _v_);};
     /*<<bytes.ml:426:7>>*/ }
    function of_seq(i){
      /*<<bytes.ml:429:2>>*/ var
       /*<<bytes.ml:429:10>>*/ n = [0, 0],
       /*<<bytes.ml:430:12>>*/ buf = [0, make(256, 0)];
-    function _u_(c){
-      /*<<bytes.ml:441:7>>*/ if(n[1] === caml_ml_bytes_length(buf[1])){
-       /*<<bytes.ml:433:18>>*/  /*<<bytes.ml:433:18>>*/ var
-       new_len =
-          /*<<bytes.ml:433:18>>*/ caml_call2
-          (Stdlib_Int[10],
-           2 * caml_ml_bytes_length(buf[1]) | 0,
-           Stdlib_Sys[12]);
-      if(caml_ml_bytes_length(buf[1]) === new_len)
-        /*<<bytes.ml:434:34>>*/  /*<<bytes.ml:434:34>>*/ caml_call1
-        (Stdlib[2], cst_Bytes_of_seq_cannot_grow_b);
-       /*<<bytes.ml:435:18>>*/  /*<<bytes.ml:435:18>>*/ var
-       new_buf = make(new_len, 0);
-       /*<<bytes.ml:436:4>>*/ blit(buf[1], 0, new_buf, 0, n[1]);
-      buf[1] = new_buf;
-     }
-      /*<<bytes.ml:442:7>>*/  /*<<bytes.ml:442:7>>*/ caml_bytes_set
-      (buf[1], n[1], c);
-     n[1]++;
-     return 0;
-     /*<<bytes.ml:443:13>>*/ }
      /*<<bytes.ml:439:2>>*/  /*<<bytes.ml:439:2>>*/ caml_call2
-     (Stdlib_Seq[4], _u_, i);
+     (Stdlib_Seq[4],
+      function(c){
+        /*<<bytes.ml:441:7>>*/ if(n[1] === caml_ml_bytes_length(buf[1])){
+         /*<<bytes.ml:433:18>>*/  /*<<bytes.ml:433:18>>*/ var
+         new_len =
+            /*<<bytes.ml:433:18>>*/ caml_call2
+            (Stdlib_Int[10],
+             2 * caml_ml_bytes_length(buf[1]) | 0,
+             Stdlib_Sys[12]);
+        if(caml_ml_bytes_length(buf[1]) === new_len)
+          /*<<bytes.ml:434:34>>*/  /*<<bytes.ml:434:34>>*/ caml_call1
+          (Stdlib[2], cst_Bytes_of_seq_cannot_grow_b);
+         /*<<bytes.ml:435:18>>*/  /*<<bytes.ml:435:18>>*/ var
+         new_buf = make(new_len, 0);
+         /*<<bytes.ml:436:4>>*/ blit(buf[1], 0, new_buf, 0, n[1]);
+        buf[1] = new_buf;
+       }
+        /*<<bytes.ml:442:7>>*/  /*<<bytes.ml:442:7>>*/ caml_bytes_set
+        (buf[1], n[1], c);
+       n[1]++;
+       return 0;
+       /*<<bytes.ml:443:13>>*/ },
+      i);
     return sub(buf[1], 0, n[1]);
     /*<<bytes.ml:445:15>>*/ }
    function unsafe_get_uint16_le(b, i){
@@ -5839,7 +5737,17 @@
    var
     set_uint8 = caml_bytes_set,
     set_uint16_ne = caml_bytes_set16,
-    dec_invalid = Stdlib_Uchar[22];
+    dec_invalid = Stdlib_Uchar[22],
+    _a_ = [0, cst_bytes_ml, 679, 9],
+    _b_ = [0, cst_bytes_ml, 654, 20],
+    cst_index_out_of_bounds = cst_index_out_of_bounds$3,
+    cst_index_out_of_bounds$0 = cst_index_out_of_bounds$3,
+    _c_ = [0, cst_bytes_ml, 777, 9],
+    _d_ = [0, cst_bytes_ml, 766, 20],
+    cst_index_out_of_bounds$1 = cst_index_out_of_bounds$3,
+    cst_index_out_of_bounds$2 = cst_index_out_of_bounds$3,
+    _e_ = [0, cst_bytes_ml, 831, 9],
+    _f_ = [0, cst_bytes_ml, 820, 20];
    function dec_ret(n, u){
      /*<<bytes.ml:557:27>>*/  /*<<bytes.ml:557:46>>*/ var
      _l_ =  /*<<bytes.ml:557:46>>*/ caml_call1(Stdlib_Uchar[9], u);
@@ -6573,18 +6481,7 @@
     Stdlib = global_data.Stdlib,
     Stdlib_Bytes = global_data.Stdlib__Bytes,
     bts = Stdlib_Bytes[44],
-    bos = Stdlib_Bytes[45],
-    cst_String_rcontains_from_Byte =
-      "String.rcontains_from / Bytes.rcontains_from",
-    cst_String_contains_from_Bytes =
-      "String.contains_from / Bytes.contains_from",
-    cst_String_rindex_from_opt_Byt =
-      "String.rindex_from_opt / Bytes.rindex_from_opt",
-    cst_String_rindex_from_Bytes_r = "String.rindex_from / Bytes.rindex_from",
-    cst_String_index_from_opt_Byte =
-      "String.index_from_opt / Bytes.index_from_opt",
-    cst_String_index_from_Bytes_in = "String.index_from / Bytes.index_from",
-    cst_String_concat = "String.concat";
+    bos = Stdlib_Bytes[45];
    function make(n, c){
      /*<<string.ml:36:2>>*/ return  /*<<string.ml:36:2>>*/ caml_call1
             (bts,  /*<<string.ml:36:2>>*/ caml_call2(Stdlib_Bytes[1], n, c));
@@ -6602,7 +6499,7 @@
               /*<<string.ml:43:2>>*/ caml_call3
               (Stdlib_Bytes[7], _X_, ofs, len));
     /*<<string.ml:43:30>>*/ }
-   var blit = Stdlib_Bytes[12];
+   var blit = Stdlib_Bytes[12], cst_String_concat = "String.concat";
    function concat(sep, l){
      /*<<?>>*/ if(! l)  /*<<string.ml:64:10>>*/ return cst;
     var seplen = caml_ml_string_length(sep);
@@ -6661,7 +6558,18 @@
              (bts, dst);
     }
    }
-   var cat = Stdlib[28];
+   var
+    cat = Stdlib[28],
+    cst_String_index_from_Bytes_in = "String.index_from / Bytes.index_from",
+    cst_String_index_from_opt_Byte =
+      "String.index_from_opt / Bytes.index_from_opt",
+    cst_String_rindex_from_Bytes_r = "String.rindex_from / Bytes.rindex_from",
+    cst_String_rindex_from_opt_Byt =
+      "String.rindex_from_opt / Bytes.rindex_from_opt",
+    cst_String_contains_from_Bytes =
+      "String.contains_from / Bytes.contains_from",
+    cst_String_rcontains_from_Byte =
+      "String.rcontains_from / Bytes.rcontains_from";
    function iter(f, s){
      /*<<string.ml:74:2>>*/ var
      _U_ = caml_ml_string_length(s) - 1 | 0,
@@ -7188,9 +7096,6 @@
     global_data = runtime.caml_get_global_data(),
     Stdlib_Bytes = global_data.Stdlib__Bytes,
     Stdlib = global_data.Stdlib,
-    cst_Marshal_from_bytes = cst_Marshal_from_bytes$1,
-    cst_Marshal_from_bytes$0 = cst_Marshal_from_bytes$1,
-    cst_Marshal_data_size = "Marshal.data_size",
     cst_Marshal_to_buffer_substrin =
       "Marshal.to_buffer: substring out of bounds";
    function to_buffer(buff, ofs, len, v, flags){
@@ -7201,7 +7106,10 @@
      /*<<marshal.ml:35:7>>*/ return  /*<<marshal.ml:35:7>>*/ caml_call1
             (Stdlib[1], cst_Marshal_to_buffer_substrin);
     /*<<marshal.ml:36:44>>*/ }
-   var header_size = 16;
+   var
+    cst_Marshal_data_size = "Marshal.data_size",
+    cst_Marshal_from_bytes = cst_Marshal_from_bytes$1,
+    cst_Marshal_from_bytes$0 = cst_Marshal_from_bytes$1;
    function data_size(buff, ofs){
      /*<<marshal.ml:50:2>>*/ if
      (0 <= ofs && (caml_ml_bytes_length(buff) - 16 | 0) >= ofs)
@@ -7240,7 +7148,7 @@
        runtime.caml_input_value,
        from_bytes,
        from_string,
-       header_size,
+       16,
        data_size,
        total_size];
    runtime.caml_register_global(6, Stdlib_Marshal, "Stdlib__Marshal");
@@ -7281,19 +7189,17 @@
     Assert_failure = global_data.Assert_failure,
     Stdlib = global_data.Stdlib,
      /*<<array.ml:37:20>>*/ Floatarray = [0],
-    _a_ = [0, "array.ml", 348, 4],
-    cst_Array_combine = "Array.combine",
-    cst_Array_exists2 = "Array.exists2",
-    cst_Array_for_all2 = "Array.for_all2",
-    cst_Array_map2_arrays_must_hav =
-      "Array.map2: arrays must have the same length",
+    cst_Array_init = "Array.init",
+    cst_Array_sub = "Array.sub",
+    cst_Array_fill = "Array.fill",
+    cst_Array_blit = "Array.blit",
     cst_Array_iter2_arrays_must_ha =
       "Array.iter2: arrays must have the same length",
-    cst_Array_blit = "Array.blit",
-    cst_Array_fill = "Array.fill",
-    cst_Array_sub = "Array.sub",
-    cst_Array_init = "Array.init",
-    cst_Stdlib_Array_Bottom = "Stdlib.Array.Bottom";
+    cst_Array_map2_arrays_must_hav =
+      "Array.map2: arrays must have the same length",
+    cst_Array_for_all2 = "Array.for_all2",
+    cst_Array_exists2 = "Array.exists2",
+    cst_Array_combine = "Array.combine";
    function init(l, f){
      /*<<array.ml:48:2>>*/ if(0 === l)  /*<<array.ml:48:16>>*/ return [0];
     if(0 > l)
@@ -7303,16 +7209,16 @@
       /*<<array.ml:53:13>>*/ res =
         /*<<array.ml:53:13>>*/ caml_make_vect
         (l,  /*<<array.ml:53:22>>*/ caml_call1(f, 0)),
-      /*<<array.ml:54:3>>*/ _ay_ = l - 1 | 0,
-      /*<<array.ml:53:13>>*/ _ax_ = 1;
-    if(_ay_ >= 1){
-     var i = _ax_;
+      /*<<array.ml:54:3>>*/ _aw_ = l - 1 | 0,
+      /*<<array.ml:53:13>>*/ _av_ = 1;
+    if(_aw_ >= 1){
+     var i = _av_;
      for(;;){
        /*<<array.ml:55:5>>*/ res[1 + i] =
         /*<<array.ml:55:22>>*/ caml_call1(f, i);
-       /*<<array.ml:55:5>>*/  /*<<array.ml:55:5>>*/ var _az_ = i + 1 | 0;
-      if(_ay_ === i) break;
-      var i = _az_;
+       /*<<array.ml:55:5>>*/  /*<<array.ml:55:5>>*/ var _ax_ = i + 1 | 0;
+      if(_aw_ === i) break;
+      var i = _ax_;
      }
     }
      /*<<array.ml:57:3>>*/ return res;
@@ -7321,15 +7227,15 @@
      /*<<array.ml:60:2>>*/ var
       /*<<array.ml:60:12>>*/ res =
         /*<<array.ml:60:12>>*/ caml_make_vect(sx, [0]),
-      /*<<array.ml:61:2>>*/ _av_ = sx - 1 | 0,
-      /*<<array.ml:60:12>>*/ _au_ = 0;
-    if(_av_ >= 0){
-     var x = _au_;
+      /*<<array.ml:61:2>>*/ _at_ = sx - 1 | 0,
+      /*<<array.ml:60:12>>*/ _as_ = 0;
+    if(_at_ >= 0){
+     var x = _as_;
      for(;;){
       res[1 + x] =  /*<<array.ml:62:21>>*/ caml_make_vect(sy, init);
-       /*<<array.ml:61:2>>*/  /*<<array.ml:61:2>>*/ var _aw_ = x + 1 | 0;
-      if(_av_ === x) break;
-      var x = _aw_;
+       /*<<array.ml:61:2>>*/  /*<<array.ml:61:2>>*/ var _au_ = x + 1 | 0;
+      if(_at_ === x) break;
+      var x = _au_;
      }
     }
      /*<<array.ml:64:2>>*/ return res;
@@ -7380,15 +7286,15 @@
     /*<<array.ml:89:38>>*/ }
    function iter(f, a){
      /*<<array.ml:92:2>>*/ var
-     _as_ = a.length - 1 - 1 | 0,
-      /*<<array.ml:92:2>>*/ _ar_ = 0;
-    if(_as_ >= 0){
-     var i = _ar_;
+     _aq_ = a.length - 1 - 1 | 0,
+      /*<<array.ml:92:2>>*/ _ap_ = 0;
+    if(_aq_ >= 0){
+     var i = _ap_;
      for(;;){
        /*<<array.ml:92:31>>*/  /*<<array.ml:92:31>>*/ caml_call1(f, a[1 + i]);
-       /*<<array.ml:92:31>>*/  /*<<array.ml:92:31>>*/ var _at_ = i + 1 | 0;
-      if(_as_ === i) break;
-      var i = _at_;
+       /*<<array.ml:92:31>>*/  /*<<array.ml:92:31>>*/ var _ar_ = i + 1 | 0;
+      if(_aq_ === i) break;
+      var i = _ar_;
      }
     }
     return 0;
@@ -7398,16 +7304,16 @@
       /*<<array.ml:96:4>>*/ return  /*<<array.ml:96:4>>*/ caml_call1
              (Stdlib[1], cst_Array_iter2_arrays_must_ha);
      /*<<array.ml:98:4>>*/ var
-     _ap_ = a.length - 1 - 1 | 0,
-      /*<<array.ml:98:4>>*/ _ao_ = 0;
-    if(_ap_ >= 0){
-     var i = _ao_;
+     _an_ = a.length - 1 - 1 | 0,
+      /*<<array.ml:98:4>>*/ _am_ = 0;
+    if(_an_ >= 0){
+     var i = _am_;
      for(;;){
        /*<<array.ml:98:33>>*/  /*<<array.ml:98:33>>*/ caml_call2
        (f, a[1 + i], b[1 + i]);
-       /*<<array.ml:98:33>>*/  /*<<array.ml:98:33>>*/ var _aq_ = i + 1 | 0;
-      if(_ap_ === i) break;
-      var i = _aq_;
+       /*<<array.ml:98:33>>*/  /*<<array.ml:98:33>>*/ var _ao_ = i + 1 | 0;
+      if(_an_ === i) break;
+      var i = _ao_;
      }
     }
     return 0;
@@ -7419,48 +7325,48 @@
       /*<<array.ml:103:12>>*/ r =
         /*<<array.ml:103:12>>*/ caml_make_vect
         (l,  /*<<array.ml:103:21>>*/ caml_call1(f, a[1])),
-      /*<<array.ml:104:4>>*/ _am_ = l - 1 | 0,
-      /*<<array.ml:103:12>>*/ _al_ = 1;
-    if(_am_ >= 1){
-     var i = _al_;
+      /*<<array.ml:104:4>>*/ _ak_ = l - 1 | 0,
+      /*<<array.ml:103:12>>*/ _aj_ = 1;
+    if(_ak_ >= 1){
+     var i = _aj_;
      for(;;){
        /*<<array.ml:105:6>>*/ r[1 + i] =
         /*<<array.ml:105:21>>*/ caml_call1(f, a[1 + i]);
-       /*<<array.ml:105:6>>*/  /*<<array.ml:105:6>>*/ var _an_ = i + 1 | 0;
-      if(_am_ === i) break;
-      var i = _an_;
+       /*<<array.ml:105:6>>*/  /*<<array.ml:105:6>>*/ var _al_ = i + 1 | 0;
+      if(_ak_ === i) break;
+      var i = _al_;
      }
     }
      /*<<array.ml:107:4>>*/ return r;
     /*<<array.ml:108:5>>*/ }
    function map_inplace(f, a){
      /*<<array.ml:111:2>>*/ var
-     _aj_ = a.length - 1 - 1 | 0,
-      /*<<array.ml:111:2>>*/ _ai_ = 0;
-    if(_aj_ >= 0){
-     var i = _ai_;
+     _ah_ = a.length - 1 - 1 | 0,
+      /*<<array.ml:111:2>>*/ _ag_ = 0;
+    if(_ah_ >= 0){
+     var i = _ag_;
      for(;;){
        /*<<array.ml:112:4>>*/ a[1 + i] =
         /*<<array.ml:112:19>>*/ caml_call1(f, a[1 + i]);
-       /*<<array.ml:112:4>>*/  /*<<array.ml:112:4>>*/ var _ak_ = i + 1 | 0;
-      if(_aj_ === i) break;
-      var i = _ak_;
+       /*<<array.ml:112:4>>*/  /*<<array.ml:112:4>>*/ var _ai_ = i + 1 | 0;
+      if(_ah_ === i) break;
+      var i = _ai_;
      }
     }
     return 0;
     /*<<array.ml:113:6>>*/ }
    function mapi_inplace(f, a){
      /*<<array.ml:116:2>>*/ var
-     _ag_ = a.length - 1 - 1 | 0,
-      /*<<array.ml:116:2>>*/ _af_ = 0;
-    if(_ag_ >= 0){
-     var i = _af_;
+     _ae_ = a.length - 1 - 1 | 0,
+      /*<<array.ml:116:2>>*/ _ad_ = 0;
+    if(_ae_ >= 0){
+     var i = _ad_;
      for(;;){
        /*<<array.ml:117:4>>*/ a[1 + i] =
         /*<<array.ml:117:19>>*/ caml_call2(f, i, a[1 + i]);
-       /*<<array.ml:117:4>>*/  /*<<array.ml:117:4>>*/ var _ah_ = i + 1 | 0;
-      if(_ag_ === i) break;
-      var i = _ah_;
+       /*<<array.ml:117:4>>*/  /*<<array.ml:117:4>>*/ var _af_ = i + 1 | 0;
+      if(_ae_ === i) break;
+      var i = _af_;
      }
     }
     return 0;
@@ -7477,32 +7383,32 @@
       /*<<array.ml:127:14>>*/ r =
         /*<<array.ml:127:14>>*/ caml_make_vect
         (la,  /*<<array.ml:127:24>>*/ caml_call2(f, a[1], b[1])),
-      /*<<array.ml:128:6>>*/ _ad_ = la - 1 | 0,
-      /*<<array.ml:127:14>>*/ _ac_ = 1;
-    if(_ad_ >= 1){
-     var i = _ac_;
+      /*<<array.ml:128:6>>*/ _ab_ = la - 1 | 0,
+      /*<<array.ml:127:14>>*/ _aa_ = 1;
+    if(_ab_ >= 1){
+     var i = _aa_;
      for(;;){
        /*<<array.ml:129:8>>*/ r[1 + i] =
         /*<<array.ml:129:23>>*/ caml_call2(f, a[1 + i], b[1 + i]);
-       /*<<array.ml:129:8>>*/  /*<<array.ml:129:8>>*/ var _ae_ = i + 1 | 0;
-      if(_ad_ === i) break;
-      var i = _ae_;
+       /*<<array.ml:129:8>>*/  /*<<array.ml:129:8>>*/ var _ac_ = i + 1 | 0;
+      if(_ab_ === i) break;
+      var i = _ac_;
      }
     }
      /*<<array.ml:131:6>>*/ return r;
     /*<<array.ml:133:5>>*/ }
    function iteri(f, a){
      /*<<array.ml:136:2>>*/ var
-     _aa_ = a.length - 1 - 1 | 0,
-      /*<<array.ml:136:2>>*/ _$_ = 0;
-    if(_aa_ >= 0){
-     var i = _$_;
+     ___ = a.length - 1 - 1 | 0,
+      /*<<array.ml:136:2>>*/ _Z_ = 0;
+    if(___ >= 0){
+     var i = _Z_;
      for(;;){
        /*<<array.ml:136:31>>*/  /*<<array.ml:136:31>>*/ caml_call2
        (f, i, a[1 + i]);
-       /*<<array.ml:136:31>>*/  /*<<array.ml:136:31>>*/ var _ab_ = i + 1 | 0;
-      if(_aa_ === i) break;
-      var i = _ab_;
+       /*<<array.ml:136:31>>*/  /*<<array.ml:136:31>>*/ var _$_ = i + 1 | 0;
+      if(___ === i) break;
+      var i = _$_;
      }
     }
     return 0;
@@ -7514,16 +7420,16 @@
       /*<<array.ml:141:12>>*/ r =
         /*<<array.ml:141:12>>*/ caml_make_vect
         (l,  /*<<array.ml:141:21>>*/ caml_call2(f, 0, a[1])),
-      /*<<array.ml:142:4>>*/ _Z_ = l - 1 | 0,
-      /*<<array.ml:141:12>>*/ _Y_ = 1;
-    if(_Z_ >= 1){
-     var i = _Y_;
+      /*<<array.ml:142:4>>*/ _X_ = l - 1 | 0,
+      /*<<array.ml:141:12>>*/ _W_ = 1;
+    if(_X_ >= 1){
+     var i = _W_;
      for(;;){
        /*<<array.ml:143:6>>*/ r[1 + i] =
         /*<<array.ml:143:21>>*/ caml_call2(f, i, a[1 + i]);
-       /*<<array.ml:143:6>>*/  /*<<array.ml:143:6>>*/ var ___ = i + 1 | 0;
-      if(_Z_ === i) break;
-      var i = ___;
+       /*<<array.ml:143:6>>*/  /*<<array.ml:143:6>>*/ var _Y_ = i + 1 | 0;
+      if(_X_ === i) break;
+      var i = _Y_;
      }
     }
      /*<<array.ml:145:4>>*/ return r;
@@ -7572,15 +7478,15 @@
    function fold_left(f, x, a){
      /*<<array.ml:168:2>>*/ var
       /*<<array.ml:168:10>>*/ r = [0, x],
-     _W_ = a.length - 1 - 1 | 0,
-      /*<<array.ml:168:10>>*/ _V_ = 0;
-    if(_W_ >= 0){
-     var i = _V_;
+     _U_ = a.length - 1 - 1 | 0,
+      /*<<array.ml:168:10>>*/ _T_ = 0;
+    if(_U_ >= 0){
+     var i = _T_;
      for(;;){
       r[1] =  /*<<array.ml:170:9>>*/ caml_call2(f, r[1], a[1 + i]);
-       /*<<array.ml:169:2>>*/  /*<<array.ml:169:2>>*/ var _X_ = i + 1 | 0;
-      if(_W_ === i) break;
-      var i = _X_;
+       /*<<array.ml:169:2>>*/  /*<<array.ml:169:2>>*/ var _V_ = i + 1 | 0;
+      if(_U_ === i) break;
+      var i = _V_;
      }
     }
     return r[1];
@@ -7597,10 +7503,10 @@
       /*<<array.ml:178:23>>*/ output_array =
         /*<<array.ml:178:23>>*/ caml_make_vect(len, elt),
       /*<<array.ml:179:14>>*/ acc$1 = [0, acc$0],
-      /*<<array.ml:180:4>>*/ _T_ = len - 1 | 0,
-      /*<<array.ml:179:14>>*/ _S_ = 1;
-    if(_T_ >= 1){
-     var i = _S_;
+      /*<<array.ml:180:4>>*/ _R_ = len - 1 | 0,
+      /*<<array.ml:179:14>>*/ _Q_ = 1;
+    if(_R_ >= 1){
+     var i = _Q_;
      for(;;){
        /*<<array.ml:181:22>>*/ var
         /*<<array.ml:181:22>>*/ match$0 =
@@ -7609,9 +7515,9 @@
        acc$2 = match$0[1];
       acc$1[1] = acc$2;
        /*<<array.ml:183:6>>*/ output_array[1 + i] = elt$0;
-       /*<<array.ml:180:4>>*/  /*<<array.ml:180:4>>*/ var _U_ = i + 1 | 0;
-      if(_T_ === i) break;
-      var i = _U_;
+       /*<<array.ml:180:4>>*/  /*<<array.ml:180:4>>*/ var _S_ = i + 1 | 0;
+      if(_R_ === i) break;
+      var i = _S_;
      }
     }
      /*<<array.ml:185:4>>*/ return [0, acc$1[1], output_array];
@@ -7619,14 +7525,14 @@
    function fold_right(f, a, x){
      /*<<array.ml:189:2>>*/ var
       /*<<array.ml:189:10>>*/ r = [0, x],
-      /*<<array.ml:190:2>>*/ _Q_ = a.length - 1 - 1 | 0;
-    if(_Q_ >= 0){
-     var i = _Q_;
+      /*<<array.ml:190:2>>*/ _O_ = a.length - 1 - 1 | 0;
+    if(_O_ >= 0){
+     var i = _O_;
      for(;;){
       r[1] =  /*<<array.ml:191:9>>*/ caml_call2(f, a[1 + i], r[1]);
-       /*<<array.ml:190:2>>*/  /*<<array.ml:190:2>>*/ var _R_ = i - 1 | 0;
+       /*<<array.ml:190:2>>*/  /*<<array.ml:190:2>>*/ var _P_ = i - 1 | 0;
       if(0 === i) break;
-      var i = _R_;
+      var i = _P_;
      }
     }
     return r[1];
@@ -7770,17 +7676,17 @@
         /*<<array.ml:293:12>>*/ caml_make_vect(n, a0),
       /*<<array.ml:294:12>>*/ b =
         /*<<array.ml:294:12>>*/ caml_make_vect(n, b0),
-      /*<<array.ml:295:4>>*/ _O_ = n - 1 | 0,
-      /*<<array.ml:294:12>>*/ _N_ = 1;
-    if(_O_ >= 1){
-     var i = _N_;
+      /*<<array.ml:295:4>>*/ _M_ = n - 1 | 0,
+      /*<<array.ml:294:12>>*/ _L_ = 1;
+    if(_M_ >= 1){
+     var i = _L_;
      for(;;){
       var match$0 = x[1 + i], bi = match$0[2], ai = match$0[1];
        /*<<array.ml:297:6>>*/ a[1 + i] = ai;
        /*<<array.ml:298:6>>*/ b[1 + i] = bi;
-       /*<<array.ml:295:4>>*/  /*<<array.ml:295:4>>*/ var _P_ = i + 1 | 0;
-      if(_O_ === i) break;
-      var i = _P_;
+       /*<<array.ml:295:4>>*/  /*<<array.ml:295:4>>*/ var _N_ = i + 1 | 0;
+      if(_M_ === i) break;
+      var i = _N_;
      }
     }
      /*<<array.ml:300:4>>*/ return [0, a, b];
@@ -7796,21 +7702,23 @@
      /*<<array.ml:309:12>>*/ var
       /*<<array.ml:309:12>>*/ x =
         /*<<array.ml:309:12>>*/ caml_make_vect(na, [0, a[1], b[1]]),
-      /*<<array.ml:310:4>>*/ _L_ = na - 1 | 0,
-      /*<<array.ml:309:12>>*/ _K_ = 1;
-    if(_L_ >= 1){
-     var i = _K_;
+      /*<<array.ml:310:4>>*/ _J_ = na - 1 | 0,
+      /*<<array.ml:309:12>>*/ _I_ = 1;
+    if(_J_ >= 1){
+     var i = _I_;
      for(;;){
       x[1 + i] = [0, a[1 + i], b[1 + i]];
-       /*<<array.ml:310:4>>*/  /*<<array.ml:310:4>>*/ var _M_ = i + 1 | 0;
-      if(_L_ === i) break;
-      var i = _M_;
+       /*<<array.ml:310:4>>*/  /*<<array.ml:310:4>>*/ var _K_ = i + 1 | 0;
+      if(_J_ === i) break;
+      var i = _K_;
      }
     }
      /*<<array.ml:313:4>>*/ return x;
     /*<<array.ml:314:5>>*/ }
-    /*<<array.ml:316:0>>*/  /*<<array.ml:316:0>>*/ var
-    Bottom = [248, cst_Stdlib_Array_Bottom, runtime.caml_fresh_oo_id(0)];
+    /*<<array.ml:316:0>>*/ var
+     /*<<array.ml:316:0>>*/ Bottom =
+      [248, "Stdlib.Array.Bottom", runtime.caml_fresh_oo_id(0)],
+    _a_ = [0, "array.ml", 348, 4];
    function sort(cmp, a){
     function maxson(l, i){
       /*<<array.ml:319:4>>*/ var
@@ -7818,42 +7726,42 @@
        /*<<array.ml:320:12>>*/ x = [0, i31];
      if((i31 + 2 | 0) < l){
        /*<<array.ml:321:22>>*/ var
-        /*<<array.ml:321:22>>*/ _D_ = i31 + 1 | 0,
-        /*<<array.ml:322:25>>*/ _E_ = caml_check_bound(a, _D_)[1 + _D_];
+        /*<<array.ml:321:22>>*/ _B_ = i31 + 1 | 0,
+        /*<<array.ml:322:25>>*/ _C_ = caml_check_bound(a, _B_)[1 + _B_];
       if
        ( /*<<array.ml:322:9>>*/ caml_call2
-         (cmp, caml_check_bound(a, i31)[1 + i31], _E_)
+         (cmp, caml_check_bound(a, i31)[1 + i31], _C_)
         < 0)
        x[1] = i31 + 1 | 0;
        /*<<array.ml:323:6>>*/ var
-        /*<<array.ml:323:6>>*/ _F_ = i31 + 2 | 0,
-        /*<<array.ml:323:24>>*/ _G_ = caml_check_bound(a, _F_)[1 + _F_],
-       _H_ = x[1];
+        /*<<array.ml:323:6>>*/ _D_ = i31 + 2 | 0,
+        /*<<array.ml:323:24>>*/ _E_ = caml_check_bound(a, _D_)[1 + _D_],
+       _F_ = x[1];
       if
        ( /*<<array.ml:323:9>>*/ caml_call2
-         (cmp, caml_check_bound(a, _H_)[1 + _H_], _G_)
+         (cmp, caml_check_bound(a, _F_)[1 + _F_], _E_)
         < 0)
        x[1] = i31 + 2 | 0;
       return x[1];
      }
      if((i31 + 1 | 0) < l){
        /*<<array.ml:326:38>>*/ var
-       _I_ = i31 + 1 | 0,
-        /*<<array.ml:326:38>>*/ _J_ = caml_check_bound(a, _I_)[1 + _I_];
+       _G_ = i31 + 1 | 0,
+        /*<<array.ml:326:38>>*/ _H_ = caml_check_bound(a, _G_)[1 + _G_];
        /*<<array.ml:326:22>>*/ if
        (0
         >
           /*<<array.ml:326:22>>*/ caml_call2
-          (cmp, caml_check_bound(a, i31)[1 + i31], _J_))
+          (cmp, caml_check_bound(a, i31)[1 + i31], _H_))
         /*<<array.ml:327:11>>*/ return i31 + 1 | 0;
      }
      if(i31 < l)  /*<<array.ml:328:27>>*/ return i31;
       /*<<array.ml:328:36>>*/ throw  /*<<array.ml:328:36>>*/ caml_maybe_attach_backtrace
             ([0, Bottom, i], 1);
      /*<<array.ml:328:52>>*/ }
-    var l = a.length - 1, _x_ = ((l + 1 | 0) / 3 | 0) - 1 | 0;
-    if(_x_ >= 0){
-     var i$6 = _x_;
+    var l = a.length - 1, _v_ = ((l + 1 | 0) / 3 | 0) - 1 | 0;
+    if(_v_ >= 0){
+     var i$6 = _v_;
      for(;;){
        /*<<array.ml:357:50>>*/  /*<<array.ml:357:50>>*/ var
        e$1 = caml_check_bound(a, i$6)[1 + i$6];
@@ -7869,8 +7777,8 @@
             (cmp, caml_check_bound(a, j)[1 + j], e$1))
          break;
          /*<<array.ml:333:14>>*/  /*<<array.ml:333:14>>*/ var
-         _u_ = caml_check_bound(a, j)[1 + j];
-         /*<<array.ml:333:6>>*/ caml_check_bound(a, i)[1 + i] = _u_;
+         _s_ = caml_check_bound(a, j)[1 + j];
+         /*<<array.ml:333:6>>*/ caml_check_bound(a, i)[1 + i] = _s_;
         var i = j;
        }
         /*<<array.ml:335:13>>*/ caml_check_bound(a, i)[1 + i] = e$1;
@@ -7881,14 +7789,14 @@
        var i$0 = exn[2];
         /*<<array.ml:339:61>>*/ caml_check_bound(a, i$0)[1 + i$0] = e$1;
       }
-       /*<<array.ml:357:38>>*/  /*<<array.ml:357:38>>*/ var _C_ = i$6 - 1 | 0;
+       /*<<array.ml:357:38>>*/  /*<<array.ml:357:38>>*/ var _A_ = i$6 - 1 | 0;
       if(0 === i$6) break;
-      var i$6 = _C_;
+      var i$6 = _A_;
      }
     }
-     /*<<array.ml:358:2>>*/  /*<<array.ml:358:2>>*/ var _y_ = l - 1 | 0;
-    if(_y_ >= 2){
-     var i$4 = _y_;
+     /*<<array.ml:358:2>>*/  /*<<array.ml:358:2>>*/ var _w_ = l - 1 | 0;
+    if(_w_ >= 2){
+     var i$4 = _w_;
      for(;;){
        /*<<array.ml:359:12>>*/  /*<<array.ml:359:12>>*/ var
        e$0 = caml_check_bound(a, i$4)[1 + i$4];
@@ -7899,8 +7807,8 @@
         /*<<array.ml:341:4>>*/ for(;;){
          /*<<array.ml:341:12>>*/ var
           /*<<array.ml:341:12>>*/ j$0 = maxson(i$4, i$1),
-          /*<<array.ml:342:12>>*/ _v_ = caml_check_bound(a, j$0)[1 + j$0];
-         /*<<array.ml:342:4>>*/ caml_check_bound(a, i$1)[1 + i$1] = _v_;
+          /*<<array.ml:342:12>>*/ _t_ = caml_check_bound(a, j$0)[1 + j$0];
+         /*<<array.ml:342:4>>*/ caml_check_bound(a, i$1)[1 + i$1] = _t_;
         var i$1 = j$0;
        }
       }
@@ -7925,8 +7833,8 @@
               (cmp, caml_check_bound(a, father)[1 + father], e$0))
            break;
            /*<<array.ml:350:14>>*/  /*<<array.ml:350:14>>*/ var
-           _w_ = caml_check_bound(a, father)[1 + father];
-           /*<<array.ml:350:6>>*/ caml_check_bound(a, i$3)[1 + i$3] = _w_;
+           _u_ = caml_check_bound(a, father)[1 + father];
+           /*<<array.ml:350:6>>*/ caml_check_bound(a, i$3)[1 + i$3] = _u_;
           if(0 >= father) break b;
           var i$3 = father;
          }
@@ -7935,23 +7843,23 @@
         }
          /*<<array.ml:351:49>>*/ caml_check_bound(a, 0)[1] = e$0;
        }
-        /*<<array.ml:358:2>>*/  /*<<array.ml:358:2>>*/ var _B_ = i$4 - 1 | 0;
+        /*<<array.ml:358:2>>*/  /*<<array.ml:358:2>>*/ var _z_ = i$4 - 1 | 0;
        if(2 === i$4) break;
-       var i$4 = _B_;
+       var i$4 = _z_;
       }
      }
     }
-    var _z_ = 1 < l ? 1 : 0;
-    if(_z_){
+    var _x_ = 1 < l ? 1 : 0;
+    if(_x_){
       /*<<array.ml:363:25>>*/  /*<<array.ml:363:25>>*/ var
       e = caml_check_bound(a, 1)[2];
       /*<<array.ml:363:38>>*/ a[2] = caml_check_bound(a, 0)[1];
       /*<<array.ml:363:57>>*/ a[1] = e;
-     var _A_ = 0;
+     var _y_ = 0;
     }
     else
-     var _A_ = _z_;
-     /*<<array.ml:363:57>>*/ return _A_;
+     var _y_ = _x_;
+     /*<<array.ml:363:57>>*/ return _y_;
     /*<<array.ml:363:67>>*/ }
    function stable_sort(cmp, a){
     function merge(src1ofs, src1len, src2, src2ofs, src2len, dst, dstofs){
@@ -7995,36 +7903,36 @@
      /*<<array.ml:386:70>>*/ }
     function isortto(srcofs, dst, dstofs, len){
       /*<<array.ml:389:4>>*/ var
-      _m_ = len - 1 | 0,
-       /*<<array.ml:389:4>>*/ _l_ = 0;
-     if(_m_ >= 0){
-      var i = _l_;
+      _k_ = len - 1 | 0,
+       /*<<array.ml:389:4>>*/ _j_ = 0;
+     if(_k_ >= 0){
+      var i = _j_;
       for(;;){
         /*<<array.ml:390:14>>*/ var
-        _n_ = srcofs + i | 0,
-         /*<<array.ml:390:14>>*/ e = caml_check_bound(a, _n_)[1 + _n_],
+        _l_ = srcofs + i | 0,
+         /*<<array.ml:390:14>>*/ e = caml_check_bound(a, _l_)[1 + _l_],
          /*<<array.ml:391:14>>*/ j = [0, (dstofs + i | 0) - 1 | 0];
        for(;;){
         if(dstofs > j[1]) break;
-        var _o_ = j[1];
+        var _m_ = j[1];
          /*<<array.ml:392:29>>*/ if
          (0
           >=
             /*<<array.ml:392:29>>*/ caml_call2
-            (cmp, caml_check_bound(dst, _o_)[1 + _o_], e))
+            (cmp, caml_check_bound(dst, _m_)[1 + _m_], e))
          break;
          /*<<array.ml:393:25>>*/ var
-         _p_ = j[1],
-          /*<<array.ml:393:25>>*/ _q_ = caml_check_bound(dst, _p_)[1 + _p_],
-         _r_ = j[1] + 1 | 0;
-         /*<<array.ml:393:8>>*/ caml_check_bound(dst, _r_)[1 + _r_] = _q_;
+         _n_ = j[1],
+          /*<<array.ml:393:25>>*/ _o_ = caml_check_bound(dst, _n_)[1 + _n_],
+         _p_ = j[1] + 1 | 0;
+         /*<<array.ml:393:8>>*/ caml_check_bound(dst, _p_)[1 + _p_] = _o_;
         j[1] += -1;
        }
-       var _s_ = j[1] + 1 | 0;
-        /*<<array.ml:396:6>>*/ caml_check_bound(dst, _s_)[1 + _s_] = e;
-        /*<<array.ml:389:4>>*/  /*<<array.ml:389:4>>*/ var _t_ = i + 1 | 0;
-       if(_m_ === i) break;
-       var i = _t_;
+       var _q_ = j[1] + 1 | 0;
+        /*<<array.ml:396:6>>*/ caml_check_bound(dst, _q_)[1 + _q_] = e;
+        /*<<array.ml:389:4>>*/  /*<<array.ml:389:4>>*/ var _r_ = i + 1 | 0;
+       if(_k_ === i) break;
+       var i = _r_;
       }
      }
      return 0;
@@ -8055,14 +7963,14 @@
        /*<<array.ml:429:9>>*/ return 0;
       /*<<array.ml:427:14>>*/ var
        /*<<array.ml:427:14>>*/ x = a[1 + i],
-       /*<<array.ml:427:14>>*/ _j_ = i + 1 | 0;
+      _h_ = i + 1 | 0;
       /*<<array.ml:428:6>>*/ return [0,
              x,
-             function(_k_){ /*<<?>>*/ return aux(_j_, _k_);}];
+             function(_i_){ /*<<?>>*/ return aux(_h_, _i_);}];
      /*<<array.ml:429:16>>*/ }
-     /*<<array.ml:431:2>>*/  /*<<array.ml:431:2>>*/ var _h_ = 0;
-     /*<<array.ml:431:2>>*/ return function(_i_){
-      /*<<?>>*/ return aux(_h_, _i_);};
+    var _f_ = 0;
+     /*<<array.ml:431:2>>*/ return function(_g_){
+      /*<<?>>*/ return aux(_f_, _g_);};
     /*<<array.ml:431:7>>*/ }
    function to_seqi(a){
     function aux(i, param){
@@ -8070,22 +7978,25 @@
        /*<<array.ml:439:9>>*/ return 0;
       /*<<array.ml:437:14>>*/ var
        /*<<array.ml:437:14>>*/ x = a[1 + i],
-       /*<<array.ml:437:14>>*/ _f_ = i + 1 | 0;
+      _d_ = i + 1 | 0;
       /*<<array.ml:438:6>>*/ return [0,
              [0, i, x],
-             function(_g_){ /*<<?>>*/ return aux(_f_, _g_);}];
+             function(_e_){ /*<<?>>*/ return aux(_d_, _e_);}];
      /*<<array.ml:439:16>>*/ }
-     /*<<array.ml:441:2>>*/  /*<<array.ml:441:2>>*/ var _d_ = 0;
-     /*<<array.ml:441:2>>*/ return function(_e_){
-      /*<<?>>*/ return aux(_d_, _e_);};
+    var _b_ = 0;
+     /*<<array.ml:441:2>>*/ return function(_c_){
+      /*<<?>>*/ return aux(_b_, _c_);};
     /*<<array.ml:441:7>>*/ }
    function of_seq(i$2){
-     /*<<array.ml:455:2>>*/ var _b_ = 0;
-    function _c_(acc, x){
-      /*<<array.ml:455:38>>*/ return [0, x, acc];
-     /*<<array.ml:455:44>>*/ }
-     /*<<array.ml:455:10>>*/  /*<<array.ml:455:10>>*/ var
-     l =  /*<<array.ml:455:10>>*/ caml_call3(Stdlib_Seq[5], _c_, _b_, i$2);
+     /*<<array.ml:455:2>>*/  /*<<array.ml:455:10>>*/ var
+     l =
+        /*<<array.ml:455:10>>*/ caml_call3
+        (Stdlib_Seq[5],
+         function(acc, x){
+           /*<<array.ml:455:38>>*/ return [0, x, acc];
+          /*<<array.ml:455:44>>*/ },
+         0,
+         i$2);
     if(! l)  /*<<array.ml:444:10>>*/ return [0];
      /*<<array.ml:446:16>>*/ var
      tl = l[2],
@@ -8199,23 +8110,7 @@
     nan = Stdlib[24],
      /*<<float.ml:38:20>>*/ signaling_nan =
        /*<<float.ml:38:20>>*/ runtime.caml_int64_float_of_bits
-       (runtime.caml_int64_create_lo_mi_hi(1, 0, 32752)),
-    _b_ = [0, cst_float_ml, 458, 6],
-    cst_Float_Array_map2_arrays_mu =
-      "Float.Array.map2: arrays must have the same length",
-    cst_Float_Array_iter2_arrays_m =
-      "Float.Array.iter2: arrays must have the same length",
-    cst_Float_array_blit = cst_Float_array_blit$1,
-    cst_Float_array_blit$0 = cst_Float_array_blit$1,
-    cst_Float_Array_fill = "Float.Array.fill",
-    cst_Float_Array_sub = "Float.Array.sub",
-    _a_ = [0, cst_float_ml, 228, 14],
-    cst_Float_Array_concat = "Float.Array.concat",
-    cst_Float_Array_init = "Float.Array.init",
-    cst_Stdlib_Float_Array_Bottom = "Stdlib.Float.Array.Bottom",
-    zero = 0.,
-    one = 1.,
-    minus_one = -1.;
+       (runtime.caml_int64_create_lo_mi_hi(1, 0, 32752));
    function is_finite(x){
      /*<<float.ml:39:27>>*/ return x - x == 0. ? 1 : 0;
     /*<<float.ml:39:38>>*/ }
@@ -8231,11 +8126,21 @@
     epsilon = Stdlib[27],
     of_string_opt = Stdlib[36],
     to_string = Stdlib[35],
-    pi = 3.141592653589793;
+    cst_Float_Array_init = "Float.Array.init",
+    cst_Float_Array_concat = "Float.Array.concat",
+    _a_ = [0, cst_float_ml, 228, 14],
+    cst_Float_Array_sub = "Float.Array.sub",
+    cst_Float_Array_fill = "Float.Array.fill",
+    cst_Float_array_blit = cst_Float_array_blit$1,
+    cst_Float_array_blit$0 = cst_Float_array_blit$1,
+    cst_Float_Array_iter2_arrays_m =
+      "Float.Array.iter2: arrays must have the same length",
+    cst_Float_Array_map2_arrays_mu =
+      "Float.Array.map2: arrays must have the same length";
    function is_integer(x){
      /*<<float.ml:116:19>>*/ var
-     _aw_ = x ==  /*<<float.ml:116:23>>*/ runtime.caml_trunc_float(x) ? 1 : 0;
-    return _aw_ ? is_finite(x) : _aw_;
+     _am_ = x ==  /*<<float.ml:116:23>>*/ runtime.caml_trunc_float(x) ? 1 : 0;
+    return _am_ ? is_finite(x) : _am_;
     /*<<float.ml:116:45>>*/ }
    function succ(x){
      /*<<float.ml:121:13>>*/ return  /*<<float.ml:121:13>>*/ caml_nextafter_float
@@ -8336,32 +8241,32 @@
             (10, 100, 0, x);
     /*<<float.ml:170:41>>*/ }
    function unsafe_fill(a, ofs, len, v){
-     /*<<float.ml:184:4>>*/ var _au_ = (ofs + len | 0) - 1 | 0;
-    if(_au_ >= ofs){
+     /*<<float.ml:184:4>>*/ var _ak_ = (ofs + len | 0) - 1 | 0;
+    if(_ak_ >= ofs){
      var i = ofs;
      for(;;){
        /*<<float.ml:184:36>>*/ a[1 + i] = v;
-       /*<<float.ml:184:36>>*/  /*<<float.ml:184:36>>*/ var _av_ = i + 1 | 0;
-      if(_au_ === i) break;
-      var i = _av_;
+       /*<<float.ml:184:36>>*/  /*<<float.ml:184:36>>*/ var _al_ = i + 1 | 0;
+      if(_ak_ === i) break;
+      var i = _al_;
      }
     }
     return 0;
     /*<<float.ml:184:57>>*/ }
    function check(a, ofs, len, msg){
-     /*<<float.ml:190:4>>*/ var _aq_ = ofs < 0 ? 1 : 0;
-    if(_aq_)
-     var _ar_ = _aq_;
+     /*<<float.ml:190:4>>*/ var _ag_ = ofs < 0 ? 1 : 0;
+    if(_ag_)
+     var _ah_ = _ag_;
     else{
-     var _as_ = len < 0 ? 1 : 0;
-     if(_as_)
-      var _ar_ = _as_;
+     var _ai_ = len < 0 ? 1 : 0;
+     if(_ai_)
+      var _ah_ = _ai_;
      else
       var
-       _at_ = (ofs + len | 0) < 0 ? 1 : 0,
-       _ar_ = _at_ || (a.length - 1 < (ofs + len | 0) ? 1 : 0);
+       _aj_ = (ofs + len | 0) < 0 ? 1 : 0,
+       _ah_ = _aj_ || (a.length - 1 < (ofs + len | 0) ? 1 : 0);
     }
-    return _ar_ ?  /*<<float.ml:191:6>>*/ caml_call1(Stdlib[1], msg) : _ar_;
+    return _ah_ ?  /*<<float.ml:191:6>>*/ caml_call1(Stdlib[1], msg) : _ah_;
     /*<<float.ml:191:21>>*/ }
    function make(n, v){
      /*<<float.ml:194:4>>*/  /*<<float.ml:194:17>>*/ var
@@ -8376,16 +8281,16 @@
      /*<<float.ml:201:16>>*/ var
       /*<<float.ml:201:16>>*/ res =
         /*<<float.ml:201:16>>*/ caml_floatarray_create(l),
-      /*<<float.ml:202:6>>*/ _ao_ = l - 1 | 0,
-      /*<<float.ml:201:16>>*/ _an_ = 0;
-    if(_ao_ >= 0){
-     var i = _an_;
+      /*<<float.ml:202:6>>*/ _ae_ = l - 1 | 0,
+      /*<<float.ml:201:16>>*/ _ad_ = 0;
+    if(_ae_ >= 0){
+     var i = _ad_;
      for(;;){
        /*<<float.ml:203:8>>*/ res[1 + i] =
         /*<<float.ml:203:25>>*/ caml_call1(f, i);
-       /*<<float.ml:203:8>>*/  /*<<float.ml:203:8>>*/ var _ap_ = i + 1 | 0;
-      if(_ao_ === i) break;
-      var i = _ap_;
+       /*<<float.ml:203:8>>*/  /*<<float.ml:203:8>>*/ var _af_ = i + 1 | 0;
+      if(_ae_ === i) break;
+      var i = _af_;
      }
     }
      /*<<float.ml:205:6>>*/ return res;
@@ -8466,11 +8371,10 @@
             (src, sofs, dst, dofs, len);
     /*<<float.ml:256:37>>*/ }
    function to_list(a){
-     /*<<float.ml:259:25>>*/ function _al_(_am_){
-      /*<<?>>*/ return a[1 + _am_];
-    }
-     /*<<float.ml:259:25>>*/ return  /*<<float.ml:259:25>>*/ caml_call2
-            (Stdlib_List[11], a.length - 1, _al_);
+     /*<<float.ml:259:4>>*/ return  /*<<float.ml:259:25>>*/ caml_call2
+            (Stdlib_List[11],
+             a.length - 1,
+             function(_ac_){ /*<<?>>*/ return a[1 + _ac_];});
     /*<<float.ml:259:39>>*/ }
    function of_list(l){
      /*<<float.ml:262:4>>*/ var
@@ -8491,16 +8395,16 @@
     /*<<float.ml:268:12>>*/ }
    function iter(f, a){
      /*<<float.ml:272:4>>*/ var
-     _aj_ = a.length - 1 - 1 | 0,
-      /*<<float.ml:272:4>>*/ _ai_ = 0;
-    if(_aj_ >= 0){
-     var i = _ai_;
+     _aa_ = a.length - 1 - 1 | 0,
+      /*<<float.ml:272:4>>*/ _$_ = 0;
+    if(_aa_ >= 0){
+     var i = _$_;
      for(;;){
        /*<<float.ml:272:33>>*/  /*<<float.ml:272:33>>*/ caml_call1
        (f, a[1 + i]);
-       /*<<float.ml:272:33>>*/  /*<<float.ml:272:33>>*/ var _ak_ = i + 1 | 0;
-      if(_aj_ === i) break;
-      var i = _ak_;
+       /*<<float.ml:272:33>>*/  /*<<float.ml:272:33>>*/ var _ab_ = i + 1 | 0;
+      if(_aa_ === i) break;
+      var i = _ab_;
      }
     }
     return 0;
@@ -8510,16 +8414,16 @@
       /*<<float.ml:277:6>>*/ return  /*<<float.ml:277:6>>*/ caml_call1
              (Stdlib[1], cst_Float_Array_iter2_arrays_m);
      /*<<float.ml:279:6>>*/ var
-     _ag_ = a.length - 1 - 1 | 0,
-      /*<<float.ml:279:6>>*/ _af_ = 0;
-    if(_ag_ >= 0){
-     var i = _af_;
+     _Z_ = a.length - 1 - 1 | 0,
+      /*<<float.ml:279:6>>*/ _Y_ = 0;
+    if(_Z_ >= 0){
+     var i = _Y_;
      for(;;){
        /*<<float.ml:279:35>>*/  /*<<float.ml:279:35>>*/ caml_call2
        (f, a[1 + i], b[1 + i]);
-       /*<<float.ml:279:35>>*/  /*<<float.ml:279:35>>*/ var _ah_ = i + 1 | 0;
-      if(_ag_ === i) break;
-      var i = _ah_;
+       /*<<float.ml:279:35>>*/  /*<<float.ml:279:35>>*/ var ___ = i + 1 | 0;
+      if(_Z_ === i) break;
+      var i = ___;
      }
     }
     return 0;
@@ -8529,32 +8433,32 @@
      l = a.length - 1,
       /*<<float.ml:283:12>>*/ r =
         /*<<float.ml:283:12>>*/ caml_floatarray_create(l),
-      /*<<float.ml:284:4>>*/ _ad_ = l - 1 | 0,
-      /*<<float.ml:283:12>>*/ _ac_ = 0;
-    if(_ad_ >= 0){
-     var i = _ac_;
+      /*<<float.ml:284:4>>*/ _W_ = l - 1 | 0,
+      /*<<float.ml:283:12>>*/ _V_ = 0;
+    if(_W_ >= 0){
+     var i = _V_;
      for(;;){
        /*<<float.ml:285:6>>*/ r[1 + i] =
         /*<<float.ml:285:21>>*/ caml_call1(f, a[1 + i]);
-       /*<<float.ml:285:6>>*/  /*<<float.ml:285:6>>*/ var _ae_ = i + 1 | 0;
-      if(_ad_ === i) break;
-      var i = _ae_;
+       /*<<float.ml:285:6>>*/  /*<<float.ml:285:6>>*/ var _X_ = i + 1 | 0;
+      if(_W_ === i) break;
+      var i = _X_;
      }
     }
      /*<<float.ml:287:4>>*/ return r;
     /*<<float.ml:287:5>>*/ }
    function map_inplace(f, a){
      /*<<float.ml:291:4>>*/ var
-     _aa_ = a.length - 1 - 1 | 0,
-      /*<<float.ml:291:4>>*/ _$_ = 0;
-    if(_aa_ >= 0){
-     var i = _$_;
+     _T_ = a.length - 1 - 1 | 0,
+      /*<<float.ml:291:4>>*/ _S_ = 0;
+    if(_T_ >= 0){
+     var i = _S_;
      for(;;){
        /*<<float.ml:292:6>>*/ a[1 + i] =
         /*<<float.ml:292:21>>*/ caml_call1(f, a[1 + i]);
-       /*<<float.ml:292:6>>*/  /*<<float.ml:292:6>>*/ var _ab_ = i + 1 | 0;
-      if(_aa_ === i) break;
-      var i = _ab_;
+       /*<<float.ml:292:6>>*/  /*<<float.ml:292:6>>*/ var _U_ = i + 1 | 0;
+      if(_T_ === i) break;
+      var i = _U_;
      }
     }
     return 0;
@@ -8569,32 +8473,32 @@
      /*<<float.ml:301:14>>*/ var
       /*<<float.ml:301:14>>*/ r =
         /*<<float.ml:301:14>>*/ caml_floatarray_create(la),
-      /*<<float.ml:302:6>>*/ _Z_ = la - 1 | 0,
-      /*<<float.ml:301:14>>*/ _Y_ = 0;
-    if(_Z_ >= 0){
-     var i = _Y_;
+      /*<<float.ml:302:6>>*/ _Q_ = la - 1 | 0,
+      /*<<float.ml:301:14>>*/ _P_ = 0;
+    if(_Q_ >= 0){
+     var i = _P_;
      for(;;){
        /*<<float.ml:303:8>>*/ r[1 + i] =
         /*<<float.ml:303:23>>*/ caml_call2(f, a[1 + i], b[1 + i]);
-       /*<<float.ml:303:8>>*/  /*<<float.ml:303:8>>*/ var ___ = i + 1 | 0;
-      if(_Z_ === i) break;
-      var i = ___;
+       /*<<float.ml:303:8>>*/  /*<<float.ml:303:8>>*/ var _R_ = i + 1 | 0;
+      if(_Q_ === i) break;
+      var i = _R_;
      }
     }
      /*<<float.ml:305:6>>*/ return r;
     /*<<float.ml:306:7>>*/ }
    function iteri(f, a){
      /*<<float.ml:310:4>>*/ var
-     _W_ = a.length - 1 - 1 | 0,
-      /*<<float.ml:310:4>>*/ _V_ = 0;
-    if(_W_ >= 0){
-     var i = _V_;
+     _N_ = a.length - 1 - 1 | 0,
+      /*<<float.ml:310:4>>*/ _M_ = 0;
+    if(_N_ >= 0){
+     var i = _M_;
      for(;;){
        /*<<float.ml:310:33>>*/  /*<<float.ml:310:33>>*/ caml_call2
        (f, i, a[1 + i]);
-       /*<<float.ml:310:33>>*/  /*<<float.ml:310:33>>*/ var _X_ = i + 1 | 0;
-      if(_W_ === i) break;
-      var i = _X_;
+       /*<<float.ml:310:33>>*/  /*<<float.ml:310:33>>*/ var _O_ = i + 1 | 0;
+      if(_N_ === i) break;
+      var i = _O_;
      }
     }
     return 0;
@@ -8604,32 +8508,32 @@
      l = a.length - 1,
       /*<<float.ml:314:12>>*/ r =
         /*<<float.ml:314:12>>*/ caml_floatarray_create(l),
-      /*<<float.ml:315:4>>*/ _T_ = l - 1 | 0,
-      /*<<float.ml:314:12>>*/ _S_ = 0;
-    if(_T_ >= 0){
-     var i = _S_;
+      /*<<float.ml:315:4>>*/ _K_ = l - 1 | 0,
+      /*<<float.ml:314:12>>*/ _J_ = 0;
+    if(_K_ >= 0){
+     var i = _J_;
      for(;;){
        /*<<float.ml:316:6>>*/ r[1 + i] =
         /*<<float.ml:316:21>>*/ caml_call2(f, i, a[1 + i]);
-       /*<<float.ml:316:6>>*/  /*<<float.ml:316:6>>*/ var _U_ = i + 1 | 0;
-      if(_T_ === i) break;
-      var i = _U_;
+       /*<<float.ml:316:6>>*/  /*<<float.ml:316:6>>*/ var _L_ = i + 1 | 0;
+      if(_K_ === i) break;
+      var i = _L_;
      }
     }
      /*<<float.ml:318:4>>*/ return r;
     /*<<float.ml:318:5>>*/ }
    function mapi_inplace(f, a){
      /*<<float.ml:322:4>>*/ var
-     _Q_ = a.length - 1 - 1 | 0,
-      /*<<float.ml:322:4>>*/ _P_ = 0;
-    if(_Q_ >= 0){
-     var i = _P_;
+     _H_ = a.length - 1 - 1 | 0,
+      /*<<float.ml:322:4>>*/ _G_ = 0;
+    if(_H_ >= 0){
+     var i = _G_;
      for(;;){
        /*<<float.ml:323:6>>*/ a[1 + i] =
         /*<<float.ml:323:21>>*/ caml_call2(f, i, a[1 + i]);
-       /*<<float.ml:323:6>>*/  /*<<float.ml:323:6>>*/ var _R_ = i + 1 | 0;
-      if(_Q_ === i) break;
-      var i = _R_;
+       /*<<float.ml:323:6>>*/  /*<<float.ml:323:6>>*/ var _I_ = i + 1 | 0;
+      if(_H_ === i) break;
+      var i = _I_;
      }
     }
     return 0;
@@ -8637,15 +8541,15 @@
    function fold_left(f, x, a){
      /*<<float.ml:328:4>>*/ var
       /*<<float.ml:328:12>>*/ r = [0, x],
-     _N_ = a.length - 1 - 1 | 0,
-      /*<<float.ml:328:12>>*/ _M_ = 0;
-    if(_N_ >= 0){
-     var i = _M_;
+     _E_ = a.length - 1 - 1 | 0,
+      /*<<float.ml:328:12>>*/ _D_ = 0;
+    if(_E_ >= 0){
+     var i = _D_;
      for(;;){
       r[1] =  /*<<float.ml:330:11>>*/ caml_call2(f, r[1], a[1 + i]);
-       /*<<float.ml:329:4>>*/  /*<<float.ml:329:4>>*/ var _O_ = i + 1 | 0;
-      if(_N_ === i) break;
-      var i = _O_;
+       /*<<float.ml:329:4>>*/  /*<<float.ml:329:4>>*/ var _F_ = i + 1 | 0;
+      if(_E_ === i) break;
+      var i = _F_;
      }
     }
     return r[1];
@@ -8653,14 +8557,14 @@
    function fold_right(f, a, x){
      /*<<float.ml:336:4>>*/ var
       /*<<float.ml:336:12>>*/ r = [0, x],
-      /*<<float.ml:337:4>>*/ _K_ = a.length - 1 - 1 | 0;
-    if(_K_ >= 0){
-     var i = _K_;
+      /*<<float.ml:337:4>>*/ _B_ = a.length - 1 - 1 | 0;
+    if(_B_ >= 0){
+     var i = _B_;
      for(;;){
       r[1] =  /*<<float.ml:338:11>>*/ caml_call2(f, a[1 + i], r[1]);
-       /*<<float.ml:337:4>>*/  /*<<float.ml:337:4>>*/ var _L_ = i - 1 | 0;
+       /*<<float.ml:337:4>>*/  /*<<float.ml:337:4>>*/ var _C_ = i - 1 | 0;
       if(0 === i) break;
-      var i = _L_;
+      var i = _C_;
      }
     }
     return r[1];
@@ -8758,8 +8662,10 @@
       i = i$0;
     }
     /*<<float.ml:423:10>>*/ }
-    /*<<float.ml:426:2>>*/  /*<<float.ml:426:2>>*/ var
-    Bottom = [248, cst_Stdlib_Float_Array_Bottom, runtime.caml_fresh_oo_id(0)];
+    /*<<float.ml:426:2>>*/ var
+     /*<<float.ml:426:2>>*/ Bottom =
+      [248, "Stdlib.Float.Array.Bottom", runtime.caml_fresh_oo_id(0)],
+    _b_ = [0, cst_float_ml, 458, 6];
    function sort(cmp, a){
     function maxson(l, i){
       /*<<float.ml:429:6>>*/ var
@@ -8796,9 +8702,9 @@
       /*<<float.ml:438:38>>*/ throw  /*<<float.ml:438:38>>*/ caml_maybe_attach_backtrace
             ([0, Bottom, i], 1);
      /*<<float.ml:438:54>>*/ }
-    var l = a.length - 1, _E_ = ((l + 1 | 0) / 3 | 0) - 1 | 0;
-    if(_E_ >= 0){
-     var i$6 = _E_;
+    var l = a.length - 1, _v_ = ((l + 1 | 0) / 3 | 0) - 1 | 0;
+    if(_v_ >= 0){
+     var i$6 = _v_;
      for(;;){
        /*<<float.ml:467:52>>*/  /*<<float.ml:467:52>>*/ var
        e$1 =  /*<<float.ml:467:52>>*/ caml_array_get(a, i$6);
@@ -8827,14 +8733,14 @@
         /*<<float.ml:449:63>>*/  /*<<float.ml:449:63>>*/ caml_array_set
         (a, i$0, e$1);
       }
-       /*<<float.ml:467:40>>*/  /*<<float.ml:467:40>>*/ var _J_ = i$6 - 1 | 0;
+       /*<<float.ml:467:40>>*/  /*<<float.ml:467:40>>*/ var _A_ = i$6 - 1 | 0;
       if(0 === i$6) break;
-      var i$6 = _J_;
+      var i$6 = _A_;
      }
     }
-     /*<<float.ml:468:4>>*/  /*<<float.ml:468:4>>*/ var _F_ = l - 1 | 0;
-    if(_F_ >= 2){
-     var i$4 = _F_;
+     /*<<float.ml:468:4>>*/  /*<<float.ml:468:4>>*/ var _w_ = l - 1 | 0;
+    if(_w_ >= 2){
+     var i$4 = _w_;
      for(;;){
        /*<<float.ml:469:14>>*/  /*<<float.ml:469:14>>*/ var
        e$0 =  /*<<float.ml:469:14>>*/ caml_array_get(a, i$4);
@@ -8883,23 +8789,23 @@
          /*<<float.ml:461:51>>*/  /*<<float.ml:461:51>>*/ caml_array_set
          (a, 0, e$0);
        }
-        /*<<float.ml:468:4>>*/  /*<<float.ml:468:4>>*/ var _I_ = i$4 - 1 | 0;
+        /*<<float.ml:468:4>>*/  /*<<float.ml:468:4>>*/ var _z_ = i$4 - 1 | 0;
        if(2 === i$4) break;
-       var i$4 = _I_;
+       var i$4 = _z_;
       }
      }
     }
-    var _G_ = 1 < l ? 1 : 0;
-    if(_G_){
+    var _x_ = 1 < l ? 1 : 0;
+    if(_x_){
       /*<<float.ml:473:27>>*/  /*<<float.ml:473:27>>*/ var
       e =  /*<<float.ml:473:27>>*/ caml_array_get(a, 1);
       /*<<float.ml:473:40>>*/  /*<<float.ml:473:40>>*/ caml_array_set
       (a, 1,  /*<<float.ml:473:48>>*/ caml_array_get(a, 0));
-     var _H_ =  /*<<float.ml:473:59>>*/ caml_array_set(a, 0, e);
+     var _y_ =  /*<<float.ml:473:59>>*/ caml_array_set(a, 0, e);
     }
     else
-     var _H_ = _G_;
-     /*<<float.ml:473:59>>*/ return _H_;
+     var _y_ = _x_;
+     /*<<float.ml:473:59>>*/ return _y_;
     /*<<float.ml:473:69>>*/ }
    function stable_sort(cmp, a){
     function merge(src1ofs, src1len, src2, src2ofs, src2len, dst, dstofs){
@@ -8949,10 +8855,10 @@
      /*<<float.ml:496:72>>*/ }
     function isortto(srcofs, dst, dstofs, len){
       /*<<float.ml:499:6>>*/ var
-      _C_ = len - 1 | 0,
-       /*<<float.ml:499:6>>*/ _B_ = 0;
-     if(_C_ >= 0){
-      var i = _B_;
+      _t_ = len - 1 | 0,
+       /*<<float.ml:499:6>>*/ _s_ = 0;
+     if(_t_ >= 0){
+      var i = _s_;
       for(;;){
         /*<<float.ml:500:16>>*/ var
          /*<<float.ml:500:16>>*/ e =
@@ -8974,9 +8880,9 @@
        }
         /*<<float.ml:506:8>>*/  /*<<float.ml:506:8>>*/ caml_array_set
         (dst, j[1] + 1 | 0, e);
-        /*<<float.ml:499:6>>*/  /*<<float.ml:499:6>>*/ var _D_ = i + 1 | 0;
-       if(_C_ === i) break;
-       var i = _D_;
+        /*<<float.ml:499:6>>*/  /*<<float.ml:499:6>>*/ var _u_ = i + 1 | 0;
+       if(_t_ === i) break;
+       var i = _u_;
       }
      }
      return 0;
@@ -9007,14 +8913,14 @@
        /*<<float.ml:537:11>>*/ return 0;
       /*<<float.ml:535:16>>*/ var
        /*<<float.ml:535:16>>*/ x = a[1 + i],
-       /*<<float.ml:535:16>>*/ _z_ = i + 1 | 0;
+      _q_ = i + 1 | 0;
       /*<<float.ml:536:8>>*/ return [0,
              x,
-             function(_A_){ /*<<?>>*/ return aux(_z_, _A_);}];
+             function(_r_){ /*<<?>>*/ return aux(_q_, _r_);}];
      /*<<float.ml:537:18>>*/ }
-     /*<<float.ml:539:4>>*/  /*<<float.ml:539:4>>*/ var _x_ = 0;
-     /*<<float.ml:539:4>>*/ return function(_y_){
-      /*<<?>>*/ return aux(_x_, _y_);};
+    var _o_ = 0;
+     /*<<float.ml:539:4>>*/ return function(_p_){
+      /*<<?>>*/ return aux(_o_, _p_);};
     /*<<float.ml:539:9>>*/ }
    function to_seqi(a){
     function aux(i, param){
@@ -9022,23 +8928,25 @@
        /*<<float.ml:548:11>>*/ return 0;
       /*<<float.ml:546:16>>*/ var
        /*<<float.ml:546:16>>*/ x = a[1 + i],
-       /*<<float.ml:546:16>>*/ _v_ = i + 1 | 0;
+      _m_ = i + 1 | 0;
       /*<<float.ml:547:8>>*/ return [0,
              [0, i, x],
-             function(_w_){ /*<<?>>*/ return aux(_v_, _w_);}];
+             function(_n_){ /*<<?>>*/ return aux(_m_, _n_);}];
      /*<<float.ml:548:18>>*/ }
-     /*<<float.ml:550:4>>*/  /*<<float.ml:550:4>>*/ var _t_ = 0;
-     /*<<float.ml:550:4>>*/ return function(_u_){
-      /*<<?>>*/ return aux(_t_, _u_);};
+    var _k_ = 0;
+     /*<<float.ml:550:4>>*/ return function(_l_){
+      /*<<?>>*/ return aux(_k_, _l_);};
     /*<<float.ml:550:9>>*/ }
    function of_seq(i$2){
-     /*<<float.ml:564:4>>*/ var _r_ = 0;
-    function _s_(acc, x){
-      /*<<float.ml:564:40>>*/ return [0, x, acc];
-     /*<<float.ml:564:46>>*/ }
-     /*<<float.ml:564:12>>*/ var
+     /*<<float.ml:564:4>>*/ var
       /*<<float.ml:564:12>>*/ l =
-        /*<<float.ml:564:12>>*/ caml_call3(Stdlib_Seq[5], _s_, _r_, i$2),
+        /*<<float.ml:564:12>>*/ caml_call3
+        (Stdlib_Seq[5],
+         function(acc, x){
+           /*<<float.ml:564:40>>*/ return [0, x, acc];
+          /*<<float.ml:564:46>>*/ },
+         0,
+         i$2),
       /*<<float.ml:554:14>>*/ len =
         /*<<float.ml:554:14>>*/ caml_call1(Stdlib_List[1], l),
       /*<<float.ml:555:12>>*/ a =
@@ -9063,16 +8971,16 @@
       /*<<float.ml:571:14>>*/ r =
         /*<<float.ml:571:14>>*/ runtime.caml_make_vect
         (l,  /*<<float.ml:571:27>>*/ caml_call1(f, a[1])),
-      /*<<float.ml:572:6>>*/ _p_ = l - 1 | 0,
-      /*<<float.ml:571:14>>*/ _o_ = 1;
-    if(_p_ >= 1){
-     var i = _o_;
+      /*<<float.ml:572:6>>*/ _i_ = l - 1 | 0,
+      /*<<float.ml:571:14>>*/ _h_ = 1;
+    if(_i_ >= 1){
+     var i = _h_;
      for(;;){
        /*<<float.ml:573:8>>*/ r[1 + i] =
         /*<<float.ml:573:29>>*/ caml_call1(f, a[1 + i]);
-       /*<<float.ml:573:8>>*/  /*<<float.ml:573:8>>*/ var _q_ = i + 1 | 0;
-      if(_p_ === i) break;
-      var i = _q_;
+       /*<<float.ml:573:8>>*/  /*<<float.ml:573:8>>*/ var _j_ = i + 1 | 0;
+      if(_i_ === i) break;
+      var i = _j_;
      }
     }
      /*<<float.ml:575:6>>*/ return r;
@@ -9082,74 +8990,26 @@
      l = a.length - 1,
       /*<<float.ml:580:12>>*/ r =
         /*<<float.ml:580:12>>*/ caml_floatarray_create(l),
-      /*<<float.ml:581:4>>*/ _m_ = l - 1 | 0,
-      /*<<float.ml:580:12>>*/ _l_ = 0;
-    if(_m_ >= 0){
-     var i = _l_;
+      /*<<float.ml:581:4>>*/ _f_ = l - 1 | 0,
+      /*<<float.ml:580:12>>*/ _e_ = 0;
+    if(_f_ >= 0){
+     var i = _e_;
      for(;;){
        /*<<float.ml:582:6>>*/ r[1 + i] =
         /*<<float.ml:582:21>>*/ caml_call1(f, a[1 + i]);
-       /*<<float.ml:582:6>>*/  /*<<float.ml:582:6>>*/ var _n_ = i + 1 | 0;
-      if(_m_ === i) break;
-      var i = _n_;
+       /*<<float.ml:582:6>>*/  /*<<float.ml:582:6>>*/ var _g_ = i + 1 | 0;
+      if(_f_ === i) break;
+      var i = _g_;
      }
     }
      /*<<float.ml:584:4>>*/ return r;
     /*<<float.ml:584:5>>*/ }
    var
-    _c_ = caml_floatarray_create,
-    _d_ = caml_array_set,
-    _e_ = caml_array_get,
-    _f_ =
-      [0,
-       function(_k_){ /*<<?>>*/ return _k_.length - 1;},
-       _e_,
-       _d_,
-       make,
-       _c_,
-       init,
-       append,
-       concat,
-       sub,
-       copy,
-       fill,
-       blit,
-       to_list,
-       of_list,
-       iter,
-       iteri,
-       map,
-       map_inplace,
-       mapi,
-       mapi_inplace,
-       fold_left,
-       fold_right,
-       iter2,
-       map2,
-       for_all,
-       exists,
-       mem,
-       mem_ieee,
-       find_opt,
-       find_index,
-       find_map,
-       find_mapi,
-       sort,
-       stable_sort,
-       stable_sort,
-       to_seq,
-       to_seqi,
-       of_seq,
-       map_to_array,
-       map_from_array],
-    _g_ = caml_floatarray_create,
-    _h_ = caml_array_set,
-    _i_ = caml_array_get,
     Stdlib_Float =
       [0,
-       zero,
-       one,
-       minus_one,
+       0.,
+       1.,
+       -1.,
        succ,
        pred,
        infinity,
@@ -9157,7 +9017,7 @@
        nan,
        signaling_nan,
        nan,
-       pi,
+       3.141592653589793,
        max_float,
        min_float,
        epsilon,
@@ -9178,11 +9038,11 @@
        seeded_hash,
        hash,
        [0,
-        function(_j_){ /*<<?>>*/ return _j_.length - 1;},
-        _i_,
-        _h_,
+        function(_d_){ /*<<?>>*/ return _d_.length - 1;},
+        caml_array_get,
+        caml_array_set,
         make,
-        _g_,
+        caml_floatarray_create,
         init,
         append,
         concat,
@@ -9218,7 +9078,47 @@
         of_seq,
         map_to_array,
         map_from_array],
-       _f_];
+       [0,
+        function(_c_){ /*<<?>>*/ return _c_.length - 1;},
+        caml_array_get,
+        caml_array_set,
+        make,
+        caml_floatarray_create,
+        init,
+        append,
+        concat,
+        sub,
+        copy,
+        fill,
+        blit,
+        to_list,
+        of_list,
+        iter,
+        iteri,
+        map,
+        map_inplace,
+        mapi,
+        mapi_inplace,
+        fold_left,
+        fold_right,
+        iter2,
+        map2,
+        for_all,
+        exists,
+        mem,
+        mem_ieee,
+        find_opt,
+        find_index,
+        find_map,
+        find_mapi,
+        sort,
+        stable_sort,
+        stable_sort,
+        to_seq,
+        to_seqi,
+        of_seq,
+        map_to_array,
+        map_from_array]];
    runtime.caml_register_global(23, Stdlib_Float, "Stdlib__Float");
    return;
    /*<<?>>*/ }
@@ -9242,9 +9142,7 @@
     Stdlib_Sys = global_data.Stdlib__Sys,
     Assert_failure = global_data.Assert_failure,
     zero = 0,
-    one = 1,
-    _b_ = [0, "int32.ml", 69, 6],
-    minus_one = -1;
+    one = 1;
    function succ(n){
      /*<<int32.ml:48:13>>*/ return n + 1 | 0;
     /*<<int32.ml:48:21>>*/ }
@@ -9257,11 +9155,15 @@
             ? n
             : - n | 0;
     /*<<int32.ml:50:40>>*/ }
-   var min_int = -2147483648, max_int = 2147483647;
    function lognot(n){
      /*<<int32.ml:53:15>>*/ return n ^ -1;
     /*<<int32.ml:53:29>>*/ }
-   var _a_ = Stdlib_Sys[9];
+   var
+    _a_ = Stdlib_Sys[9],
+    _b_ = [0, "int32.ml", 69, 6],
+    minus_one = -1,
+    min_int = -2147483648,
+    max_int = 2147483647;
    if(32 === _a_)
      /*<<int32.ml:58:6>>*/ var
       /*<<int32.ml:58:6>>*/ max_int$0 = Stdlib[19],
@@ -9396,10 +9298,10 @@
     min_int = runtime.caml_int64_create_lo_mi_hi(0, 0, 32768),
     max_int = runtime.caml_int64_create_lo_mi_hi(16777215, 16777215, 32767),
     Stdlib = global_data.Stdlib,
-    _d_ = runtime.caml_int64_create_lo_mi_hi(16777215, 16777215, 65535),
-    _c_ = runtime.caml_int64_create_lo_mi_hi(0, 0, 0),
+    _a_ = runtime.caml_int64_create_lo_mi_hi(1, 0, 0),
     _b_ = runtime.caml_int64_create_lo_mi_hi(1, 0, 0),
-    _a_ = runtime.caml_int64_create_lo_mi_hi(1, 0, 0);
+    _c_ = runtime.caml_int64_create_lo_mi_hi(0, 0, 0),
+    _d_ = runtime.caml_int64_create_lo_mi_hi(16777215, 16777215, 65535);
    function succ(n){
      /*<<int64.ml:46:13>>*/ return  /*<<int64.ml:46:13>>*/ runtime.caml_int64_add
             (n, _a_);
@@ -9546,8 +9448,7 @@
     Stdlib = global_data.Stdlib,
     Stdlib_Sys = global_data.Stdlib__Sys,
     zero = 0,
-    one = 1,
-    minus_one = -1;
+    one = 1;
    function succ(n){
      /*<<nativeint.ml:44:13>>*/ return n + 1 | 0;
     /*<<nativeint.ml:44:21>>*/ }
@@ -9647,7 +9548,7 @@
       [0,
        zero,
        one,
-       minus_one,
+       -1,
        unsigned_div,
        unsigned_rem,
        succ,
@@ -9722,12 +9623,12 @@
      /*<<lexing.ml:65:2>>*/ var
       /*<<lexing.ml:65:15>>*/ result =
         /*<<lexing.ml:65:15>>*/ runtime.caml_lex_engine(tbl, state, buf),
-     _F_ = 0 <= result ? 1 : 0,
-     _G_ = _F_ ? buf[12] !== dummy_pos ? 1 : 0 : _F_;
-    if(_G_){
+     _n_ = 0 <= result ? 1 : 0,
+     _o_ = _n_ ? buf[12] !== dummy_pos ? 1 : 0 : _n_;
+    if(_o_){
      buf[11] = buf[12];
-     var _H_ = buf[12];
-     buf[12] = [0, _H_[1], _H_[2], _H_[3], buf[4] + buf[6] | 0];
+     var _p_ = buf[12];
+     buf[12] = [0, _p_[1], _p_[2], _p_[3], buf[4] + buf[6] | 0];
     }
      /*<<lexing.ml:71:2>>*/ return result;
     /*<<lexing.ml:71:8>>*/ }
@@ -9735,12 +9636,12 @@
      /*<<lexing.ml:75:2>>*/ var
       /*<<lexing.ml:75:15>>*/ result =
         /*<<lexing.ml:75:15>>*/ runtime.caml_new_lex_engine(tbl, state, buf),
-     _C_ = 0 <= result ? 1 : 0,
-     _D_ = _C_ ? buf[12] !== dummy_pos ? 1 : 0 : _C_;
-    if(_D_){
+     _k_ = 0 <= result ? 1 : 0,
+     _l_ = _k_ ? buf[12] !== dummy_pos ? 1 : 0 : _k_;
+    if(_l_){
      buf[11] = buf[12];
-     var _E_ = buf[12];
-     buf[12] = [0, _E_[1], _E_[2], _E_[3], buf[4] + buf[6] | 0];
+     var _m_ = buf[12];
+     buf[12] = [0, _m_[1], _m_[2], _m_[3], buf[4] + buf[6] | 0];
     }
      /*<<lexing.ml:81:2>>*/ return result;
     /*<<lexing.ml:81:8>>*/ }
@@ -9750,20 +9651,10 @@
     else
      var with_positions = 1;
      /*<<lexing.ml:148:2>>*/ var
-      /*<<lexing.ml:148:2>>*/ _o_ = with_positions ? zero_pos : dummy_pos,
-     _p_ = with_positions ? zero_pos : dummy_pos,
+      /*<<lexing.ml:148:2>>*/ _f_ = with_positions ? zero_pos : dummy_pos,
+     _g_ = with_positions ? zero_pos : dummy_pos,
       /*<<lexing.ml:148:31>>*/ aux_buffer =
-        /*<<lexing.ml:148:31>>*/ caml_create_bytes(512),
-     _q_ = [0],
-      /*<<lexing.ml:156:14>>*/ _r_ = 0,
-     _s_ = 0,
-     _t_ = 0,
-     _u_ = 0,
-     _v_ = 0,
-     _w_ = 0,
-     _x_ = 0,
-      /*<<lexing.ml:149:17>>*/ _y_ =
-        /*<<lexing.ml:149:17>>*/ caml_create_bytes(1024);
+        /*<<lexing.ml:148:31>>*/ caml_create_bytes(512);
      /*<<lexing.ml:148:2>>*/ return [0,
             function(lexbuf){
               /*<<lexing.ml:85:4>>*/ var
@@ -9809,18 +9700,18 @@
               lexbuf[5] = 0;
               lexbuf[7] = lexbuf[7] - s | 0;
               lexbuf[3] = lexbuf[3] - s | 0;
-              var t = lexbuf[10], _A_ = t.length - 1 - 1 | 0, _z_ = 0;
-              if(_A_ >= 0){
-               var i = _z_;
+              var t = lexbuf[10], _i_ = t.length - 1 - 1 | 0, _h_ = 0;
+              if(_i_ >= 0){
+               var i = _h_;
                for(;;){
                  /*<<lexing.ml:131:14>>*/  /*<<lexing.ml:131:14>>*/ var
                  v = caml_check_bound(t, i)[1 + i];
                 if(0 <= v)
                   /*<<lexing.ml:133:8>>*/ caml_check_bound(t, i)[1 + i] = v - s | 0;
                  /*<<lexing.ml:130:4>>*/  /*<<lexing.ml:130:4>>*/ var
-                 _B_ = i + 1 | 0;
-                if(_A_ === i) break;
-                var i = _B_;
+                 _j_ = i + 1 | 0;
+                if(_i_ === i) break;
+                var i = _j_;
                }
               }
              }
@@ -9829,17 +9720,17 @@
              lexbuf[3] = lexbuf[3] + n | 0;
              return 0;
             },
-            _y_,
-            _x_,
-            _w_,
-            _v_,
-            _u_,
-            _t_,
-            _s_,
-            _r_,
-            _q_,
-            _p_,
-            _o_];
+             /*<<lexing.ml:149:17>>*/ caml_create_bytes(1024),
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            [0],
+            _g_,
+            _f_];
     /*<<lexing.ml:160:3>>*/ }
    function from_channel(with_positions, ic){
      /*<<lexing.ml:163:2>>*/ return from_function
@@ -9856,31 +9747,21 @@
      var with_positions = 1;
      /*<<lexing.ml:166:2>>*/ var
       /*<<lexing.ml:166:2>>*/ _d_ = with_positions ? zero_pos : dummy_pos,
-     _e_ = with_positions ? zero_pos : dummy_pos,
-     _f_ = [0],
-      /*<<lexing.ml:175:14>>*/ _g_ = 1,
-     _h_ = 0,
-     _i_ = 0,
-     _j_ = 0,
-     _k_ = 0,
-     _l_ = 0,
-     _m_ = runtime.caml_ml_string_length(s),
-      /*<<lexing.ml:167:17>>*/ _n_ =
-        /*<<lexing.ml:167:17>>*/ caml_call1(Stdlib_Bytes[5], s);
+     _e_ = with_positions ? zero_pos : dummy_pos;
      /*<<lexing.ml:166:2>>*/ return [0,
             function(lexbuf){
               /*<<lexing.ml:166:33>>*/ lexbuf[9] = 1;
              return 0;
              /*<<lexing.ml:166:63>>*/ },
-            _n_,
-            _m_,
-            _l_,
-            _k_,
-            _j_,
-            _i_,
-            _h_,
-            _g_,
-            _f_,
+             /*<<lexing.ml:167:17>>*/ caml_call1(Stdlib_Bytes[5], s),
+            runtime.caml_ml_string_length(s),
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            [0],
             _e_,
             _d_];
     /*<<lexing.ml:179:3>>*/ }
@@ -10042,8 +9923,7 @@
        0,
        0,
        0,
-       0],
-    cst_syntax_error = "syntax error";
+       0];
    function grow_stacks(param){
      /*<<parsing.ml:108:2>>*/ var
      oldsize = env[5],
@@ -10077,12 +9957,13 @@
     env[8] = 0;
     return 0;
     /*<<parsing.ml:126:25>>*/ }
-    /*<<parsing.ml:128:28>>*/  /*<<parsing.ml:128:28>>*/ var
-    current_lookahead_fun =
+    /*<<parsing.ml:128:28>>*/ var
+     /*<<parsing.ml:128:28>>*/ current_lookahead_fun =
       [0,
        function(param){
          /*<<parsing.ml:128:52>>*/ return 0;
-        /*<<parsing.ml:128:57>>*/ }];
+        /*<<parsing.ml:128:57>>*/ }],
+    cst_syntax_error = "syntax error";
    function yyparse(tables, start, lexer, lexbuf){
      /*<<parsing.ml:131:2>>*/ var
      init_asp = env[11],
@@ -10288,14 +10169,14 @@
     Stdlib_Seq = global_data.Stdlib__Seq,
     Stdlib_List = global_data.Stdlib__List,
     Assert_failure = global_data.Assert_failure,
-    cst_Set_remove_min_elt = "Set.remove_min_elt",
-    _a_ = [0, 0, 0, 0],
-    _b_ = [0, 0, 0],
-    _c_ = [0, "set.ml", 571, 18],
     cst_Set_bal = cst_Set_bal$3,
     cst_Set_bal$0 = cst_Set_bal$3,
     cst_Set_bal$1 = cst_Set_bal$3,
     cst_Set_bal$2 = cst_Set_bal$3,
+    cst_Set_remove_min_elt = "Set.remove_min_elt",
+    _a_ = [0, 0, 0, 0],
+    _b_ = [0, 0, 0],
+    _c_ = [0, "set.ml", 571, 18],
     Stdlib_Set =
       [0,
        function(Ord){
@@ -10307,8 +10188,8 @@
         function create(l, v, r){
           /*<<set.ml:91:6>>*/ if(l) var h = l[4], hl = h; else var hl = 0;
           /*<<set.ml:92:6>>*/ if(r) var h$0 = r[4], hr = h$0; else var hr = 0;
-         var _Z_ = hr <= hl ? hl + 1 | 0 : hr + 1 | 0;
-          /*<<set.ml:93:10>>*/ return [0, l, v, r, _Z_];
+         var _Y_ = hr <= hl ? hl + 1 | 0 : hr + 1 | 0;
+          /*<<set.ml:93:10>>*/ return [0, l, v, r, _Y_];
          /*<<set.ml:93:60>>*/ }
         function bal(l, v, r){
           /*<<set.ml:101:6>>*/ if(l) var h = l[4], hl = h; else var hl = 0;
@@ -10324,8 +10205,8 @@
            lr = l[3],
            lv = l[2],
            ll = l[1],
-            /*<<set.ml:107:28>>*/ _U_ = height(lr);
-          if(_U_ <= height(ll))
+            /*<<set.ml:107:28>>*/ _T_ = height(lr);
+          if(_T_ <= height(ll))
             /*<<set.ml:108:27>>*/ return create(ll, lv, create(lr, v, r));
           if(! lr)
             /*<<set.ml:111:25>>*/ return  /*<<set.ml:111:25>>*/ caml_call1
@@ -10334,12 +10215,12 @@
            lrr = lr[3],
            lrv = lr[2],
            lrl = lr[1],
-            /*<<set.ml:113:48>>*/ _V_ = create(lrr, v, r);
-           /*<<set.ml:113:48>>*/ return create(create(ll, lv, lrl), lrv, _V_);
+            /*<<set.ml:113:48>>*/ _U_ = create(lrr, v, r);
+           /*<<set.ml:113:48>>*/ return create(create(ll, lv, lrl), lrv, _U_);
          }
          if((hl + 2 | 0) >= hr){
-          var _Y_ = hr <= hl ? hl + 1 | 0 : hr + 1 | 0;
-           /*<<set.ml:128:12>>*/ return [0, l, v, r, _Y_];
+          var _X_ = hr <= hl ? hl + 1 | 0 : hr + 1 | 0;
+           /*<<set.ml:128:12>>*/ return [0, l, v, r, _X_];
          }
          if(! r)
            /*<<set.ml:117:19>>*/ return  /*<<set.ml:117:19>>*/ caml_call1
@@ -10348,8 +10229,8 @@
           rr = r[3],
           rv = r[2],
           rl = r[1],
-           /*<<set.ml:119:28>>*/ _W_ = height(rl);
-         if(_W_ <= height(rr))
+           /*<<set.ml:119:28>>*/ _V_ = height(rl);
+         if(_V_ <= height(rr))
            /*<<set.ml:120:14>>*/ return create(create(l, v, rl), rv, rr);
          if(! rl)
            /*<<set.ml:123:25>>*/ return  /*<<set.ml:123:25>>*/ caml_call1
@@ -10358,8 +10239,8 @@
           rlr = rl[3],
           rlv = rl[2],
           rll = rl[1],
-           /*<<set.ml:125:46>>*/ _X_ = create(rlr, rv, rr);
-          /*<<set.ml:125:46>>*/ return create(create(l, v, rll), rlv, _X_);
+           /*<<set.ml:125:46>>*/ _W_ = create(rlr, rv, rr);
+          /*<<set.ml:125:46>>*/ return create(create(l, v, rll), rlv, _W_);
          /*<<set.ml:128:62>>*/ }
         function add(x, t){
           /*<<?>>*/ if(! t)  /*<<set.ml:133:21>>*/ return [0, 0, x, 0, 1];
@@ -10472,8 +10353,8 @@
           /*<<set.ml:219:6>>*/ if(! t1)  /*<<set.ml:220:22>>*/ return t2;
          if(! t2)  /*<<set.ml:221:22>>*/ return t1;
           /*<<set.ml:222:39>>*/  /*<<set.ml:222:39>>*/ var
-          _T_ = remove_min_elt(t2);
-          /*<<set.ml:222:39>>*/ return join(t1, min_elt(t2), _T_);
+          _S_ = remove_min_elt(t2);
+          /*<<set.ml:222:39>>*/ return join(t1, min_elt(t2), _S_);
          /*<<set.ml:222:58>>*/ }
         function split(x, param){
           /*<<?>>*/ if(! param)  /*<<set.ml:232:10>>*/ return _a_;
@@ -10514,8 +10395,8 @@
            l = param$0[1],
             /*<<set.ml:250:18>>*/ c =
               /*<<set.ml:250:18>>*/ caml_call2(Ord[1], x, v),
-           _S_ = 0 === c ? 1 : 0;
-          if(_S_) return _S_;
+           _R_ = 0 === c ? 1 : 0;
+          if(_R_) return _R_;
           var r$0 = 0 <= c ? r : l, param$0 = r$0;
          }
         }
@@ -10531,8 +10412,8 @@
           if(! t1)  /*<<set.ml:210:22>>*/ return t2;
           if(! t2)  /*<<set.ml:211:22>>*/ return t1;
            /*<<set.ml:212:38>>*/  /*<<set.ml:212:38>>*/ var
-           _R_ = remove_min_elt(t2);
-           /*<<set.ml:212:38>>*/ return bal(t1, min_elt(t2), _R_);
+           _Q_ = remove_min_elt(t2);
+           /*<<set.ml:212:38>>*/ return bal(t1, min_elt(t2), _Q_);
          }
          if(0 <= c){
            /*<<set.ml:264:23>>*/  /*<<set.ml:264:23>>*/ var
@@ -10560,16 +10441,16 @@
             /*<<set.ml:275:32>>*/ match = split(v1, s2),
            r2$0 = match[3],
            l2$0 = match[1],
-            /*<<set.ml:276:36>>*/ _P_ = union(r1, r2$0);
-           /*<<set.ml:276:36>>*/ return join(union(l1, l2$0), v1, _P_);
+            /*<<set.ml:276:36>>*/ _O_ = union(r1, r2$0);
+           /*<<set.ml:276:36>>*/ return join(union(l1, l2$0), v1, _O_);
          }
          if(1 === h1)  /*<<set.ml:279:27>>*/ return add(v1, s2);
           /*<<set.ml:280:32>>*/ var
            /*<<set.ml:280:32>>*/ match$0 = split(v2, s1),
           r1$0 = match$0[3],
           l1$0 = match$0[1],
-           /*<<set.ml:281:36>>*/ _Q_ = union(r1$0, r2);
-          /*<<set.ml:281:36>>*/ return join(union(l1$0, l2), v2, _Q_);
+           /*<<set.ml:281:36>>*/ _P_ = union(r1$0, r2);
+          /*<<set.ml:281:36>>*/ return join(union(l1$0, l2), v2, _P_);
          /*<<set.ml:282:15>>*/ }
         function inter(s1, s2){
           /*<<set.ml:285:6>>*/ if(! s1)  /*<<set.ml:286:22>>*/ return 0;
@@ -10578,18 +10459,18 @@
           r1 = s1[3],
           v1 = s1[2],
           l1 = s1[1],
-           /*<<set.ml:289:16>>*/ _M_ = split(v1, s2),
-          l2 = _M_[1];
-         if(_M_[2]){
+           /*<<set.ml:289:16>>*/ _L_ = split(v1, s2),
+          l2 = _L_[1];
+         if(_L_[2]){
            /*<<set.ml:293:36>>*/ var
-           r2 = _M_[3],
-            /*<<set.ml:293:36>>*/ _N_ = inter(r1, r2);
-           /*<<set.ml:293:36>>*/ return join(inter(l1, l2), v1, _N_);
+           r2 = _L_[3],
+            /*<<set.ml:293:36>>*/ _M_ = inter(r1, r2);
+           /*<<set.ml:293:36>>*/ return join(inter(l1, l2), v1, _M_);
          }
           /*<<set.ml:291:35>>*/ var
-          r2$0 = _M_[3],
-           /*<<set.ml:291:35>>*/ _O_ = inter(r1, r2$0);
-          /*<<set.ml:291:35>>*/ return concat(inter(l1, l2), _O_);
+          r2$0 = _L_[3],
+           /*<<set.ml:291:35>>*/ _N_ = inter(r1, r2$0);
+          /*<<set.ml:291:35>>*/ return concat(inter(l1, l2), _N_);
          /*<<set.ml:293:49>>*/ }
         function split_bis(x, param){
           /*<<?>>*/ if(! param)
@@ -10634,8 +10515,8 @@
             /*<<set.ml:324:34>>*/ var
             r2 = match[2],
             l2 = match[1],
-             /*<<set.ml:324:34>>*/ _L_ = disjoint(l1, l2);
-            /*<<set.ml:324:34>>*/ if(! _L_)  /*<<set.ml:324:34>>*/ return _L_;
+             /*<<set.ml:324:34>>*/ _K_ = disjoint(l1, l2);
+            /*<<set.ml:324:34>>*/ if(! _K_)  /*<<set.ml:324:34>>*/ return _K_;
             /*<<set.ml:324:64>>*/ var
              /*<<set.ml:324:64>>*/ s2$1 = r2(0),
             s1$0 = r1,
@@ -10652,18 +10533,18 @@
           r1 = s1[3],
           v1 = s1[2],
           l1 = s1[1],
-           /*<<set.ml:332:16>>*/ _I_ = split(v1, s2),
-          l2 = _I_[1];
-         if(_I_[2]){
+           /*<<set.ml:332:16>>*/ _H_ = split(v1, s2),
+          l2 = _H_[1];
+         if(_H_[2]){
            /*<<set.ml:336:34>>*/ var
-           r2 = _I_[3],
-            /*<<set.ml:336:34>>*/ _J_ = diff(r1, r2);
-           /*<<set.ml:336:34>>*/ return concat(diff(l1, l2), _J_);
+           r2 = _H_[3],
+            /*<<set.ml:336:34>>*/ _I_ = diff(r1, r2);
+           /*<<set.ml:336:34>>*/ return concat(diff(l1, l2), _I_);
          }
           /*<<set.ml:334:35>>*/ var
-          r2$0 = _I_[3],
-           /*<<set.ml:334:35>>*/ _K_ = diff(r1, r2$0);
-          /*<<set.ml:334:35>>*/ return join(diff(l1, l2), v1, _K_);
+          r2$0 = _H_[3],
+           /*<<set.ml:334:35>>*/ _J_ = diff(r1, r2$0);
+          /*<<set.ml:334:35>>*/ return join(diff(l1, l2), v1, _J_);
          /*<<set.ml:336:46>>*/ }
         function cons_enum(s, e){
           /*<<set.ml:341:6>>*/ var s$0 = s, e$0 = e;
@@ -10723,20 +10604,20 @@
               /*<<set.ml:369:18>>*/ caml_call2(Ord[1], v1, v2);
            /*<<set.ml:370:10>>*/ if(0 === c){
             /*<<set.ml:371:12>>*/  /*<<set.ml:371:12>>*/ var
-            _F_ = subset(l1, l2);
-            /*<<set.ml:371:12>>*/ if(! _F_)  /*<<set.ml:371:12>>*/ return _F_;
+            _E_ = subset(l1, l2);
+            /*<<set.ml:371:12>>*/ if(! _E_)  /*<<set.ml:371:12>>*/ return _E_;
            var s1$0 = r1, s2$0 = r2;
           }
           else if(0 <= c){
             /*<<set.ml:375:12>>*/  /*<<set.ml:375:12>>*/ var
-            _G_ = subset([0, 0, v1, r1, 0], r2);
-            /*<<set.ml:375:12>>*/ if(! _G_)  /*<<set.ml:375:12>>*/ return _G_;
+            _F_ = subset([0, 0, v1, r1, 0], r2);
+            /*<<set.ml:375:12>>*/ if(! _F_)  /*<<set.ml:375:12>>*/ return _F_;
            var s1$0 = l1;
           }
           else{
             /*<<set.ml:373:12>>*/  /*<<set.ml:373:12>>*/ var
-            _H_ = subset([0, l1, v1, 0, 0], l2);
-            /*<<set.ml:373:12>>*/ if(! _H_)  /*<<set.ml:373:12>>*/ return _H_;
+            _G_ = subset([0, l1, v1, 0, 0], l2);
+            /*<<set.ml:373:12>>*/ if(! _G_)  /*<<set.ml:373:12>>*/ return _G_;
            var s1$0 = r1;
           }
          }
@@ -10773,17 +10654,17 @@
            r = param$0[3],
            v = param$0[2],
            l = param$0[1],
-            /*<<set.ml:388:25>>*/ _C_ =
+            /*<<set.ml:388:25>>*/ _B_ =
               /*<<set.ml:388:25>>*/ caml_call1(p, v);
-           /*<<set.ml:388:25>>*/ if(_C_){
+           /*<<set.ml:388:25>>*/ if(_B_){
             /*<<set.ml:388:32>>*/  /*<<set.ml:388:32>>*/ var
-            _D_ = for_all(p, l);
-            /*<<set.ml:388:32>>*/ if(_D_){var param$0 = r; continue;}
-           var _E_ = _D_;
+            _C_ = for_all(p, l);
+            /*<<set.ml:388:32>>*/ if(_C_){var param$0 = r; continue;}
+           var _D_ = _C_;
           }
           else
-           var _E_ = _C_;
-           /*<<set.ml:388:32>>*/ return _E_;
+           var _D_ = _B_;
+           /*<<set.ml:388:32>>*/ return _D_;
          }
         }
         function exists(p, param){
@@ -10794,17 +10675,17 @@
            r = param$0[3],
            v = param$0[2],
            l = param$0[1],
-            /*<<set.ml:392:25>>*/ _z_ =
+            /*<<set.ml:392:25>>*/ _y_ =
               /*<<set.ml:392:25>>*/ caml_call1(p, v);
-           /*<<set.ml:392:25>>*/ if(_z_)
-           var _A_ = _z_;
+           /*<<set.ml:392:25>>*/ if(_y_)
+           var _z_ = _y_;
           else{
             /*<<set.ml:392:32>>*/  /*<<set.ml:392:32>>*/ var
-            _B_ = exists(p, l);
-            /*<<set.ml:392:32>>*/ if(! _B_){var param$0 = r; continue;}
-           var _A_ = _B_;
+            _A_ = exists(p, l);
+            /*<<set.ml:392:32>>*/ if(! _A_){var param$0 = r; continue;}
+           var _z_ = _A_;
           }
-           /*<<set.ml:392:25>>*/ return _A_;
+           /*<<set.ml:392:25>>*/ return _z_;
          }
         }
         function filter(p, t){
@@ -10836,20 +10717,20 @@
           rt = match$0[1];
           /*<<set.ml:412:10>>*/ if(pv){
            /*<<set.ml:413:30>>*/  /*<<set.ml:413:30>>*/ var
-           _x_ = concat(lf, rf);
-           /*<<set.ml:413:15>>*/ return [0, join(lt, v, rt), _x_];
+           _w_ = concat(lf, rf);
+           /*<<set.ml:413:15>>*/ return [0, join(lt, v, rt), _w_];
          }
           /*<<set.ml:414:30>>*/  /*<<set.ml:414:30>>*/ var
-          _y_ = join(lf, v, rf);
-          /*<<set.ml:414:15>>*/ return [0, concat(lt, rt), _y_];
+          _x_ = join(lf, v, rf);
+          /*<<set.ml:414:15>>*/ return [0, concat(lt, rt), _x_];
         }
         function cardinal(param){
           /*<<set.ml:416:23>>*/ if(! param)  /*<<set.ml:417:17>>*/ return 0;
           /*<<set.ml:418:39>>*/ var
           r = param[3],
           l = param[1],
-           /*<<set.ml:418:39>>*/ _w_ = cardinal(r);
-         return (cardinal(l) + 1 | 0) + _w_ | 0;
+           /*<<set.ml:418:39>>*/ _v_ = cardinal(r);
+         return (cardinal(l) + 1 | 0) + _v_ | 0;
          /*<<set.ml:418:49>>*/ }
         function elements_aux(accu, param){
          var accu$0 = accu, param$0 = param;
@@ -10994,15 +10875,15 @@
           /*<<set.ml:521:6>>*/ a:
          {
           if(0 !== l){
-            /*<<set.ml:521:35>>*/  /*<<set.ml:521:35>>*/ var _v_ = max_elt(l);
+            /*<<set.ml:521:35>>*/  /*<<set.ml:521:35>>*/ var _u_ = max_elt(l);
             /*<<set.ml:521:23>>*/ if
-            (0 <=  /*<<set.ml:521:23>>*/ caml_call2(Ord[1], _v_, v))
+            (0 <=  /*<<set.ml:521:23>>*/ caml_call2(Ord[1], _u_, v))
             break a;
           }
           if(0 !== r){
-            /*<<set.ml:522:37>>*/  /*<<set.ml:522:37>>*/ var _u_ = min_elt(r);
+            /*<<set.ml:522:37>>*/  /*<<set.ml:522:37>>*/ var _t_ = min_elt(r);
             /*<<set.ml:522:23>>*/ if
-            (0 <=  /*<<set.ml:522:23>>*/ caml_call2(Ord[1], v, _u_))
+            (0 <=  /*<<set.ml:522:23>>*/ caml_call2(Ord[1], v, _t_))
             break a;
           }
            /*<<set.ml:523:11>>*/ return join(l, v, r);
@@ -11040,23 +10921,23 @@
          if(! t1)  /*<<set.ml:538:22>>*/ return t2;
          if(! t2)  /*<<set.ml:539:22>>*/ return t1;
           /*<<set.ml:540:43>>*/  /*<<set.ml:540:43>>*/ var
-          _t_ = remove_min_elt(t2);
-          /*<<set.ml:540:43>>*/ return try_join(t1, min_elt(t2), _t_);
+          _s_ = remove_min_elt(t2);
+          /*<<set.ml:540:43>>*/ return try_join(t1, min_elt(t2), _s_);
         }
         function of_list(l){
           /*<<set.ml:581:6>>*/ if(! l) return empty;
-         var _o_ = l[2], x0 = l[1];
-         if(! _o_)  /*<<set.ml:583:16>>*/ return singleton(x0);
-         var _p_ = _o_[2], x1 = _o_[1];
-         if(! _p_)  /*<<set.ml:584:27>>*/ return add(x1, singleton(x0));
-         var _q_ = _p_[2], x2 = _p_[1];
-         if(! _q_)
+         var _n_ = l[2], x0 = l[1];
+         if(! _n_)  /*<<set.ml:583:16>>*/ return singleton(x0);
+         var _o_ = _n_[2], x1 = _n_[1];
+         if(! _o_)  /*<<set.ml:584:27>>*/ return add(x1, singleton(x0));
+         var _p_ = _o_[2], x2 = _o_[1];
+         if(! _p_)
            /*<<set.ml:585:31>>*/ return add(x2, add(x1, singleton(x0)));
-         var _r_ = _q_[2], x3 = _q_[1];
-         if(! _r_)
+         var _q_ = _p_[2], x3 = _p_[1];
+         if(! _q_)
            /*<<set.ml:586:35>>*/ return add
                   (x3, add(x2, add(x1, singleton(x0))));
-         if(_r_[2]){
+         if(_q_[2]){
            /*<<set.ml:588:28>>*/ var
             /*<<set.ml:588:28>>*/ l$0 =
               /*<<set.ml:588:28>>*/ caml_call2(Stdlib_List[62], Ord[1], l),
@@ -11085,14 +10966,14 @@
                   break;
                  default:
                   if(l){
-                   var _s_ = l[2];
-                   if(_s_){
-                    var match$2 = _s_[2];
+                   var _r_ = l[2];
+                   if(_r_){
+                    var match$2 = _r_[2];
                     if(match$2){
                      var
                       l$5 = match$2[2],
                       x2 = match$2[1],
-                      x1$0 = _s_[1],
+                      x1$0 = _r_[1],
                       x0$1 = l[1];
                       /*<<set.ml:565:12>>*/ return [0,
                              [0, [0, 0, x0$1, 0, 1], x1$0, [0, 0, x2, 0, 1], 2],
@@ -11122,34 +11003,31 @@
                     l$0)
                   [1];
          }
-         var x4 = _r_[1];
+         var x4 = _q_[1];
           /*<<set.ml:587:39>>*/ return add
                  (x4, add(x3, add(x2, add(x1, singleton(x0)))));
          /*<<set.ml:588:58>>*/ }
         function add_seq(i, m){
-         function _n_(s, x){
-           /*<<set.ml:591:32>>*/ return add(x, s);
-          /*<<set.ml:591:39>>*/ }
           /*<<set.ml:591:6>>*/ return  /*<<set.ml:591:6>>*/ caml_call3
-                 (Stdlib_Seq[5], _n_, m, i);
+                 (Stdlib_Seq[5],
+                  function(s, x){
+                    /*<<set.ml:591:32>>*/ return add(x, s);
+                   /*<<set.ml:591:39>>*/ },
+                  m,
+                  i);
          /*<<set.ml:591:44>>*/ }
         function of_seq(i){
           /*<<set.ml:593:19>>*/ return add_seq(i, empty);
          /*<<set.ml:593:34>>*/ }
         function seq_of_enum(c, param){
           /*<<set.ml:595:32>>*/ if(! c)  /*<<set.ml:596:15>>*/ return 0;
-          /*<<set.ml:597:55>>*/ var
-          rest = c[3],
-          t = c[2],
-          x = c[1],
-           /*<<set.ml:597:55>>*/ _l_ = cons_enum(t, rest);
+         var rest = c[3], t = c[2], x = c[1], _l_ = cons_enum(t, rest);
           /*<<set.ml:597:29>>*/ return [0,
                  x,
                  function(_m_){ /*<<?>>*/ return seq_of_enum(_l_, _m_);}];
          /*<<set.ml:597:74>>*/ }
         function to_seq(c){
-          /*<<set.ml:599:19>>*/  /*<<set.ml:599:32>>*/ var
-          _j_ = cons_enum(c, 0);
+          /*<<set.ml:599:19>>*/ var _j_ = cons_enum(c, 0);
           /*<<set.ml:599:32>>*/ return function(_k_){
            /*<<?>>*/ return seq_of_enum(_j_, _k_);};
          /*<<set.ml:599:49>>*/ }
@@ -11168,18 +11046,13 @@
          /*<<set.ml:604:52>>*/ }
         function rev_seq_of_enum(c, param){
           /*<<set.ml:606:36>>*/ if(! c)  /*<<set.ml:607:15>>*/ return 0;
-          /*<<set.ml:608:59>>*/ var
-          rest = c[3],
-          t = c[2],
-          x = c[1],
-           /*<<set.ml:608:59>>*/ _h_ = snoc_enum(t, rest);
+         var rest = c[3], t = c[2], x = c[1], _h_ = snoc_enum(t, rest);
           /*<<set.ml:608:29>>*/ return [0,
                  x,
                  function(_i_){ /*<<?>>*/ return rev_seq_of_enum(_h_, _i_);}];
          /*<<set.ml:608:78>>*/ }
         function to_rev_seq(c){
-          /*<<set.ml:610:23>>*/  /*<<set.ml:610:40>>*/ var
-          _f_ = snoc_enum(c, 0);
+          /*<<set.ml:610:23>>*/ var _f_ = snoc_enum(c, 0);
           /*<<set.ml:610:40>>*/ return function(_g_){
            /*<<?>>*/ return rev_seq_of_enum(_f_, _g_);};
          /*<<set.ml:610:57>>*/ }
@@ -11294,14 +11167,14 @@
     Assert_failure = global_data.Assert_failure,
     Stdlib_Seq = global_data.Stdlib__Seq,
     Stdlib_List = global_data.Stdlib__List,
-    cst_Map_remove_min_elt = "Map.remove_min_elt",
-    _a_ = [0, 0, 0, 0],
-    _b_ = [0, "map.ml", 408, 10],
-    _c_ = [0, 0, 0],
     cst_Map_bal = cst_Map_bal$3,
     cst_Map_bal$0 = cst_Map_bal$3,
     cst_Map_bal$1 = cst_Map_bal$3,
     cst_Map_bal$2 = cst_Map_bal$3,
+    cst_Map_remove_min_elt = "Map.remove_min_elt",
+    _a_ = [0, 0, 0, 0],
+    _b_ = [0, "map.ml", 408, 10],
+    _c_ = [0, 0, 0],
     Stdlib_Map =
       [0,
        function(Ord){
@@ -11314,8 +11187,8 @@
           /*<<map.ml:86:6>>*/ var
            /*<<map.ml:86:15>>*/ hl = height(l),
            /*<<map.ml:86:33>>*/ hr = height(r),
-          _M_ = hr <= hl ? hl + 1 | 0 : hr + 1 | 0;
-          /*<<map.ml:87:10>>*/ return [0, l, x, d, r, _M_];
+          _K_ = hr <= hl ? hl + 1 | 0 : hr + 1 | 0;
+          /*<<map.ml:87:10>>*/ return [0, l, x, d, r, _K_];
          /*<<map.ml:87:65>>*/ }
         function singleton(x, d){
           /*<<map.ml:89:24>>*/ return [0, 0, x, d, 0, 1];
@@ -11332,8 +11205,8 @@
            ld = l[3],
            lv = l[2],
            ll = l[1],
-            /*<<map.ml:98:28>>*/ _H_ = height(lr);
-          if(_H_ <= height(ll))
+            /*<<map.ml:98:28>>*/ _F_ = height(lr);
+          if(_F_ <= height(ll))
             /*<<map.ml:99:30>>*/ return create
                    (ll, lv, ld, create(lr, x, d, r));
           if(! lr)
@@ -11344,13 +11217,13 @@
            lrd = lr[3],
            lrv = lr[2],
            lrl = lr[1],
-            /*<<map.ml:104:55>>*/ _I_ = create(lrr, x, d, r);
+            /*<<map.ml:104:55>>*/ _G_ = create(lrr, x, d, r);
            /*<<map.ml:104:55>>*/ return create
-                  (create(ll, lv, ld, lrl), lrv, lrd, _I_);
+                  (create(ll, lv, ld, lrl), lrv, lrd, _G_);
          }
          if((hl + 2 | 0) >= hr){
-          var _L_ = hr <= hl ? hl + 1 | 0 : hr + 1 | 0;
-           /*<<map.ml:119:12>>*/ return [0, l, x, d, r, _L_];
+          var _J_ = hr <= hl ? hl + 1 | 0 : hr + 1 | 0;
+           /*<<map.ml:119:12>>*/ return [0, l, x, d, r, _J_];
          }
          if(! r)
            /*<<map.ml:108:19>>*/ return  /*<<map.ml:108:19>>*/ caml_call1
@@ -11360,8 +11233,8 @@
           rd = r[3],
           rv = r[2],
           rl = r[1],
-           /*<<map.ml:110:28>>*/ _J_ = height(rl);
-         if(_J_ <= height(rr))
+           /*<<map.ml:110:28>>*/ _H_ = height(rl);
+         if(_H_ <= height(rr))
            /*<<map.ml:111:14>>*/ return create
                   (create(l, x, d, rl), rv, rd, rr);
          if(! rl)
@@ -11372,9 +11245,9 @@
           rld = rl[3],
           rlv = rl[2],
           rll = rl[1],
-           /*<<map.ml:116:52>>*/ _K_ = create(rlr, rv, rd, rr);
+           /*<<map.ml:116:52>>*/ _I_ = create(rlr, rv, rd, rr);
           /*<<map.ml:116:52>>*/ return create
-                 (create(l, x, d, rll), rlv, rld, _K_);
+                 (create(l, x, d, rll), rlv, rld, _I_);
          /*<<map.ml:119:67>>*/ }
         var empty = 0;
         function is_empty(param){
@@ -11553,8 +11426,8 @@
            l = param$0[1],
             /*<<map.ml:231:18>>*/ c =
               /*<<map.ml:231:18>>*/ caml_call2(Ord[1], x, v),
-           _G_ = 0 === c ? 1 : 0;
-          if(_G_) return _G_;
+           _E_ = 0 === c ? 1 : 0;
+          if(_E_) return _E_;
           var r$0 = 0 <= c ? r : l, param$0 = r$0;
          }
         }
@@ -11749,17 +11622,17 @@
            d = param$0[3],
            v = param$0[2],
            l = param$0[1],
-            /*<<map.ml:333:29>>*/ _D_ =
+            /*<<map.ml:333:29>>*/ _B_ =
               /*<<map.ml:333:29>>*/ caml_call2(p, v, d);
-           /*<<map.ml:333:29>>*/ if(_D_){
+           /*<<map.ml:333:29>>*/ if(_B_){
             /*<<map.ml:333:38>>*/  /*<<map.ml:333:38>>*/ var
-            _E_ = for_all(p, l);
-            /*<<map.ml:333:38>>*/ if(_E_){var param$0 = r; continue;}
-           var _F_ = _E_;
+            _C_ = for_all(p, l);
+            /*<<map.ml:333:38>>*/ if(_C_){var param$0 = r; continue;}
+           var _D_ = _C_;
           }
           else
-           var _F_ = _D_;
-           /*<<map.ml:333:38>>*/ return _F_;
+           var _D_ = _B_;
+           /*<<map.ml:333:38>>*/ return _D_;
          }
         }
         function exists(p, param){
@@ -11771,17 +11644,17 @@
            d = param$0[3],
            v = param$0[2],
            l = param$0[1],
-            /*<<map.ml:337:29>>*/ _A_ =
+            /*<<map.ml:337:29>>*/ _y_ =
               /*<<map.ml:337:29>>*/ caml_call2(p, v, d);
-           /*<<map.ml:337:29>>*/ if(_A_)
-           var _B_ = _A_;
+           /*<<map.ml:337:29>>*/ if(_y_)
+           var _z_ = _y_;
           else{
             /*<<map.ml:337:38>>*/  /*<<map.ml:337:38>>*/ var
-            _C_ = exists(p, l);
-            /*<<map.ml:337:38>>*/ if(! _C_){var param$0 = r; continue;}
-           var _B_ = _C_;
+            _A_ = exists(p, l);
+            /*<<map.ml:337:38>>*/ if(! _A_){var param$0 = r; continue;}
+           var _z_ = _A_;
           }
-           /*<<map.ml:337:29>>*/ return _B_;
+           /*<<map.ml:337:29>>*/ return _z_;
          }
         }
         function add_min_binding(k, x, param){
@@ -11868,11 +11741,11 @@
             r2 = match[3],
             d2 = match[2],
             l2 = match[1],
-             /*<<map.ml:403:64>>*/ _w_ = merge(f, r1, r2),
-             /*<<map.ml:403:44>>*/ _x_ =
+             /*<<map.ml:403:64>>*/ _u_ = merge(f, r1, r2),
+             /*<<map.ml:403:44>>*/ _v_ =
                /*<<map.ml:403:44>>*/ caml_call3(f, v1, [0, d1], d2);
             /*<<map.ml:403:64>>*/ return concat_or_join
-                   (merge(f, l1, l2), v1, _x_, _w_);
+                   (merge(f, l1, l2), v1, _v_, _u_);
           }
          }
          else if(! s2)  /*<<map.ml:400:26>>*/ return 0;
@@ -11888,11 +11761,11 @@
           r1$0 = match$0[3],
           d1$0 = match$0[2],
           l1$0 = match$0[1],
-           /*<<map.ml:406:64>>*/ _y_ = merge(f, r1$0, r2$0),
-           /*<<map.ml:406:44>>*/ _z_ =
+           /*<<map.ml:406:64>>*/ _w_ = merge(f, r1$0, r2$0),
+           /*<<map.ml:406:44>>*/ _x_ =
              /*<<map.ml:406:44>>*/ caml_call3(f, v2, d1$0, [0, d2$0]);
           /*<<map.ml:406:64>>*/ return concat_or_join
-                 (merge(f, l1$0, l2$0), v2, _z_, _y_);
+                 (merge(f, l1$0, l2$0), v2, _x_, _w_);
          /*<<map.ml:408:22>>*/ }
         function union(f, s1, s2){
           /*<<map.ml:411:6>>*/ if(s1){
@@ -11996,12 +11869,12 @@
           rt = match$0[1];
           /*<<map.ml:457:10>>*/ if(pvd){
            /*<<map.ml:458:32>>*/  /*<<map.ml:458:32>>*/ var
-           _u_ = concat(lf, rf);
-           /*<<map.ml:458:15>>*/ return [0, join(lt, v, d, rt), _u_];
+           _s_ = concat(lf, rf);
+           /*<<map.ml:458:15>>*/ return [0, join(lt, v, d, rt), _s_];
          }
           /*<<map.ml:459:30>>*/  /*<<map.ml:459:30>>*/ var
-          _v_ = join(lf, v, d, rf);
-          /*<<map.ml:459:15>>*/ return [0, concat(lt, rt), _v_];
+          _t_ = join(lf, v, d, rf);
+          /*<<map.ml:459:15>>*/ return [0, concat(lt, rt), _t_];
         }
         function cons_enum(m, e){
           /*<<map.ml:464:6>>*/ var m$0 = m, e$0 = e;
@@ -12067,12 +11940,12 @@
            r1 = e1[3],
            d1 = e1[2],
            v1 = e1[1],
-           _r_ =
+           _p_ =
              0 ===  /*<<map.ml:489:12>>*/ caml_call2(Ord[1], v1, v2) ? 1 : 0;
-          if(_r_){
+          if(_p_){
             /*<<map.ml:489:37>>*/  /*<<map.ml:489:37>>*/ var
-            _s_ =  /*<<map.ml:489:37>>*/ caml_call2(cmp, d1, d2);
-            /*<<map.ml:489:37>>*/ if(_s_){
+            _q_ =  /*<<map.ml:489:37>>*/ caml_call2(cmp, d1, d2);
+            /*<<map.ml:489:37>>*/ if(_q_){
              /*<<map.ml:490:40>>*/ var
               /*<<map.ml:490:40>>*/ e2$1 = cons_enum(r2, e2$0),
               /*<<map.ml:490:22>>*/ e1$1 = cons_enum(r1, e1$0),
@@ -12080,11 +11953,11 @@
              e2 = e2$1;
             continue;
            }
-           var _t_ = _s_;
+           var _r_ = _q_;
           }
           else
-           var _t_ = _r_;
-           /*<<map.ml:489:37>>*/ return _t_;
+           var _r_ = _p_;
+           /*<<map.ml:489:37>>*/ return _r_;
          }
          /*<<map.ml:491:56>>*/ }
         function cardinal(param){
@@ -12092,8 +11965,8 @@
           /*<<map.ml:495:40>>*/ var
           r = param[4],
           l = param[1],
-           /*<<map.ml:495:40>>*/ _q_ = cardinal(r);
-         return (cardinal(l) + 1 | 0) + _q_ | 0;
+           /*<<map.ml:495:40>>*/ _o_ = cardinal(r);
+         return (cardinal(l) + 1 | 0) + _o_ | 0;
          /*<<map.ml:495:50>>*/ }
         function bindings_aux(accu, param){
          var accu$0 = accu, param$0 = param;
@@ -12114,39 +11987,42 @@
           /*<<map.ml:502:6>>*/ return bindings_aux(0, s);
          /*<<map.ml:502:23>>*/ }
         function of_list(bs){
-         function _p_(m, param){
-           /*<<map.ml:509:36>>*/ var v = param[2], k = param[1];
-           /*<<map.ml:509:53>>*/ return add(k, v, m);
-          /*<<map.ml:509:63>>*/ }
           /*<<map.ml:509:21>>*/ return  /*<<map.ml:509:21>>*/ caml_call3
-                 (Stdlib_List[26], _p_, empty, bs);
+                 (Stdlib_List[26],
+                  function(m, param){
+                    /*<<map.ml:509:36>>*/ var v = param[2], k = param[1];
+                    /*<<map.ml:509:53>>*/ return add(k, v, m);
+                   /*<<map.ml:509:63>>*/ },
+                  empty,
+                  bs);
          /*<<map.ml:509:72>>*/ }
         function add_seq(i, m){
-         function _o_(m, param){
-           /*<<map.ml:512:20>>*/ var v = param[2], k = param[1];
-           /*<<map.ml:512:36>>*/ return add(k, v, m);
-          /*<<map.ml:512:46>>*/ }
           /*<<map.ml:512:6>>*/ return  /*<<map.ml:512:6>>*/ caml_call3
-                 (Stdlib_Seq[5], _o_, m, i);
+                 (Stdlib_Seq[5],
+                  function(m, param){
+                    /*<<map.ml:512:20>>*/ var v = param[2], k = param[1];
+                    /*<<map.ml:512:36>>*/ return add(k, v, m);
+                   /*<<map.ml:512:46>>*/ },
+                  m,
+                  i);
          /*<<map.ml:512:50>>*/ }
         function of_seq(i){
           /*<<map.ml:514:19>>*/ return add_seq(i, empty);
          /*<<map.ml:514:34>>*/ }
         function seq_of_enum(c, param){
           /*<<map.ml:516:32>>*/ if(! c)  /*<<map.ml:517:15>>*/ return 0;
-          /*<<map.ml:518:59>>*/ var
+         var
           rest = c[4],
           t = c[3],
           v = c[2],
           k = c[1],
-           /*<<map.ml:518:59>>*/ _m_ = cons_enum(t, rest);
+          _m_ = cons_enum(t, rest);
           /*<<map.ml:518:29>>*/ return [0,
                  [0, k, v],
                  function(_n_){ /*<<?>>*/ return seq_of_enum(_m_, _n_);}];
          /*<<map.ml:518:78>>*/ }
         function to_seq(m){
-          /*<<map.ml:521:6>>*/  /*<<map.ml:521:19>>*/ var
-          _k_ = cons_enum(m, 0);
+          /*<<map.ml:521:6>>*/ var _k_ = cons_enum(m, 0);
           /*<<map.ml:521:19>>*/ return function(_l_){
            /*<<?>>*/ return seq_of_enum(_k_, _l_);};
          /*<<map.ml:521:36>>*/ }
@@ -12166,19 +12042,18 @@
          /*<<map.ml:526:58>>*/ }
         function rev_seq_of_enum(c, param){
           /*<<map.ml:528:36>>*/ if(! c)  /*<<map.ml:529:15>>*/ return 0;
-          /*<<map.ml:531:44>>*/ var
+         var
           rest = c[4],
           t = c[3],
           v = c[2],
           k = c[1],
-           /*<<map.ml:531:44>>*/ _i_ = snoc_enum(t, rest);
+          _i_ = snoc_enum(t, rest);
           /*<<map.ml:531:10>>*/ return [0,
                  [0, k, v],
                  function(_j_){ /*<<?>>*/ return rev_seq_of_enum(_i_, _j_);}];
          /*<<map.ml:531:63>>*/ }
         function to_rev_seq(c){
-          /*<<map.ml:534:6>>*/  /*<<map.ml:534:23>>*/ var
-          _g_ = snoc_enum(c, 0);
+          /*<<map.ml:534:6>>*/ var _g_ = snoc_enum(c, 0);
           /*<<map.ml:534:23>>*/ return function(_h_){
            /*<<?>>*/ return rev_seq_of_enum(_g_, _h_);};
          /*<<map.ml:534:40>>*/ }
@@ -12367,11 +12242,12 @@
      /*<<stack.ml:63:15>>*/ return caml_call1(Stdlib_List[64], s[1]);
     /*<<stack.ml:63:30>>*/ }
    function add_seq(q, i){
-    function _a_(x){
-      /*<<stack.ml:65:37>>*/ return push(x, q);
-     /*<<stack.ml:65:45>>*/ }
      /*<<stack.ml:65:18>>*/ return  /*<<stack.ml:65:18>>*/ caml_call2
-            (Stdlib_Seq[4], _a_, i);
+            (Stdlib_Seq[4],
+             function(x){
+               /*<<stack.ml:65:37>>*/ return push(x, q);
+              /*<<stack.ml:65:45>>*/ },
+             i);
     /*<<stack.ml:65:48>>*/ }
    function of_seq(g){
      /*<<stack.ml:68:2>>*/  /*<<stack.ml:68:10>>*/ var s = create(0);
@@ -12458,13 +12334,13 @@
      /*<<queue.ml:66:24>>*/ return [0, content];
     /*<<queue.ml:66:36>>*/ }
    function take(q){
-     /*<<queue.ml:72:2>>*/ var _g_ = q[2];
-    if(! _g_)
+     /*<<queue.ml:72:2>>*/ var _f_ = q[2];
+    if(! _f_)
       /*<<queue.ml:73:11>>*/ throw  /*<<queue.ml:73:11>>*/ caml_maybe_attach_backtrace
             (Empty, 1);
-    var content = _g_[1];
-    if(_g_[2]){
-     var next = _g_[2];
+    var content = _f_[1];
+    if(_f_[2]){
+     var next = _f_[2];
      q[1] = q[1] - 1 | 0;
      q[2] = next;
       /*<<queue.ml:80:4>>*/ return content;
@@ -12473,11 +12349,11 @@
      /*<<queue.ml:75:4>>*/ return content;
     /*<<queue.ml:80:11>>*/ }
    function take_opt(q){
-     /*<<queue.ml:83:2>>*/ var _f_ = q[2];
-    if(! _f_)  /*<<queue.ml:84:11>>*/ return 0;
-    var content = _f_[1];
-    if(_f_[2]){
-     var next = _f_[2];
+     /*<<queue.ml:83:2>>*/ var _e_ = q[2];
+    if(! _e_)  /*<<queue.ml:84:11>>*/ return 0;
+    var content = _e_[1];
+    if(_e_[2]){
+     var next = _e_[2];
      q[1] = q[1] - 1 | 0;
      q[2] = next;
       /*<<queue.ml:91:4>>*/ return [0, content];
@@ -12533,8 +12409,8 @@
     }
     /*<<queue.ml:134:37>>*/ }
    function transfer(q1, q2){
-     /*<<queue.ml:137:2>>*/ var _e_ = 0 < q1[1] ? 1 : 0;
-    if(! _e_) return _e_;
+     /*<<queue.ml:137:2>>*/ var _d_ = 0 < q1[1] ? 1 : 0;
+    if(! _d_) return _d_;
     var match = q2[3];
     return match
             ? (q2
@@ -12551,18 +12427,19 @@
      var x = c[1], next = c[2];
       /*<<queue.ml:155:35>>*/ return [0,
              x,
-             function(_d_){ /*<<?>>*/ return aux(next, _d_);}];
+             function(_c_){ /*<<?>>*/ return aux(next, _c_);}];
      /*<<queue.ml:155:57>>*/ }
-    var _b_ = q[2];
-     /*<<queue.ml:153:2>>*/ return function(_c_){
-      /*<<?>>*/ return aux(_b_, _c_);};
+    var _a_ = q[2];
+     /*<<queue.ml:153:2>>*/ return function(_b_){
+      /*<<?>>*/ return aux(_a_, _b_);};
     /*<<queue.ml:157:13>>*/ }
    function add_seq(q, i){
-    function _a_(x){
-      /*<<queue.ml:159:37>>*/ return add(x, q);
-     /*<<queue.ml:159:45>>*/ }
      /*<<queue.ml:159:18>>*/ return  /*<<queue.ml:159:18>>*/ caml_call2
-            (Stdlib_Seq[4], _a_, i);
+            (Stdlib_Seq[4],
+             function(x){
+               /*<<queue.ml:159:37>>*/ return add(x, q);
+              /*<<queue.ml:159:45>>*/ },
+             i);
     /*<<queue.ml:159:48>>*/ }
    function of_seq(g){
      /*<<queue.ml:162:2>>*/  /*<<queue.ml:162:10>>*/ var q = create(0);
@@ -12653,14 +12530,10 @@
     Stdlib = global_data.Stdlib,
     Stdlib_String = global_data.Stdlib__String,
     Assert_failure = global_data.Assert_failure,
-    cst_Buffer_truncate = "Buffer.truncate",
-    _a_ = [0, "buffer.ml", 220, 9],
-    cst_Buffer_add_channel = "Buffer.add_channel",
-    cst_Buffer_add_substring_add_s = "Buffer.add_substring/add_subbytes",
-    cst_Buffer_add_cannot_grow_buf = "Buffer.add: cannot grow buffer",
-    cst_Buffer_nth = "Buffer.nth",
+    cst_Buffer_sub = "Buffer.sub",
     cst_Buffer_blit = "Buffer.blit",
-    cst_Buffer_sub = "Buffer.sub";
+    cst_Buffer_nth = "Buffer.nth",
+    cst_Buffer_add_cannot_grow_buf = "Buffer.add: cannot grow buffer";
    function create(n){
      /*<<buffer.ml:41:1>>*/ var
      n$0 = 1 <= n ? n : 1,
@@ -12761,7 +12634,13 @@
     b[2] = pos + 1 | 0;
     return 0;
     /*<<buffer.ml:120:23>>*/ }
-   var uchar_utf_8_byte_length_max = 4, uchar_utf_16_byte_length_max = 4;
+   var
+    uchar_utf_8_byte_length_max = 4,
+    uchar_utf_16_byte_length_max = 4,
+    cst_Buffer_add_substring_add_s = "Buffer.add_substring/add_subbytes",
+    cst_Buffer_add_channel = "Buffer.add_channel",
+    _a_ = [0, "buffer.ml", 220, 9],
+    cst_Buffer_truncate = "Buffer.truncate";
    function add_utf_8_uchar(b, u){
      /*<<buffer.ml:126:2>>*/ for(;;){
      var pos = b[2];
@@ -12802,14 +12681,14 @@
     }
     /*<<buffer.ml:147:30>>*/ }
    function add_substring(b, s, offset, len){
-     /*<<buffer.ml:150:2>>*/ var _r_ = offset < 0 ? 1 : 0;
-    if(_r_)
-     var _s_ = _r_;
+     /*<<buffer.ml:150:2>>*/ var _q_ = offset < 0 ? 1 : 0;
+    if(_q_)
+     var _r_ = _q_;
     else
      var
-      _t_ = len < 0 ? 1 : 0,
-      _s_ = _t_ || ((caml_ml_string_length(s) - len | 0) < offset ? 1 : 0);
-    if(_s_)
+      _s_ = len < 0 ? 1 : 0,
+      _r_ = _s_ || ((caml_ml_string_length(s) - len | 0) < offset ? 1 : 0);
+    if(_r_)
       /*<<buffer.ml:151:7>>*/  /*<<buffer.ml:151:7>>*/ caml_call1
       (Stdlib[1], cst_Buffer_add_substring_add_s);
      /*<<buffer.ml:153:2>>*/ var
@@ -12864,9 +12743,9 @@
     /*<<buffer.ml:180:46>>*/ }
    function add_channel(b, ic, to_read$1){
      /*<<buffer.ml:206:2>>*/ var
-     _p_ = to_read$1 < 0 ? 1 : 0,
-     _q_ = _p_ || (Stdlib_Sys[12] < to_read$1 ? 1 : 0);
-    if(_q_)
+     _o_ = to_read$1 < 0 ? 1 : 0,
+     _p_ = _o_ || (Stdlib_Sys[12] < to_read$1 ? 1 : 0);
+    if(_p_)
       /*<<buffer.ml:207:4>>*/  /*<<buffer.ml:207:4>>*/ caml_call1
       (Stdlib[1], cst_Buffer_add_channel);
     if(b[1][2] < (b[2] + to_read$1 | 0))
@@ -12912,8 +12791,8 @@
      i$4 = 0;
      /*<<buffer.ml:262:4>>*/ for(;;){
      if(i$4 >= lim$1){
-      var _o_ = 92 === previous ? 1 : 0;
-      return _o_ ? add_char(b, previous) : _o_;
+      var _n_ = 92 === previous ? 1 : 0;
+      return _n_ ? add_char(b, previous) : _n_;
      }
       /*<<buffer.ml:263:12>>*/  /*<<buffer.ml:263:12>>*/ var
       previous$0 =  /*<<buffer.ml:263:12>>*/ caml_string_get(s, i$4);
@@ -13049,14 +12928,14 @@
       /*<<buffer.ml:298:14>>*/ var
        /*<<buffer.ml:298:14>>*/ x =
          /*<<buffer.ml:298:14>>*/ caml_bytes_get(b[1][1], i),
-       /*<<buffer.ml:298:14>>*/ _m_ = i + 1 | 0;
+      _l_ = i + 1 | 0;
       /*<<buffer.ml:299:6>>*/ return [0,
              x,
-             function(_n_){ /*<<?>>*/ return aux(_m_, _n_);}];
+             function(_m_){ /*<<?>>*/ return aux(_l_, _m_);}];
      /*<<buffer.ml:299:29>>*/ }
-     /*<<buffer.ml:301:2>>*/  /*<<buffer.ml:301:2>>*/ var _k_ = 0;
-     /*<<buffer.ml:301:2>>*/ return function(_l_){
-      /*<<?>>*/ return aux(_k_, _l_);};
+    var _j_ = 0;
+     /*<<buffer.ml:301:2>>*/ return function(_k_){
+      /*<<?>>*/ return aux(_j_, _k_);};
     /*<<buffer.ml:301:7>>*/ }
    function to_seqi(b){
     function aux(i, param){
@@ -13065,21 +12944,20 @@
       /*<<buffer.ml:308:14>>*/ var
        /*<<buffer.ml:308:14>>*/ x =
          /*<<buffer.ml:308:14>>*/ caml_bytes_get(b[1][1], i),
-       /*<<buffer.ml:308:14>>*/ _i_ = i + 1 | 0;
+      _h_ = i + 1 | 0;
       /*<<buffer.ml:309:6>>*/ return [0,
              [0, i, x],
-             function(_j_){ /*<<?>>*/ return aux(_i_, _j_);}];
+             function(_i_){ /*<<?>>*/ return aux(_h_, _i_);}];
      /*<<buffer.ml:309:33>>*/ }
-     /*<<buffer.ml:311:2>>*/  /*<<buffer.ml:311:2>>*/ var _g_ = 0;
-     /*<<buffer.ml:311:2>>*/ return function(_h_){
-      /*<<?>>*/ return aux(_g_, _h_);};
+    var _f_ = 0;
+     /*<<buffer.ml:311:2>>*/ return function(_g_){
+      /*<<?>>*/ return aux(_f_, _g_);};
     /*<<buffer.ml:311:7>>*/ }
    function add_seq(b, seq){
-     /*<<buffer.ml:313:29>>*/ function _e_(_f_){
-      /*<<?>>*/ return add_char(b, _f_);
-    }
      /*<<buffer.ml:313:20>>*/ return  /*<<buffer.ml:313:20>>*/ caml_call2
-            (Stdlib_Seq[4], _e_, seq);
+            (Stdlib_Seq[4],
+             function(_e_){ /*<<?>>*/ return add_char(b, _e_);},
+             seq);
     /*<<buffer.ml:313:45>>*/ }
    function of_seq(i){
      /*<<buffer.ml:316:2>>*/  /*<<buffer.ml:316:10>>*/ var b = create(32);
@@ -13314,9 +13192,9 @@
     Stdlib_Mutex = global_data.Stdlib__Mutex,
     Stdlib_Condition = global_data.Stdlib__Condition,
     Stdlib = global_data.Stdlib,
-    cst_Semaphore_Counting_release = "Semaphore.Counting.release: overflow",
     cst_Semaphore_Counting_init_wr =
-      "Semaphore.Counting.init: wrong initial value";
+      "Semaphore.Counting.init: wrong initial value",
+    cst_Semaphore_Counting_release = "Semaphore.Counting.release: overflow";
    function make(v){
      /*<<semaphore.ml:29:2>>*/ if(v < 0)
       /*<<semaphore.ml:29:16>>*/  /*<<semaphore.ml:29:16>>*/ caml_call1
@@ -13452,9 +13330,7 @@
     Stdlib = global_data.Stdlib,
     Stdlib_Atomic = global_data.Stdlib__Atomic,
     Stdlib_List = global_data.Stdlib__List,
-    Stdlib_Array = global_data.Stdlib__Array,
-    cst_internal_error_Am_I_alread = "internal error: Am I already finished?",
-    cst_first_domain_already_spawn = "first domain already spawned";
+    Stdlib_Array = global_data.Stdlib__Array;
    function cpu_relax(param){
      /*<<domain.ml:32:19>>*/ return  /*<<domain.ml:32:19>>*/ runtime.caml_ml_domain_cpu_relax
             (0);
@@ -13555,7 +13431,8 @@
       [0,
        function(param){
          /*<<domain.ml:147:42>>*/ return;
-        /*<<domain.ml:147:44>>*/ }];
+        /*<<domain.ml:147:44>>*/ }],
+    cst_first_domain_already_spawn = "first domain already spawned";
    function before_first_spawn(f){
      /*<<domain.ml:150:2>>*/ if
      ( /*<<domain.ml:150:5>>*/ caml_call1
@@ -13575,7 +13452,7 @@
     at_exit_key =
       new_key
        (0,
-        function(param, _e_){
+        function(param, _c_){
           /*<<domain.ml:166:52>>*/ return 0;
          /*<<domain.ml:166:54>>*/ });
    function at_exit(f){
@@ -13594,6 +13471,8 @@
      /*<<domain.ml:181:2>>*/ return  /*<<domain.ml:181:2>>*/ caml_call1(f, 0);
     /*<<domain.ml:181:6>>*/ }
    Stdlib[104][1] = do_at_exit;
+   var
+    cst_internal_error_Am_I_alread = "internal error: Am I already finished?";
    function spawn(f){
      /*<<domain.ml:188:2>>*/ if
      (1
@@ -13609,17 +13488,22 @@
         /*<<domain.ml:163:39>>*/ return 0;
        /*<<domain.ml:163:41>>*/ };
     }
-     /*<<domain.ml:124:6>>*/  /*<<domain.ml:124:6>>*/ var
-     _a_ =  /*<<domain.ml:124:6>>*/ caml_call1(Stdlib_Atomic[2], parent_keys);
-    function _b_(param){
-      /*<<domain.ml:122:6>>*/ var split = param[2], k = param[1], idx = k[1];
-      /*<<domain.ml:123:11>>*/ return [0,
-             idx,
-              /*<<domain.ml:123:26>>*/ caml_call1(split, get(k))];
-     /*<<domain.ml:123:43>>*/ }
      /*<<domain.ml:124:6>>*/ var
+      /*<<domain.ml:124:6>>*/ _a_ =
+        /*<<domain.ml:124:6>>*/ caml_call1(Stdlib_Atomic[2], parent_keys),
       /*<<domain.ml:124:6>>*/ pk =
-        /*<<domain.ml:124:6>>*/ caml_call2(Stdlib_List[20], _b_, _a_),
+        /*<<domain.ml:124:6>>*/ caml_call2
+        (Stdlib_List[20],
+         function(param){
+           /*<<domain.ml:122:6>>*/ var
+           split = param[2],
+           k = param[1],
+           idx = k[1];
+           /*<<domain.ml:123:11>>*/ return [0,
+                  idx,
+                   /*<<domain.ml:123:26>>*/ caml_call1(split, get(k))];
+          /*<<domain.ml:123:43>>*/ },
+         _a_),
       /*<<domain.ml:193:19>>*/ term_mutex =
         /*<<domain.ml:193:19>>*/ caml_call1(Stdlib_Mutex[1], 0),
       /*<<domain.ml:194:23>>*/ term_condition =
@@ -13630,18 +13514,17 @@
      {
        /*<<domain.ml:198:4>>*/ try{
         /*<<domain.ml:200:8>>*/ create_dls(0);
-       var
-        _c_ =
-          function(param){
-            /*<<domain.ml:128:6>>*/ var
-            v = param[2],
-            idx = param[1],
-             /*<<domain.ml:129:17>>*/ st = maybe_grow(idx);
-            /*<<domain.ml:129:35>>*/ caml_check_bound(st, idx)[1 + idx] = v;
-            /*<<domain.ml:129:35>>*/ return 0;
-           /*<<domain.ml:129:49>>*/ };
         /*<<domain.ml:127:4>>*/  /*<<domain.ml:127:4>>*/ caml_call2
-        (Stdlib_List[18], _c_, pk);
+        (Stdlib_List[18],
+         function(param){
+           /*<<domain.ml:128:6>>*/ var
+           v = param[2],
+           idx = param[1],
+            /*<<domain.ml:129:17>>*/ st = maybe_grow(idx);
+           /*<<domain.ml:129:35>>*/ caml_check_bound(st, idx)[1 + idx] = v;
+           /*<<domain.ml:129:35>>*/ return 0;
+          /*<<domain.ml:129:49>>*/ },
+         pk);
         /*<<domain.ml:202:18>>*/  /*<<domain.ml:202:18>>*/ var
         res =  /*<<domain.ml:202:18>>*/ caml_call1(f, 0);
       }
@@ -13658,8 +13541,8 @@
      catch(ex){
        /*<<domain.ml:215:10>>*/ var
        ex$0 = caml_wrap_exception(ex),
-        /*<<domain.ml:215:10>>*/ _d_ = 0 === result[0] ? [1, ex$0] : result,
-       result$0 = _d_;
+        /*<<domain.ml:215:10>>*/ _b_ = 0 === result[0] ? [1, ex$0] : result,
+       result$0 = _b_;
      }
       /*<<domain.ml:230:4>>*/  /*<<domain.ml:230:4>>*/ caml_call1
       (Stdlib_Mutex[2], term_mutex);
@@ -13841,6 +13724,7 @@
     Stdlib_Char = global_data.Stdlib__Char,
     Stdlib_Bytes = global_data.Stdlib__Bytes,
     Stdlib_Int = global_data.Stdlib__Int,
+    _a_ = [0, 0, 0],
     cst_c = "%c",
     cst_s = "%s",
     cst_i = cst_i$3,
@@ -13853,262 +13737,23 @@
     cst_t = "%t",
     cst_r = "%r",
     cst_r$0 = "%_r",
-    _b_ = [0, cst_camlinternalFormat_ml, 850, 23],
-    _m_ = [0, cst_camlinternalFormat_ml, 814, 21],
-    _e_ = [0, cst_camlinternalFormat_ml, 815, 21],
-    _n_ = [0, cst_camlinternalFormat_ml, 818, 21],
-    _f_ = [0, cst_camlinternalFormat_ml, 819, 21],
-    _o_ = [0, cst_camlinternalFormat_ml, 822, 19],
-    _g_ = [0, cst_camlinternalFormat_ml, 823, 19],
-    _p_ = [0, cst_camlinternalFormat_ml, 826, 22],
-    _h_ = [0, cst_camlinternalFormat_ml, 827, 22],
-    _q_ = [0, cst_camlinternalFormat_ml, 831, 30],
-    _i_ = [0, cst_camlinternalFormat_ml, 832, 30],
-    _k_ = [0, cst_camlinternalFormat_ml, 836, 26],
-    _c_ = [0, cst_camlinternalFormat_ml, 837, 26],
-    _l_ = [0, cst_camlinternalFormat_ml, 846, 28],
-    _d_ = [0, cst_camlinternalFormat_ml, 847, 28],
-    _j_ = [0, cst_camlinternalFormat_ml, 851, 23],
-    _s_ = [0, cst_camlinternalFormat_ml, 1558, 4],
-    cst_Printf_bad_conversion = "Printf: bad conversion %[",
-    _t_ = [0, cst_camlinternalFormat_ml, 1626, 39],
-    _u_ = [0, cst_camlinternalFormat_ml, 1649, 31],
-    _v_ = [0, cst_camlinternalFormat_ml, 1650, 31],
-    cst_Printf_bad_conversion$0 = "Printf: bad conversion %_",
-    _w_ = [0, cst_camlinternalFormat_ml, 1830, 8],
-    ___ =
-      [0,
-       [11, cst_bad_input_format_type_mism, [3, 0, [11, cst_and, [3, 0, 0]]]],
-       cst_bad_input_format_type_mism$0],
-    _Z_ =
-      [0,
-       [11, cst_bad_input_format_type_mism, [3, 0, [11, cst_and, [3, 0, 0]]]],
-       cst_bad_input_format_type_mism$0],
-    _C_ =
-      [0,
-       [11,
-        cst_invalid_format,
-        [3,
-         0,
-         [11,
-          cst_at_character_number,
-          [4, 0, 0, 0, [11, ", duplicate flag ", [1, 0]]]]]],
-       "invalid format %S: at character number %d, duplicate flag %C"],
-    cst_0 = cst_0$3,
-    cst_padding = "padding",
-    _D_ = [0, 1, 0],
-    _E_ = [0, 0],
-    cst_precision = cst_precision$3,
-    _F_ = [1, 0],
-    _G_ = [1, 1],
-    cst_0$2 = "'0'",
-    cst_0$0 = cst_0$3,
-    _I_ = [1, 1],
-    cst_0$1 = cst_0$3,
-    cst_precision$0 = cst_precision$3,
-    _H_ = [1, 1],
-    cst_precision$1 = cst_precision$3,
-    _M_ =
-      [0,
-       [11,
-        cst_invalid_format,
-        [3,
-         0,
-         [11,
-          cst_at_character_number,
-          [4,
-           0,
-           0,
-           0,
-           [11,
-            ", flag ",
-            [1,
-             [11,
-              " is only allowed after the '",
-              [12, 37, [11, "', before padding and precision", 0]]]]]]]]],
-       "invalid format %S: at character number %d, flag %C is only allowed after the '%%', before padding and precision"],
-    _J_ =
-      [0,
-       [11,
-        cst_invalid_format,
-        [3,
-         0,
-         [11,
-          cst_at_character_number,
-          [4,
-           0,
-           0,
-           0,
-           [11, ', invalid conversion "', [12, 37, [0, [12, 34, 0]]]]]]]],
-       'invalid format %S: at character number %d, invalid conversion "%%%c"'],
-    _K_ = [0, 0],
-    cst_padding$0 = "`padding'",
-    _L_ = [0, 0],
-    cst_precision$2 = "`precision'",
-    _N_ = [0, [12, 64, 0]],
-    _O_ = [0, "@ ", 1, 0],
-    _P_ = [0, "@,", 0, 0],
-    _Q_ = [2, 60],
-    _R_ =
-      [0,
-       [11,
-        cst_invalid_format,
-        [3,
-         0,
-         [11,
-          ": '",
-          [12,
-           37,
-           [11,
-            "' alone is not accepted in character sets, use ",
-            [12,
-             37,
-             [12,
-              37,
-              [11, " instead at position ", [4, 0, 0, 0, [12, 46, 0]]]]]]]]]],
-       "invalid format %S: '%%' alone is not accepted in character sets, use %%%% instead at position %d."],
-    _S_ =
-      [0,
-       [11,
-        cst_invalid_format,
-        [3,
-         0,
-         [11,
-          ": integer ",
-          [4, 0, 0, 0, [11, " is greater than the limit ", [4, 0, 0, 0, 0]]]]]],
-       "invalid format %S: integer %d is greater than the limit %d"],
-    cst_digit = "digit",
-    _T_ = [0, cst_camlinternalFormat_ml, 2837, 11],
-    _U_ =
-      [0,
-       [11,
-        cst_invalid_format,
-        [3,
-         0,
-         [11,
-          ': unclosed sub-format, expected "',
-          [12, 37, [0, [11, '" at character number ', [4, 0, 0, 0, 0]]]]]]],
-       'invalid format %S: unclosed sub-format, expected "%%%c" at character number %d'],
-    cst_character = "character ')'",
-    cst_character$0 = "character '}'",
-    _V_ = [0, cst_camlinternalFormat_ml, 2899, 34],
-    _W_ = [0, cst_camlinternalFormat_ml, 2935, 28],
-    _X_ = [0, cst_camlinternalFormat_ml, 2957, 11],
-    _Y_ =
-      [0,
-       [11,
-        cst_invalid_format,
-        [3,
-         0,
-         [11,
-          cst_at_character_number,
-          [4,
-           0,
-           0,
-           0,
-           [11,
-            cst$44,
-            [2,
-             0,
-             [11,
-              " is incompatible with '",
-              [0, [11, "' in sub-format ", [3, 0, 0]]]]]]]]]],
-       "invalid format %S: at character number %d, %s is incompatible with '%c' in sub-format %S"],
-    _B_ =
-      [0,
-       [11,
-        cst_invalid_format,
-        [3,
-         0,
-         [11,
-          cst_at_character_number,
-          [4, 0, 0, 0, [11, cst$44, [2, 0, [11, " expected, read ", [1, 0]]]]]]]],
-       "invalid format %S: at character number %d, %s expected, read %C"],
-    _A_ =
-      [0,
-       [11,
-        cst_invalid_format,
-        [3,
-         0,
-         [11,
-          cst_at_character_number,
-          [4, 0, 0, 0, [11, ", '", [0, [11, "' without ", [2, 0, 0]]]]]]]],
-       "invalid format %S: at character number %d, '%c' without %s"],
-    cst_non_zero_widths_are_unsupp =
-      "non-zero widths are unsupported for %c conversions",
-    cst_unexpected_end_of_format = "unexpected end of format",
-    _z_ =
-      [0,
-       [11,
-        cst_invalid_format,
-        [3,
-         0,
-         [11, cst_at_character_number, [4, 0, 0, 0, [11, cst$44, [2, 0, 0]]]]]],
-       "invalid format %S: at character number %d, %s"],
-    _y_ =
-      [0,
-       [11, "invalid box description ", [3, 0, 0]],
-       "invalid box description %S"],
-    _x_ = [0, 0, 4],
-    cst_nan = "nan",
-    cst_neg_infinity = "neg_infinity",
-    cst_infinity = "infinity",
-    _r_ = [0, 103],
-    cst_nd$0 = "%+nd",
-    cst_nd$1 = "% nd",
-    cst_ni$1 = "%+ni",
-    cst_ni$2 = "% ni",
-    cst_nx = "%nx",
-    cst_nx$0 = "%#nx",
-    cst_nX = "%nX",
-    cst_nX$0 = "%#nX",
-    cst_no = "%no",
-    cst_no$0 = "%#no",
-    cst_nd = "%nd",
-    cst_ni$0 = cst_ni$3,
-    cst_nu = "%nu",
-    cst_ld$0 = "%+ld",
-    cst_ld$1 = "% ld",
-    cst_li$1 = "%+li",
-    cst_li$2 = "% li",
-    cst_lx = "%lx",
-    cst_lx$0 = "%#lx",
-    cst_lX = "%lX",
-    cst_lX$0 = "%#lX",
-    cst_lo = "%lo",
-    cst_lo$0 = "%#lo",
-    cst_ld = "%ld",
-    cst_li$0 = cst_li$3,
-    cst_lu = "%lu",
-    cst_Ld$0 = "%+Ld",
-    cst_Ld$1 = "% Ld",
-    cst_Li$1 = "%+Li",
-    cst_Li$2 = "% Li",
-    cst_Lx = "%Lx",
-    cst_Lx$0 = "%#Lx",
-    cst_LX = "%LX",
-    cst_LX$0 = "%#LX",
-    cst_Lo = "%Lo",
-    cst_Lo$0 = "%#Lo",
-    cst_Ld = "%Ld",
-    cst_Li$0 = cst_Li$3,
-    cst_Lu = "%Lu",
-    cst_d$0 = "%+d",
-    cst_d$1 = "% d",
-    cst_i$1 = "%+i",
-    cst_i$2 = "% i",
-    cst_x = "%x",
-    cst_x$0 = "%#x",
-    cst_X = "%X",
-    cst_X$0 = "%#X",
-    cst_o = "%o",
-    cst_o$0 = "%#o",
-    cst_d = "%d",
-    cst_i$0 = cst_i$3,
-    cst_u = cst_u$0,
     cst_0c = "0c",
-    _a_ = [0, 0, 0],
-    cst_CamlinternalFormat_Type_mi = "CamlinternalFormat.Type_mismatch";
+    _b_ = [0, cst_camlinternalFormat_ml, 850, 23],
+    _c_ = [0, cst_camlinternalFormat_ml, 837, 26],
+    _d_ = [0, cst_camlinternalFormat_ml, 847, 28],
+    _e_ = [0, cst_camlinternalFormat_ml, 815, 21],
+    _f_ = [0, cst_camlinternalFormat_ml, 819, 21],
+    _g_ = [0, cst_camlinternalFormat_ml, 823, 19],
+    _h_ = [0, cst_camlinternalFormat_ml, 827, 22],
+    _i_ = [0, cst_camlinternalFormat_ml, 832, 30],
+    _j_ = [0, cst_camlinternalFormat_ml, 851, 23],
+    _k_ = [0, cst_camlinternalFormat_ml, 836, 26],
+    _l_ = [0, cst_camlinternalFormat_ml, 846, 28],
+    _m_ = [0, cst_camlinternalFormat_ml, 814, 21],
+    _n_ = [0, cst_camlinternalFormat_ml, 818, 21],
+    _o_ = [0, cst_camlinternalFormat_ml, 822, 19],
+    _p_ = [0, cst_camlinternalFormat_ml, 826, 22],
+    _q_ = [0, cst_camlinternalFormat_ml, 831, 30];
    function create_char_set(param){
      /*<<camlinternalFormat.ml:24:25>>*/ return  /*<<camlinternalFormat.ml:24:25>>*/ caml_call2
             (Stdlib_Bytes[1], 32, 0);
@@ -14117,14 +13762,14 @@
      /*<<camlinternalFormat.ml:28:2>>*/ var
      str_ind = c >>> 3 | 0,
      mask = 1 << (c & 7),
-      /*<<camlinternalFormat.ml:31:30>>*/ _du_ =
+      /*<<camlinternalFormat.ml:31:30>>*/ _dt_ =
         /*<<camlinternalFormat.ml:31:30>>*/ runtime.caml_bytes_get
         (char_set, str_ind)
        | mask;
      /*<<camlinternalFormat.ml:30:2>>*/ return  /*<<camlinternalFormat.ml:30:2>>*/ caml_bytes_set
             (char_set,
              str_ind,
-              /*<<camlinternalFormat.ml:31:4>>*/ caml_call1(Stdlib[29], _du_));
+              /*<<camlinternalFormat.ml:31:4>>*/ caml_call1(Stdlib[29], _dt_));
     /*<<camlinternalFormat.ml:31:69>>*/ }
    function freeze_char_set(char_set){
      /*<<camlinternalFormat.ml:34:2>>*/ return  /*<<camlinternalFormat.ml:34:2>>*/ caml_call1
@@ -14136,19 +13781,19 @@
      i = 0;
     for(;;){
       /*<<camlinternalFormat.ml:41:32>>*/  /*<<camlinternalFormat.ml:41:32>>*/ var
-      _ds_ =
+      _dr_ =
          /*<<camlinternalFormat.ml:41:32>>*/ caml_string_get(char_set, i)
         ^ 255;
       /*<<camlinternalFormat.ml:40:4>>*/  /*<<camlinternalFormat.ml:40:4>>*/ caml_bytes_set
       (char_set$0,
        i,
-        /*<<camlinternalFormat.ml:41:6>>*/ caml_call1(Stdlib[29], _ds_));
+        /*<<camlinternalFormat.ml:41:6>>*/ caml_call1(Stdlib[29], _dr_));
       /*<<camlinternalFormat.ml:40:4>>*/  /*<<camlinternalFormat.ml:40:4>>*/ var
-      _dt_ = i + 1 | 0;
+      _ds_ = i + 1 | 0;
      if(31 === i)
        /*<<camlinternalFormat.ml:43:2>>*/ return  /*<<camlinternalFormat.ml:43:2>>*/ caml_call1
               (Stdlib_Bytes[44], char_set$0);
-     var i = _dt_;
+     var i = _ds_;
     }
     /*<<camlinternalFormat.ml:43:34>>*/ }
    function is_in_char_set(char_set, c){
@@ -14208,11 +13853,11 @@
       case 6:
        var prec_opt = ign[2], pad_opt$5 = ign[1];
        if(prec_opt)
-        var ndec = prec_opt[1], _dr_ = [0, ndec];
+        var ndec = prec_opt[1], _dq_ = [0, ndec];
        else
-        var _dr_ = 0;
+        var _dq_ = 0;
         /*<<camlinternalFormat.ml:97:4>>*/ return [0,
-               [8, _a_, pad_of_pad_opt(pad_opt$5), _dr_, fmt]];
+               [8, _a_, pad_of_pad_opt(pad_opt$5), _dq_, fmt]];
       case 7:
        var pad_opt$6 = ign[1];
         /*<<camlinternalFormat.ml:101:4>>*/ return [0,
@@ -14445,11 +14090,11 @@
       default:
         /*<<camlinternalFormat.ml:475:26>>*/ var
         c = formatting_lit[1],
-         /*<<camlinternalFormat.ml:475:26>>*/ _dq_ =
+         /*<<camlinternalFormat.ml:475:26>>*/ _dp_ =
            /*<<camlinternalFormat.ml:475:26>>*/ caml_call2
            (Stdlib_String[1], 1, c);
         /*<<camlinternalFormat.ml:475:26>>*/ return  /*<<camlinternalFormat.ml:475:26>>*/ caml_call2
-               (Stdlib[28], cst$7, _dq_);
+               (Stdlib[28], cst$7, _dp_);
     }
     /*<<camlinternalFormat.ml:475:43>>*/ }
    function bprint_char_literal(buf, chr){
@@ -14459,17 +14104,17 @@
     /*<<camlinternalFormat.ml:482:32>>*/ }
    function bprint_string_literal(buf, str){
      /*<<camlinternalFormat.ml:486:2>>*/ var
-     _do_ = caml_ml_string_length(str) - 1 | 0,
-      /*<<camlinternalFormat.ml:486:2>>*/ _dn_ = 0;
-    if(_do_ >= 0){
-     var i = _dn_;
+     _dn_ = caml_ml_string_length(str) - 1 | 0,
+      /*<<camlinternalFormat.ml:486:2>>*/ _dm_ = 0;
+    if(_dn_ >= 0){
+     var i = _dm_;
      for(;;){
        /*<<camlinternalFormat.ml:487:4>>*/ bprint_char_literal
        (buf,  /*<<camlinternalFormat.ml:487:28>>*/ caml_string_get(str, i));
        /*<<camlinternalFormat.ml:487:4>>*/  /*<<camlinternalFormat.ml:487:4>>*/ var
-       _dp_ = i + 1 | 0;
-      if(_do_ === i) break;
-      var i = _dp_;
+       _do_ = i + 1 | 0;
+      if(_dn_ === i) break;
+      var i = _do_;
      }
     }
     return;
@@ -14792,27 +14437,29 @@
              ? (buffer_add_char(buf, 94), rev_char_set(char_set))
              : char_set;
          let set$0 = set;
-         function is_alone(c){
-           /*<<camlinternalFormat.ml:316:6>>*/ var
-            /*<<camlinternalFormat.ml:316:50>>*/ after =
-              /*<<camlinternalFormat.ml:316:50>>*/ caml_call1
-              (Stdlib_Char[1], c + 1 | 0),
-            /*<<camlinternalFormat.ml:316:32>>*/ before =
-              /*<<camlinternalFormat.ml:316:32>>*/ caml_call1
-              (Stdlib_Char[1], c - 1 | 0),
-            /*<<camlinternalFormat.ml:317:6>>*/ _dj_ =
-             is_in_char_set(set$0, c);
-           /*<<camlinternalFormat.ml:317:6>>*/ if(_dj_)
-            /*<<camlinternalFormat.ml:318:14>>*/ var
-             /*<<camlinternalFormat.ml:318:14>>*/ _dk_ =
-              is_in_char_set(set$0, before),
-             /*<<camlinternalFormat.ml:318:14>>*/ _dl_ =
-              _dk_ ? is_in_char_set(set$0, after) : _dk_,
-            _dm_ = 1 - _dl_;
-          else
-           var _dm_ = _dj_;
-           /*<<camlinternalFormat.ml:318:43>>*/ return _dm_;
-          /*<<camlinternalFormat.ml:318:68>>*/ }
+         var
+          is_alone =
+            function(c){
+              /*<<camlinternalFormat.ml:316:6>>*/ var
+               /*<<camlinternalFormat.ml:316:50>>*/ after =
+                 /*<<camlinternalFormat.ml:316:50>>*/ caml_call1
+                 (Stdlib_Char[1], c + 1 | 0),
+               /*<<camlinternalFormat.ml:316:32>>*/ before =
+                 /*<<camlinternalFormat.ml:316:32>>*/ caml_call1
+                 (Stdlib_Char[1], c - 1 | 0),
+               /*<<camlinternalFormat.ml:317:6>>*/ _di_ =
+                is_in_char_set(set$0, c);
+              /*<<camlinternalFormat.ml:317:6>>*/ if(_di_)
+               /*<<camlinternalFormat.ml:318:14>>*/ var
+                /*<<camlinternalFormat.ml:318:14>>*/ _dj_ =
+                 is_in_char_set(set$0, before),
+                /*<<camlinternalFormat.ml:318:14>>*/ _dk_ =
+                 _dj_ ? is_in_char_set(set$0, after) : _dj_,
+               _dl_ = 1 - _dk_;
+             else
+              var _dl_ = _di_;
+              /*<<camlinternalFormat.ml:318:43>>*/ return _dl_;
+             /*<<camlinternalFormat.ml:318:68>>*/ };
           /*<<camlinternalFormat.ml:319:7>>*/ if(is_alone(93))
            /*<<camlinternalFormat.ml:319:25>>*/ buffer_add_char(buf, 93);
          a:
@@ -14950,12 +14597,12 @@
           (buf, ign_flag$0);
          switch(counter){
            case 0:
-            var _df_ = 108; break;
+            var _de_ = 108; break;
            case 1:
-            var _df_ = 110; break;
-           default: var _df_ = 78;
+            var _de_ = 110; break;
+           default: var _de_ = 78;
          }
-          /*<<camlinternalFormat.ml:614:6>>*/ buffer_add_char(buf, _df_);
+          /*<<camlinternalFormat.ml:614:6>>*/ buffer_add_char(buf, _de_);
          var fmt$0 = rest$20, ign_flag$0 = 0;
          break;
         case 22:
@@ -14979,20 +14626,20 @@
           /*<<camlinternalFormat.ml:578:20>>*/ var
           rest$23 = fmt$0[3],
           arity = fmt$0[1],
-           /*<<camlinternalFormat.ml:578:20>>*/ _dh_ =
+           /*<<camlinternalFormat.ml:578:20>>*/ _dg_ =
             int_of_custom_arity(arity),
-          _dg_ = 1;
-         if(_dh_ >= 1){
-          var i$8 = _dg_;
+          _df_ = 1;
+         if(_dg_ >= 1){
+          var i$8 = _df_;
           for(;;){
             /*<<camlinternalFormat.ml:579:8>>*/ buffer_add_char(buf, 37);
             /*<<camlinternalFormat.ml:579:33>>*/ bprint_ignored_flag
             (buf, ign_flag$0);
             /*<<camlinternalFormat.ml:580:8>>*/ buffer_add_char(buf, 63);
             /*<<camlinternalFormat.ml:580:8>>*/  /*<<camlinternalFormat.ml:580:8>>*/ var
-            _di_ = i$8 + 1 | 0;
-           if(_dh_ === i$8) break;
-           var i$8 = _di_;
+            _dh_ = i$8 + 1 | 0;
+           if(_dg_ === i$8) break;
+           var i$8 = _dh_;
           }
          }
          var fmt$0 = rest$23, ign_flag$0 = 0;
@@ -15607,11 +15254,11 @@
                     /*<<camlinternalFormat.ml:835:34>>*/ var
                     rest2$7 = ty2[2],
                     ty2$0 = ty2[1],
-                     /*<<camlinternalFormat.ml:835:34>>*/ _de_ =
+                     /*<<camlinternalFormat.ml:835:34>>*/ _dd_ =
                       trans(rest1$7, rest2$7);
                     /*<<camlinternalFormat.ml:835:4>>*/ return [8,
                            trans(ty1$0, ty2$0),
-                           _de_];
+                           _dd_];
                   case 10:
                    break a;
                   case 11:
@@ -15889,13 +15536,13 @@
          /*<<camlinternalFormat.ml:914:54>>*/ var
          rest$13 = fmtty$0[2],
          formatting_gen = fmtty$0[1],
-          /*<<camlinternalFormat.ml:914:54>>*/ _db_ = fmtty_of_fmt(rest$13);
+          /*<<camlinternalFormat.ml:914:54>>*/ _da_ = fmtty_of_fmt(rest$13);
         if(0 === formatting_gen[0])
-         var fmt = formatting_gen[1][1], _dc_ = fmtty_of_fmt(fmt);
+         var fmt = formatting_gen[1][1], _db_ = fmtty_of_fmt(fmt);
         else
-         var fmt$0 = formatting_gen[1][1], _dc_ = fmtty_of_fmt(fmt$0);
+         var fmt$0 = formatting_gen[1][1], _db_ = fmtty_of_fmt(fmt$0);
          /*<<camlinternalFormat.ml:914:54>>*/ return  /*<<camlinternalFormat.ml:914:54>>*/ caml_call2
-                (CamlinternalFormatBasics[1], _dc_, _db_);
+                (CamlinternalFormatBasics[1], _db_, _da_);
        case 19:
         var rest$14 = fmtty$0[1];
          /*<<camlinternalFormat.ml:897:34>>*/ return [13,
@@ -15948,10 +15595,10 @@
            case 9:
              /*<<camlinternalFormat.ml:943:58>>*/ var
              fmtty$6 = ign[2],
-              /*<<camlinternalFormat.ml:943:58>>*/ _dd_ =
+              /*<<camlinternalFormat.ml:943:58>>*/ _dc_ =
                fmtty_of_fmt(fmtty$5);
              /*<<camlinternalFormat.ml:943:58>>*/ return  /*<<camlinternalFormat.ml:943:58>>*/ caml_call2
-                    (CamlinternalFormatBasics[1], fmtty$6, _dd_);
+                    (CamlinternalFormatBasics[1], fmtty$6, _dc_);
            case 10:
             var fmtty$0 = fmtty$5; break;
            default: var fmtty$0 = fmtty$5;
@@ -15981,9 +15628,246 @@
             ? prec ? [2, fmtty] : fmtty
             : fmtty;
     /*<<camlinternalFormat.ml:963:37>>*/ }
-    /*<<camlinternalFormat.ml:969:0>>*/  /*<<camlinternalFormat.ml:969:0>>*/ var
-    Type_mismatch =
-      [248, cst_CamlinternalFormat_Type_mi, runtime.caml_fresh_oo_id(0)];
+    /*<<camlinternalFormat.ml:969:0>>*/ var
+     /*<<camlinternalFormat.ml:969:0>>*/ Type_mismatch =
+      [248, "CamlinternalFormat.Type_mismatch", runtime.caml_fresh_oo_id(0)],
+    cst_d = "%d",
+    cst_d$0 = "%+d",
+    cst_d$1 = "% d",
+    cst_i$0 = cst_i$3,
+    cst_i$1 = "%+i",
+    cst_i$2 = "% i",
+    cst_x = "%x",
+    cst_x$0 = "%#x",
+    cst_X = "%X",
+    cst_X$0 = "%#X",
+    cst_o = "%o",
+    cst_o$0 = "%#o",
+    cst_u = cst_u$0,
+    cst_Ld = "%Ld",
+    cst_Ld$0 = "%+Ld",
+    cst_Ld$1 = "% Ld",
+    cst_Li$0 = cst_Li$3,
+    cst_Li$1 = "%+Li",
+    cst_Li$2 = "% Li",
+    cst_Lx = "%Lx",
+    cst_Lx$0 = "%#Lx",
+    cst_LX = "%LX",
+    cst_LX$0 = "%#LX",
+    cst_Lo = "%Lo",
+    cst_Lo$0 = "%#Lo",
+    cst_Lu = "%Lu",
+    cst_ld = "%ld",
+    cst_ld$0 = "%+ld",
+    cst_ld$1 = "% ld",
+    cst_li$0 = cst_li$3,
+    cst_li$1 = "%+li",
+    cst_li$2 = "% li",
+    cst_lx = "%lx",
+    cst_lx$0 = "%#lx",
+    cst_lX = "%lX",
+    cst_lX$0 = "%#lX",
+    cst_lo = "%lo",
+    cst_lo$0 = "%#lo",
+    cst_lu = "%lu",
+    cst_nd = "%nd",
+    cst_nd$0 = "%+nd",
+    cst_nd$1 = "% nd",
+    cst_ni$0 = cst_ni$3,
+    cst_ni$1 = "%+ni",
+    cst_ni$2 = "% ni",
+    cst_nx = "%nx",
+    cst_nx$0 = "%#nx",
+    cst_nX = "%nX",
+    cst_nX$0 = "%#nX",
+    cst_no = "%no",
+    cst_no$0 = "%#no",
+    cst_nu = "%nu",
+    _r_ = [0, 103],
+    cst_neg_infinity = "neg_infinity",
+    cst_infinity = "infinity",
+    cst_nan = "nan",
+    _s_ = [0, cst_camlinternalFormat_ml, 1558, 4],
+    cst_Printf_bad_conversion = "Printf: bad conversion %[",
+    _t_ = [0, cst_camlinternalFormat_ml, 1626, 39],
+    _u_ = [0, cst_camlinternalFormat_ml, 1649, 31],
+    _v_ = [0, cst_camlinternalFormat_ml, 1650, 31],
+    cst_Printf_bad_conversion$0 = "Printf: bad conversion %_",
+    _w_ = [0, cst_camlinternalFormat_ml, 1830, 8],
+    _x_ = [0, 0, 4],
+    _y_ =
+      [0,
+       [11, "invalid box description ", [3, 0, 0]],
+       "invalid box description %S"],
+    _z_ =
+      [0,
+       [11,
+        cst_invalid_format,
+        [3,
+         0,
+         [11, cst_at_character_number, [4, 0, 0, 0, [11, cst$44, [2, 0, 0]]]]]],
+       "invalid format %S: at character number %d, %s"],
+    cst_unexpected_end_of_format = "unexpected end of format",
+    cst_non_zero_widths_are_unsupp =
+      "non-zero widths are unsupported for %c conversions",
+    _A_ =
+      [0,
+       [11,
+        cst_invalid_format,
+        [3,
+         0,
+         [11,
+          cst_at_character_number,
+          [4, 0, 0, 0, [11, ", '", [0, [11, "' without ", [2, 0, 0]]]]]]]],
+       "invalid format %S: at character number %d, '%c' without %s"],
+    _B_ =
+      [0,
+       [11,
+        cst_invalid_format,
+        [3,
+         0,
+         [11,
+          cst_at_character_number,
+          [4, 0, 0, 0, [11, cst$44, [2, 0, [11, " expected, read ", [1, 0]]]]]]]],
+       "invalid format %S: at character number %d, %s expected, read %C"],
+    _C_ =
+      [0,
+       [11,
+        cst_invalid_format,
+        [3,
+         0,
+         [11,
+          cst_at_character_number,
+          [4, 0, 0, 0, [11, ", duplicate flag ", [1, 0]]]]]],
+       "invalid format %S: at character number %d, duplicate flag %C"],
+    cst_padding = "padding",
+    _D_ = [0, 1, 0],
+    cst_0 = cst_0$3,
+    _E_ = [0, 0],
+    cst_precision = cst_precision$3,
+    _F_ = [1, 0],
+    _G_ = [1, 1],
+    cst_precision$0 = cst_precision$3,
+    _H_ = [1, 1],
+    cst_precision$1 = cst_precision$3,
+    cst_0$0 = cst_0$3,
+    _I_ = [1, 1],
+    cst_0$1 = cst_0$3,
+    cst_0$2 = "'0'",
+    _J_ =
+      [0,
+       [11,
+        cst_invalid_format,
+        [3,
+         0,
+         [11,
+          cst_at_character_number,
+          [4,
+           0,
+           0,
+           0,
+           [11, ', invalid conversion "', [12, 37, [0, [12, 34, 0]]]]]]]],
+       'invalid format %S: at character number %d, invalid conversion "%%%c"'],
+    _K_ = [0, 0],
+    cst_padding$0 = "`padding'",
+    _L_ = [0, 0],
+    cst_precision$2 = "`precision'",
+    _M_ =
+      [0,
+       [11,
+        cst_invalid_format,
+        [3,
+         0,
+         [11,
+          cst_at_character_number,
+          [4,
+           0,
+           0,
+           0,
+           [11,
+            ", flag ",
+            [1,
+             [11,
+              " is only allowed after the '",
+              [12, 37, [11, "', before padding and precision", 0]]]]]]]]],
+       "invalid format %S: at character number %d, flag %C is only allowed after the '%%', before padding and precision"],
+    _N_ = [0, [12, 64, 0]],
+    _O_ = [0, "@ ", 1, 0],
+    _P_ = [0, "@,", 0, 0],
+    _Q_ = [2, 60],
+    _R_ =
+      [0,
+       [11,
+        cst_invalid_format,
+        [3,
+         0,
+         [11,
+          ": '",
+          [12,
+           37,
+           [11,
+            "' alone is not accepted in character sets, use ",
+            [12,
+             37,
+             [12,
+              37,
+              [11, " instead at position ", [4, 0, 0, 0, [12, 46, 0]]]]]]]]]],
+       "invalid format %S: '%%' alone is not accepted in character sets, use %%%% instead at position %d."],
+    _S_ =
+      [0,
+       [11,
+        cst_invalid_format,
+        [3,
+         0,
+         [11,
+          ": integer ",
+          [4, 0, 0, 0, [11, " is greater than the limit ", [4, 0, 0, 0, 0]]]]]],
+       "invalid format %S: integer %d is greater than the limit %d"],
+    _T_ = [0, cst_camlinternalFormat_ml, 2837, 11],
+    cst_digit = "digit",
+    _U_ =
+      [0,
+       [11,
+        cst_invalid_format,
+        [3,
+         0,
+         [11,
+          ': unclosed sub-format, expected "',
+          [12, 37, [0, [11, '" at character number ', [4, 0, 0, 0, 0]]]]]]],
+       'invalid format %S: unclosed sub-format, expected "%%%c" at character number %d'],
+    cst_character = "character ')'",
+    cst_character$0 = "character '}'",
+    _V_ = [0, cst_camlinternalFormat_ml, 2899, 34],
+    _W_ = [0, cst_camlinternalFormat_ml, 2935, 28],
+    _X_ = [0, cst_camlinternalFormat_ml, 2957, 11],
+    _Y_ =
+      [0,
+       [11,
+        cst_invalid_format,
+        [3,
+         0,
+         [11,
+          cst_at_character_number,
+          [4,
+           0,
+           0,
+           0,
+           [11,
+            cst$44,
+            [2,
+             0,
+             [11,
+              " is incompatible with '",
+              [0, [11, "' in sub-format ", [3, 0, 0]]]]]]]]]],
+       "invalid format %S: at character number %d, %s is incompatible with '%c' in sub-format %S"],
+    _Z_ =
+      [0,
+       [11, cst_bad_input_format_type_mism, [3, 0, [11, cst_and, [3, 0, 0]]]],
+       cst_bad_input_format_type_mism$0],
+    ___ =
+      [0,
+       [11, cst_bad_input_format_type_mism, [3, 0, [11, cst_and, [3, 0, 0]]]],
+       cst_bad_input_format_type_mism$0];
    function type_padding(pad, fmtty){
      /*<<camlinternalFormat.ml:977:17>>*/ if(typeof pad === "number")
       /*<<camlinternalFormat.ml:978:21>>*/ return [0, 0, fmtty];
@@ -16019,11 +15903,11 @@
     /*<<camlinternalFormat.ml:996:54>>*/ }
    function type_format(fmt, fmtty){
      /*<<camlinternalFormat.ml:1008:19>>*/  /*<<camlinternalFormat.ml:1008:25>>*/ var
-     _da_ = type_format_gen(fmt, fmtty);
-    if(typeof _da_[2] !== "number")
+     _c$_ = type_format_gen(fmt, fmtty);
+    if(typeof _c$_[2] !== "number")
       /*<<camlinternalFormat.ml:1010:9>>*/ throw  /*<<camlinternalFormat.ml:1010:9>>*/ caml_maybe_attach_backtrace
             (Type_mismatch, 1);
-    var fmt$0 = _da_[1];
+    var fmt$0 = _c$_[1];
      /*<<camlinternalFormat.ml:1009:42>>*/ return fmt$0;
     /*<<camlinternalFormat.ml:1010:28>>*/ }
    function type_format_gen(fmt, fmtty0){
@@ -16298,7 +16182,7 @@
          fmt_rest$13 = fmt[3],
          sub_fmtty$1 = fmt[2],
          pad_opt$0 = fmt[1],
-          /*<<camlinternalFormat.ml:1099:42>>*/ _c__ =
+          /*<<camlinternalFormat.ml:1099:42>>*/ _c9_ =
            [0,
              /*<<camlinternalFormat.ml:1099:52>>*/ caml_call1
              (CamlinternalFormatBasics[2], sub_fmtty1)];
@@ -16307,7 +16191,7 @@
            ([0,
               /*<<camlinternalFormat.ml:1099:17>>*/ caml_call1
               (CamlinternalFormatBasics[2], sub_fmtty$1)],
-            _c__))
+            _c9_))
           /*<<camlinternalFormat.ml:1100:6>>*/ throw  /*<<camlinternalFormat.ml:1100:6>>*/ caml_maybe_attach_backtrace
                 (Type_mismatch, 1);
          /*<<camlinternalFormat.ml:1102:6>>*/ var
@@ -16477,12 +16361,12 @@
             /*<<camlinternalFormat.ml:1176:6>>*/ var
             sub_fmtty$3 = ign[2],
             pad_opt$2 = ign[1],
-             /*<<camlinternalFormat.ml:1176:6>>*/ _c$_ =
+             /*<<camlinternalFormat.ml:1176:6>>*/ _c__ =
               type_ignored_format_substituti(sub_fmtty$3, rest, fmtty0),
-            match$43 = _c$_[2],
+            match$43 = _c__[2],
             fmtty$21 = match$43[2],
             fmt$22 = match$43[1],
-            sub_fmtty$4 = _c$_[1];
+            sub_fmtty$4 = _c__[1];
             /*<<camlinternalFormat.ml:1177:4>>*/ return [0,
                    [23, [9, pad_opt$2, sub_fmtty$4], fmt$22],
                    fmtty$21];
@@ -16684,7 +16568,7 @@
          sub_fmtty_rest$17 = sub_fmtty[3],
          sub2_fmtty$2 = sub_fmtty[2],
          sub1_fmtty$0 = sub_fmtty[1],
-          /*<<camlinternalFormat.ml:1261:43>>*/ _c8_ =
+          /*<<camlinternalFormat.ml:1261:43>>*/ _c7_ =
            [0,
              /*<<camlinternalFormat.ml:1261:53>>*/ caml_call1
              (CamlinternalFormatBasics[2], sub1_fmtty)];
@@ -16693,11 +16577,11 @@
            ([0,
               /*<<camlinternalFormat.ml:1261:17>>*/ caml_call1
               (CamlinternalFormatBasics[2], sub1_fmtty$0)],
-            _c8_))
+            _c7_))
           /*<<camlinternalFormat.ml:1262:9>>*/ throw  /*<<camlinternalFormat.ml:1262:9>>*/ caml_maybe_attach_backtrace
                 (Type_mismatch, 1);
          /*<<camlinternalFormat.ml:1263:43>>*/  /*<<camlinternalFormat.ml:1263:43>>*/ var
-         _c9_ =
+         _c8_ =
            [0,
              /*<<camlinternalFormat.ml:1263:53>>*/ caml_call1
              (CamlinternalFormatBasics[2], sub2_fmtty$1)];
@@ -16706,7 +16590,7 @@
            ([0,
               /*<<camlinternalFormat.ml:1263:17>>*/ caml_call1
               (CamlinternalFormatBasics[2], sub2_fmtty$2)],
-            _c9_))
+            _c8_))
           /*<<camlinternalFormat.ml:1264:9>>*/ throw  /*<<camlinternalFormat.ml:1264:9>>*/ caml_maybe_attach_backtrace
                 (Type_mismatch, 1);
          /*<<camlinternalFormat.ml:1265:21>>*/ var
@@ -16798,11 +16682,11 @@
     /*<<camlinternalFormat.ml:1277:28>>*/ }
    function recast(fmt, fmtty){
      /*<<camlinternalFormat.ml:1312:2>>*/  /*<<camlinternalFormat.ml:1312:29>>*/ var
-     _c7_ = symm(fmtty);
+     _c6_ = symm(fmtty);
      /*<<camlinternalFormat.ml:1312:18>>*/ return type_format
             (fmt,
               /*<<camlinternalFormat.ml:1312:18>>*/ caml_call1
-              (CamlinternalFormatBasics[2], _c7_));
+              (CamlinternalFormatBasics[2], _c6_));
     /*<<camlinternalFormat.ml:1312:42>>*/ }
    function fix_padding(padty, width, str){
      /*<<camlinternalFormat.ml:1319:2>>*/ var
@@ -16812,10 +16696,10 @@
         /*<<camlinternalFormat.ml:1321:4>>*/ caml_call1(Stdlib[18], width);
     if(width$0 <= len)  /*<<camlinternalFormat.ml:1332:23>>*/ return str;
      /*<<camlinternalFormat.ml:1333:14>>*/ var
-     _c6_ = 2 === padty$0 ? 48 : 32,
+     _c5_ = 2 === padty$0 ? 48 : 32,
       /*<<camlinternalFormat.ml:1333:14>>*/ res =
         /*<<camlinternalFormat.ml:1333:14>>*/ caml_call2
-        (Stdlib_Bytes[1], width$0, _c6_);
+        (Stdlib_Bytes[1], width$0, _c5_);
      /*<<camlinternalFormat.ml:1334:4>>*/ switch(padty$0){
       case 0:
         /*<<camlinternalFormat.ml:1335:15>>*/  /*<<camlinternalFormat.ml:1335:15>>*/ caml_call5
@@ -17007,16 +16891,16 @@
       /*<<camlinternalFormat.ml:1447:9>>*/ return s;
      /*<<camlinternalFormat.ml:1428:14>>*/ var
       /*<<camlinternalFormat.ml:1428:14>>*/ n = [0, 0],
-     _c1_ = caml_ml_string_length(s) - 1 | 0,
-      /*<<camlinternalFormat.ml:1428:14>>*/ _c0_ = 0;
-    if(_c1_ >= 0){
-     var i$0 = _c0_;
+     _c0_ = caml_ml_string_length(s) - 1 | 0,
+      /*<<camlinternalFormat.ml:1428:14>>*/ _cZ_ = 0;
+    if(_c0_ >= 0){
+     var i$0 = _cZ_;
      for(;;){
       if(9 >= caml_string_unsafe_get(s, i$0) - 48 >>> 0) n[1]++;
        /*<<camlinternalFormat.ml:1429:6>>*/  /*<<camlinternalFormat.ml:1429:6>>*/ var
-       _c5_ = i$0 + 1 | 0;
-      if(_c1_ === i$0) break;
-      var i$0 = _c5_;
+       _c4_ = i$0 + 1 | 0;
+      if(_c0_ === i$0) break;
+      var i$0 = _c4_;
      }
     }
      /*<<camlinternalFormat.ml:1436:14>>*/ var
@@ -17034,10 +16918,10 @@
      /*<<camlinternalFormat.ml:1439:15>>*/ var
       /*<<camlinternalFormat.ml:1439:15>>*/ left =
        [0, ((digits - 1 | 0) % 3 | 0) + 1 | 0],
-     _c3_ = caml_ml_string_length(s) - 1 | 0,
-      /*<<camlinternalFormat.ml:1439:15>>*/ _c2_ = 0;
-    if(_c3_ >= 0){
-     var i = _c2_;
+     _c2_ = caml_ml_string_length(s) - 1 | 0,
+      /*<<camlinternalFormat.ml:1439:15>>*/ _c1_ = 0;
+    if(_c2_ >= 0){
+     var i = _c1_;
      for(;;){
       var c = caml_string_unsafe_get(s, i);
       if(9 < c - 48 >>> 0)
@@ -17051,9 +16935,9 @@
         /*<<camlinternalFormat.ml:1443:61>>*/ put(c);
       }
        /*<<camlinternalFormat.ml:1440:4>>*/  /*<<camlinternalFormat.ml:1440:4>>*/ var
-       _c4_ = i + 1 | 0;
-      if(_c3_ === i) break;
-      var i = _c4_;
+       _c3_ = i + 1 | 0;
+      if(_c2_ === i) break;
+      var i = _c3_;
      }
     }
      /*<<camlinternalFormat.ml:1446:4>>*/ return  /*<<camlinternalFormat.ml:1446:4>>*/ caml_call1
@@ -17062,139 +16946,139 @@
    function convert_int(iconv, n){
      /*<<camlinternalFormat.ml:1451:2>>*/ switch(iconv){
       case 1:
-       var _cZ_ = cst_d$0; break;
+       var _cY_ = cst_d$0; break;
       case 2:
-       var _cZ_ = cst_d$1; break;
+       var _cY_ = cst_d$1; break;
       case 4:
-       var _cZ_ = cst_i$1; break;
+       var _cY_ = cst_i$1; break;
       case 5:
-       var _cZ_ = cst_i$2; break;
+       var _cY_ = cst_i$2; break;
       case 6:
-       var _cZ_ = cst_x; break;
+       var _cY_ = cst_x; break;
       case 7:
-       var _cZ_ = cst_x$0; break;
+       var _cY_ = cst_x$0; break;
       case 8:
-       var _cZ_ = cst_X; break;
+       var _cY_ = cst_X; break;
       case 9:
-       var _cZ_ = cst_X$0; break;
+       var _cY_ = cst_X$0; break;
       case 10:
-       var _cZ_ = cst_o; break;
+       var _cY_ = cst_o; break;
       case 11:
-       var _cZ_ = cst_o$0; break;
+       var _cY_ = cst_o$0; break;
       case 0:
       case 13:
-       var _cZ_ = cst_d; break;
+       var _cY_ = cst_d; break;
       case 3:
       case 14:
-       var _cZ_ = cst_i$0; break;
-      default: var _cZ_ = cst_u;
+       var _cY_ = cst_i$0; break;
+      default: var _cY_ = cst_u;
     }
      /*<<camlinternalFormat.ml:1451:26>>*/ return transform_int_alt
             (iconv,
-              /*<<camlinternalFormat.ml:1451:26>>*/ caml_format_int(_cZ_, n));
+              /*<<camlinternalFormat.ml:1451:26>>*/ caml_format_int(_cY_, n));
     /*<<camlinternalFormat.ml:1451:64>>*/ }
    function convert_int32(iconv, n){
      /*<<camlinternalFormat.ml:1453:2>>*/ switch(iconv){
       case 1:
-       var _cY_ = cst_ld$0; break;
+       var _cX_ = cst_ld$0; break;
       case 2:
-       var _cY_ = cst_ld$1; break;
+       var _cX_ = cst_ld$1; break;
       case 4:
-       var _cY_ = cst_li$1; break;
+       var _cX_ = cst_li$1; break;
       case 5:
-       var _cY_ = cst_li$2; break;
+       var _cX_ = cst_li$2; break;
       case 6:
-       var _cY_ = cst_lx; break;
+       var _cX_ = cst_lx; break;
       case 7:
-       var _cY_ = cst_lx$0; break;
+       var _cX_ = cst_lx$0; break;
       case 8:
-       var _cY_ = cst_lX; break;
+       var _cX_ = cst_lX; break;
       case 9:
-       var _cY_ = cst_lX$0; break;
+       var _cX_ = cst_lX$0; break;
       case 10:
-       var _cY_ = cst_lo; break;
+       var _cX_ = cst_lo; break;
       case 11:
-       var _cY_ = cst_lo$0; break;
+       var _cX_ = cst_lo$0; break;
       case 0:
       case 13:
-       var _cY_ = cst_ld; break;
+       var _cX_ = cst_ld; break;
       case 3:
       case 14:
-       var _cY_ = cst_li$0; break;
-      default: var _cY_ = cst_lu;
+       var _cX_ = cst_li$0; break;
+      default: var _cX_ = cst_lu;
     }
      /*<<camlinternalFormat.ml:1453:26>>*/ return transform_int_alt
             (iconv,
-              /*<<camlinternalFormat.ml:1453:26>>*/ caml_format_int(_cY_, n));
+              /*<<camlinternalFormat.ml:1453:26>>*/ caml_format_int(_cX_, n));
     /*<<camlinternalFormat.ml:1453:67>>*/ }
    function convert_nativeint(iconv, n){
      /*<<camlinternalFormat.ml:1455:2>>*/ switch(iconv){
       case 1:
-       var _cX_ = cst_nd$0; break;
+       var _cW_ = cst_nd$0; break;
       case 2:
-       var _cX_ = cst_nd$1; break;
+       var _cW_ = cst_nd$1; break;
       case 4:
-       var _cX_ = cst_ni$1; break;
+       var _cW_ = cst_ni$1; break;
       case 5:
-       var _cX_ = cst_ni$2; break;
+       var _cW_ = cst_ni$2; break;
       case 6:
-       var _cX_ = cst_nx; break;
+       var _cW_ = cst_nx; break;
       case 7:
-       var _cX_ = cst_nx$0; break;
+       var _cW_ = cst_nx$0; break;
       case 8:
-       var _cX_ = cst_nX; break;
+       var _cW_ = cst_nX; break;
       case 9:
-       var _cX_ = cst_nX$0; break;
+       var _cW_ = cst_nX$0; break;
       case 10:
-       var _cX_ = cst_no; break;
+       var _cW_ = cst_no; break;
       case 11:
-       var _cX_ = cst_no$0; break;
+       var _cW_ = cst_no$0; break;
       case 0:
       case 13:
-       var _cX_ = cst_nd; break;
+       var _cW_ = cst_nd; break;
       case 3:
       case 14:
-       var _cX_ = cst_ni$0; break;
-      default: var _cX_ = cst_nu;
+       var _cW_ = cst_ni$0; break;
+      default: var _cW_ = cst_nu;
     }
      /*<<camlinternalFormat.ml:1455:26>>*/ return transform_int_alt
             (iconv,
-              /*<<camlinternalFormat.ml:1455:26>>*/ caml_format_int(_cX_, n));
+              /*<<camlinternalFormat.ml:1455:26>>*/ caml_format_int(_cW_, n));
     /*<<camlinternalFormat.ml:1455:71>>*/ }
    function convert_int64(iconv, n){
      /*<<camlinternalFormat.ml:1457:2>>*/ switch(iconv){
       case 1:
-       var _cW_ = cst_Ld$0; break;
+       var _cV_ = cst_Ld$0; break;
       case 2:
-       var _cW_ = cst_Ld$1; break;
+       var _cV_ = cst_Ld$1; break;
       case 4:
-       var _cW_ = cst_Li$1; break;
+       var _cV_ = cst_Li$1; break;
       case 5:
-       var _cW_ = cst_Li$2; break;
+       var _cV_ = cst_Li$2; break;
       case 6:
-       var _cW_ = cst_Lx; break;
+       var _cV_ = cst_Lx; break;
       case 7:
-       var _cW_ = cst_Lx$0; break;
+       var _cV_ = cst_Lx$0; break;
       case 8:
-       var _cW_ = cst_LX; break;
+       var _cV_ = cst_LX; break;
       case 9:
-       var _cW_ = cst_LX$0; break;
+       var _cV_ = cst_LX$0; break;
       case 10:
-       var _cW_ = cst_Lo; break;
+       var _cV_ = cst_Lo; break;
       case 11:
-       var _cW_ = cst_Lo$0; break;
+       var _cV_ = cst_Lo$0; break;
       case 0:
       case 13:
-       var _cW_ = cst_Ld; break;
+       var _cV_ = cst_Ld; break;
       case 3:
       case 14:
-       var _cW_ = cst_Li$0; break;
-      default: var _cW_ = cst_Lu;
+       var _cV_ = cst_Li$0; break;
+      default: var _cV_ = cst_Lu;
     }
      /*<<camlinternalFormat.ml:1457:26>>*/ return transform_int_alt
             (iconv,
               /*<<camlinternalFormat.ml:1457:26>>*/ runtime.caml_int64_format
-              (_cW_, n));
+              (_cV_, n));
     /*<<camlinternalFormat.ml:1457:67>>*/ }
    function convert_float(fconv, prec, x){
     function hex(param){
@@ -17226,41 +17110,41 @@
         i = 0;
         /*<<camlinternalFormat.ml:1472:6>>*/ for(;;){
         if(i === len)
-         var _cT_ = 0;
+         var _cS_ = 0;
         else{
           /*<<camlinternalFormat.ml:1473:14>>*/  /*<<camlinternalFormat.ml:1473:14>>*/ var
-          _cS_ =
+          _cR_ =
              /*<<camlinternalFormat.ml:1473:14>>*/ caml_string_get(str, i)
             - 46
             | 0;
          a:
          {
-          if(23 < _cS_ >>> 0){
-           if(55 === _cS_) break a;
+          if(23 < _cR_ >>> 0){
+           if(55 === _cR_) break a;
           }
-          else if(21 < _cS_ - 1 >>> 0) break a;
+          else if(21 < _cR_ - 1 >>> 0) break a;
            /*<<camlinternalFormat.ml:1475:15>>*/ var
             /*<<camlinternalFormat.ml:1475:15>>*/ i$0 = i + 1 | 0,
            i = i$0;
           continue;
          }
-         var _cT_ = 1;
+         var _cS_ = 1;
         }
          /*<<camlinternalFormat.ml:1476:7>>*/  /*<<camlinternalFormat.ml:1476:7>>*/ var
-         _cU_ =
-           _cT_
+         _cT_ =
+           _cS_
             ? str
             :  /*<<camlinternalFormat.ml:1476:32>>*/ caml_call2
               (Stdlib[28], str, cst$17);
-         /*<<camlinternalFormat.ml:1487:21>>*/ return caml_special_val(_cU_);
+         /*<<camlinternalFormat.ml:1487:21>>*/ return caml_special_val(_cT_);
        }
       case 6:
         /*<<camlinternalFormat.ml:1482:15>>*/ return hex(0);
       case 7:
         /*<<camlinternalFormat.ml:1483:38>>*/  /*<<camlinternalFormat.ml:1483:38>>*/ var
-        _cV_ = hex(0);
+        _cU_ = hex(0);
         /*<<camlinternalFormat.ml:1483:38>>*/ return  /*<<camlinternalFormat.ml:1483:38>>*/ caml_call1
-               (Stdlib_String[26], _cV_);
+               (Stdlib_String[26], _cU_);
       case 8:
         /*<<camlinternalFormat.ml:1484:33>>*/ return caml_special_val(hex(0));
       default:
@@ -17491,12 +17375,12 @@
          /*<<camlinternalFormat.ml:1573:4>>*/ return function(param){
           /*<<camlinternalFormat.ml:1573:4>>*/ var
           fmt = param[1],
-           /*<<camlinternalFormat.ml:1574:18>>*/ _cR_ = recast(fmt, fmtty);
+           /*<<camlinternalFormat.ml:1574:18>>*/ _cQ_ = recast(fmt, fmtty);
           /*<<camlinternalFormat.ml:1574:6>>*/ return make_printf
                  (k$0,
                   acc$0,
                    /*<<camlinternalFormat.ml:1574:6>>*/ caml_call2
-                   (CamlinternalFormatBasics[3], _cR_, rest$13)); /*<<camlinternalFormat.ml:1574:42>>*/ };
+                   (CamlinternalFormatBasics[3], _cQ_, rest$13)); /*<<camlinternalFormat.ml:1574:42>>*/ };
        case 15:
         var rest$14 = fmt$0[1];
          /*<<camlinternalFormat.ml:1544:4>>*/ return function(f, x){
@@ -17523,24 +17407,32 @@
          fmt$0 = rest$16;
         break;
        case 18:
-        var _cP_ = fmt$0[1];
-        if(0 === _cP_[0]){
-         var rest$17 = fmt$0[2], fmt$1 = _cP_[1][1];
-         let acc = acc$0, k$1 = k$0, rest = rest$17;
-         function k(kacc){
-           /*<<camlinternalFormat.ml:1597:6>>*/ return make_printf
-                  (k$1, [1, acc, [0, kacc]], rest);
-          /*<<camlinternalFormat.ml:1597:70>>*/ }
-         var k$0 = k, acc$0 = 0, fmt$0 = fmt$1;
+        var _cO_ = fmt$0[1];
+        if(0 === _cO_[0]){
+         var rest$17 = fmt$0[2], fmt$1 = _cO_[1][1];
+         let acc = acc$0, k = k$0, rest = rest$17;
+         var
+          k$1 =
+            function(kacc){
+              /*<<camlinternalFormat.ml:1597:6>>*/ return make_printf
+                     (k, [1, acc, [0, kacc]], rest);
+             /*<<camlinternalFormat.ml:1597:70>>*/ },
+          k$0 = k$1,
+          acc$0 = 0,
+          fmt$0 = fmt$1;
         }
         else{
-         var rest$18 = fmt$0[2], fmt$2 = _cP_[1][1];
-         let acc = acc$0, k$1 = k$0, rest = rest$18;
-         function k(kacc){
-           /*<<camlinternalFormat.ml:1601:6>>*/ return make_printf
-                  (k$1, [1, acc, [1, kacc]], rest);
-          /*<<camlinternalFormat.ml:1601:70>>*/ }
-         var k$0 = k, acc$0 = 0, fmt$0 = fmt$2;
+         var rest$18 = fmt$0[2], fmt$2 = _cO_[1][1];
+         let acc = acc$0, k = k$0, rest = rest$18;
+         var
+          k$2 =
+            function(kacc){
+              /*<<camlinternalFormat.ml:1601:6>>*/ return make_printf
+                     (k, [1, acc, [1, kacc]], rest);
+             /*<<camlinternalFormat.ml:1601:70>>*/ },
+          k$0 = k$2,
+          acc$0 = 0,
+          fmt$0 = fmt$2;
         }
         break;
        case 19:
@@ -17585,14 +17477,14 @@
          rest$23 = fmt$0[3],
          f = fmt$0[2],
          arity = fmt$0[1],
-          /*<<camlinternalFormat.ml:1548:33>>*/ _cQ_ =
+          /*<<camlinternalFormat.ml:1548:33>>*/ _cP_ =
             /*<<camlinternalFormat.ml:1548:33>>*/ caml_call1(f, 0);
          /*<<camlinternalFormat.ml:1548:33>>*/ if(counter >= 50)
           /*<<camlinternalFormat.ml:1548:33>>*/ return  /*<<camlinternalFormat.ml:1548:33>>*/ caml_trampoline_return
-                 (make_custom$0, [0, k$0, acc$0, rest$23, arity, _cQ_]);
+                 (make_custom$0, [0, k$0, acc$0, rest$23, arity, _cP_]);
         var counter$0 = counter + 1 | 0;
          /*<<camlinternalFormat.ml:1548:33>>*/ return make_custom$0
-                (counter$0, k$0, acc$0, rest$23, arity, _cQ_);
+                (counter$0, k$0, acc$0, rest$23, arity, _cP_);
      }
     }
     /*<<camlinternalFormat.ml:1605:9>>*/ }
@@ -17782,7 +17674,7 @@
                   fmt); /*<<camlinternalFormat.ml:1655:61>>*/ };
        case 10:
         var rest$9 = fmtty[1];
-         /*<<camlinternalFormat.ml:1646:31>>*/ return function(param, _cO_){
+         /*<<camlinternalFormat.ml:1646:31>>*/ return function(param, _cN_){
           /*<<camlinternalFormat.ml:1646:42>>*/ return make_from_fmtty
                  (k, acc, rest$9, fmt); /*<<camlinternalFormat.ml:1646:72>>*/ };
        case 11:
@@ -17815,13 +17707,13 @@
    }
    function make_invalid_arg(counter, k, acc, fmt){
      /*<<camlinternalFormat.ml:1663:2>>*/  /*<<camlinternalFormat.ml:1663:16>>*/ var
-     _cN_ = [8, acc, cst_Printf_bad_conversion$0];
+     _cM_ = [8, acc, cst_Printf_bad_conversion$0];
      /*<<camlinternalFormat.ml:1663:2>>*/ if(counter >= 50)
       /*<<camlinternalFormat.ml:1663:2>>*/ return  /*<<camlinternalFormat.ml:1663:2>>*/ caml_trampoline_return
-             (make_printf$0, [0, k, _cN_, fmt]);
+             (make_printf$0, [0, k, _cM_, fmt]);
     var counter$0 = counter + 1 | 0;
      /*<<camlinternalFormat.ml:1663:2>>*/ return make_printf$0
-            (counter$0, k, _cN_, fmt);
+            (counter$0, k, _cM_, fmt);
     /*<<camlinternalFormat.ml:1663:72>>*/ }
    function make_padding(k, acc, fmt, pad, trans){
      /*<<camlinternalFormat.ml:1670:29>>*/ if(typeof pad === "number")
@@ -17989,13 +17881,13 @@
                 /*<<camlinternalFormat.ml:1782:35>>*/ caml_call1(f, x)); /*<<camlinternalFormat.ml:1782:40>>*/ };
     }
      /*<<camlinternalFormat.ml:1779:33>>*/  /*<<camlinternalFormat.ml:1779:33>>*/ var
-     _cM_ = [4, acc, f];
+     _cL_ = [4, acc, f];
      /*<<camlinternalFormat.ml:1779:19>>*/ if(counter >= 50)
       /*<<camlinternalFormat.ml:1779:19>>*/ return  /*<<camlinternalFormat.ml:1779:19>>*/ caml_trampoline_return
-             (make_printf$0, [0, k, _cM_, rest]);
+             (make_printf$0, [0, k, _cL_, rest]);
     var counter$0 = counter + 1 | 0;
      /*<<camlinternalFormat.ml:1779:19>>*/ return make_printf$0
-            (counter$0, k, _cM_, rest);
+            (counter$0, k, _cL_, rest);
     /*<<camlinternalFormat.ml:1782:40>>*/ }
    function make_custom(k, acc, rest, arity, f){
      /*<<?>>*/ return caml_trampoline
@@ -18009,70 +17901,50 @@
               (k$0, o);
      switch(fmt$0[0]){
        case 0:
-         /*<<camlinternalFormat.ml:1790:14>>*/ var
-         rest = fmt$0[1],
-          /*<<camlinternalFormat.ml:1790:14>>*/ _b2_ =
-           make_iprintf(k$0, o, rest);
-         /*<<camlinternalFormat.ml:1790:14>>*/ return function(_cL_){
+        var rest = fmt$0[1], _b2_ = make_iprintf(k$0, o, rest);
+         /*<<camlinternalFormat.ml:1790:14>>*/ return function(_cK_){
           /*<<?>>*/ return _b2_;};
        case 1:
-         /*<<camlinternalFormat.ml:1792:14>>*/ var
-         rest$0 = fmt$0[1],
-          /*<<camlinternalFormat.ml:1792:14>>*/ _b3_ =
-           make_iprintf(k$0, o, rest$0);
-         /*<<camlinternalFormat.ml:1792:14>>*/ return function(_cK_){
+        var rest$0 = fmt$0[1], _b3_ = make_iprintf(k$0, o, rest$0);
+         /*<<camlinternalFormat.ml:1792:14>>*/ return function(_cJ_){
           /*<<?>>*/ return _b3_;};
        case 2:
         var _b4_ = fmt$0[1];
         if(typeof _b4_ === "number"){
-          /*<<camlinternalFormat.ml:1794:14>>*/ var
-          rest$1 = fmt$0[2],
-           /*<<camlinternalFormat.ml:1794:14>>*/ _b5_ =
-            make_iprintf(k$0, o, rest$1);
-          /*<<camlinternalFormat.ml:1794:14>>*/ return function(_cJ_){
+         var rest$1 = fmt$0[2], _b5_ = make_iprintf(k$0, o, rest$1);
+          /*<<camlinternalFormat.ml:1794:14>>*/ return function(_cI_){
            /*<<?>>*/ return _b5_;};
         }
         if(0 === _b4_[0]){
-          /*<<camlinternalFormat.ml:1796:14>>*/ var
-          rest$2 = fmt$0[2],
-           /*<<camlinternalFormat.ml:1796:14>>*/ _b6_ =
-            make_iprintf(k$0, o, rest$2);
-          /*<<camlinternalFormat.ml:1796:14>>*/ return function(_cI_){
+         var rest$2 = fmt$0[2], _b6_ = make_iprintf(k$0, o, rest$2);
+          /*<<camlinternalFormat.ml:1796:14>>*/ return function(_cH_){
            /*<<?>>*/ return _b6_;};
         }
-         /*<<camlinternalFormat.ml:1798:21>>*/ var
+         /*<<camlinternalFormat.ml:1798:14>>*/ var
          rest$3 = fmt$0[2],
-          /*<<camlinternalFormat.ml:1798:21>>*/ _b7_ =
-           make_iprintf(k$0, o, rest$3),
+         _b7_ = make_iprintf(k$0, o, rest$3),
           /*<<camlinternalFormat.ml:1798:14>>*/ _b8_ =
-           function(_cH_){ /*<<?>>*/ return _b7_;};
-         /*<<camlinternalFormat.ml:1798:14>>*/ return function(_cG_){
+           function(_cG_){ /*<<?>>*/ return _b7_;};
+         /*<<camlinternalFormat.ml:1798:14>>*/ return function(_cF_){
           /*<<?>>*/ return _b8_;};
        case 3:
         var _b9_ = fmt$0[1];
         if(typeof _b9_ === "number"){
-          /*<<camlinternalFormat.ml:1800:14>>*/ var
-          rest$4 = fmt$0[2],
-           /*<<camlinternalFormat.ml:1800:14>>*/ _b__ =
-            make_iprintf(k$0, o, rest$4);
-          /*<<camlinternalFormat.ml:1800:14>>*/ return function(_cF_){
+         var rest$4 = fmt$0[2], _b__ = make_iprintf(k$0, o, rest$4);
+          /*<<camlinternalFormat.ml:1800:14>>*/ return function(_cE_){
            /*<<?>>*/ return _b__;};
         }
         if(0 === _b9_[0]){
-          /*<<camlinternalFormat.ml:1802:14>>*/ var
-          rest$5 = fmt$0[2],
-           /*<<camlinternalFormat.ml:1802:14>>*/ _b$_ =
-            make_iprintf(k$0, o, rest$5);
-          /*<<camlinternalFormat.ml:1802:14>>*/ return function(_cE_){
+         var rest$5 = fmt$0[2], _b$_ = make_iprintf(k$0, o, rest$5);
+          /*<<camlinternalFormat.ml:1802:14>>*/ return function(_cD_){
            /*<<?>>*/ return _b$_;};
         }
-         /*<<camlinternalFormat.ml:1804:21>>*/ var
+         /*<<camlinternalFormat.ml:1804:14>>*/ var
          rest$6 = fmt$0[2],
-          /*<<camlinternalFormat.ml:1804:21>>*/ _ca_ =
-           make_iprintf(k$0, o, rest$6),
+         _ca_ = make_iprintf(k$0, o, rest$6),
           /*<<camlinternalFormat.ml:1804:14>>*/ _cb_ =
-           function(_cD_){ /*<<?>>*/ return _ca_;};
-         /*<<camlinternalFormat.ml:1804:14>>*/ return function(_cC_){
+           function(_cC_){ /*<<?>>*/ return _ca_;};
+         /*<<camlinternalFormat.ml:1804:14>>*/ return function(_cB_){
           /*<<?>>*/ return _cb_;};
        case 4:
         var rest$7 = fmt$0[4], prec = fmt$0[3], pad = fmt$0[2];
@@ -18097,28 +17969,21 @@
        case 9:
         var _cc_ = fmt$0[1];
         if(typeof _cc_ === "number"){
-          /*<<camlinternalFormat.ml:1816:14>>*/ var
-          rest$12 = fmt$0[2],
-           /*<<camlinternalFormat.ml:1816:14>>*/ _cd_ =
-            make_iprintf(k$0, o, rest$12);
-          /*<<camlinternalFormat.ml:1816:14>>*/ return function(_cB_){
+         var rest$12 = fmt$0[2], _cd_ = make_iprintf(k$0, o, rest$12);
+          /*<<camlinternalFormat.ml:1816:14>>*/ return function(_cA_){
            /*<<?>>*/ return _cd_;};
         }
         if(0 === _cc_[0]){
-          /*<<camlinternalFormat.ml:1818:14>>*/ var
-          rest$13 = fmt$0[2],
-           /*<<camlinternalFormat.ml:1818:14>>*/ _ce_ =
-            make_iprintf(k$0, o, rest$13);
-          /*<<camlinternalFormat.ml:1818:14>>*/ return function(_cA_){
+         var rest$13 = fmt$0[2], _ce_ = make_iprintf(k$0, o, rest$13);
+          /*<<camlinternalFormat.ml:1818:14>>*/ return function(_cz_){
            /*<<?>>*/ return _ce_;};
         }
-         /*<<camlinternalFormat.ml:1820:21>>*/ var
+         /*<<camlinternalFormat.ml:1820:14>>*/ var
          rest$14 = fmt$0[2],
-          /*<<camlinternalFormat.ml:1820:21>>*/ _cf_ =
-           make_iprintf(k$0, o, rest$14),
+         _cf_ = make_iprintf(k$0, o, rest$14),
           /*<<camlinternalFormat.ml:1820:14>>*/ _cg_ =
-           function(_cz_){ /*<<?>>*/ return _cf_;};
-         /*<<camlinternalFormat.ml:1820:14>>*/ return function(_cy_){
+           function(_cy_){ /*<<?>>*/ return _cf_;};
+         /*<<camlinternalFormat.ml:1820:14>>*/ return function(_cx_){
           /*<<?>>*/ return _cg_;};
        case 10:
         var rest$15 = fmt$0[1], fmt$0 = rest$15; break;
@@ -18127,38 +17992,31 @@
        case 12:
         var rest$17 = fmt$0[2], fmt$0 = rest$17; break;
        case 13:
-         /*<<camlinternalFormat.ml:1838:14>>*/ var
-         rest$18 = fmt$0[3],
-          /*<<camlinternalFormat.ml:1838:14>>*/ _ch_ =
-           make_iprintf(k$0, o, rest$18);
-         /*<<camlinternalFormat.ml:1838:14>>*/ return function(_cx_){
+        var rest$18 = fmt$0[3], _ch_ = make_iprintf(k$0, o, rest$18);
+         /*<<camlinternalFormat.ml:1838:14>>*/ return function(_cw_){
           /*<<?>>*/ return _ch_;};
        case 14:
         var rest$19 = fmt$0[3], fmtty = fmt$0[2];
          /*<<camlinternalFormat.ml:1840:8>>*/ return function(param){
           /*<<camlinternalFormat.ml:1840:8>>*/ var
           fmt = param[1],
-           /*<<camlinternalFormat.ml:1842:24>>*/ _cw_ = recast(fmt, fmtty);
+           /*<<camlinternalFormat.ml:1842:24>>*/ _cv_ = recast(fmt, fmtty);
           /*<<camlinternalFormat.ml:1842:12>>*/ return make_iprintf
                  (k$0,
                   o,
                    /*<<camlinternalFormat.ml:1842:12>>*/ caml_call2
-                   (CamlinternalFormatBasics[3], _cw_, rest$19)); /*<<camlinternalFormat.ml:1842:48>>*/ };
+                   (CamlinternalFormatBasics[3], _cv_, rest$19)); /*<<camlinternalFormat.ml:1842:48>>*/ };
        case 15:
-         /*<<camlinternalFormat.ml:1822:21>>*/ var
+         /*<<camlinternalFormat.ml:1822:14>>*/ var
          rest$20 = fmt$0[1],
-          /*<<camlinternalFormat.ml:1822:21>>*/ _ci_ =
-           make_iprintf(k$0, o, rest$20),
+         _ci_ = make_iprintf(k$0, o, rest$20),
           /*<<camlinternalFormat.ml:1822:14>>*/ _cj_ =
-           function(_cv_){ /*<<?>>*/ return _ci_;};
-         /*<<camlinternalFormat.ml:1822:14>>*/ return function(_cu_){
+           function(_cu_){ /*<<?>>*/ return _ci_;};
+         /*<<camlinternalFormat.ml:1822:14>>*/ return function(_ct_){
           /*<<?>>*/ return _cj_;};
        case 16:
-         /*<<camlinternalFormat.ml:1824:14>>*/ var
-         rest$21 = fmt$0[1],
-          /*<<camlinternalFormat.ml:1824:14>>*/ _ck_ =
-           make_iprintf(k$0, o, rest$21);
-         /*<<camlinternalFormat.ml:1824:14>>*/ return function(_ct_){
+        var rest$21 = fmt$0[1], _ck_ = make_iprintf(k$0, o, rest$21);
+         /*<<camlinternalFormat.ml:1824:14>>*/ return function(_cs_){
           /*<<?>>*/ return _ck_;};
        case 17:
         var rest$22 = fmt$0[2], fmt$0 = rest$22; break;
@@ -18166,55 +18024,52 @@
         var _cl_ = fmt$0[1];
         if(0 === _cl_[0]){
          var rest$23 = fmt$0[2], fmt$1 = _cl_[1][1];
-         let k$1 = k$0, rest = rest$23;
-         function k(koc){
-           /*<<camlinternalFormat.ml:1854:33>>*/ return make_iprintf
-                  (k$1, koc, rest);
-          /*<<camlinternalFormat.ml:1854:56>>*/ }
-         var k$0 = k, fmt$0 = fmt$1;
+         let k = k$0, rest = rest$23;
+         var
+          k$1 =
+            function(koc){
+              /*<<camlinternalFormat.ml:1854:33>>*/ return make_iprintf
+                     (k, koc, rest);
+             /*<<camlinternalFormat.ml:1854:56>>*/ },
+          k$0 = k$1,
+          fmt$0 = fmt$1;
         }
         else{
          var rest$24 = fmt$0[2], fmt$2 = _cl_[1][1];
-         let k$1 = k$0, rest = rest$24;
-         function k(koc){
-           /*<<camlinternalFormat.ml:1856:33>>*/ return make_iprintf
-                  (k$1, koc, rest);
-          /*<<camlinternalFormat.ml:1856:56>>*/ }
-         var k$0 = k, fmt$0 = fmt$2;
+         let k = k$0, rest = rest$24;
+         var
+          k$2 =
+            function(koc){
+              /*<<camlinternalFormat.ml:1856:33>>*/ return make_iprintf
+                     (k, koc, rest);
+             /*<<camlinternalFormat.ml:1856:56>>*/ },
+          k$0 = k$2,
+          fmt$0 = fmt$2;
         }
         break;
        case 19:
          /*<<camlinternalFormat.ml:1830:8>>*/ throw  /*<<camlinternalFormat.ml:1830:8>>*/ caml_maybe_attach_backtrace
                ([0, Assert_failure, _w_], 1);
        case 20:
-         /*<<camlinternalFormat.ml:1844:14>>*/ var
-         rest$25 = fmt$0[3],
-          /*<<camlinternalFormat.ml:1844:14>>*/ _cm_ =
-           make_iprintf(k$0, o, rest$25);
-         /*<<camlinternalFormat.ml:1844:14>>*/ return function(_cs_){
+        var rest$25 = fmt$0[3], _cm_ = make_iprintf(k$0, o, rest$25);
+         /*<<camlinternalFormat.ml:1844:14>>*/ return function(_cr_){
           /*<<?>>*/ return _cm_;};
        case 21:
-         /*<<camlinternalFormat.ml:1846:14>>*/ var
-         rest$26 = fmt$0[2],
-          /*<<camlinternalFormat.ml:1846:14>>*/ _cn_ =
-           make_iprintf(k$0, o, rest$26);
-         /*<<camlinternalFormat.ml:1846:14>>*/ return function(_cr_){
+        var rest$26 = fmt$0[2], _cn_ = make_iprintf(k$0, o, rest$26);
+         /*<<camlinternalFormat.ml:1846:14>>*/ return function(_cq_){
           /*<<?>>*/ return _cn_;};
        case 22:
-         /*<<camlinternalFormat.ml:1848:14>>*/ var
-         rest$27 = fmt$0[1],
-          /*<<camlinternalFormat.ml:1848:14>>*/ _co_ =
-           make_iprintf(k$0, o, rest$27);
-         /*<<camlinternalFormat.ml:1848:14>>*/ return function(_cq_){
+        var rest$27 = fmt$0[1], _co_ = make_iprintf(k$0, o, rest$27);
+         /*<<camlinternalFormat.ml:1848:14>>*/ return function(_cp_){
           /*<<?>>*/ return _co_;};
        case 23:
-        var rest$28 = fmt$0[2], ign = fmt$0[1], _cp_ = 0;
+        var rest$28 = fmt$0[2], ign = fmt$0[1];
          /*<<camlinternalFormat.ml:1850:8>>*/ return make_ignored_param
                 (function(param){
                    /*<<camlinternalFormat.ml:1850:37>>*/ return caml_call1
                           (k$0, o);
                   /*<<camlinternalFormat.ml:1850:40>>*/ },
-                 _cp_,
+                 0,
                  ign,
                  rest$28);
        default:
@@ -18234,55 +18089,51 @@
    function fn_of_padding_precision(k, o, fmt, pad, prec){
      /*<<camlinternalFormat.ml:1863:26>>*/ if(typeof pad === "number"){
      if(typeof prec !== "number"){
-       /*<<camlinternalFormat.ml:1867:14>>*/  /*<<camlinternalFormat.ml:1867:14>>*/ var
-       _bB_ = make_iprintf(k, o, fmt);
+      var _bB_ = make_iprintf(k, o, fmt);
        /*<<camlinternalFormat.ml:1867:14>>*/ return function(_b1_){
         /*<<?>>*/ return _bB_;};
      }
      if(prec){
-       /*<<camlinternalFormat.ml:1869:21>>*/ var
-        /*<<camlinternalFormat.ml:1869:21>>*/ _by_ = make_iprintf(k, o, fmt),
+       /*<<camlinternalFormat.ml:1869:14>>*/ var
+       _by_ = make_iprintf(k, o, fmt),
         /*<<camlinternalFormat.ml:1869:14>>*/ _bz_ =
          function(_b0_){ /*<<?>>*/ return _by_;};
        /*<<camlinternalFormat.ml:1869:14>>*/ return function(_bZ_){
         /*<<?>>*/ return _bz_;};
      }
-      /*<<camlinternalFormat.ml:1865:14>>*/  /*<<camlinternalFormat.ml:1865:14>>*/ var
-      _bA_ = make_iprintf(k, o, fmt);
+     var _bA_ = make_iprintf(k, o, fmt);
       /*<<camlinternalFormat.ml:1865:14>>*/ return function(_bY_){
        /*<<?>>*/ return _bA_;};
     }
     if(0 === pad[0]){
      if(typeof prec !== "number"){
-       /*<<camlinternalFormat.ml:1873:14>>*/  /*<<camlinternalFormat.ml:1873:14>>*/ var
-       _bF_ = make_iprintf(k, o, fmt);
+      var _bF_ = make_iprintf(k, o, fmt);
        /*<<camlinternalFormat.ml:1873:14>>*/ return function(_bX_){
         /*<<?>>*/ return _bF_;};
      }
      if(prec){
-       /*<<camlinternalFormat.ml:1875:21>>*/ var
-        /*<<camlinternalFormat.ml:1875:21>>*/ _bC_ = make_iprintf(k, o, fmt),
+       /*<<camlinternalFormat.ml:1875:14>>*/ var
+       _bC_ = make_iprintf(k, o, fmt),
         /*<<camlinternalFormat.ml:1875:14>>*/ _bD_ =
          function(_bW_){ /*<<?>>*/ return _bC_;};
        /*<<camlinternalFormat.ml:1875:14>>*/ return function(_bV_){
         /*<<?>>*/ return _bD_;};
      }
-      /*<<camlinternalFormat.ml:1871:14>>*/  /*<<camlinternalFormat.ml:1871:14>>*/ var
-      _bE_ = make_iprintf(k, o, fmt);
+     var _bE_ = make_iprintf(k, o, fmt);
       /*<<camlinternalFormat.ml:1871:14>>*/ return function(_bU_){
        /*<<?>>*/ return _bE_;};
     }
     if(typeof prec !== "number"){
-      /*<<camlinternalFormat.ml:1879:21>>*/ var
-       /*<<camlinternalFormat.ml:1879:21>>*/ _bL_ = make_iprintf(k, o, fmt),
+      /*<<camlinternalFormat.ml:1879:14>>*/ var
+      _bL_ = make_iprintf(k, o, fmt),
        /*<<camlinternalFormat.ml:1879:14>>*/ _bM_ =
         function(_bT_){ /*<<?>>*/ return _bL_;};
       /*<<camlinternalFormat.ml:1879:14>>*/ return function(_bS_){
        /*<<?>>*/ return _bM_;};
     }
     if(prec){
-      /*<<camlinternalFormat.ml:1881:28>>*/ var
-       /*<<camlinternalFormat.ml:1881:28>>*/ _bG_ = make_iprintf(k, o, fmt),
+      /*<<camlinternalFormat.ml:1881:21>>*/ var
+      _bG_ = make_iprintf(k, o, fmt),
        /*<<camlinternalFormat.ml:1881:21>>*/ _bH_ =
         function(_bR_){ /*<<?>>*/ return _bG_;},
        /*<<camlinternalFormat.ml:1881:14>>*/ _bI_ =
@@ -18290,8 +18141,7 @@
       /*<<camlinternalFormat.ml:1881:14>>*/ return function(_bP_){
        /*<<?>>*/ return _bI_;};
     }
-     /*<<camlinternalFormat.ml:1877:21>>*/  /*<<camlinternalFormat.ml:1877:21>>*/ var
-     _bJ_ = make_iprintf(k, o, fmt);
+    var _bJ_ = make_iprintf(k, o, fmt);
      /*<<camlinternalFormat.ml:1877:14>>*/ function _bK_(_bO_){
       /*<<?>>*/ return _bJ_;
     }
@@ -18300,10 +18150,7 @@
     /*<<camlinternalFormat.ml:1881:52>>*/ }
    function fn_of_custom_arity$0(counter, k, o, fmt, param){
      /*<<?>>*/ if(param){
-      /*<<camlinternalFormat.ml:1889:14>>*/ var
-      arity = param[1],
-       /*<<camlinternalFormat.ml:1889:14>>*/ _bw_ =
-        fn_of_custom_arity(k, o, fmt, arity);
+     var arity = param[1], _bw_ = fn_of_custom_arity(k, o, fmt, arity);
       /*<<camlinternalFormat.ml:1889:14>>*/ return function(_bx_){
        /*<<?>>*/ return _bw_;};
     }
@@ -20488,28 +20335,28 @@
     CamlinternalFormat = global_data.CamlinternalFormat,
     Stdlib = global_data.Stdlib;
    function kfprintf(k, o, param){
-     /*<<printf.ml:20:2>>*/ var
-     fmt = param[1],
-      /*<<printf.ml:20:2>>*/ _g_ = 0;
-    function _h_(acc){
-      /*<<printf.ml:20:26>>*/  /*<<printf.ml:20:26>>*/ caml_call2
-      (CamlinternalFormat[9], o, acc);
-     return caml_call1(k, o);
-     /*<<printf.ml:20:47>>*/ }
+    var fmt = param[1];
      /*<<printf.ml:20:2>>*/ return  /*<<printf.ml:20:2>>*/ caml_call3
-            (CamlinternalFormat[7], _h_, _g_, fmt);
+            (CamlinternalFormat[7],
+             function(acc){
+               /*<<printf.ml:20:26>>*/  /*<<printf.ml:20:26>>*/ caml_call2
+               (CamlinternalFormat[9], o, acc);
+              return caml_call1(k, o);
+              /*<<printf.ml:20:47>>*/ },
+             0,
+             fmt);
    }
    function kbprintf(k, b, param){
-     /*<<printf.ml:22:2>>*/ var
-     fmt = param[1],
-      /*<<printf.ml:22:2>>*/ _e_ = 0;
-    function _f_(acc){
-      /*<<printf.ml:22:26>>*/  /*<<printf.ml:22:26>>*/ caml_call2
-      (CamlinternalFormat[10], b, acc);
-     return caml_call1(k, b);
-     /*<<printf.ml:22:47>>*/ }
+    var fmt = param[1];
      /*<<printf.ml:22:2>>*/ return  /*<<printf.ml:22:2>>*/ caml_call3
-            (CamlinternalFormat[7], _f_, _e_, fmt);
+            (CamlinternalFormat[7],
+             function(acc){
+               /*<<printf.ml:22:26>>*/  /*<<printf.ml:22:26>>*/ caml_call2
+               (CamlinternalFormat[10], b, acc);
+              return caml_call1(k, b);
+              /*<<printf.ml:22:47>>*/ },
+             0,
+             fmt);
    }
    function ikfprintf(k, oc, param){
     var fmt = param[1];
@@ -20656,61 +20503,22 @@
      /*<<arg.ml:50:0>>*/ Bad = [248, "Stdlib.Arg.Bad", caml_fresh_oo_id(0)],
      /*<<arg.ml:51:0>>*/ Help = [248, "Stdlib.Arg.Help", caml_fresh_oo_id(0)],
      /*<<arg.ml:59:0>>*/ Stop = [248, "Stdlib.Arg.Stop", caml_fresh_oo_id(0)],
-    _v_ = [0, [2, 0, [0, 0]], "%s%c"],
-    _p_ = [0, [2, 0, 0], cst_s],
-    _q_ = [0, [2, 0, 0], cst_s],
-    _n_ = [0, [2, 0, 0], cst_s],
-    _o_ = [0, [2, 0, 0], cst_s],
-    _l_ = [0, [2, 0, 0], cst_s],
-    _m_ = [0, [2, 0, 0], cst_s],
-    cst_a_boolean = "a boolean",
-    cst_an_integer = cst_an_integer$1,
-    cst_an_integer$0 = cst_an_integer$1,
-    cst_a_float = cst_a_float$1,
-    cst_a_float$0 = cst_a_float$1,
-    cst_one_of = "one of: ",
-    cst_Arg_Expand_is_is_only_allo =
-      "Arg.Expand is is only allowed with Arg.parse_and_expand_argv_dynamic",
-    cst_no_argument = "no argument",
-    _f_ =
-      [0,
-       [2, 0, [11, ": unknown option '", [2, 0, [11, "'.\n", 0]]]],
-       "%s: unknown option '%s'.\n"],
-    _i_ =
-      [0,
-       [2,
-        0,
-        [11,
-         ": wrong argument '",
-         [2,
-          0,
-          [11,
-           "'; option '",
-           [2, 0, [11, "' expects ", [2, 0, [11, cst$9, 0]]]]]]]],
-       "%s: wrong argument '%s'; option '%s' expects %s.\n"],
-    _j_ =
-      [0,
-       [2, 0, [11, ": option '", [2, 0, [11, "' needs an argument.\n", 0]]]],
-       "%s: option '%s' needs an argument.\n"],
-    _k_ = [0, [2, 0, [11, ": ", [2, 0, [11, cst$9, 0]]]], "%s: %s.\n"],
-    _g_ = [0, cst_help$3],
-    _h_ = [0, cst_help$4],
-    _e_ = [0, [2, 0, 0], cst_s],
-    _d_ = [0, [2, 0, [12, 10, 0]], "%s\n"],
-    cst_help$2 = cst_help$3,
-    cst_Display_this_list_of_optio = cst_Display_this_list_of_optio$1,
-    cst_help = cst_help$3,
-    cst_help$1 = cst_help$4,
-    cst_Display_this_list_of_optio$0 = cst_Display_this_list_of_optio$1,
-    cst_help$0 = cst_help$4,
-    _c_ = [0, cst_help$3],
+    cst_none = "<none>",
     _a_ =
       [0, [11, cst$10, [2, 0, [12, 32, [2, 0, [12, 10, 0]]]]], "  %s %s\n"],
     _b_ =
       [0,
        [11, cst$10, [2, 0, [12, 32, [2, 0, [2, 0, [12, 10, 0]]]]]],
        "  %s %s%s\n"],
-    cst_none = "<none>";
+    _c_ = [0, cst_help$3],
+    cst_Display_this_list_of_optio = cst_Display_this_list_of_optio$1,
+    cst_help = cst_help$3,
+    cst_Display_this_list_of_optio$0 = cst_Display_this_list_of_optio$1,
+    cst_help$0 = cst_help$4,
+    cst_help$1 = cst_help$4,
+    cst_help$2 = cst_help$3,
+    _d_ = [0, [2, 0, [12, 10, 0]], "%s\n"],
+    _e_ = [0, [2, 0, 0], cst_s];
    function assoc3(x, l){
      /*<<arg.ml:64:2>>*/ var l$0 = l;
      /*<<arg.ml:64:2>>*/ for(;;){
@@ -20728,18 +20536,21 @@
      /*<<arg.ml:79:53>>*/ var
      t = l[2],
      h = l[1],
-      /*<<arg.ml:79:53>>*/ _aD_ =
-        /*<<arg.ml:79:53>>*/ caml_call2(Stdlib[28], prefix, h);
-    function _aE_(x, y){
-      /*<<arg.ml:79:40>>*/  /*<<arg.ml:79:44>>*/ var
-      _aG_ =  /*<<arg.ml:79:44>>*/ caml_call2(Stdlib[28], sep, y);
-      /*<<arg.ml:79:44>>*/ return  /*<<arg.ml:79:44>>*/ caml_call2
-             (Stdlib[28], x, _aG_);
-     /*<<arg.ml:79:51>>*/ }
-     /*<<arg.ml:79:12>>*/  /*<<arg.ml:79:12>>*/ var
-     _aF_ =  /*<<arg.ml:79:12>>*/ caml_call3(Stdlib_List[26], _aE_, _aD_, t);
+      /*<<arg.ml:79:53>>*/ _az_ =
+        /*<<arg.ml:79:53>>*/ caml_call2(Stdlib[28], prefix, h),
+      /*<<arg.ml:79:12>>*/ _aA_ =
+        /*<<arg.ml:79:12>>*/ caml_call3
+        (Stdlib_List[26],
+         function(x, y){
+           /*<<arg.ml:79:40>>*/  /*<<arg.ml:79:44>>*/ var
+           _aB_ =  /*<<arg.ml:79:44>>*/ caml_call2(Stdlib[28], sep, y);
+           /*<<arg.ml:79:44>>*/ return  /*<<arg.ml:79:44>>*/ caml_call2
+                  (Stdlib[28], x, _aB_);
+          /*<<arg.ml:79:51>>*/ },
+         _az_,
+         t);
      /*<<arg.ml:79:12>>*/ return  /*<<arg.ml:79:12>>*/ caml_call2
-            (Stdlib[28], _aF_, suffix);
+            (Stdlib[28], _aA_, suffix);
     /*<<arg.ml:79:77>>*/ }
    function help_action(param){
      /*<<arg.ml:91:21>>*/ throw  /*<<arg.ml:91:21>>*/ caml_maybe_attach_backtrace
@@ -20748,11 +20559,11 @@
    function add_help(speclist){
      /*<<arg.ml:94:2>>*/ try{
       /*<<arg.ml:95:15>>*/ assoc3(cst_help$2, speclist);
-      /*<<arg.ml:95:42>>*/ var  /*<<arg.ml:95:42>>*/ _aA_ = 0, add1 = _aA_;
+      /*<<arg.ml:95:42>>*/ var  /*<<arg.ml:95:42>>*/ _aw_ = 0, add1 = _aw_;
     }
-    catch(_aC_){
-     var _aw_ = caml_wrap_exception(_aC_);
-     if(_aw_ !== Stdlib[8]) throw caml_maybe_attach_backtrace(_aw_, 0);
+    catch(_ay_){
+     var _as_ = caml_wrap_exception(_ay_);
+     if(_as_ !== Stdlib[8]) throw caml_maybe_attach_backtrace(_as_, 0);
      var
       add1 =
         [0,
@@ -20761,11 +20572,11 @@
     }
     try{
       /*<<arg.ml:99:15>>*/ assoc3(cst_help$1, speclist);
-      /*<<arg.ml:99:43>>*/ var  /*<<arg.ml:99:43>>*/ _az_ = 0, add2 = _az_;
+      /*<<arg.ml:99:43>>*/ var  /*<<arg.ml:99:43>>*/ _av_ = 0, add2 = _av_;
     }
-    catch(_aB_){
-     var _ax_ = caml_wrap_exception(_aB_);
-     if(_ax_ !== Stdlib[8]) throw caml_maybe_attach_backtrace(_ax_, 0);
+    catch(_ax_){
+     var _at_ = caml_wrap_exception(_ax_);
+     if(_at_ !== Stdlib[8]) throw caml_maybe_attach_backtrace(_at_, 0);
      var
       add2 =
         [0,
@@ -20773,33 +20584,35 @@
          0];
     }
      /*<<arg.ml:103:13>>*/  /*<<arg.ml:103:13>>*/ var
-     _ay_ =  /*<<arg.ml:103:13>>*/ caml_call2(Stdlib[37], add1, add2);
+     _au_ =  /*<<arg.ml:103:13>>*/ caml_call2(Stdlib[37], add1, add2);
      /*<<arg.ml:103:13>>*/ return  /*<<arg.ml:103:13>>*/ caml_call2
-            (Stdlib[37], speclist, _ay_);
+            (Stdlib[37], speclist, _au_);
     /*<<arg.ml:103:26>>*/ }
    function usage_b(buf, speclist, errmsg){
      /*<<arg.ml:107:2>>*/  /*<<arg.ml:107:2>>*/ caml_call3
      (Stdlib_Printf[5], buf, _d_, errmsg);
      /*<<arg.ml:108:29>>*/  /*<<arg.ml:108:29>>*/ var
-     _as_ = add_help(speclist);
-     /*<<arg.ml:108:12>>*/ function _at_(param){
-     var
-      doc = param[3],
-      spec = param[2],
-      key = param[1],
-      _au_ = 0 <  /*<<arg.ml:83:2>>*/ caml_ml_string_length(doc) ? 1 : 0;
-     if(! _au_) return _au_;
-     if(11 !== spec[0])
-       /*<<arg.ml:88:8>>*/ return  /*<<arg.ml:88:8>>*/ caml_call4
-              (Stdlib_Printf[5], buf, _a_, key, doc);
-      /*<<arg.ml:86:38>>*/ var
-      l = spec[1],
-       /*<<arg.ml:86:38>>*/ _av_ = make_symlist(cst$1, cst$0, cst, l);
-      /*<<arg.ml:86:8>>*/ return  /*<<arg.ml:86:8>>*/ caml_call5
-             (Stdlib_Printf[5], buf, _b_, key, _av_, doc);
-    }
+     _ap_ = add_help(speclist);
      /*<<arg.ml:108:29>>*/ return  /*<<arg.ml:108:29>>*/ caml_call2
-            (Stdlib_List[18], _at_, _as_);
+            (Stdlib_List[18],
+             function(param){
+              var
+               doc = param[3],
+               spec = param[2],
+               key = param[1],
+               _aq_ =
+                 0 <  /*<<arg.ml:83:2>>*/ caml_ml_string_length(doc) ? 1 : 0;
+              if(! _aq_) return _aq_;
+              if(11 !== spec[0])
+                /*<<arg.ml:88:8>>*/ return  /*<<arg.ml:88:8>>*/ caml_call4
+                       (Stdlib_Printf[5], buf, _a_, key, doc);
+               /*<<arg.ml:86:38>>*/ var
+               l = spec[1],
+                /*<<arg.ml:86:38>>*/ _ar_ = make_symlist(cst$1, cst$0, cst, l);
+               /*<<arg.ml:86:8>>*/ return  /*<<arg.ml:86:8>>*/ caml_call5
+                      (Stdlib_Printf[5], buf, _b_, key, _ar_, doc);
+             },
+             _ap_);
     /*<<arg.ml:108:48>>*/ }
    function usage_string(speclist, errmsg){
      /*<<arg.ml:112:2>>*/  /*<<arg.ml:112:10>>*/ var
@@ -20810,33 +20623,72 @@
     /*<<arg.ml:114:19>>*/ }
    function usage(speclist, errmsg){
      /*<<arg.ml:118:2>>*/  /*<<arg.ml:118:15>>*/ var
-     _ar_ = usage_string(speclist, errmsg);
+     _ao_ = usage_string(speclist, errmsg);
      /*<<arg.ml:118:15>>*/ return  /*<<arg.ml:118:15>>*/ caml_call2
-            (Stdlib_Printf[3], _e_, _ar_);
+            (Stdlib_Printf[3], _e_, _ao_);
     /*<<arg.ml:118:45>>*/ }
-    /*<<arg.ml:121:14>>*/  /*<<arg.ml:121:14>>*/ var current = [0, 0];
+    /*<<arg.ml:121:14>>*/ var
+     /*<<arg.ml:121:14>>*/ current = [0, 0],
+    _f_ =
+      [0,
+       [2, 0, [11, ": unknown option '", [2, 0, [11, "'.\n", 0]]]],
+       "%s: unknown option '%s'.\n"],
+    _g_ = [0, cst_help$3],
+    _h_ = [0, cst_help$4],
+    _i_ =
+      [0,
+       [2,
+        0,
+        [11,
+         ": wrong argument '",
+         [2,
+          0,
+          [11,
+           "'; option '",
+           [2, 0, [11, "' expects ", [2, 0, [11, cst$9, 0]]]]]]]],
+       "%s: wrong argument '%s'; option '%s' expects %s.\n"],
+    _j_ =
+      [0,
+       [2, 0, [11, ": option '", [2, 0, [11, "' needs an argument.\n", 0]]]],
+       "%s: option '%s' needs an argument.\n"],
+    _k_ = [0, [2, 0, [11, ": ", [2, 0, [11, cst$9, 0]]]], "%s: %s.\n"],
+    cst_no_argument = "no argument",
+    cst_a_boolean = "a boolean",
+    cst_an_integer = cst_an_integer$1,
+    cst_an_integer$0 = cst_an_integer$1,
+    cst_a_float = cst_a_float$1,
+    cst_a_float$0 = cst_a_float$1,
+    cst_one_of = "one of: ",
+    cst_Arg_Expand_is_is_only_allo =
+      "Arg.Expand is is only allowed with Arg.parse_and_expand_argv_dynamic",
+    _l_ = [0, [2, 0, 0], cst_s],
+    _m_ = [0, [2, 0, 0], cst_s],
+    _n_ = [0, [2, 0, 0], cst_s],
+    _o_ = [0, [2, 0, 0], cst_s],
+    _p_ = [0, [2, 0, 0], cst_s],
+    _q_ = [0, [2, 0, 0], cst_s];
    function int_of_string_opt(x){
      /*<<arg.ml:128:2>>*/ try{
       /*<<arg.ml:128:6>>*/  /*<<arg.ml:128:6>>*/ var
-      _ap_ = [0,  /*<<arg.ml:128:11>>*/ runtime.caml_int_of_string(x)];
-      /*<<arg.ml:128:6>>*/ return _ap_;
+      _am_ = [0,  /*<<arg.ml:128:11>>*/ runtime.caml_int_of_string(x)];
+      /*<<arg.ml:128:6>>*/ return _am_;
     }
-    catch(_aq_){
-     var _ao_ = caml_wrap_exception(_aq_);
-     if(_ao_[1] === Stdlib[7])  /*<<arg.ml:129:20>>*/ return 0;
-     throw caml_maybe_attach_backtrace(_ao_, 0);
+    catch(_an_){
+     var _al_ = caml_wrap_exception(_an_);
+     if(_al_[1] === Stdlib[7])  /*<<arg.ml:129:20>>*/ return 0;
+     throw caml_maybe_attach_backtrace(_al_, 0);
     }
     /*<<arg.ml:129:24>>*/ }
    function float_of_string_opt(x){
      /*<<arg.ml:132:2>>*/ try{
       /*<<arg.ml:132:6>>*/  /*<<arg.ml:132:6>>*/ var
-      _am_ = [0,  /*<<arg.ml:132:11>>*/ runtime.caml_float_of_string(x)];
-      /*<<arg.ml:132:6>>*/ return _am_;
+      _aj_ = [0,  /*<<arg.ml:132:11>>*/ runtime.caml_float_of_string(x)];
+      /*<<arg.ml:132:6>>*/ return _aj_;
     }
-    catch(_an_){
-     var _al_ = caml_wrap_exception(_an_);
-     if(_al_[1] === Stdlib[7])  /*<<arg.ml:133:20>>*/ return 0;
-     throw caml_maybe_attach_backtrace(_al_, 0);
+    catch(_ak_){
+     var _ai_ = caml_wrap_exception(_ak_);
+     if(_ai_[1] === Stdlib[7])  /*<<arg.ml:133:20>>*/ return 0;
+     throw caml_maybe_attach_backtrace(_ai_, 0);
     }
     /*<<arg.ml:133:24>>*/ }
    function parse_and_expand_argv_dynamic_
@@ -20891,20 +20743,20 @@
      if(current[1] >= argv[1].length - 1) return 0;
       /*<<arg.ml:166:4>>*/ try{
        /*<<arg.ml:167:14>>*/ var
-       _Y_ = current[1],
-        /*<<arg.ml:167:14>>*/ s = caml_check_bound(argv[1], _Y_)[1 + _Y_];
+       _V_ = current[1],
+        /*<<arg.ml:167:14>>*/ s = caml_check_bound(argv[1], _V_)[1 + _V_];
        /*<<arg.ml:168:9>>*/ if
        ( /*<<arg.ml:168:9>>*/ caml_call2(Stdlib_String[11], cst$3, s)){
        try{
          /*<<arg.ml:170:14>>*/ var
          follow$1 = 0,
-          /*<<arg.ml:170:14>>*/ _aa_ = assoc3(s, speclist[1]),
+          /*<<arg.ml:170:14>>*/ _Z_ = assoc3(s, speclist[1]),
          follow$0 = follow$1,
-         action = _aa_;
+         action = _Z_;
        }
-       catch(_aj_){
-        var _Z_ = caml_wrap_exception(_aj_);
-        if(_Z_ !== Stdlib[8]) throw caml_maybe_attach_backtrace(_Z_, 0);
+       catch(_ag_){
+        var _W_ = caml_wrap_exception(_ag_);
+        if(_W_ !== Stdlib[8]) throw caml_maybe_attach_backtrace(_W_, 0);
          /*<<arg.ml:172:10>>*/ try{
           /*<<arg.ml:71:10>>*/ var
            /*<<arg.ml:71:10>>*/ i =
@@ -20917,16 +20769,16 @@
            /*<<arg.ml:73:2>>*/ keyword =
              /*<<arg.ml:73:2>>*/ caml_call3(Stdlib_String[16], s, 0, i),
            /*<<arg.ml:174:38>>*/ follow = [0, arg],
-           /*<<arg.ml:174:12>>*/ _$_ = assoc3(keyword, speclist[1]),
+           /*<<arg.ml:174:12>>*/ _Y_ = assoc3(keyword, speclist[1]),
           follow$0 = follow,
-          action = _$_;
+          action = _Y_;
         }
-        catch(_ak_){
-         var ___ = caml_wrap_exception(_ak_);
-         if(___ === Stdlib[8])
+        catch(_ah_){
+         var _X_ = caml_wrap_exception(_ah_);
+         if(_X_ === Stdlib[8])
            /*<<arg.ml:175:28>>*/ throw  /*<<arg.ml:175:28>>*/ caml_maybe_attach_backtrace
                  ([0, Stop, [0, s]], 1);
-         throw caml_maybe_attach_backtrace(___, 0);
+         throw caml_maybe_attach_backtrace(_X_, 0);
         }
        }
        let s$0 = s, follow$2 = follow$0;
@@ -20944,9 +20796,9 @@
         if((current[1] + 1 | 0) >= argv[1].length - 1)
           /*<<arg.ml:185:19>>*/ throw  /*<<arg.ml:185:19>>*/ caml_maybe_attach_backtrace
                 ([0, Stop, [2, s$0]], 1);
-        var _ai_ = current[1] + 1 | 0;
-         /*<<arg.ml:184:58>>*/ return caml_check_bound(argv[1], _ai_)
-                [1 + _ai_];
+        var _af_ = current[1] + 1 | 0;
+         /*<<arg.ml:184:58>>*/ return caml_check_bound(argv[1], _af_)
+                [1 + _af_];
         /*<<arg.ml:186:27>>*/ }
        function consume_arg(param){
          /*<<arg.ml:189:10>>*/ return follow$2 ? 0 : (current[1]++, 0);
@@ -20964,14 +20816,14 @@
              /*<<arg.ml:196:22>>*/ arg = get_arg(0);
             /*<<arg.ml:124:2>>*/ try{
              /*<<arg.ml:124:6>>*/ var
-              /*<<arg.ml:124:6>>*/ _ac_ =
+              /*<<arg.ml:124:6>>*/ _$_ =
                [0,  /*<<arg.ml:124:11>>*/ caml_call1(Stdlib[32], arg)],
-             match = _ac_;
+             match = _$_;
            }
-           catch(_ah_){
-            var _ab_ = caml_wrap_exception(_ah_);
-            if(_ab_[1] !== Stdlib[6])
-             throw caml_maybe_attach_backtrace(_ab_, 0);
+           catch(_ae_){
+            var ___ = caml_wrap_exception(_ae_);
+            if(___[1] !== Stdlib[6])
+             throw caml_maybe_attach_backtrace(___, 0);
             var match = 0;
            }
            if(! match)
@@ -21062,7 +20914,7 @@
              /*<<arg.ml:211:14>>*/ return consume_arg(0);
            }
             /*<<arg.ml:215:44>>*/  /*<<arg.ml:215:44>>*/ var
-            _ad_ = make_symlist(cst$6, cst$5, cst$4, symb);
+            _aa_ = make_symlist(cst$6, cst$5, cst$4, symb);
             /*<<arg.ml:213:21>>*/ throw  /*<<arg.ml:213:21>>*/ caml_maybe_attach_backtrace
                   ([0,
                     Stop,
@@ -21070,16 +20922,16 @@
                      s$0,
                      arg$5,
                       /*<<arg.ml:214:42>>*/ caml_call2
-                      (Stdlib[28], cst_one_of, _ad_)]],
+                      (Stdlib[28], cst_one_of, _aa_)]],
                    1);
           case 12:
            var f$5 = param[1];
             /*<<arg.ml:252:12>>*/ no_arg(0);
             /*<<arg.ml:255:14>>*/ for(;;){
             if(current[1] >= (argv[1].length - 1 - 1 | 0)) return 0;
-            var _ae_ = current[1] + 1 | 0;
+            var _ab_ = current[1] + 1 | 0;
              /*<<arg.ml:254:14>>*/  /*<<arg.ml:254:14>>*/ caml_call1
-             (f$5, caml_check_bound(argv[1], _ae_)[1 + _ae_]);
+             (f$5, caml_check_bound(argv[1], _ab_)[1 + _ab_]);
              /*<<arg.ml:255:14>>*/ consume_arg(0);
            }
            break;
@@ -21092,8 +20944,8 @@
               /*<<arg.ml:264:14>>*/ return  /*<<arg.ml:264:14>>*/ caml_call1
                      (f$6,
                        /*<<arg.ml:264:14>>*/ caml_call1(Stdlib_List[10], acc[1]));
-            var _ag_ = current[1] + 1 | 0, _af_ = acc[1];
-            acc[1] = [0, caml_check_bound(argv[1], _ag_)[1 + _ag_], _af_];
+            var _ad_ = current[1] + 1 | 0, _ac_ = acc[1];
+            acc[1] = [0, caml_check_bound(argv[1], _ad_)[1 + _ad_], _ac_];
              /*<<arg.ml:262:14>>*/ consume_arg(0);
            }
            break;
@@ -21167,8 +21019,8 @@
    function parse(l, f, msg){
      /*<<arg.ml:299:2>>*/ try{
       /*<<arg.ml:300:4>>*/  /*<<arg.ml:300:4>>*/ var
-      _X_ = parse_argv(0, caml_sys_argv(0), l, f, msg);
-      /*<<arg.ml:300:4>>*/ return _X_;
+      _U_ = parse_argv(0, caml_sys_argv(0), l, f, msg);
+      /*<<arg.ml:300:4>>*/ return _U_;
     }
     catch(exn$0){
      var exn = caml_wrap_exception(exn$0);
@@ -21190,8 +21042,8 @@
    function parse_dynamic(l, f, msg){
      /*<<arg.ml:307:2>>*/ try{
       /*<<arg.ml:308:4>>*/  /*<<arg.ml:308:4>>*/ var
-      _W_ = parse_argv_dynamic(0, caml_sys_argv(0), l, f, msg);
-      /*<<arg.ml:308:4>>*/ return _W_;
+      _T_ = parse_argv_dynamic(0, caml_sys_argv(0), l, f, msg);
+      /*<<arg.ml:308:4>>*/ return _T_;
     }
     catch(exn$0){
      var exn = caml_wrap_exception(exn$0);
@@ -21216,9 +21068,9 @@
        /*<<arg.ml:315:15>>*/ argv = [0, caml_sys_argv(0)],
        /*<<arg.ml:316:15>>*/ spec = [0, l],
        /*<<arg.ml:317:18>>*/ current$0 = [0, current[1]],
-       /*<<arg.ml:318:4>>*/ _V_ =
+       /*<<arg.ml:318:4>>*/ _S_ =
         parse_and_expand_argv_dynamic(current$0, argv, spec, f, msg);
-      /*<<arg.ml:318:4>>*/ return _V_;
+      /*<<arg.ml:318:4>>*/ return _S_;
     }
     catch(exn$0){
      var exn = caml_wrap_exception(exn$0);
@@ -21255,17 +21107,17 @@
       /*<<arg.ml:331:8>>*/  /*<<arg.ml:331:8>>*/ var
       n$0 =  /*<<arg.ml:331:8>>*/ caml_call2(Stdlib_String[36], s, 9);
     }
-    catch(_T_){
-     var _R_ = caml_wrap_exception(_T_);
-     if(_R_ !== Stdlib[8]) throw caml_maybe_attach_backtrace(_R_, 0);
+    catch(_Q_){
+     var _O_ = caml_wrap_exception(_Q_);
+     if(_O_ !== Stdlib[8]) throw caml_maybe_attach_backtrace(_O_, 0);
       /*<<arg.ml:334:6>>*/ try{
        /*<<arg.ml:334:18>>*/  /*<<arg.ml:334:18>>*/ var
        n =  /*<<arg.ml:334:18>>*/ caml_call2(Stdlib_String[36], s, 32);
      }
-     catch(_U_){
-      var _S_ = caml_wrap_exception(_U_);
-      if(_S_ === Stdlib[8])  /*<<arg.ml:336:31>>*/ return len;
-      throw caml_maybe_attach_backtrace(_S_, 0);
+     catch(_R_){
+      var _P_ = caml_wrap_exception(_R_);
+      if(_P_ === Stdlib[8])  /*<<arg.ml:336:31>>*/ return len;
+      throw caml_maybe_attach_backtrace(_P_, 0);
      }
       /*<<arg.ml:334:18>>*/ return loop(n + 1 | 0);
     }
@@ -21275,20 +21127,21 @@
     var doc = param[3], spec = param[2], kwd = param[1];
      /*<<arg.ml:341:2>>*/ if(11 === spec[0])
      return caml_call2(Stdlib_Int[11], cur, caml_ml_string_length(kwd));
-    var _Q_ = caml_ml_string_length(kwd) + second_word(doc) | 0;
-    return caml_call2(Stdlib_Int[11], cur, _Q_);
+    var _N_ = caml_ml_string_length(kwd) + second_word(doc) | 0;
+    return caml_call2(Stdlib_Int[11], cur, _N_);
    }
    function replace_leading_tab(s){
      /*<<arg.ml:347:2>>*/  /*<<arg.ml:347:13>>*/ var seen = [0, 0];
-    function _P_(c){
-      /*<<arg.ml:348:13>>*/ if(9 === c && ! seen[1]){
-      seen[1] = 1;
-       /*<<arg.ml:348:60>>*/ return 32;
-     }
-      /*<<arg.ml:348:71>>*/ return c;
-     /*<<arg.ml:348:73>>*/ }
      /*<<arg.ml:348:2>>*/ return  /*<<arg.ml:348:2>>*/ caml_call2
-            (Stdlib_String[18], _P_, s);
+            (Stdlib_String[18],
+             function(c){
+               /*<<arg.ml:348:13>>*/ if(9 === c && ! seen[1]){
+               seen[1] = 1;
+                /*<<arg.ml:348:60>>*/ return 32;
+              }
+               /*<<arg.ml:348:71>>*/ return c;
+              /*<<arg.ml:348:73>>*/ },
+             s);
     /*<<arg.ml:348:75>>*/ }
    function align(opt, speclist){
      /*<<arg.ml:374:2>>*/ if(opt)
@@ -21302,59 +21155,64 @@
         (Stdlib_List[26], max_arg_len, 0, completed),
       /*<<arg.ml:376:12>>*/ len$0 =
         /*<<arg.ml:376:12>>*/ caml_call2(Stdlib_Int[10], len, limit);
-     /*<<arg.ml:377:11>>*/ function _J_(ksd){
-     var kwd = ksd[1], spec = ksd[2];
-     if(! caml_string_notequal(ksd[3], cst$8))
-       /*<<arg.ml:355:6>>*/ return ksd;
-     if(11 === spec[0]){
-       /*<<arg.ml:357:19>>*/ var
-       msg$0 = ksd[3],
-        /*<<arg.ml:357:19>>*/ cutcol$0 = second_word(msg$0),
-        /*<<arg.ml:358:32>>*/ _M_ =
-          /*<<arg.ml:358:32>>*/ caml_call2
-          (Stdlib_Int[11], 0, len$0 - cutcol$0 | 0)
-         + 3
-         | 0,
-        /*<<arg.ml:358:19>>*/ spaces$0 =
-          /*<<arg.ml:358:19>>*/ caml_call2(Stdlib_String[1], _M_, 32),
-        /*<<arg.ml:359:34>>*/ _N_ = replace_leading_tab(msg$0),
-        /*<<arg.ml:359:25>>*/ _O_ =
-          /*<<arg.ml:359:25>>*/ caml_call2(Stdlib[28], spaces$0, _N_);
-       /*<<arg.ml:359:6>>*/ return [0,
-              kwd,
-              spec,
-               /*<<arg.ml:359:18>>*/ caml_call2(Stdlib[28], cst$7, _O_)];
-     }
-      /*<<arg.ml:361:19>>*/ var
-      msg = ksd[3],
-      spec$0 = ksd[2],
-       /*<<arg.ml:361:19>>*/ cutcol = second_word(msg),
-       /*<<arg.ml:362:6>>*/ kwd_len =
-         /*<<arg.ml:362:6>>*/ caml_ml_string_length(kwd),
-      diff = (len$0 - kwd_len | 0) - cutcol | 0;
-      /*<<arg.ml:364:6>>*/ if(0 >= diff)
-       /*<<arg.ml:365:8>>*/ return [0, kwd, spec$0, replace_leading_tab(msg)];
-      /*<<arg.ml:367:21>>*/ var
-       /*<<arg.ml:367:21>>*/ spaces =
-         /*<<arg.ml:367:21>>*/ caml_call2(Stdlib_String[1], diff, 32),
-       /*<<arg.ml:368:32>>*/ _K_ = replace_leading_tab(msg),
-       /*<<arg.ml:368:21>>*/ prefix =
-         /*<<arg.ml:368:21>>*/ caml_call3(Stdlib_String[16], _K_, 0, cutcol),
-       /*<<arg.ml:369:21>>*/ suffix =
-         /*<<arg.ml:369:21>>*/ caml_call3
-         (Stdlib_String[16],
-          msg,
-          cutcol,
-          caml_ml_string_length(msg) - cutcol | 0),
-       /*<<arg.ml:370:29>>*/ _L_ =
-         /*<<arg.ml:370:29>>*/ caml_call2(Stdlib[28], spaces, suffix);
-      /*<<arg.ml:370:8>>*/ return [0,
-             kwd,
-             spec$0,
-              /*<<arg.ml:370:20>>*/ caml_call2(Stdlib[28], prefix, _L_)];
-    }
      /*<<arg.ml:377:2>>*/ return  /*<<arg.ml:377:2>>*/ caml_call2
-            (Stdlib_List[20], _J_, completed);
+            (Stdlib_List[20],
+             function(ksd){
+              var kwd = ksd[1], spec = ksd[2];
+              if(! caml_string_notequal(ksd[3], cst$8))
+                /*<<arg.ml:355:6>>*/ return ksd;
+              if(11 === spec[0]){
+                /*<<arg.ml:357:19>>*/ var
+                msg$0 = ksd[3],
+                 /*<<arg.ml:357:19>>*/ cutcol$0 = second_word(msg$0),
+                 /*<<arg.ml:358:32>>*/ _K_ =
+                   /*<<arg.ml:358:32>>*/ caml_call2
+                   (Stdlib_Int[11], 0, len$0 - cutcol$0 | 0)
+                  + 3
+                  | 0,
+                 /*<<arg.ml:358:19>>*/ spaces$0 =
+                   /*<<arg.ml:358:19>>*/ caml_call2(Stdlib_String[1], _K_, 32),
+                 /*<<arg.ml:359:34>>*/ _L_ = replace_leading_tab(msg$0),
+                 /*<<arg.ml:359:25>>*/ _M_ =
+                   /*<<arg.ml:359:25>>*/ caml_call2(Stdlib[28], spaces$0, _L_);
+                /*<<arg.ml:359:6>>*/ return [0,
+                       kwd,
+                       spec,
+                        /*<<arg.ml:359:18>>*/ caml_call2(Stdlib[28], cst$7, _M_)];
+              }
+               /*<<arg.ml:361:19>>*/ var
+               msg = ksd[3],
+               spec$0 = ksd[2],
+                /*<<arg.ml:361:19>>*/ cutcol = second_word(msg),
+                /*<<arg.ml:362:6>>*/ kwd_len =
+                  /*<<arg.ml:362:6>>*/ caml_ml_string_length(kwd),
+               diff = (len$0 - kwd_len | 0) - cutcol | 0;
+               /*<<arg.ml:364:6>>*/ if(0 >= diff)
+                /*<<arg.ml:365:8>>*/ return [0,
+                       kwd,
+                       spec$0,
+                       replace_leading_tab(msg)];
+               /*<<arg.ml:367:21>>*/ var
+                /*<<arg.ml:367:21>>*/ spaces =
+                  /*<<arg.ml:367:21>>*/ caml_call2(Stdlib_String[1], diff, 32),
+                /*<<arg.ml:368:32>>*/ _I_ = replace_leading_tab(msg),
+                /*<<arg.ml:368:21>>*/ prefix =
+                  /*<<arg.ml:368:21>>*/ caml_call3
+                  (Stdlib_String[16], _I_, 0, cutcol),
+                /*<<arg.ml:369:21>>*/ suffix =
+                  /*<<arg.ml:369:21>>*/ caml_call3
+                  (Stdlib_String[16],
+                   msg,
+                   cutcol,
+                   caml_ml_string_length(msg) - cutcol | 0),
+                /*<<arg.ml:370:29>>*/ _J_ =
+                  /*<<arg.ml:370:29>>*/ caml_call2(Stdlib[28], spaces, suffix);
+               /*<<arg.ml:370:8>>*/ return [0,
+                      kwd,
+                      spec$0,
+                       /*<<arg.ml:370:20>>*/ caml_call2(Stdlib[28], prefix, _J_)];
+             },
+             completed);
     /*<<arg.ml:377:38>>*/ }
    function read_aux(trim, sep, file){
      /*<<arg.ml:387:2>>*/ var
@@ -21374,14 +21232,14 @@
         (0 < len
          && 13 ===  /*<<arg.ml:381:16>>*/ caml_string_get(word, len - 1 | 0)){
         var
-         _I_ =
+         _H_ =
             /*<<arg.ml:382:4>>*/ caml_call3
             (Stdlib_String[16], word, 0, len - 1 | 0);
         break a;
        }
-       var _I_ = word;
+       var _H_ = word;
       }
-      var word$0 = _I_;
+      var word$0 = _H_;
      }
      else
       var word$0 = word;
@@ -21400,35 +21258,36 @@
         (Stdlib_Buffer[12], buf, c);
      }
     }
-    catch(_H_){
-     var _F_ = caml_wrap_exception(_H_);
-     if(_F_ !== Stdlib[12]) throw caml_maybe_attach_backtrace(_F_, 0);
+    catch(_G_){
+     var _E_ = caml_wrap_exception(_G_);
+     if(_E_ !== Stdlib[12]) throw caml_maybe_attach_backtrace(_E_, 0);
      if(0 <  /*<<arg.ml:403:5>>*/ caml_call1(Stdlib_Buffer[7], buf))
        /*<<arg.ml:403:32>>*/ stash(0);
       /*<<arg.ml:404:2>>*/  /*<<arg.ml:404:2>>*/ caml_call1(Stdlib[93], ic);
       /*<<arg.ml:405:16>>*/  /*<<arg.ml:405:16>>*/ var
-      _G_ =  /*<<arg.ml:405:16>>*/ caml_call1(Stdlib_List[10], words[1]);
+      _F_ =  /*<<arg.ml:405:16>>*/ caml_call1(Stdlib_List[10], words[1]);
       /*<<arg.ml:405:16>>*/ return  /*<<arg.ml:405:16>>*/ caml_call1
-             (Stdlib_Array[10], _G_);
+             (Stdlib_Array[10], _F_);
     }
     /*<<arg.ml:405:33>>*/ }
    var _r_ = 10, _s_ = 1;
-    /*<<arg.ml:407:15>>*/ function read_arg(_E_){
-     /*<<?>>*/ return read_aux(_s_, _r_, _E_);
+    /*<<arg.ml:407:15>>*/ function read_arg(_D_){
+     /*<<?>>*/ return read_aux(_s_, _r_, _D_);
    }
-    /*<<arg.ml:407:15>>*/ var  /*<<arg.ml:407:15>>*/ _t_ = 0, _u_ = 0;
-    /*<<arg.ml:409:16>>*/ function read_arg0(_D_){
-     /*<<?>>*/ return read_aux(_u_, _t_, _D_);
+   var _t_ = 0, _u_ = 0, _v_ = [0, [2, 0, [0, 0]], "%s%c"];
+    /*<<arg.ml:409:16>>*/ function read_arg0(_C_){
+     /*<<?>>*/ return read_aux(_u_, _t_, _C_);
    }
    function write_aux(sep, file, args){
      /*<<arg.ml:412:2>>*/  /*<<arg.ml:412:11>>*/ var
      oc =  /*<<arg.ml:412:11>>*/ caml_call1(Stdlib[61], file);
-    function _C_(s){
-      /*<<arg.ml:413:23>>*/ return caml_call4
-             (Stdlib_Printf[1], oc, _v_, s, sep);
-     /*<<arg.ml:413:46>>*/ }
      /*<<arg.ml:413:2>>*/  /*<<arg.ml:413:2>>*/ caml_call2
-     (Stdlib_Array[11], _C_, args);
+     (Stdlib_Array[11],
+      function(s){
+        /*<<arg.ml:413:23>>*/ return caml_call4
+               (Stdlib_Printf[1], oc, _v_, s, sep);
+       /*<<arg.ml:413:46>>*/ },
+      args);
      /*<<arg.ml:413:2>>*/ return  /*<<arg.ml:413:2>>*/ caml_call1
             (Stdlib[76], oc);
     /*<<arg.ml:414:14>>*/ }
@@ -21436,7 +21295,7 @@
     /*<<arg.ml:416:16>>*/ function write_arg(_A_, _B_){
      /*<<?>>*/ return write_aux(_w_, _A_, _B_);
    }
-    /*<<arg.ml:416:16>>*/  /*<<arg.ml:416:16>>*/ var _x_ = 0;
+   var _x_ = 0;
     /*<<arg.ml:418:17>>*/ function write_arg0(_y_, _z_){
      /*<<?>>*/ return write_aux(_x_, _y_, _z_);
    }
@@ -21541,30 +21400,24 @@
     Stdlib_Obj = global_data.Stdlib__Obj,
      /*<<printexc.ml:20:15>>*/ printers =
        /*<<printexc.ml:20:15>>*/ caml_call1(Stdlib_Atomic[1], 0),
+    _a_ = [0, [3, 0, 0], "%S"],
+    _b_ = [0, [4, 0, 0, 0, 0], "%d"],
     _c_ = [0, [11, ", ", [2, 0, [2, 0, 0]]], ", %s%s"],
-    _o_ =
+    _d_ = [0, [12, 40, [2, 0, [2, 0, [12, 41, 0]]]], "(%s%s)"],
+    _e_ = [0, [12, 40, [2, 0, [12, 41, 0]]], "(%s)"],
+    cst_Out_of_memory = "Out of memory",
+    cst_Stack_overflow = "Stack overflow",
+    cst_Pattern_matching_failed = "Pattern matching failed",
+    cst_Assertion_failed = "Assertion failed",
+    cst_Undefined_recursive_module = "Undefined recursive module",
+    _f_ =
       [0,
-       [11, cst_Fatal_error_exception, [2, 0, [12, 10, 0]]],
-       cst_Fatal_error_exception_s],
-    _p_ =
+       [11, cst_Uncaught_exception, [2, 0, [12, 10, 0]]],
+       cst_Uncaught_exception_s],
+    _g_ =
       [0,
-       [11,
-        "Fatal error in uncaught exception handler: exception ",
-        [2, 0, [12, 10, 0]]],
-       "Fatal error in uncaught exception handler: exception %s\n"],
-    cst_Fatal_error_out_of_memory_ =
-      "Fatal error: out of memory in uncaught exception handler",
-    _n_ =
-      [0,
-       [11, cst_Fatal_error_exception, [2, 0, [12, 10, 0]]],
-       cst_Fatal_error_exception_s],
-    _l_ = [0, [2, 0, [12, 10, 0]], cst_s],
-    cst_Program_not_linked_with_g_ = cst_Program_not_linked_with_g_$0,
-    _j_ = [0, [2, 0, [12, 10, 0]], cst_s],
-    _k_ =
-      [0,
-       [11, cst_Program_not_linked_with_g_$0, 0],
-       cst_Program_not_linked_with_g_$0],
+       [11, cst_Uncaught_exception, [2, 0, [12, 10, 0]]],
+       cst_Uncaught_exception_s],
     cst_Raised_at = "Raised at",
     cst_Re_raised_at = "Re-raised at",
     cst_Raised_by_primitive_operat = "Raised by primitive operation at",
@@ -21589,30 +21442,13 @@
               [11, ", line ", [4, 0, 0, 0, [11, cst_characters, partial]]]]]]]]]],
        '%s %s in file "%s"%s, line %d, characters %d-%d'],
     _i_ = [0, [2, 0, [11, " unknown location", 0]], "%s unknown location"],
-    _g_ =
+    _j_ = [0, [2, 0, [12, 10, 0]], cst_s],
+    _k_ =
       [0,
-       [11, cst_Uncaught_exception, [2, 0, [12, 10, 0]]],
-       cst_Uncaught_exception_s],
-    _f_ =
-      [0,
-       [11, cst_Uncaught_exception, [2, 0, [12, 10, 0]]],
-       cst_Uncaught_exception_s],
-    cst_Out_of_memory = "Out of memory",
-    cst_Stack_overflow = "Stack overflow",
-    cst_Pattern_matching_failed = "Pattern matching failed",
-    cst_Assertion_failed = "Assertion failed",
-    cst_Undefined_recursive_module = "Undefined recursive module",
-    _d_ = [0, [12, 40, [2, 0, [2, 0, [12, 41, 0]]]], "(%s%s)"],
-    _e_ = [0, [12, 40, [2, 0, [12, 41, 0]]], "(%s)"],
-    _b_ = [0, [4, 0, 0, 0, 0], "%d"],
-    _a_ = [0, [3, 0, 0], "%S"],
-    _m_ =
-      [0,
-       cst$4,
-       "(Cannot print locations:\n bytecode executable program file not found)",
-       "(Cannot print locations:\n bytecode executable program file appears to be corrupt)",
-       "(Cannot print locations:\n bytecode executable program file has wrong magic number)",
-       "(Cannot print locations:\n bytecode executable program file cannot be opened;\n -- too many open files. Try running with OCAMLRUNPARAM=b=2)"];
+       [11, cst_Program_not_linked_with_g_$0, 0],
+       cst_Program_not_linked_with_g_$0],
+    _l_ = [0, [2, 0, [12, 10, 0]], cst_s],
+    cst_Program_not_linked_with_g_ = cst_Program_not_linked_with_g_$0;
    function field(x, i){
      /*<<printexc.ml:25:2>>*/  /*<<printexc.ml:25:10>>*/ var f = x[1 + i];
      /*<<printexc.ml:26:9>>*/ if
@@ -21620,13 +21456,13 @@
       /*<<printexc.ml:27:4>>*/ return  /*<<printexc.ml:27:4>>*/ caml_call2
              (Stdlib_Printf[4], _b_, f);
      /*<<printexc.ml:28:7>>*/  /*<<printexc.ml:28:7>>*/ var
-     _al_ = Stdlib_Obj[15];
-    if( /*<<printexc.ml:28:10>>*/ caml_obj_tag(f) === _al_)
+     _ag_ = Stdlib_Obj[15];
+    if( /*<<printexc.ml:28:10>>*/ caml_obj_tag(f) === _ag_)
       /*<<printexc.ml:29:4>>*/ return  /*<<printexc.ml:29:4>>*/ caml_call2
              (Stdlib_Printf[4], _a_, f);
      /*<<printexc.ml:30:7>>*/  /*<<printexc.ml:30:7>>*/ var
-     _am_ = Stdlib_Obj[16];
-    return  /*<<printexc.ml:30:10>>*/ caml_obj_tag(f) === _am_
+     _ah_ = Stdlib_Obj[16];
+    return  /*<<printexc.ml:30:10>>*/ caml_obj_tag(f) === _ah_
             ?  /*<<printexc.ml:31:4>>*/ caml_call1(Stdlib[35], f)
             : cst;
     /*<<printexc.ml:33:7>>*/ }
@@ -21634,10 +21470,10 @@
      /*<<printexc.ml:36:2>>*/ if(x.length - 1 <= i)
       /*<<printexc.ml:36:26>>*/ return cst$0;
      /*<<printexc.ml:37:36>>*/ var
-      /*<<printexc.ml:37:36>>*/ _aj_ = other_fields(x, i + 1 | 0),
-      /*<<printexc.ml:37:24>>*/ _ak_ = field(x, i);
+      /*<<printexc.ml:37:36>>*/ _ae_ = other_fields(x, i + 1 | 0),
+      /*<<printexc.ml:37:24>>*/ _af_ = field(x, i);
      /*<<printexc.ml:37:36>>*/ return  /*<<printexc.ml:37:36>>*/ caml_call3
-            (Stdlib_Printf[4], _c_, _ak_, _aj_);
+            (Stdlib_Printf[4], _c_, _af_, _ae_);
     /*<<printexc.ml:37:58>>*/ }
    function use_printers(x){
      /*<<printexc.ml:47:2>>*/ var
@@ -21651,7 +21487,7 @@
         /*<<printexc.ml:49:15>>*/  /*<<printexc.ml:49:15>>*/ var
         val =  /*<<printexc.ml:49:15>>*/ caml_call1(hd, x);
       }
-      catch(_ai_){break a;}
+      catch(_ad_){break a;}
       if(val){var s = val[1];  /*<<printexc.ml:51:21>>*/ return [0, s];}
      }
      var param = tl;
@@ -21665,24 +21501,24 @@
       match = t.length - 1;
      if(2 < match >>> 0)
        /*<<printexc.ml:44:38>>*/ var
-        /*<<printexc.ml:44:38>>*/ _ae_ = other_fields(t, 2),
-        /*<<printexc.ml:44:26>>*/ _af_ = field(t, 1),
-       _ah_ =
+        /*<<printexc.ml:44:38>>*/ _$_ = other_fields(t, 2),
+        /*<<printexc.ml:44:26>>*/ _aa_ = field(t, 1),
+       _ac_ =
           /*<<printexc.ml:44:38>>*/ caml_call3
-          (Stdlib_Printf[4], _d_, _af_, _ae_);
+          (Stdlib_Printf[4], _d_, _aa_, _$_);
      else
       switch(match){
         case 0:
-         var _ah_ = cst$1; break;
+         var _ac_ = cst$1; break;
         case 1:
-         var _ah_ = cst$2; break;
+         var _ac_ = cst$2; break;
         default:
           /*<<printexc.ml:43:24>>*/ var
-           /*<<printexc.ml:43:24>>*/ _ag_ = field(t, 1),
-          _ah_ =
-             /*<<printexc.ml:43:24>>*/ caml_call2(Stdlib_Printf[4], _e_, _ag_);
+           /*<<printexc.ml:43:24>>*/ _ab_ = field(t, 1),
+          _ac_ =
+             /*<<printexc.ml:43:24>>*/ caml_call2(Stdlib_Printf[4], _e_, _ab_);
       }
-     var match$0 = [0, constructor, [0, _ah_]];
+     var match$0 = [0, constructor, [0, _ac_]];
     }
     else
      var match$0 = [0, t[1], 0];
@@ -21749,15 +21585,15 @@
    function print(fct, arg){
      /*<<printexc.ml:87:2>>*/ try{
       /*<<printexc.ml:88:4>>*/  /*<<printexc.ml:88:4>>*/ var
-      _ad_ =  /*<<printexc.ml:88:4>>*/ caml_call1(fct, arg);
-      /*<<printexc.ml:88:4>>*/ return _ad_;
+      ___ =  /*<<printexc.ml:88:4>>*/ caml_call1(fct, arg);
+      /*<<printexc.ml:88:4>>*/ return ___;
     }
     catch(x$0){
       /*<<printexc.ml:90:39>>*/ var
       x = caml_wrap_exception(x$0),
-       /*<<printexc.ml:90:39>>*/ _ac_ = to_string(x);
+       /*<<printexc.ml:90:39>>*/ _Z_ = to_string(x);
       /*<<printexc.ml:90:4>>*/  /*<<printexc.ml:90:4>>*/ caml_call2
-      (Stdlib_Printf[3], _f_, _ac_);
+      (Stdlib_Printf[3], _f_, _Z_);
       /*<<printexc.ml:91:4>>*/  /*<<printexc.ml:91:4>>*/ caml_call1
       (Stdlib[63], Stdlib[40]);
       /*<<printexc.ml:92:4>>*/ throw  /*<<printexc.ml:92:4>>*/ caml_maybe_attach_backtrace
@@ -21767,17 +21603,17 @@
    function catch$0(fct, arg){
      /*<<printexc.ml:95:2>>*/ try{
       /*<<printexc.ml:96:4>>*/  /*<<printexc.ml:96:4>>*/ var
-      _ab_ =  /*<<printexc.ml:96:4>>*/ caml_call1(fct, arg);
-      /*<<printexc.ml:96:4>>*/ return _ab_;
+      _Y_ =  /*<<printexc.ml:96:4>>*/ caml_call1(fct, arg);
+      /*<<printexc.ml:96:4>>*/ return _Y_;
     }
     catch(x$0){
      var x = caml_wrap_exception(x$0);
       /*<<printexc.ml:98:4>>*/  /*<<printexc.ml:98:4>>*/ caml_call1
       (Stdlib[63], Stdlib[39]);
       /*<<printexc.ml:99:39>>*/  /*<<printexc.ml:99:39>>*/ var
-      _aa_ = to_string(x);
+      _X_ = to_string(x);
       /*<<printexc.ml:99:4>>*/  /*<<printexc.ml:99:4>>*/ caml_call2
-      (Stdlib_Printf[3], _g_, _aa_);
+      (Stdlib_Printf[3], _g_, _X_);
       /*<<printexc.ml:99:4>>*/ return  /*<<printexc.ml:99:4>>*/ caml_call1
              (Stdlib[99], 2);
     }
@@ -21797,21 +21633,21 @@
      /*<<printexc.ml:149:75>>*/ }
      /*<<printexc.ml:151:2>>*/ if(0 === slot[0]){
       /*<<printexc.ml:159:14>>*/ var
-      _U_ = slot[5],
-      _V_ = slot[4],
-      _W_ = slot[3],
-      _X_ = slot[6] ? cst_inlined : cst$3,
-      _Y_ = slot[2],
-      _Z_ = slot[7],
-       /*<<printexc.ml:159:14>>*/ ___ = info(slot[1]);
+      _P_ = slot[5],
+      _Q_ = slot[4],
+      _R_ = slot[3],
+      _S_ = slot[6] ? cst_inlined : cst$3,
+      _T_ = slot[2],
+      _U_ = slot[7],
+       /*<<printexc.ml:159:14>>*/ _V_ = info(slot[1]);
       /*<<printexc.ml:158:6>>*/ return [0,
               /*<<printexc.ml:158:11>>*/ caml_call8
-              (Stdlib_Printf[4], _h_, ___, _Z_, _Y_, _X_, _W_, _V_, _U_)];
+              (Stdlib_Printf[4], _h_, _V_, _U_, _T_, _S_, _R_, _Q_, _P_)];
     }
     if(slot[1])  /*<<printexc.ml:154:50>>*/ return 0;
-     /*<<printexc.ml:156:44>>*/  /*<<printexc.ml:156:44>>*/ var _$_ = info(0);
+     /*<<printexc.ml:156:44>>*/  /*<<printexc.ml:156:44>>*/ var _W_ = info(0);
      /*<<printexc.ml:156:8>>*/ return [0,
-             /*<<printexc.ml:156:13>>*/ caml_call2(Stdlib_Printf[4], _i_, _$_)];
+             /*<<printexc.ml:156:13>>*/ caml_call2(Stdlib_Printf[4], _i_, _W_)];
     /*<<printexc.ml:161:52>>*/ }
    function print_raw_backtrace(outchan, raw_backtrace){
      /*<<printexc.ml:176:2>>*/  /*<<printexc.ml:176:36>>*/ var
@@ -21819,9 +21655,9 @@
     if(! backtrace)
       /*<<printexc.ml:166:6>>*/ return  /*<<printexc.ml:166:6>>*/ caml_call2
              (Stdlib_Printf[1], outchan, _k_);
-    var a = backtrace[1], _S_ = a.length - 1 - 1 | 0, _R_ = 0;
-    if(_S_ >= 0){
-     var i = _R_;
+    var a = backtrace[1], _N_ = a.length - 1 - 1 | 0, _M_ = 0;
+    if(_N_ >= 0){
+     var i = _M_;
      for(;;){
        /*<<printexc.ml:170:14>>*/  /*<<printexc.ml:170:14>>*/ var
        match = format_backtrace_slot(i, caml_check_bound(a, i)[1 + i]);
@@ -21831,9 +21667,9 @@
         (Stdlib_Printf[1], outchan, _j_, str);
       }
        /*<<printexc.ml:169:6>>*/  /*<<printexc.ml:169:6>>*/ var
-       _T_ = i + 1 | 0;
-      if(_S_ === i) break;
-      var i = _T_;
+       _O_ = i + 1 | 0;
+      if(_N_ === i) break;
+      var i = _O_;
      }
     }
     return 0;
@@ -21852,10 +21688,10 @@
      a = backtrace[1],
       /*<<printexc.ml:187:14>>*/ b =
         /*<<printexc.ml:187:14>>*/ caml_call1(Stdlib_Buffer[1], 1024),
-     _P_ = a.length - 1 - 1 | 0,
-      /*<<printexc.ml:187:14>>*/ _O_ = 0;
-    if(_P_ >= 0){
-     var i = _O_;
+     _K_ = a.length - 1 - 1 | 0,
+      /*<<printexc.ml:187:14>>*/ _J_ = 0;
+    if(_K_ >= 0){
+     var i = _J_;
      for(;;){
        /*<<printexc.ml:189:14>>*/  /*<<printexc.ml:189:14>>*/ var
        match = format_backtrace_slot(i, caml_check_bound(a, i)[1 + i]);
@@ -21865,9 +21701,9 @@
         (Stdlib_Printf[5], b, _l_, str);
       }
        /*<<printexc.ml:188:6>>*/  /*<<printexc.ml:188:6>>*/ var
-       _Q_ = i + 1 | 0;
-      if(_P_ === i) break;
-      var i = _Q_;
+       _L_ = i + 1 | 0;
+      if(_K_ === i) break;
+      var i = _L_;
      }
     }
      /*<<printexc.ml:193:6>>*/ return  /*<<printexc.ml:193:6>>*/ caml_call1
@@ -21897,16 +21733,16 @@
     var backtrace = match[1], i$1 = backtrace.length - 1 - 1 | 0, i = i$1;
      /*<<printexc.ml:241:30>>*/ for(;;){
      if(-1 === i)
-      var _N_ = 0;
+      var _I_ = 0;
      else{
-      var _M_ = 0 === caml_check_bound(backtrace, i)[1 + i][0] ? 1 : 0;
-       /*<<printexc.ml:243:15>>*/ if(! _M_){
+      var _H_ = 0 === caml_check_bound(backtrace, i)[1 + i][0] ? 1 : 0;
+       /*<<printexc.ml:243:15>>*/ if(! _H_){
        var i$0 = i - 1 | 0, i = i$0;
        continue;
       }
-      var _N_ = _M_;
+      var _I_ = _H_;
      }
-      /*<<printexc.ml:244:9>>*/ return _N_ ? [0, backtrace] : 0;
+      /*<<printexc.ml:244:9>>*/ return _I_ ? [0, backtrace] : 0;
     }
     /*<<printexc.ml:246:15>>*/ }
    function backtrace_slots_of_raw_entry(entry){
@@ -21928,8 +21764,8 @@
        /*<<printexc.ml:279:16>>*/ success =
          /*<<printexc.ml:279:16>>*/ caml_call3
          (Stdlib_Atomic[5], printers, old_printers, new_printers),
-       /*<<printexc.ml:280:2>>*/ _L_ = 1 - success;
-     if(! _L_)  /*<<printexc.ml:280:2>>*/ return _L_;
+       /*<<printexc.ml:280:2>>*/ _G_ = 1 - success;
+     if(! _G_)  /*<<printexc.ml:280:2>>*/ return _G_;
     }
     /*<<printexc.ml:280:41>>*/ }
    function exn_slot(x){
@@ -21948,22 +21784,34 @@
      slot = exn_slot(x);
      /*<<printexc.ml:294:11>>*/ return slot[1];
     /*<<printexc.ml:294:39>>*/ }
-   var errors = _m_.slice();
+   var
+    errors =
+      [0,
+        cst$4,
+        "(Cannot print locations:\n bytecode executable program file not found)",
+        "(Cannot print locations:\n bytecode executable program file appears to be corrupt)",
+        "(Cannot print locations:\n bytecode executable program file has wrong magic number)",
+        "(Cannot print locations:\n bytecode executable program file cannot be opened;\n -- too many open files. Try running with OCAMLRUNPARAM=b=2)"].slice
+       (),
+    _m_ =
+      [0,
+       [11, cst_Fatal_error_exception, [2, 0, [12, 10, 0]]],
+       cst_Fatal_error_exception_s];
    function default_uncaught_exception_han(exn, raw_backtrace){
      /*<<printexc.ml:316:2>>*/  /*<<printexc.ml:316:40>>*/ var
-     _I_ = to_string(exn);
+     _D_ = to_string(exn);
      /*<<printexc.ml:316:2>>*/  /*<<printexc.ml:316:2>>*/ caml_call2
-     (Stdlib_Printf[3], _n_, _I_);
+     (Stdlib_Printf[3], _m_, _D_);
      /*<<printexc.ml:317:2>>*/ print_raw_backtrace(Stdlib[40], raw_backtrace);
      /*<<printexc.ml:318:15>>*/  /*<<printexc.ml:318:15>>*/ var
      status =  /*<<printexc.ml:318:15>>*/ runtime.caml_ml_debug_info_status(0);
     if(status < 0){
       /*<<printexc.ml:320:26>>*/ var
-       /*<<printexc.ml:320:26>>*/ _J_ =
+       /*<<printexc.ml:320:26>>*/ _E_ =
          /*<<printexc.ml:320:26>>*/ caml_call1(Stdlib[18], status),
-       /*<<printexc.ml:320:18>>*/ _K_ = caml_check_bound(errors, _J_)[1 + _J_];
+       /*<<printexc.ml:320:18>>*/ _F_ = caml_check_bound(errors, _E_)[1 + _E_];
       /*<<printexc.ml:320:4>>*/  /*<<printexc.ml:320:4>>*/ caml_call1
-      (Stdlib[53], _K_);
+      (Stdlib[53], _F_);
     }
      /*<<printexc.ml:320:4>>*/ return  /*<<printexc.ml:320:4>>*/ caml_call1
             (Stdlib[63], Stdlib[40]);
@@ -21974,7 +21822,20 @@
      /*<<printexc.ml:325:40>>*/ uncaught_exception_handler[1] = fn;
     return 0;
     /*<<printexc.ml:325:72>>*/ }
-   var empty_backtrace = [0];
+   var
+    empty_backtrace = [0],
+    cst_Fatal_error_out_of_memory_ =
+      "Fatal error: out of memory in uncaught exception handler",
+    _n_ =
+      [0,
+       [11, cst_Fatal_error_exception, [2, 0, [12, 10, 0]]],
+       cst_Fatal_error_exception_s],
+    _o_ =
+      [0,
+       [11,
+        "Fatal error in uncaught exception handler: exception ",
+        [2, 0, [12, 10, 0]]],
+       "Fatal error in uncaught exception handler: exception %s\n"];
    function handle_uncaught_exception(exn$0, debugger_in_use){
      /*<<printexc.ml:364:2>>*/ try{
       /*<<printexc.ml:336:2>>*/ try{
@@ -21987,66 +21848,50 @@
         /*<<printexc.ml:345:9>>*/  /*<<printexc.ml:345:9>>*/ caml_call1
         (Stdlib[103], 0);
       }
-      catch(_H_){}
+      catch(_C_){}
        /*<<printexc.ml:346:4>>*/ try{
         /*<<printexc.ml:347:6>>*/ var
-         /*<<printexc.ml:347:6>>*/ _D_ =
+         /*<<printexc.ml:347:6>>*/ _y_ =
            /*<<printexc.ml:347:6>>*/ caml_call2
            (uncaught_exception_handler[1], exn$0, raw_backtrace),
-        _C_ = _D_;
+        _x_ = _y_;
       }
       catch(exn$1){
         /*<<printexc.ml:349:27>>*/ var
         exn = caml_wrap_exception(exn$1),
          /*<<printexc.ml:349:27>>*/ raw_backtrace$0 =
            /*<<printexc.ml:349:27>>*/ caml_get_exception_raw_backtra(0),
-         /*<<printexc.ml:350:44>>*/ _A_ = to_string(exn$0);
+         /*<<printexc.ml:350:44>>*/ _v_ = to_string(exn$0);
         /*<<printexc.ml:350:6>>*/  /*<<printexc.ml:350:6>>*/ caml_call2
-        (Stdlib_Printf[3], _o_, _A_);
+        (Stdlib_Printf[3], _n_, _v_);
         /*<<printexc.ml:351:6>>*/ print_raw_backtrace
         (Stdlib[40], raw_backtrace);
         /*<<printexc.ml:353:8>>*/  /*<<printexc.ml:353:8>>*/ var
-        _B_ = to_string(exn);
+        _w_ = to_string(exn);
         /*<<printexc.ml:352:6>>*/  /*<<printexc.ml:352:6>>*/ caml_call2
-        (Stdlib_Printf[3], _p_, _B_);
+        (Stdlib_Printf[3], _o_, _w_);
         /*<<printexc.ml:354:6>>*/ print_raw_backtrace
         (Stdlib[40], raw_backtrace$0);
        var
-        _C_ =  /*<<printexc.ml:355:6>>*/ caml_call1(Stdlib[63], Stdlib[40]);
+        _x_ =  /*<<printexc.ml:355:6>>*/ caml_call1(Stdlib[63], Stdlib[40]);
       }
-      var _E_ = _C_;
+      var _z_ = _x_;
      }
-     catch(_G_){
-      var _z_ = caml_wrap_exception(_G_);
-      if(_z_ !== Stdlib[9]) throw caml_maybe_attach_backtrace(_z_, 0);
+     catch(_B_){
+      var _u_ = caml_wrap_exception(_B_);
+      if(_u_ !== Stdlib[9]) throw caml_maybe_attach_backtrace(_u_, 0);
       var
-       _E_ =
+       _z_ =
           /*<<printexc.ml:358:8>>*/ caml_call1
           (Stdlib[53], cst_Fatal_error_out_of_memory_);
      }
-      /*<<printexc.ml:365:4>>*/ return _E_;
+      /*<<printexc.ml:365:4>>*/ return _z_;
     }
-    catch(_F_){ /*<<printexc.ml:368:4>>*/ return 0;}
+    catch(_A_){ /*<<printexc.ml:368:4>>*/ return 0;}
     /*<<printexc.ml:368:6>>*/ }
     /*<<printexc.ml:374:2>>*/  /*<<printexc.ml:374:2>>*/ runtime.caml_register_named_value
     ("Printexc.handle_uncaught_exception", handle_uncaught_exception);
-   function _q_(_y_){
-     /*<<?>>*/ return runtime.caml_raw_backtrace_next_slot(_y_);
-   }
-   function _r_(_x_){
-     /*<<?>>*/ return runtime.caml_convert_raw_backtrace_slot(_x_);
-   }
-   function _s_(_w_, _v_){
-     /*<<?>>*/ return runtime.caml_raw_backtrace_slot(_w_, _v_);
-   }
    var
-    _t_ =
-      [0,
-       backtrace_slot_is_raise,
-       backtrace_slot_is_inline,
-       backtrace_slot_location,
-       backtrace_slot_defname,
-       format_backtrace_slot],
     Stdlib_Printexc =
       [0,
        to_string,
@@ -22060,18 +21905,29 @@
        register_printer,
        use_printers,
        raw_backtrace_entries,
-       function(_u_){ /*<<?>>*/ return caml_get_exception_raw_backtra(_u_);},
+       function(_t_){ /*<<?>>*/ return caml_get_exception_raw_backtra(_t_);},
        print_raw_backtrace,
        raw_backtrace_to_string,
        default_uncaught_exception_han,
        set_uncaught_exception_handler,
        backtrace_slots,
        backtrace_slots_of_raw_entry,
-       _t_,
+       [0,
+        backtrace_slot_is_raise,
+        backtrace_slot_is_inline,
+        backtrace_slot_location,
+        backtrace_slot_defname,
+        format_backtrace_slot],
        raw_backtrace_length,
-       _s_,
-       _r_,
-       _q_,
+       function(_s_, _r_){
+         /*<<?>>*/ return runtime.caml_raw_backtrace_slot(_s_, _r_);
+       },
+       function(_q_){
+         /*<<?>>*/ return runtime.caml_convert_raw_backtrace_slot(_q_);
+       },
+       function(_p_){
+         /*<<?>>*/ return runtime.caml_raw_backtrace_next_slot(_p_);
+       },
        exn_slot_id,
        exn_slot_name,
        string_of_extension_constructo];
@@ -22104,9 +21960,7 @@
     undef = undefined,
     global_data = runtime.caml_get_global_data(),
     Stdlib_Printexc = global_data.Stdlib__Printexc,
-    Stdlib = global_data.Stdlib,
-    cst_Fun_Finally_raised = "Fun.Finally_raised: ",
-    cst_Stdlib_Fun_Finally_raised = "Stdlib.Fun.Finally_raised";
+    Stdlib = global_data.Stdlib;
    function const$0(c, param){
      /*<<fun.ml:17:16>>*/ return c;
     /*<<fun.ml:17:17>>*/ }
@@ -22116,22 +21970,23 @@
    function negate(p, v){
      /*<<fun.ml:19:17>>*/ return 1 -  /*<<fun.ml:19:21>>*/ caml_call1(p, v);
     /*<<fun.ml:19:26>>*/ }
-    /*<<fun.ml:21:0>>*/  /*<<fun.ml:21:0>>*/ var
-    Finally_raised =
-      [248, cst_Stdlib_Fun_Finally_raised, runtime.caml_fresh_oo_id(0)];
-   function _a_(param){
-     /*<<fun.ml:23:38>>*/ if(param[1] !== Finally_raised)
-      /*<<fun.ml:25:7>>*/ return 0;
-     /*<<fun.ml:24:55>>*/ var
-     exn = param[2],
-      /*<<fun.ml:24:55>>*/ _b_ =
-        /*<<fun.ml:24:55>>*/ caml_call1(Stdlib_Printexc[1], exn);
-     /*<<fun.ml:24:24>>*/ return [0,
-             /*<<fun.ml:24:29>>*/ caml_call2
-             (Stdlib[28], cst_Fun_Finally_raised, _b_)];
-    /*<<fun.ml:25:11>>*/ }
+    /*<<fun.ml:21:0>>*/ var
+     /*<<fun.ml:21:0>>*/ Finally_raised =
+      [248, "Stdlib.Fun.Finally_raised", runtime.caml_fresh_oo_id(0)],
+    cst_Fun_Finally_raised = "Fun.Finally_raised: ";
     /*<<fun.ml:23:9>>*/  /*<<fun.ml:23:9>>*/ caml_call1
-    (Stdlib_Printexc[9], _a_);
+    (Stdlib_Printexc[9],
+     function(param){
+       /*<<fun.ml:23:38>>*/ if(param[1] !== Finally_raised)
+        /*<<fun.ml:25:7>>*/ return 0;
+       /*<<fun.ml:24:55>>*/ var
+       exn = param[2],
+        /*<<fun.ml:24:55>>*/ _a_ =
+          /*<<fun.ml:24:55>>*/ caml_call1(Stdlib_Printexc[1], exn);
+       /*<<fun.ml:24:24>>*/ return [0,
+               /*<<fun.ml:24:29>>*/ caml_call2
+               (Stdlib[28], cst_Fun_Finally_raised, _a_)];
+      /*<<fun.ml:25:11>>*/ });
    function protect(finally$0, work){
     function finally_no_exn(param){
       /*<<fun.ml:29:4>>*/ try{
@@ -22365,24 +22220,21 @@
      /*<<gc.ml:157:6>>*/ return  /*<<gc.ml:157:6>>*/ runtime.caml_memprof_start
             (sampling_rate, callstack_size, tracker);
     /*<<gc.ml:157:50>>*/ }
-   var _v_ = [0, null_tracker, start, runtime.caml_memprof_stop];
-   function _w_(_A_){ /*<<?>>*/ return runtime.caml_final_release(_A_);}
    var
-    _x_ = runtime.caml_final_register_called_without_value,
     Stdlib_Gc =
       [0,
        print_stat,
        allocated_bytes,
-       function(_z_, _y_){
-         /*<<?>>*/ return runtime.caml_final_register(_z_, _y_);
+       function(_x_, _w_){
+         /*<<?>>*/ return runtime.caml_final_register(_x_, _w_);
        },
-       _x_,
-       _w_,
+       runtime.caml_final_register_called_without_value,
+       function(_v_){ /*<<?>>*/ return runtime.caml_final_release(_v_);},
        create_alarm,
        delete_alarm,
        eventlog_pause,
        eventlog_resume,
-       _v_];
+       [0, null_tracker, start, runtime.caml_memprof_stop]];
    runtime.caml_register_global(26, Stdlib_Gc, "Stdlib__Gc");
    return;
    /*<<?>>*/ }
@@ -22421,10 +22273,10 @@
     Stdlib_String = global_data.Stdlib__String,
     compare = Stdlib_String[10],
     equal = Stdlib_String[9],
-    cst_Digest_from_hex$0 = cst_Digest_from_hex$1,
-    cst_Digest_from_hex = cst_Digest_from_hex$1,
+    cst_Digest_substring = "Digest.substring",
     cst_Digest_to_hex = "Digest.to_hex",
-    cst_Digest_substring = "Digest.substring";
+    cst_Digest_from_hex = cst_Digest_from_hex$1,
+    cst_Digest_from_hex$0 = cst_Digest_from_hex$1;
    function string(str){
      /*<<digest.ml:27:2>>*/ return  /*<<digest.ml:27:2>>*/ caml_md5_string
             (str, 0, caml_ml_string_length(str));
@@ -22596,28 +22448,7 @@
     global_data = runtime.caml_get_global_data(),
     Stdlib = global_data.Stdlib,
     Stdlib_Array = global_data.Stdlib__Array,
-    Stdlib_Sys = global_data.Stdlib__Sys,
-    cst_Bigarray_array3_of_genarra = "Bigarray.array3_of_genarray",
-    cst_Bigarray_array2_of_genarra = "Bigarray.array2_of_genarray",
-    cst_Bigarray_array1_of_genarra = "Bigarray.array1_of_genarray",
-    cst_Bigarray_array0_of_genarra = "Bigarray.array0_of_genarray",
-    cst_Bigarray_Array3_of_array_n = cst_Bigarray_Array3_of_array_n$1,
-    cst_Bigarray_Array3_of_array_n$0 = cst_Bigarray_Array3_of_array_n$1,
-    cst_Bigarray_Array2_of_array_n =
-      "Bigarray.Array2.of_array: non-rectangular data",
-    float32 = 0,
-    float64 = 1,
-    int8_signed = 2,
-    int8_unsigned = 3,
-    int16_signed = 4,
-    int16_unsigned = 5,
-    int32 = 6,
-    int64 = 7,
-    int$0 = 8,
-    nativeint = 9,
-    complex32 = 10,
-    complex64 = 11,
-    char$0 = 12;
+    Stdlib_Sys = global_data.Stdlib__Sys;
    function kind_size_in_bytes(param){
      /*<<?>>*/ switch(param){
       case 0:
@@ -22647,7 +22478,15 @@
       default:  /*<<bigarray.ml:86:12>>*/ return 1;
     }
    }
-   var c_layout = 0, fortran_layout = 1;
+   var
+    cst_Bigarray_Array2_of_array_n =
+      "Bigarray.Array2.of_array: non-rectangular data",
+    cst_Bigarray_Array3_of_array_n = cst_Bigarray_Array3_of_array_n$1,
+    cst_Bigarray_Array3_of_array_n$0 = cst_Bigarray_Array3_of_array_n$1,
+    cst_Bigarray_array0_of_genarra = "Bigarray.array0_of_genarray",
+    cst_Bigarray_array1_of_genarra = "Bigarray.array1_of_genarray",
+    cst_Bigarray_array2_of_genarra = "Bigarray.array2_of_genarray",
+    cst_Bigarray_array3_of_genarra = "Bigarray.array3_of_genarray";
    function cloop(arr, idx, f, col, max){
      /*<<bigarray.ml:104:4>>*/ if(col === idx.length - 1){
       /*<<bigarray.ml:104:35>>*/  /*<<bigarray.ml:104:35>>*/ caml_ba_set_generic
@@ -22755,7 +22594,7 @@
             (arr, [0]);
     /*<<bigarray.ml:158:37>>*/ }
    function set(arr){
-     /*<<bigarray.ml:159:16>>*/  /*<<bigarray.ml:159:16>>*/ var _aa_ = [0];
+     /*<<bigarray.ml:159:16>>*/ var _aa_ = [0];
      /*<<bigarray.ml:159:33>>*/ return function(_ab_){
       /*<<?>>*/ return caml_ba_set_generic(arr, _aa_, _ab_);};
     /*<<bigarray.ml:159:37>>*/ }
@@ -23189,22 +23028,22 @@
    var
     Stdlib_Bigarray =
       [0,
-       float32,
-       float64,
-       complex32,
-       complex64,
-       int8_signed,
-       int8_unsigned,
-       int16_signed,
-       int16_unsigned,
-       int$0,
-       int32,
-       int64,
-       nativeint,
-       char$0,
+       0,
+       1,
+       10,
+       11,
+       2,
+       3,
+       4,
+       5,
+       8,
+       6,
+       7,
+       9,
+       12,
        kind_size_in_bytes,
-       c_layout,
-       fortran_layout,
+       0,
+       1,
        [0, init, dims, size_in_bytes],
        [0,
         create,
@@ -23307,25 +23146,11 @@
     Stdlib_Sys = global_data.Stdlib__Sys,
     Stdlib_Bigarray = global_data.Stdlib__Bigarray,
     Stdlib_Nativeint = global_data.Stdlib__Nativeint,
-    _j_ = runtime.caml_int64_create_lo_mi_hi(14371852, 15349651, 22696),
-    _k_ = runtime.caml_int64_create_lo_mi_hi(12230193, 11438743, 35013),
-    _l_ = runtime.caml_int64_create_lo_mi_hi(1424933, 15549263, 2083),
-    _m_ = runtime.caml_int64_create_lo_mi_hi(9492471, 4696708, 43520),
-    _f_ = runtime.caml_int64_create_lo_mi_hi(1, 0, 0),
-    _h_ = runtime.caml_int64_create_lo_mi_hi(0, 0, 0),
-    _i_ = runtime.caml_int64_create_lo_mi_hi(0, 0, 0),
-    _g_ = runtime.caml_int64_create_lo_mi_hi(0, 0, 0),
-    cst_Random_int64 = "Random.int64",
-    cst_Random_int32 = "Random.int32",
-    cst_Random_full_int = "Random.full_int",
-    cst_Random_int = "Random.int",
-    cst_Random_State_of_binary_str =
-      "Random.State.of_binary_string: expected a format compatible with OCaml ",
     _a_ = runtime.caml_int64_create_lo_mi_hi(1, 0, 0),
     _b_ = runtime.caml_int64_create_lo_mi_hi(0, 0, 0),
-    _e_ = runtime.caml_int64_create_lo_mi_hi(1, 0, 0),
     _c_ = runtime.caml_int64_create_lo_mi_hi(0, 0, 0),
-    _d_ = runtime.caml_int64_create_lo_mi_hi(2, 0, 0);
+    _d_ = runtime.caml_int64_create_lo_mi_hi(2, 0, 0),
+    _e_ = runtime.caml_int64_create_lo_mi_hi(1, 0, 0);
    function create(param){
      /*<<random.ml:31:4>>*/ return  /*<<random.ml:31:4>>*/ caml_call3
             (Stdlib_Bigarray[19][1], 7, 0, 4);
@@ -23347,7 +23172,13 @@
      /*<<random.ml:41:4>>*/ set(s, i1, i2, i3, i4);
      /*<<random.ml:41:4>>*/ return s;
     /*<<random.ml:41:24>>*/ }
-   var serialization_prefix_len = 5;
+   var
+    serialization_prefix_len = 5,
+    cst_Random_State_of_binary_str =
+      "Random.State.of_binary_string: expected a format compatible with OCaml ",
+    cst_Random_int = "Random.int",
+    cst_Random_full_int = "Random.full_int",
+    cst_Random_int32 = "Random.int32";
    function to_binary_string(s){
      /*<<random.ml:61:4>>*/  /*<<random.ml:63:14>>*/ var
      buf =  /*<<random.ml:63:14>>*/ caml_create_bytes(37);
@@ -23515,7 +23346,11 @@
        /*<<random.ml:157:9>>*/ return v;
     }
     /*<<random.ml:162:25>>*/ }
-   var bits64 = caml_lxm_next;
+   var
+    bits64 = caml_lxm_next,
+    _f_ = runtime.caml_int64_create_lo_mi_hi(1, 0, 0),
+    _g_ = runtime.caml_int64_create_lo_mi_hi(0, 0, 0),
+    cst_Random_int64 = "Random.int64";
    function int64(s, bound){
      /*<<random.ml:177:4>>*/ if
      ( /*<<random.ml:177:7>>*/ caml_lessequal(bound, _g_))
@@ -23539,6 +23374,12 @@
     }
     /*<<random.ml:179:25>>*/ }
    var
+    _j_ = runtime.caml_int64_create_lo_mi_hi(14371852, 15349651, 22696),
+    _k_ = runtime.caml_int64_create_lo_mi_hi(12230193, 11438743, 35013),
+    _l_ = runtime.caml_int64_create_lo_mi_hi(1424933, 15549263, 2083),
+    _m_ = runtime.caml_int64_create_lo_mi_hi(9492471, 4696708, 43520),
+    _h_ = runtime.caml_int64_create_lo_mi_hi(0, 0, 0),
+    _i_ = runtime.caml_int64_create_lo_mi_hi(0, 0, 0),
     nativebits =
       32 === Stdlib_Nativeint[9]
        ? function
@@ -23774,28 +23615,28 @@
     Stdlib_Int = global_data.Stdlib__Int,
     Stdlib_Array = global_data.Stdlib__Array;
    global_data.Assert_failure;
-   var
-    Stdlib_String = global_data.Stdlib__String,
-    cst_Hashtbl_unsupported_hash_t = "Hashtbl: unsupported hash table format",
-    _d_ = [0, 0];
+   var Stdlib_String = global_data.Stdlib__String;
    function ongoing_traversal(h){
      /*<<hashtbl.ml:41:2>>*/ var
-     _aB_ = h.length - 1 < 4 ? 1 : 0,
-     _aC_ = _aB_ || (h[4] < 0 ? 1 : 0);
-    return _aC_;
+     _an_ = h.length - 1 < 4 ? 1 : 0,
+     _ao_ = _an_ || (h[4] < 0 ? 1 : 0);
+    return _ao_;
     /*<<hashtbl.ml:42:23>>*/ }
    function flip_ongoing_traversal(h){
      /*<<hashtbl.ml:45:2>>*/ h[4] = - h[4] | 0;
     return 0;
     /*<<hashtbl.ml:45:36>>*/ }
+   var
+    cst_Hashtbl_unsupported_hash_t = "Hashtbl: unsupported hash table format",
+    _d_ = [0, 0];
    try{
      /*<<hashtbl.ml:51:8>>*/ var
       /*<<hashtbl.ml:51:8>>*/ _f_ =
         /*<<hashtbl.ml:51:8>>*/ caml_sys_getenv("OCAMLRUNPARAM"),
      params = _f_;
    }
-   catch(_az_){
-    var _a_ = caml_wrap_exception(_az_);
+   catch(_al_){
+    var _a_ = caml_wrap_exception(_al_);
     if(_a_ !== Stdlib[8]) throw caml_maybe_attach_backtrace(_a_, 0);
      /*<<hashtbl.ml:52:4>>*/ try{
       /*<<hashtbl.ml:52:8>>*/ var
@@ -23803,8 +23644,8 @@
          /*<<hashtbl.ml:52:8>>*/ caml_sys_getenv("CAMLRUNPARAM"),
       _c_ = _e_;
     }
-    catch(_aA_){
-     var _b_ = caml_wrap_exception(_aA_);
+    catch(_am_){
+     var _b_ = caml_wrap_exception(_am_);
      if(_b_ !== Stdlib[8]) throw caml_maybe_attach_backtrace(_b_, 0);
      var _c_ = cst;
     }
@@ -23846,9 +23687,9 @@
      s = power_2_above(16, initial_size);
      /*<<hashtbl.ml:75:2>>*/ if(random)
       /*<<hashtbl.ml:76:37>>*/ var
-       /*<<hashtbl.ml:76:37>>*/ _ay_ =
+       /*<<hashtbl.ml:76:37>>*/ _ak_ =
          /*<<hashtbl.ml:76:37>>*/ caml_call1(Stdlib_Domain[10][2], prng_key),
-      seed =  /*<<hashtbl.ml:76:19>>*/ caml_call1(Stdlib_Random[15][4], _ay_);
+      seed =  /*<<hashtbl.ml:76:19>>*/ caml_call1(Stdlib_Random[15][4], _ak_);
     else
      var seed = 0;
      /*<<hashtbl.ml:78:2>>*/ return [0,
@@ -23858,14 +23699,14 @@
             s];
     /*<<hashtbl.ml:78:72>>*/ }
    function clear(h){
-     /*<<hashtbl.ml:81:2>>*/ var _ax_ = 0 < h[1] ? 1 : 0;
-    return _ax_
+     /*<<hashtbl.ml:81:2>>*/ var _aj_ = 0 < h[1] ? 1 : 0;
+    return _aj_
             ? (h
                [1]
               = 0,
                /*<<hashtbl.ml:83:4>>*/ caml_call4
                (Stdlib_Array[7], h[2], 0, h[2].length - 1, 0))
-            : _ax_;
+            : _aj_;
     /*<<hashtbl.ml:84:5>>*/ }
    function reset(h){
      /*<<hashtbl.ml:87:2>>*/ var len = h[2].length - 1;
@@ -23902,12 +23743,12 @@
     /*<<hashtbl.ml:111:7>>*/ }
    function copy(h){
      /*<<hashtbl.ml:113:13>>*/ var
-     _au_ = h[4],
-     _av_ = h[3],
-      /*<<hashtbl.ml:113:29>>*/ _aw_ =
+     _ag_ = h[4],
+     _ah_ = h[3],
+      /*<<hashtbl.ml:113:29>>*/ _ai_ =
         /*<<hashtbl.ml:113:29>>*/ caml_call2
         (Stdlib_Array[13], copy_bucketlist, h[2]);
-     /*<<hashtbl.ml:113:13>>*/ return [0, h[1], _aw_, _av_, _au_];
+     /*<<hashtbl.ml:113:13>>*/ return [0, h[1], _ai_, _ah_, _ag_];
     /*<<hashtbl.ml:113:63>>*/ }
    function length(h){
      /*<<hashtbl.ml:115:15>>*/ return h[1];
@@ -23917,10 +23758,10 @@
      nsize = ndata.length - 1,
       /*<<hashtbl.ml:119:19>>*/ ndata_tail =
         /*<<hashtbl.ml:119:19>>*/ caml_make_vect(nsize, 0),
-     _ao_ = odata.length - 1 - 1 | 0,
-      /*<<hashtbl.ml:135:2>>*/ _an_ = 0;
-    if(_ao_ >= 0){
-     var i$0 = _an_;
+     _aa_ = odata.length - 1 - 1 | 0,
+      /*<<hashtbl.ml:135:2>>*/ _$_ = 0;
+    if(_aa_ >= 0){
+     var i$0 = _$_;
      for(;;){
        /*<<hashtbl.ml:136:18>>*/ var
         /*<<hashtbl.ml:136:18>>*/ cell$1 =
@@ -23946,40 +23787,40 @@
        var cell = next;
       }
        /*<<hashtbl.ml:136:4>>*/  /*<<hashtbl.ml:136:4>>*/ var
-       _at_ = i$0 + 1 | 0;
-      if(_ao_ === i$0) break;
-      var i$0 = _at_;
+       _af_ = i$0 + 1 | 0;
+      if(_aa_ === i$0) break;
+      var i$0 = _af_;
      }
     }
     if(inplace){
       /*<<hashtbl.ml:139:4>>*/ var
-      _aq_ = nsize - 1 | 0,
-       /*<<hashtbl.ml:139:4>>*/ _ap_ = 0;
-     if(_aq_ >= 0){
-      var i = _ap_;
+      _ac_ = nsize - 1 | 0,
+       /*<<hashtbl.ml:139:4>>*/ _ab_ = 0;
+     if(_ac_ >= 0){
+      var i = _ab_;
       for(;;){
         /*<<hashtbl.ml:140:12>>*/  /*<<hashtbl.ml:140:12>>*/ var
         match$0 = caml_check_bound(ndata_tail, i)[1 + i];
        if(match$0) match$0[3] = 0;
         /*<<hashtbl.ml:139:4>>*/  /*<<hashtbl.ml:139:4>>*/ var
-        _as_ = i + 1 | 0;
-       if(_aq_ === i) break;
-       var i = _as_;
+        _ae_ = i + 1 | 0;
+       if(_ac_ === i) break;
+       var i = _ae_;
       }
      }
-     var _ar_ = 0;
+     var _ad_ = 0;
     }
     else
-     var _ar_ = inplace;
-    return _ar_;
+     var _ad_ = inplace;
+    return _ad_;
     /*<<hashtbl.ml:143:8>>*/ }
    function resize(indexfun, h){
      /*<<hashtbl.ml:146:2>>*/ var
      odata = h[2],
       /*<<hashtbl.ml:147:2>>*/ osize = odata.length - 1,
      nsize = osize * 2 | 0,
-     _am_ = nsize < Stdlib_Sys[13] ? 1 : 0;
-    if(! _am_) return _am_;
+     ___ = nsize < Stdlib_Sys[13] ? 1 : 0;
+    if(! ___) return ___;
      /*<<hashtbl.ml:150:16>>*/ var
       /*<<hashtbl.ml:150:16>>*/ ndata =
         /*<<hashtbl.ml:150:16>>*/ caml_make_vect(nsize, 0),
@@ -23996,9 +23837,9 @@
      old_trav = ongoing_traversal(h);
     if(1 - old_trav)  /*<<hashtbl.ml:163:23>>*/ flip_ongoing_traversal(h);
      /*<<hashtbl.ml:163:23>>*/ try{
-     var d = h[2], _ai_ = d.length - 1 - 1 | 0, _ah_ = 0;
-     if(_ai_ >= 0){
-      var i = _ah_;
+     var d = h[2], _W_ = d.length - 1 - 1 | 0, _V_ = 0;
+     if(_W_ >= 0){
+      var i = _V_;
       for(;;){
        var param = caml_check_bound(d, i)[1 + i];
         /*<<hashtbl.ml:157:22>>*/ for(;;){
@@ -24009,13 +23850,13 @@
         var param = next;
        }
         /*<<hashtbl.ml:167:6>>*/  /*<<hashtbl.ml:167:6>>*/ var
-        _al_ = i + 1 | 0;
-       if(_ai_ === i) break;
-       var i = _al_;
+        _Z_ = i + 1 | 0;
+       if(_W_ === i) break;
+       var i = _Z_;
       }
      }
-     var _aj_ = 1 - old_trav, _ak_ = _aj_ ? flip_ongoing_traversal(h) : _aj_;
-      /*<<hashtbl.ml:169:25>>*/ return _ak_;
+     var _X_ = 1 - old_trav, _Y_ = _X_ ? flip_ongoing_traversal(h) : _X_;
+      /*<<hashtbl.ml:169:25>>*/ return _Y_;
     }
     catch(exn$0){
      var exn = caml_wrap_exception(exn$0);
@@ -24032,9 +23873,9 @@
       /*<<hashtbl.ml:196:17>>*/ old_trav = ongoing_traversal(h);
     if(1 - old_trav)  /*<<hashtbl.ml:197:23>>*/ flip_ongoing_traversal(h);
      /*<<hashtbl.ml:197:23>>*/ try{
-     var _ad_ = d.length - 1 - 1 | 0, _ac_ = 0;
-     if(_ad_ >= 0){
-      var i = _ac_;
+     var _R_ = d.length - 1 - 1 | 0, _Q_ = 0;
+     if(_R_ >= 0){
+      var i = _Q_;
       for(;;){
         /*<<hashtbl.ml:200:44>>*/ var
          /*<<hashtbl.ml:200:44>>*/ slot$0 = caml_check_bound(h[2], i)[1 + i],
@@ -24064,13 +23905,13 @@
        else
          /*<<hashtbl.ml:177:17>>*/ caml_check_bound(h[2], i)[1 + i] = 0;
         /*<<hashtbl.ml:200:6>>*/  /*<<hashtbl.ml:200:6>>*/ var
-        _ag_ = i + 1 | 0;
-       if(_ad_ === i) break;
-       var i = _ag_;
+        _U_ = i + 1 | 0;
+       if(_R_ === i) break;
+       var i = _U_;
       }
      }
-     var _ae_ = 1 - old_trav, _af_ = _ae_ ? flip_ongoing_traversal(h) : _ae_;
-      /*<<hashtbl.ml:202:25>>*/ return _af_;
+     var _S_ = 1 - old_trav, _T_ = _S_ ? flip_ongoing_traversal(h) : _S_;
+      /*<<hashtbl.ml:202:25>>*/ return _T_;
     }
     catch(exn$0){
      var exn = caml_wrap_exception(exn$0);
@@ -24089,10 +23930,10 @@
       /*<<hashtbl.ml:218:15>>*/ var
       d = h[2],
        /*<<hashtbl.ml:218:15>>*/ accu$1 = [0, init],
-      _$_ = d.length - 1 - 1 | 0,
-       /*<<hashtbl.ml:218:15>>*/ ___ = 0;
-     if(_$_ >= 0){
-      var i = ___;
+      _N_ = d.length - 1 - 1 | 0,
+       /*<<hashtbl.ml:218:15>>*/ _M_ = 0;
+     if(_N_ >= 0){
+      var i = _M_;
       for(;;){
         /*<<hashtbl.ml:220:24>>*/ var
         accu$2 = accu$1[1],
@@ -24112,14 +23953,14 @@
        }
        accu$1[1] = accu;
         /*<<hashtbl.ml:219:4>>*/  /*<<hashtbl.ml:219:4>>*/ var
-        _ab_ = i + 1 | 0;
-       if(_$_ === i) break;
-       var i = _ab_;
+        _P_ = i + 1 | 0;
+       if(_N_ === i) break;
+       var i = _P_;
       }
      }
      if(1 - old_trav)  /*<<hashtbl.ml:222:25>>*/ flip_ongoing_traversal(h);
-     var _aa_ = accu$1[1];
-     return _aa_;
+     var _O_ = accu$1[1];
+     return _O_;
     }
     catch(exn$0){
      var exn = caml_wrap_exception(exn$0);
@@ -24142,28 +23983,30 @@
     }
    }
    function stats(h){
-     /*<<hashtbl.ml:240:2>>*/ var _U_ = h[2], _V_ = 0;
-    function _W_(m, b){
-      /*<<hashtbl.ml:241:32>>*/  /*<<hashtbl.ml:241:42>>*/ var
-      _Z_ = bucket_length(0, b);
-      /*<<hashtbl.ml:241:42>>*/ return  /*<<hashtbl.ml:241:42>>*/ caml_call2
-             (Stdlib_Int[11], m, _Z_);
-     /*<<hashtbl.ml:241:61>>*/ }
-     /*<<hashtbl.ml:241:4>>*/ var
+     /*<<hashtbl.ml:240:2>>*/ var
       /*<<hashtbl.ml:241:4>>*/ mbl =
-        /*<<hashtbl.ml:241:4>>*/ caml_call3(Stdlib_Array[17], _W_, _V_, _U_),
+        /*<<hashtbl.ml:241:4>>*/ caml_call3
+        (Stdlib_Array[17],
+         function(m, b){
+           /*<<hashtbl.ml:241:32>>*/  /*<<hashtbl.ml:241:42>>*/ var
+           _L_ = bucket_length(0, b);
+           /*<<hashtbl.ml:241:42>>*/ return  /*<<hashtbl.ml:241:42>>*/ caml_call2
+                  (Stdlib_Int[11], m, _L_);
+          /*<<hashtbl.ml:241:61>>*/ },
+         0,
+         h[2]),
       /*<<hashtbl.ml:242:14>>*/ histo =
-        /*<<hashtbl.ml:242:14>>*/ caml_make_vect(mbl + 1 | 0, 0),
-      /*<<hashtbl.ml:243:2>>*/ _X_ = h[2];
-    function _Y_(b){
-      /*<<hashtbl.ml:245:6>>*/  /*<<hashtbl.ml:245:14>>*/ var
-      l = bucket_length(0, b);
-      /*<<hashtbl.ml:246:6>>*/ histo[1 + l] =
-      caml_check_bound(histo, l)[1 + l] + 1 | 0;
-      /*<<hashtbl.ml:246:6>>*/ return 0;
-     /*<<hashtbl.ml:246:32>>*/ }
+        /*<<hashtbl.ml:242:14>>*/ caml_make_vect(mbl + 1 | 0, 0);
      /*<<hashtbl.ml:243:2>>*/  /*<<hashtbl.ml:243:2>>*/ caml_call2
-     (Stdlib_Array[11], _Y_, _X_);
+     (Stdlib_Array[11],
+      function(b){
+        /*<<hashtbl.ml:245:6>>*/  /*<<hashtbl.ml:245:14>>*/ var
+        l = bucket_length(0, b);
+        /*<<hashtbl.ml:246:6>>*/ histo[1 + l] =
+        caml_check_bound(histo, l)[1 + l] + 1 | 0;
+        /*<<hashtbl.ml:246:6>>*/ return 0;
+       /*<<hashtbl.ml:246:32>>*/ },
+      h[2]);
      /*<<hashtbl.ml:248:2>>*/ return [0, h[1], h[2].length - 1, mbl, histo];
     /*<<hashtbl.ml:251:30>>*/ }
    function to_seq(tbl){
@@ -24175,7 +24018,7 @@
        var key = buck$0[1], data = buck$0[2], next = buck$0[3];
         /*<<hashtbl.ml:266:8>>*/ return [0,
                [0, key, data],
-               function(_T_){ /*<<?>>*/ return aux(i$0, next, _T_);}];
+               function(_K_){ /*<<?>>*/ return aux(i$0, next, _K_);}];
       }
       if(i$0 === tbl_data.length - 1)  /*<<hashtbl.ml:263:13>>*/ return 0;
        /*<<hashtbl.ml:264:22>>*/ var
@@ -24186,28 +24029,26 @@
        buck$0 = buck$1;
      }
      /*<<hashtbl.ml:266:42>>*/ }
-     /*<<hashtbl.ml:268:2>>*/ var  /*<<hashtbl.ml:268:2>>*/ _Q_ = 0, _R_ = 0;
-     /*<<hashtbl.ml:268:2>>*/ return function(_S_){
-      /*<<?>>*/ return aux(_R_, _Q_, _S_);};
+    var _H_ = 0, _I_ = 0;
+     /*<<hashtbl.ml:268:2>>*/ return function(_J_){
+      /*<<?>>*/ return aux(_I_, _H_, _J_);};
     /*<<hashtbl.ml:268:13>>*/ }
    function to_seq_keys(m){
-     /*<<hashtbl.ml:270:20>>*/  /*<<hashtbl.ml:270:32>>*/ var _N_ = to_seq(m);
-    function _O_(_P_){ /*<<?>>*/ return _P_[1];}
+     /*<<hashtbl.ml:270:20>>*/  /*<<hashtbl.ml:270:32>>*/ var _F_ = to_seq(m);
      /*<<hashtbl.ml:270:32>>*/ return  /*<<hashtbl.ml:270:32>>*/ caml_call2
-            (Stdlib_Seq[29], _O_, _N_);
+            (Stdlib_Seq[29], function(_G_){ /*<<?>>*/ return _G_[1];}, _F_);
     /*<<hashtbl.ml:270:42>>*/ }
    function to_seq_values(m){
-     /*<<hashtbl.ml:272:22>>*/  /*<<hashtbl.ml:272:34>>*/ var _K_ = to_seq(m);
-    function _L_(_M_){ /*<<?>>*/ return _M_[2];}
+     /*<<hashtbl.ml:272:22>>*/  /*<<hashtbl.ml:272:34>>*/ var _D_ = to_seq(m);
      /*<<hashtbl.ml:272:34>>*/ return  /*<<hashtbl.ml:272:34>>*/ caml_call2
-            (Stdlib_Seq[29], _L_, _K_);
+            (Stdlib_Seq[29], function(_E_){ /*<<?>>*/ return _E_[2];}, _D_);
     /*<<hashtbl.ml:272:44>>*/ }
    function MakeSeeded(H){
     function key_index(h, key){
-      /*<<hashtbl.ml:357:6>>*/ var _J_ = h[2].length - 1 - 1 | 0;
+      /*<<hashtbl.ml:357:6>>*/ var _C_ = h[2].length - 1 - 1 | 0;
       /*<<hashtbl.ml:357:6>>*/ return  /*<<hashtbl.ml:357:6>>*/ caml_call2
              (H[2], h[3], key)
-            & _J_;
+            & _C_;
      /*<<hashtbl.ml:357:63>>*/ }
     function add(h, key, data){
       /*<<hashtbl.ml:360:6>>*/ var
@@ -24216,8 +24057,8 @@
         [0, key, data, caml_check_bound(h[2], i)[1 + i]];
       /*<<hashtbl.ml:362:6>>*/ caml_check_bound(h[2], i)[1 + i] = bucket;
      h[1] = h[1] + 1 | 0;
-     var _I_ = h[2].length - 1 << 1 < h[1] ? 1 : 0;
-     return _I_ ? resize(key_index, h) : _I_;
+     var _B_ = h[2].length - 1 << 1 < h[1] ? 1 : 0;
+     return _B_ ? resize(key_index, h) : _B_;
      /*<<hashtbl.ml:364:67>>*/ }
     function remove(h, key){
       /*<<hashtbl.ml:380:6>>*/ var
@@ -24240,8 +24081,8 @@
      /*<<hashtbl.ml:381:44>>*/ }
     function find(h, key){
       /*<<hashtbl.ml:390:6>>*/ var
-       /*<<hashtbl.ml:390:20>>*/ _H_ = key_index(h, key),
-       /*<<hashtbl.ml:390:12>>*/ match = caml_check_bound(h[2], _H_)[1 + _H_];
+       /*<<hashtbl.ml:390:20>>*/ _A_ = key_index(h, key),
+       /*<<hashtbl.ml:390:12>>*/ match = caml_check_bound(h[2], _A_)[1 + _A_];
      if(! match)
        /*<<hashtbl.ml:391:17>>*/ throw  /*<<hashtbl.ml:391:17>>*/ caml_maybe_attach_backtrace
              (Stdlib[8], 1);
@@ -24277,8 +24118,8 @@
      /*<<hashtbl.ml:401:67>>*/ }
     function find_opt(h, key){
       /*<<hashtbl.ml:410:6>>*/ var
-       /*<<hashtbl.ml:410:20>>*/ _G_ = key_index(h, key),
-       /*<<hashtbl.ml:410:12>>*/ match = caml_check_bound(h[2], _G_)[1 + _G_];
+       /*<<hashtbl.ml:410:20>>*/ _z_ = key_index(h, key),
+       /*<<hashtbl.ml:410:12>>*/ match = caml_check_bound(h[2], _z_)[1 + _z_];
      if(! match)  /*<<hashtbl.ml:411:17>>*/ return 0;
      var k1 = match[1], d1 = match[2], next1 = match[3];
       /*<<hashtbl.ml:413:13>>*/ if
@@ -24306,8 +24147,8 @@
      /*<<hashtbl.ml:421:76>>*/ }
     function find_all(h, key){
       /*<<hashtbl.ml:424:6>>*/ var
-       /*<<hashtbl.ml:431:29>>*/ _F_ = key_index(h, key),
-      param = caml_check_bound(h[2], _F_)[1 + _F_];
+       /*<<hashtbl.ml:431:29>>*/ _y_ = key_index(h, key),
+      param = caml_check_bound(h[2], _y_)[1 + _y_];
       /*<<hashtbl.ml:424:47>>*/ for(;;){
       if(! param)  /*<<hashtbl.ml:426:10>>*/ return 0;
       var k = param[1], d = param[2], next = param[3];
@@ -24350,53 +24191,55 @@
         (!  /*<<hashtbl.ml:437:13>>*/ caml_call2(H[1], k, key)){var slot = next; continue;}
        slot[1] = key;
        slot[2] = data;
-       var _C_ = 0;
+       var _v_ = 0;
       }
       else
-       var _C_ = 1;
-       /*<<hashtbl.ml:444:9>>*/ if(_C_){
+       var _v_ = 1;
+       /*<<hashtbl.ml:444:9>>*/ if(_v_){
         /*<<hashtbl.ml:445:8>>*/ caml_check_bound(h[2], i)[1 + i] = [0, key, data, l];
        h[1] = h[1] + 1 | 0;
-       var _D_ = h[2].length - 1 << 1 < h[1] ? 1 : 0;
-       if(_D_)  /*<<hashtbl.ml:447:51>>*/ return resize(key_index, h);
-       var _E_ = _D_;
+       var _w_ = h[2].length - 1 << 1 < h[1] ? 1 : 0;
+       if(_w_)  /*<<hashtbl.ml:447:51>>*/ return resize(key_index, h);
+       var _x_ = _w_;
       }
       else
-       var _E_ = _C_;
-      return _E_;
+       var _x_ = _v_;
+      return _x_;
      }
      /*<<hashtbl.ml:448:9>>*/ }
     function mem(h, key){
       /*<<hashtbl.ml:457:6>>*/ var
-       /*<<hashtbl.ml:457:32>>*/ _B_ = key_index(h, key),
-      param = caml_check_bound(h[2], _B_)[1 + _B_];
+       /*<<hashtbl.ml:457:32>>*/ _u_ = key_index(h, key),
+      param = caml_check_bound(h[2], _u_)[1 + _u_];
      for(;;){
       if(! param)  /*<<hashtbl.ml:452:10>>*/ return 0;
        /*<<hashtbl.ml:454:10>>*/ var
        k = param[1],
        next = param[3],
-        /*<<hashtbl.ml:454:10>>*/ _A_ =
+        /*<<hashtbl.ml:454:10>>*/ _t_ =
           /*<<hashtbl.ml:454:10>>*/ caml_call2(H[1], k, key);
-       /*<<hashtbl.ml:454:10>>*/ if(_A_)
-        /*<<hashtbl.ml:454:10>>*/ return _A_;
+       /*<<hashtbl.ml:454:10>>*/ if(_t_)
+        /*<<hashtbl.ml:454:10>>*/ return _t_;
       var param = next;
      }
      /*<<hashtbl.ml:457:48>>*/ }
     function add_seq(tbl, i){
-     function _z_(param){
-       /*<<hashtbl.ml:460:15>>*/ var v = param[2], k = param[1];
-       /*<<hashtbl.ml:460:29>>*/ return add(tbl, k, v);
-      /*<<hashtbl.ml:460:41>>*/ }
       /*<<hashtbl.ml:460:6>>*/ return  /*<<hashtbl.ml:460:6>>*/ caml_call2
-             (Stdlib_Seq[4], _z_, i);
+             (Stdlib_Seq[4],
+              function(param){
+                /*<<hashtbl.ml:460:15>>*/ var v = param[2], k = param[1];
+                /*<<hashtbl.ml:460:29>>*/ return add(tbl, k, v);
+               /*<<hashtbl.ml:460:41>>*/ },
+              i);
      /*<<hashtbl.ml:460:43>>*/ }
     function replace_seq(tbl, i){
-     function _y_(param){
-       /*<<hashtbl.ml:463:15>>*/ var v = param[2], k = param[1];
-       /*<<hashtbl.ml:463:29>>*/ return replace(tbl, k, v);
-      /*<<hashtbl.ml:463:45>>*/ }
       /*<<hashtbl.ml:463:6>>*/ return  /*<<hashtbl.ml:463:6>>*/ caml_call2
-             (Stdlib_Seq[4], _y_, i);
+             (Stdlib_Seq[4],
+              function(param){
+                /*<<hashtbl.ml:463:15>>*/ var v = param[2], k = param[1];
+                /*<<hashtbl.ml:463:29>>*/ return replace(tbl, k, v);
+               /*<<hashtbl.ml:463:45>>*/ },
+              i);
      /*<<hashtbl.ml:463:47>>*/ }
     function of_seq(i){
       /*<<hashtbl.ml:466:6>>*/  /*<<hashtbl.ml:466:16>>*/ var
@@ -24456,10 +24299,10 @@
      to_seq_values = include[19],
      add_seq = include[20],
      replace_seq = include[21],
-     _x_ = include[1];
+     _s_ = include[1];
     function create(sz){
       /*<<hashtbl.ml:487:20>>*/ return  /*<<hashtbl.ml:487:20>>*/ caml_call2
-             (_x_, _d_, sz);
+             (_s_, _d_, sz);
      /*<<hashtbl.ml:487:43>>*/ }
     function of_seq(i){
       /*<<hashtbl.ml:489:6>>*/  /*<<hashtbl.ml:489:16>>*/ var
@@ -24519,8 +24362,8 @@
        [0, key, data, caml_check_bound(h[2], i)[1 + i]];
      /*<<hashtbl.ml:513:2>>*/ caml_check_bound(h[2], i)[1 + i] = bucket;
     h[1] = h[1] + 1 | 0;
-    var _w_ = h[2].length - 1 << 1 < h[1] ? 1 : 0;
-    return _w_ ? resize(key_index, h) : _w_;
+    var _r_ = h[2].length - 1 << 1 < h[1] ? 1 : 0;
+    return _r_ ? resize(key_index, h) : _r_;
     /*<<hashtbl.ml:515:63>>*/ }
    function remove(h, key){
      /*<<hashtbl.ml:531:2>>*/ var
@@ -24543,8 +24386,8 @@
     /*<<hashtbl.ml:532:40>>*/ }
    function find(h, key){
      /*<<hashtbl.ml:541:2>>*/ var
-      /*<<hashtbl.ml:541:16>>*/ _v_ = key_index(h, key),
-      /*<<hashtbl.ml:541:8>>*/ match = caml_check_bound(h[2], _v_)[1 + _v_];
+      /*<<hashtbl.ml:541:16>>*/ _q_ = key_index(h, key),
+      /*<<hashtbl.ml:541:8>>*/ match = caml_check_bound(h[2], _q_)[1 + _q_];
     if(! match)
       /*<<hashtbl.ml:542:13>>*/ throw  /*<<hashtbl.ml:542:13>>*/ caml_maybe_attach_backtrace
             (Stdlib[8], 1);
@@ -24580,8 +24423,8 @@
     /*<<hashtbl.ml:552:67>>*/ }
    function find_opt(h, key){
      /*<<hashtbl.ml:561:2>>*/ var
-      /*<<hashtbl.ml:561:16>>*/ _u_ = key_index(h, key),
-      /*<<hashtbl.ml:561:8>>*/ match = caml_check_bound(h[2], _u_)[1 + _u_];
+      /*<<hashtbl.ml:561:16>>*/ _p_ = key_index(h, key),
+      /*<<hashtbl.ml:561:8>>*/ match = caml_check_bound(h[2], _p_)[1 + _p_];
     if(! match)  /*<<hashtbl.ml:562:13>>*/ return 0;
     var k1 = match[1], d1 = match[2], next1 = match[3];
      /*<<hashtbl.ml:564:9>>*/ if
@@ -24609,8 +24452,8 @@
     /*<<hashtbl.ml:572:76>>*/ }
    function find_all(h, key){
      /*<<hashtbl.ml:575:2>>*/ var
-      /*<<hashtbl.ml:582:25>>*/ _t_ = key_index(h, key),
-     param = caml_check_bound(h[2], _t_)[1 + _t_];
+      /*<<hashtbl.ml:582:25>>*/ _o_ = key_index(h, key),
+     param = caml_check_bound(h[2], _o_)[1 + _o_];
      /*<<hashtbl.ml:575:43>>*/ for(;;){
      if(! param)  /*<<hashtbl.ml:577:6>>*/ return 0;
      var k = param[1], data = param[2], next = param[3];
@@ -24653,51 +24496,53 @@
        (0 !==  /*<<hashtbl.ml:588:9>>*/ caml_compare(k, key)){var slot = next; continue;}
       slot[1] = key;
       slot[2] = data;
-      var _q_ = 0;
+      var _l_ = 0;
      }
      else
-      var _q_ = 1;
-      /*<<hashtbl.ml:595:5>>*/ if(_q_){
+      var _l_ = 1;
+      /*<<hashtbl.ml:595:5>>*/ if(_l_){
        /*<<hashtbl.ml:596:4>>*/ caml_check_bound(h[2], i)[1 + i] = [0, key, data, l];
       h[1] = h[1] + 1 | 0;
-      var _r_ = h[2].length - 1 << 1 < h[1] ? 1 : 0;
-      if(_r_)  /*<<hashtbl.ml:598:47>>*/ return resize(key_index, h);
-      var _s_ = _r_;
+      var _m_ = h[2].length - 1 << 1 < h[1] ? 1 : 0;
+      if(_m_)  /*<<hashtbl.ml:598:47>>*/ return resize(key_index, h);
+      var _n_ = _m_;
      }
      else
-      var _s_ = _q_;
-     return _s_;
+      var _n_ = _l_;
+     return _n_;
     }
     /*<<hashtbl.ml:599:5>>*/ }
    function mem(h, key){
      /*<<hashtbl.ml:608:2>>*/ var
-      /*<<hashtbl.ml:608:28>>*/ _p_ = key_index(h, key),
-     param = caml_check_bound(h[2], _p_)[1 + _p_];
+      /*<<hashtbl.ml:608:28>>*/ _k_ = key_index(h, key),
+     param = caml_check_bound(h[2], _k_)[1 + _k_];
     for(;;){
      if(! param)  /*<<hashtbl.ml:603:6>>*/ return 0;
      var
       k = param[1],
       next = param[3],
-      _o_ = 0 ===  /*<<hashtbl.ml:605:6>>*/ caml_compare(k, key) ? 1 : 0;
-     if(_o_) return _o_;
+      _j_ = 0 ===  /*<<hashtbl.ml:605:6>>*/ caml_compare(k, key) ? 1 : 0;
+     if(_j_) return _j_;
      var param = next;
     }
     /*<<hashtbl.ml:608:44>>*/ }
    function add_seq(tbl, i){
-    function _n_(param){
-      /*<<hashtbl.ml:611:11>>*/ var v = param[2], k = param[1];
-      /*<<hashtbl.ml:611:25>>*/ return add(tbl, k, v);
-     /*<<hashtbl.ml:611:37>>*/ }
      /*<<hashtbl.ml:611:2>>*/ return  /*<<hashtbl.ml:611:2>>*/ caml_call2
-            (Stdlib_Seq[4], _n_, i);
+            (Stdlib_Seq[4],
+             function(param){
+               /*<<hashtbl.ml:611:11>>*/ var v = param[2], k = param[1];
+               /*<<hashtbl.ml:611:25>>*/ return add(tbl, k, v);
+              /*<<hashtbl.ml:611:37>>*/ },
+             i);
     /*<<hashtbl.ml:611:39>>*/ }
    function replace_seq(tbl, i){
-    function _m_(param){
-      /*<<hashtbl.ml:614:11>>*/ var v = param[2], k = param[1];
-      /*<<hashtbl.ml:614:25>>*/ return replace(tbl, k, v);
-     /*<<hashtbl.ml:614:41>>*/ }
      /*<<hashtbl.ml:614:2>>*/ return  /*<<hashtbl.ml:614:2>>*/ caml_call2
-            (Stdlib_Seq[4], _m_, i);
+            (Stdlib_Seq[4],
+             function(param){
+               /*<<hashtbl.ml:614:11>>*/ var v = param[2], k = param[1];
+               /*<<hashtbl.ml:614:25>>*/ return replace(tbl, k, v);
+              /*<<hashtbl.ml:614:41>>*/ },
+             i);
     /*<<hashtbl.ml:614:43>>*/ }
    function of_seq(i){
      /*<<hashtbl.ml:617:2>>*/  /*<<hashtbl.ml:617:12>>*/ var
@@ -24724,12 +24569,9 @@
      /*<<hashtbl.ml:627:11>>*/ var
      _h_ = 4 <= h.length - 1 ? h[4] : s,
       /*<<hashtbl.ml:627:11>>*/ h$0 =
-       [0, h[1],  /*<<hashtbl.ml:629:11>>*/ caml_make_vect(s, 0), seed, _h_],
-     _i_ = h$0[2],
-     _j_ = h[2],
-     _k_ = 0;
+       [0, h[1],  /*<<hashtbl.ml:629:11>>*/ caml_make_vect(s, 0), seed, _h_];
      /*<<hashtbl.ml:633:2>>*/ insert_all_buckets
-     (function(_l_){ /*<<?>>*/ return key_index(h$0, _l_);}, _k_, _j_, _i_);
+     (function(_i_){ /*<<?>>*/ return key_index(h$0, _i_);}, 0, h[2], h$0[2]);
      /*<<hashtbl.ml:633:2>>*/ return h$0;
     /*<<hashtbl.ml:634:4>>*/ }
    var
@@ -24814,19 +24656,19 @@
     Stdlib_Int = global_data.Stdlib__Int,
     Stdlib_Array = global_data.Stdlib__Array,
     Stdlib_Obj = global_data.Stdlib__Obj,
-    cst_Weak_Make_hash_bucket_cann = "Weak.Make: hash bucket cannot grow more",
-    cst_Weak_fill = "Weak.fill",
-    cst_Weak_blit = "Weak.blit",
-    cst_Weak_check = "Weak.check",
-    cst_Weak_get_copy = "Weak.get_copy",
-    cst_Weak_get = "Weak.get",
+    cst_Weak_create = "Weak.create",
     cst_Weak_set = "Weak.set",
-    cst_Weak_create = "Weak.create";
+    cst_Weak_get = "Weak.get",
+    cst_Weak_get_copy = "Weak.get_copy",
+    cst_Weak_check = "Weak.check",
+    cst_Weak_blit = "Weak.blit",
+    cst_Weak_fill = "Weak.fill",
+    cst_Weak_Make_hash_bucket_cann = "Weak.Make: hash bucket cannot grow more";
    function create(l){
      /*<<weak.ml:28:2>>*/ var
-     _U_ = 0 <= l ? 1 : 0,
-     _V_ = _U_ ? l <= Stdlib_Obj[24][15] ? 1 : 0 : _U_;
-    if(1 - _V_)
+     _J_ = 0 <= l ? 1 : 0,
+     _K_ = _J_ ? l <= Stdlib_Obj[24][15] ? 1 : 0 : _J_;
+    if(1 - _K_)
       /*<<weak.ml:29:4>>*/  /*<<weak.ml:29:4>>*/ caml_call1
       (Stdlib[1], cst_Weak_create);
      /*<<weak.ml:30:2>>*/ return  /*<<weak.ml:30:2>>*/ runtime.caml_weak_create
@@ -24837,10 +24679,10 @@
     /*<<weak.ml:33:55>>*/ }
    function raise_if_invalid_offset(e, o, msg){
      /*<<weak.ml:36:2>>*/ var
-     _R_ = 0 <= o ? 1 : 0,
-     _S_ = _R_ ? o < length(e) ? 1 : 0 : _R_,
-     _T_ = 1 - _S_;
-    return _T_ ?  /*<<weak.ml:37:4>>*/ caml_call1(Stdlib[1], msg) : _T_;
+     _G_ = 0 <= o ? 1 : 0,
+     _H_ = _G_ ? o < length(e) ? 1 : 0 : _G_,
+     _I_ = 1 - _H_;
+    return _I_ ?  /*<<weak.ml:37:4>>*/ caml_call1(Stdlib[1], msg) : _I_;
     /*<<weak.ml:37:20>>*/ }
    function set(e, o, x){
      /*<<weak.ml:42:2>>*/ raise_if_invalid_offset(e, o, cst_Weak_set);
@@ -24873,13 +24715,13 @@
        0 <= o1
        && (length(e1) - l | 0) >= o1 && 0 <= o2 && (length(e2) - l | 0) >= o2){
      var
-      _P_ = 0 !== l ? 1 : 0,
-      _Q_ =
-        _P_
+      _E_ = 0 !== l ? 1 : 0,
+      _F_ =
+        _E_
          ?  /*<<weak.ml:69:22>>*/ runtime.caml_ephe_blit_key
            (e1, o1, e2, o2, l)
-         : _P_;
-      /*<<weak.ml:69:22>>*/ return _Q_;
+         : _E_;
+      /*<<weak.ml:69:22>>*/ return _F_;
     }
      /*<<weak.ml:68:7>>*/ return  /*<<weak.ml:68:7>>*/ caml_call1
             (Stdlib[1], cst_Weak_blit);
@@ -24887,14 +24729,14 @@
    function fill(ar, ofs, len, x){
      /*<<weak.ml:72:2>>*/ if
      (0 <= ofs && 0 <= len && (length(ar) - len | 0) >= ofs){
-     var _N_ = (ofs + len | 0) - 1 | 0;
-     if(_N_ >= ofs){
+     var _C_ = (ofs + len | 0) - 1 | 0;
+     if(_C_ >= ofs){
       var i = ofs;
       for(;;){
         /*<<weak.ml:76:6>>*/ set(ar, i, x);
-        /*<<weak.ml:76:6>>*/  /*<<weak.ml:76:6>>*/ var _O_ = i + 1 | 0;
-       if(_N_ === i) break;
-       var i = _O_;
+        /*<<weak.ml:76:6>>*/  /*<<weak.ml:76:6>>*/ var _D_ = i + 1 | 0;
+       if(_C_ === i) break;
+       var i = _D_;
       }
      }
      return 0;
@@ -24922,16 +24764,16 @@
      /*<<weak.ml:131:5>>*/ }
     function clear(t){
       /*<<weak.ml:134:4>>*/ var
-      _L_ = t[1].length - 1 - 1 | 0,
-       /*<<weak.ml:134:4>>*/ _K_ = 0;
-     if(_L_ >= 0){
-      var i = _K_;
+      _A_ = t[1].length - 1 - 1 | 0,
+       /*<<weak.ml:134:4>>*/ _z_ = 0;
+     if(_A_ >= 0){
+      var i = _z_;
       for(;;){
         /*<<weak.ml:135:6>>*/ caml_check_bound(t[1], i)[1 + i] = emptybucket;
         /*<<weak.ml:136:6>>*/ caml_check_bound(t[2], i)[1 + i] = [0];
-        /*<<weak.ml:136:6>>*/  /*<<weak.ml:136:6>>*/ var _M_ = i + 1 | 0;
-       if(_L_ === i) break;
-       var i = _M_;
+        /*<<weak.ml:136:6>>*/  /*<<weak.ml:136:6>>*/ var _B_ = i + 1 | 0;
+       if(_A_ === i) break;
+       var i = _B_;
       }
      }
      t[3] = limit;
@@ -24939,70 +24781,73 @@
      return 0;
      /*<<weak.ml:139:19>>*/ }
     function fold(f, t, init){
-      /*<<weak.ml:143:4>>*/ var _I_ = t[1], i = 0;
-      /*<<weak.ml:149:21>>*/ function _J_(b, accu$1){
-      var i$0 = i, accu = accu$1;
-       /*<<weak.ml:144:6>>*/ for(;;){
-       if(length(b) <= i$0)  /*<<weak.ml:144:28>>*/ return accu;
-        /*<<weak.ml:145:12>>*/  /*<<weak.ml:145:12>>*/ var
-        match = get(b, i$0);
-       if(match)
-         /*<<weak.ml:146:38>>*/ var
-         v = match[1],
-          /*<<weak.ml:146:38>>*/ accu$0 =
-            /*<<weak.ml:146:38>>*/ caml_call2(f, v, accu),
-         i$1 = i$0 + 1 | 0,
-         i$0 = i$1,
-         accu = accu$0;
-       else
-        var i$2 = i$0 + 1 | 0, i$0 = i$2;
-      }
-     }
+      /*<<weak.ml:143:4>>*/ var i = 0;
       /*<<weak.ml:149:4>>*/ return  /*<<weak.ml:149:4>>*/ caml_call3
-             (Stdlib_Array[19], _J_, _I_, init);
+             (Stdlib_Array[19],
+              function(b, accu$1){
+               var i$0 = i, accu = accu$1;
+                /*<<weak.ml:144:6>>*/ for(;;){
+                if(length(b) <= i$0)  /*<<weak.ml:144:28>>*/ return accu;
+                 /*<<weak.ml:145:12>>*/  /*<<weak.ml:145:12>>*/ var
+                 match = get(b, i$0);
+                if(match)
+                  /*<<weak.ml:146:38>>*/ var
+                  v = match[1],
+                   /*<<weak.ml:146:38>>*/ accu$0 =
+                     /*<<weak.ml:146:38>>*/ caml_call2(f, v, accu),
+                  i$1 = i$0 + 1 | 0,
+                  i$0 = i$1,
+                  accu = accu$0;
+                else
+                 var i$2 = i$0 + 1 | 0, i$0 = i$2;
+               }
+              },
+              t[1],
+              init);
      /*<<weak.ml:149:49>>*/ }
     function iter(f, t){
-      /*<<weak.ml:153:4>>*/ var _G_ = t[1], i = 0;
-      /*<<weak.ml:159:15>>*/ function _H_(b){
-      var i$0 = i;
-       /*<<weak.ml:154:6>>*/ for(;;){
-       if(length(b) <= i$0)  /*<<weak.ml:154:28>>*/ return 0;
-        /*<<weak.ml:155:12>>*/  /*<<weak.ml:155:12>>*/ var
-        match = get(b, i$0);
-       if(match){
-        var v = match[1];
-         /*<<weak.ml:156:18>>*/  /*<<weak.ml:156:18>>*/ caml_call1(f, v);
-        var i$1 = i$0 + 1 | 0, i$0 = i$1;
-       }
-       else
-        var i$2 = i$0 + 1 | 0, i$0 = i$2;
-      }
-     }
+      /*<<weak.ml:153:4>>*/ var i = 0;
       /*<<weak.ml:159:15>>*/ return  /*<<weak.ml:159:15>>*/ caml_call2
-             (Stdlib_Array[11], _H_, _G_);
+             (Stdlib_Array[11],
+              function(b){
+               var i$0 = i;
+                /*<<weak.ml:154:6>>*/ for(;;){
+                if(length(b) <= i$0)  /*<<weak.ml:154:28>>*/ return 0;
+                 /*<<weak.ml:155:12>>*/  /*<<weak.ml:155:12>>*/ var
+                 match = get(b, i$0);
+                if(match){
+                 var v = match[1];
+                  /*<<weak.ml:156:18>>*/  /*<<weak.ml:156:18>>*/ caml_call1
+                  (f, v);
+                 var i$1 = i$0 + 1 | 0, i$0 = i$1;
+                }
+                else
+                 var i$2 = i$0 + 1 | 0, i$0 = i$2;
+               }
+              },
+              t[1]);
      /*<<weak.ml:159:38>>*/ }
     function count_bucket(i, b, accu){
       /*<<weak.ml:173:4>>*/ var i$0 = i, accu$0 = accu;
       /*<<weak.ml:173:4>>*/ for(;;){
       if(length(b) <= i$0)  /*<<weak.ml:173:26>>*/ return accu$0;
        /*<<weak.ml:174:37>>*/ var
-        /*<<weak.ml:174:37>>*/ _F_ = check(b, i$0) ? 1 : 0,
-       accu$1 = accu$0 + _F_ | 0,
+        /*<<weak.ml:174:37>>*/ _y_ = check(b, i$0) ? 1 : 0,
+       accu$1 = accu$0 + _y_ | 0,
        i$1 = i$0 + 1 | 0,
        i$0 = i$1,
        accu$0 = accu$1;
      }
      /*<<weak.ml:174:62>>*/ }
     function count(t){
-      /*<<weak.ml:178:4>>*/ var
-       /*<<weak.ml:178:4>>*/ _z_ = 0,
-      _A_ = t[1],
-      _B_ = 0;
-      /*<<weak.ml:178:21>>*/ function _C_(_D_, _E_){
-       /*<<?>>*/ return count_bucket(_B_, _D_, _E_);
-     }
+      /*<<weak.ml:178:4>>*/ var _v_ = 0;
       /*<<weak.ml:178:4>>*/ return  /*<<weak.ml:178:4>>*/ caml_call3
-             (Stdlib_Array[19], _C_, _A_, _z_);
+             (Stdlib_Array[19],
+              function(_w_, _x_){
+                /*<<?>>*/ return count_bucket(_v_, _w_, _x_);
+              },
+              t[1],
+              0);
      /*<<weak.ml:178:47>>*/ }
     function add_aux(t, setter, d, h, index){
       /*<<weak.ml:238:4>>*/ var
@@ -25045,16 +24890,16 @@
       /*<<weak.ml:252:8>>*/ caml_check_bound(newhashes, sz)[1 + sz] = h;
       /*<<weak.ml:253:8>>*/ caml_check_bound(t[1], index)[1 + index] = newbucket$0;
       /*<<weak.ml:254:8>>*/ caml_check_bound(t[2], index)[1 + index] = newhashes;
-     var _v_ = sz <= t[3] ? 1 : 0, _w_ = _v_ ? t[3] < newsz ? 1 : 0 : _v_;
-     if(_w_){
+     var _r_ = sz <= t[3] ? 1 : 0, _s_ = _r_ ? t[3] < newsz ? 1 : 0 : _r_;
+     if(_s_){
       t[4] = t[4] + 1 | 0;
       var i$4 = 0;
       for(;;){
         /*<<weak.ml:185:17>>*/ var
-        _l_ = t[5],
-         /*<<weak.ml:185:17>>*/ bucket = caml_check_bound(t[1], _l_)[1 + _l_],
-         /*<<weak.ml:186:4>>*/ _m_ = t[5],
-         /*<<weak.ml:186:18>>*/ hbucket = caml_check_bound(t[2], _m_)[1 + _m_],
+        _h_ = t[5],
+         /*<<weak.ml:185:17>>*/ bucket = caml_check_bound(t[1], _h_)[1 + _h_],
+         /*<<weak.ml:186:4>>*/ _i_ = t[5],
+         /*<<weak.ml:186:18>>*/ hbucket = caml_check_bound(t[2], _i_)[1 + _i_],
          /*<<weak.ml:187:14>>*/ len = length(bucket),
         prev_len = (((len - 3 | 0) * 2 | 0) + 2 | 0) / 3 | 0,
          /*<<weak.ml:189:15>>*/ live = count_bucket(0, bucket, 0);
@@ -25070,8 +24915,8 @@
          else if(check(bucket, j)){
            /*<<weak.ml:195:12>>*/ blit(bucket, j, bucket, i$0, 1);
            /*<<weak.ml:196:27>>*/  /*<<weak.ml:196:27>>*/ var
-           _n_ = caml_check_bound(hbucket, j)[1 + j];
-           /*<<weak.ml:196:12>>*/ caml_check_bound(hbucket, i$0)[1 + i$0] = _n_;
+           _j_ = caml_check_bound(hbucket, j)[1 + j];
+           /*<<weak.ml:196:12>>*/ caml_check_bound(hbucket, i$0)[1 + i$0] = _j_;
            /*<<weak.ml:196:12>>*/ var
             /*<<weak.ml:196:12>>*/ j$0 = j - 1 | 0,
            i$2 = i$0 + 1 | 0,
@@ -25084,37 +24929,37 @@
            j = j$1;
         }
         if(0 === prev_len){
-         var _o_ = t[5];
-          /*<<weak.ml:203:8>>*/ caml_check_bound(t[1], _o_)[1 + _o_] = emptybucket;
-         var _p_ = t[5];
-          /*<<weak.ml:204:8>>*/ caml_check_bound(t[2], _p_)[1 + _p_] = [0];
+         var _k_ = t[5];
+          /*<<weak.ml:203:8>>*/ caml_check_bound(t[1], _k_)[1 + _k_] = emptybucket;
+         var _l_ = t[5];
+          /*<<weak.ml:204:8>>*/ caml_check_bound(t[2], _l_)[1 + _l_] = [0];
         }
         else{
           /*<<weak.ml:206:24>>*/  /*<<weak.ml:206:24>>*/ var
           newbucket = create(prev_len);
           /*<<weak.ml:207:8>>*/ blit(bucket, 0, newbucket, 0, prev_len);
-         var _s_ = t[5];
-          /*<<weak.ml:208:8>>*/ caml_check_bound(t[1], _s_)[1 + _s_] = newbucket;
+         var _o_ = t[5];
+          /*<<weak.ml:208:8>>*/ caml_check_bound(t[1], _o_)[1 + _o_] = newbucket;
           /*<<weak.ml:209:30>>*/ var
-           /*<<weak.ml:209:30>>*/ _t_ =
+           /*<<weak.ml:209:30>>*/ _p_ =
              /*<<weak.ml:209:30>>*/ caml_call3
              (Stdlib_Array[5], hbucket, 0, prev_len),
-          _u_ = t[5];
-          /*<<weak.ml:209:8>>*/ caml_check_bound(t[2], _u_)[1 + _u_] = _t_;
+          _q_ = t[5];
+          /*<<weak.ml:209:8>>*/ caml_check_bound(t[2], _q_)[1 + _q_] = _p_;
         }
         var
-         _q_ = t[3] < len ? 1 : 0,
-         _r_ = _q_ ? prev_len <= t[3] ? 1 : 0 : _q_;
-        if(_r_) t[4] = t[4] - 1 | 0;
+         _m_ = t[3] < len ? 1 : 0,
+         _n_ = _m_ ? prev_len <= t[3] ? 1 : 0 : _m_;
+        if(_n_) t[4] = t[4] - 1 | 0;
        }
        t[5] = caml_mod(t[5] + 1 | 0, t[1].length - 1);
-        /*<<weak.ml:257:38>>*/  /*<<weak.ml:257:38>>*/ var _y_ = i$4 + 1 | 0;
+        /*<<weak.ml:257:38>>*/  /*<<weak.ml:257:38>>*/ var _u_ = i$4 + 1 | 0;
        if(2 === i$4) break;
-       var i$4 = _y_;
+       var i$4 = _u_;
       }
      }
-     var _x_ = ((t[1].length - 1) / 2 | 0) < t[4] ? 1 : 0;
-     if(! _x_) return _x_;
+     var _t_ = ((t[1].length - 1) / 2 | 0) < t[4] ? 1 : 0;
+     if(! _t_) return _t_;
       /*<<weak.ml:181:18>>*/ var
       oldlen = t[1].length - 1,
        /*<<weak.ml:181:18>>*/ newlen =
@@ -25123,32 +24968,32 @@
      if(oldlen < newlen){
        /*<<weak.ml:220:17>>*/ var
         /*<<weak.ml:220:17>>*/ newt = create$0(newlen),
-       _j_ = t[1],
-       i = 0,
-        /*<<weak.ml:169:16>>*/ _k_ =
-         function(j, ob){
-          var oi = i;
-           /*<<weak.ml:164:6>>*/ for(;;){
-           if(length(ob) <= oi)  /*<<weak.ml:164:28>>*/ return 0;
-           if(check(ob, oi)){
-             /*<<weak.ml:166:20>>*/  /*<<weak.ml:166:20>>*/ var
-             oh = caml_check_bound(t[2], j)[1 + j];
-            let oi$0 = oi;
-            function setter(nb, ni, param){
-              /*<<weak.ml:222:29>>*/ return blit(ob, oi$0, nb, ni, 1);
-             /*<<weak.ml:222:47>>*/ }
-             /*<<weak.ml:223:16>>*/  /*<<weak.ml:223:16>>*/ var
-             h = caml_check_bound(oh, oi)[1 + oi];
-             /*<<weak.ml:224:35>>*/ add_aux
-             (newt, setter, 0, h, get_index(newt, h));
-            var i$0 = oi + 1 | 0, oi = i$0;
-           }
-           else
-            var i$1 = oi + 1 | 0, oi = i$1;
-          }
-         };
+       i = 0;
        /*<<weak.ml:169:16>>*/  /*<<weak.ml:169:16>>*/ caml_call2
-       (Stdlib_Array[12], _k_, _j_);
+       (Stdlib_Array[12],
+        function(j, ob){
+         var oi = i;
+          /*<<weak.ml:164:6>>*/ for(;;){
+          if(length(ob) <= oi)  /*<<weak.ml:164:28>>*/ return 0;
+          if(check(ob, oi)){
+            /*<<weak.ml:166:20>>*/  /*<<weak.ml:166:20>>*/ var
+            oh = caml_check_bound(t[2], j)[1 + j];
+           let oi$0 = oi;
+            /*<<weak.ml:223:16>>*/ var
+            setter =
+              function(nb, ni, param){
+                /*<<weak.ml:222:29>>*/ return blit(ob, oi$0, nb, ni, 1);
+               /*<<weak.ml:222:47>>*/ },
+             /*<<weak.ml:223:16>>*/ h = caml_check_bound(oh, oi)[1 + oi];
+            /*<<weak.ml:224:35>>*/ add_aux
+            (newt, setter, 0, h, get_index(newt, h));
+           var i$0 = oi + 1 | 0, oi = i$0;
+          }
+          else
+           var i$1 = oi + 1 | 0, oi = i$1;
+         }
+        },
+        t[1]);
       t[1] = newt[1];
       t[2] = newt[2];
       t[3] = newt[3];
@@ -25298,17 +25143,19 @@
          /*<<weak.ml:327:15>>*/ caml_call2(Stdlib_Array[13], length, t[1]);
       /*<<weak.ml:328:4>>*/  /*<<weak.ml:328:4>>*/ caml_call2
       (Stdlib_Array[34], runtime.caml_int_compare, lens);
-     var _a_ = 0;
-     function _b_(_i_, _h_){ /*<<?>>*/ return _i_ + _h_ | 0;}
       /*<<weak.ml:329:17>>*/ var
        /*<<weak.ml:329:17>>*/ totlen =
-         /*<<weak.ml:329:17>>*/ caml_call3(Stdlib_Array[17], _b_, _a_, lens),
-       /*<<weak.ml:329:17>>*/ _c_ = len - 1 | 0,
-      _e_ = len / 2 | 0,
-       /*<<weak.ml:330:51>>*/ _d_ = caml_check_bound(lens, _c_)[1 + _c_],
-       /*<<weak.ml:330:37>>*/ _f_ = caml_check_bound(lens, _e_)[1 + _e_],
-       /*<<weak.ml:330:27>>*/ _g_ = caml_check_bound(lens, 0)[1];
-      /*<<weak.ml:330:4>>*/ return [0, len, count(t), totlen, _g_, _f_, _d_];
+         /*<<weak.ml:329:17>>*/ caml_call3
+         (Stdlib_Array[17],
+          function(_g_, _f_){ /*<<?>>*/ return _g_ + _f_ | 0;},
+          0,
+          lens),
+       /*<<weak.ml:329:17>>*/ _a_ = len - 1 | 0,
+      _c_ = len / 2 | 0,
+       /*<<weak.ml:330:51>>*/ _b_ = caml_check_bound(lens, _a_)[1 + _a_],
+       /*<<weak.ml:330:37>>*/ _d_ = caml_check_bound(lens, _c_)[1 + _c_],
+       /*<<weak.ml:330:27>>*/ _e_ = caml_check_bound(lens, 0)[1];
+      /*<<weak.ml:330:4>>*/ return [0, len, count(t), totlen, _e_, _d_, _b_];
      /*<<weak.ml:330:64>>*/ }
      /*<<weak.ml:101:66>>*/ return [0,
             create$0,
@@ -25394,26 +25241,25 @@
     Stdlib_List = global_data.Stdlib__List,
     Stdlib_Stack = global_data.Stdlib__Stack,
     Stdlib_Int = global_data.Stdlib__Int,
-    Stdlib_Bytes = global_data.Stdlib__Bytes,
-    _f_ = [3, 0, 3],
-    cst_Format_pp_set_geometry = "Format.pp_set_geometry: ",
-    _e_ = [1, "max_indent < 2"],
-    _c_ = [1, "margin <= max_indent"],
-    _d_ = [0, 0],
-    _b_ = [0, cst$16],
-    _a_ = [0, cst$16, 0, cst$16],
-    cst_Stdlib_Format_String_tag = "Stdlib.Format.String_tag";
+    Stdlib_Bytes = global_data.Stdlib__Bytes;
    function id(x){ /*<<format.ml:23:11>>*/ return x; /*<<format.ml:23:12>>*/ }
     /*<<format.ml:91:13>>*/ var
     zero = 0,
     unknown = -1,
      /*<<format.ml:91:13>>*/ String_tag =
-      [248, cst_Stdlib_Format_String_tag, runtime.caml_fresh_oo_id(0)];
+      [248, "Stdlib.Format.String_tag", runtime.caml_fresh_oo_id(0)];
    function pp_enqueue(state, token){
      /*<<format.ml:219:2>>*/ state[13] = state[13] + token[3] | 0;
     return caml_call2(Stdlib_Queue[3], token, state[28]);
     /*<<format.ml:220:32>>*/ }
-   var pp_infinity = 1000000010;
+   var
+    pp_infinity = 1000000010,
+    _a_ = [0, cst$16, 0, cst$16],
+    _b_ = [0, cst$16],
+    _c_ = [1, "margin <= max_indent"],
+    _d_ = [0, 0],
+    _e_ = [1, "max_indent < 2"],
+    cst_Format_pp_set_geometry = "Format.pp_set_geometry: ";
    function pp_output_string(state, s){
      /*<<format.ml:251:31>>*/ return caml_call3
             (state[17], s, 0, caml_ml_string_length(s));
@@ -25430,10 +25276,10 @@
     /*<<format.ml:260:31>>*/ }
    function format_string(state, s){
      /*<<format.ml:264:2>>*/  /*<<format.ml:264:5>>*/ var
-     _bH_ =  /*<<format.ml:264:5>>*/ runtime.caml_string_notequal(s, cst$16);
-     /*<<format.ml:264:5>>*/ return _bH_
+     _a9_ =  /*<<format.ml:264:5>>*/ runtime.caml_string_notequal(s, cst$16);
+     /*<<format.ml:264:5>>*/ return _a9_
             ? format_pp_text(state, caml_ml_string_length(s), s)
-            : _bH_;
+            : _a9_;
     /*<<format.ml:264:58>>*/ }
    function break_new_line(state, param, width){
     var after = param[3], offset = param[2], before = param[1];
@@ -25500,8 +25346,8 @@
         var width$0 = match$4[1][2];
          /*<<format.ml:380:26>>*/ return break_line(state, width$0);
        case 4:
-        var _bF_ = state[10] !== (state[6] - state[9] | 0) ? 1 : 0;
-        if(! _bF_) return _bF_;
+        var _a7_ = state[10] !== (state[6] - state[9] | 0) ? 1 : 0;
+        if(! _a7_) return _a7_;
          /*<<format.ml:306:8>>*/  /*<<format.ml:306:8>>*/ var
          match$1 =
             /*<<format.ml:306:8>>*/ caml_call1(Stdlib_Queue[6], state[28]);
@@ -25587,11 +25433,11 @@
          if(param$0){
           var tail = param$0[2], head = param$0[1];
           if(insertion_point > head){var param$0 = tail; continue;}
-          var _bG_ = head;
+          var _a8_ = head;
          }
          else
-          var _bG_ = first;
-         var tab = _bG_;
+          var _a8_ = first;
+         var tab = _a8_;
          break;
         }
        }
@@ -25649,10 +25495,10 @@
       length = match$0[3],
       token = match$0[2],
       pending_count = state[13] - state[12] | 0,
-       /*<<format.ml:435:7>>*/ _bD_ = 0 <= size ? 1 : 0,
-       /*<<format.ml:435:7>>*/ _bE_ =
-        _bD_ || (state[9] <= pending_count ? 1 : 0);
-     if(! _bE_)  /*<<format.ml:435:7>>*/ return _bE_;
+       /*<<format.ml:435:7>>*/ _a5_ = 0 <= size ? 1 : 0,
+       /*<<format.ml:435:7>>*/ _a6_ =
+        _a5_ || (state[9] <= pending_count ? 1 : 0);
+     if(! _a6_)  /*<<format.ml:435:7>>*/ return _a6_;
       /*<<format.ml:436:6>>*/  /*<<format.ml:436:6>>*/ caml_call1
       (Stdlib_Queue[5], state[28]);
       /*<<format.ml:437:20>>*/  /*<<format.ml:437:20>>*/ var
@@ -25687,9 +25533,9 @@
      left_total = match$0[1],
       /*<<format.ml:479:4>>*/ size = queue_elem[1];
     if(left_total < state[12]) return initialize_scan_stack(state[1]);
-    var _bC_ = queue_elem[2];
-    if(typeof _bC_ !== "number")
-     switch(_bC_[0]){
+    var _a4_ = queue_elem[2];
+    if(typeof _a4_ !== "number")
+     switch(_a4_[0]){
        case 3:
         if(1 - ty){
          queue_elem[1] = state[13] + size | 0;
@@ -25724,26 +25570,26 @@
        /*<<format.ml:516:15>>*/ elem = [0, size, [3, indent, br_ty], 0];
       /*<<format.ml:517:4>>*/ return scan_push(state, 0, elem);
     }
-    var _bB_ = state[14] === state[15] ? 1 : 0;
-    if(! _bB_) return _bB_;
+    var _a3_ = state[14] === state[15] ? 1 : 0;
+    if(! _a3_) return _a3_;
     var s = state[16];
      /*<<format.ml:454:2>>*/ return enqueue_string_as
             (state, caml_ml_string_length(s), s);
     /*<<format.ml:519:45>>*/ }
    function pp_close_box(state, param){
-     /*<<format.ml:527:2>>*/ var _bz_ = 1 < state[14] ? 1 : 0;
-    if(_bz_){
+     /*<<format.ml:527:2>>*/ var _a1_ = 1 < state[14] ? 1 : 0;
+    if(_a1_){
      if(state[14] < state[15]){
        /*<<format.ml:531:6>>*/ pp_enqueue(state, [0, zero, 1, 0]);
        /*<<format.ml:532:6>>*/ set_size(state, 1);
        /*<<format.ml:532:27>>*/ set_size(state, 0);
      }
      state[14] = state[14] - 1 | 0;
-     var _bA_ = 0;
+     var _a2_ = 0;
     }
     else
-     var _bA_ = _bz_;
-    return _bA_;
+     var _a2_ = _a1_;
+    return _a2_;
     /*<<format.ml:535:5>>*/ }
    function pp_open_stag(state, tag_name){
      /*<<format.ml:540:2>>*/ if(state[22]){
@@ -25752,8 +25598,8 @@
       /*<<format.ml:543:4>>*/  /*<<format.ml:543:4>>*/ caml_call1
       (state[26], tag_name);
     }
-    var _by_ = state[23];
-    if(! _by_) return _by_;
+    var _a0_ = state[23];
+    if(! _a0_) return _a0_;
      /*<<format.ml:546:16>>*/  /*<<format.ml:546:16>>*/ var
      token = [5, tag_name];
      /*<<format.ml:547:21>>*/ return pp_enqueue(state, [0, zero, token, 0]);
@@ -25761,8 +25607,8 @@
    function pp_close_stag(state, param){
      /*<<format.ml:552:2>>*/ if(state[23])
       /*<<format.ml:553:4>>*/ pp_enqueue(state, [0, zero, 5, 0]);
-    var _bw_ = state[22];
-    if(_bw_){
+    var _aY_ = state[22];
+    if(_aY_){
       /*<<format.ml:555:10>>*/  /*<<format.ml:555:10>>*/ var
       match =  /*<<format.ml:555:10>>*/ caml_call1(Stdlib_Stack[5], state[4]);
      if(match){
@@ -25770,11 +25616,11 @@
        /*<<format.ml:558:6>>*/ return  /*<<format.ml:558:6>>*/ caml_call1
               (state[27], tag_name);
      }
-     var _bx_ = 0;
+     var _aZ_ = 0;
     }
     else
-     var _bx_ = _bw_;
-     /*<<format.ml:556:14>>*/ return _bx_;
+     var _aZ_ = _aY_;
+     /*<<format.ml:556:14>>*/ return _aZ_;
     /*<<format.ml:558:39>>*/ }
    function pp_set_print_tags(state, b){
      /*<<format.ml:560:32>>*/ state[22] = b;
@@ -25828,12 +25674,12 @@
      /*<<format.ml:523:28>>*/ return pp_open_box_gen(state, 0, 3);
     /*<<format.ml:600:23>>*/ }
    function pp_flush_queue(state, end_with_newline){
-     /*<<format.ml:608:2>>*/ var _bu_ = state[4];
-    function _bv_(param){
-      /*<<format.ml:603:23>>*/ return pp_close_stag(state, 0);
-     /*<<format.ml:603:45>>*/ }
-     /*<<format.ml:603:13>>*/  /*<<format.ml:603:13>>*/ caml_call2
-     (Stdlib_Stack[13], _bv_, _bu_);
+     /*<<format.ml:608:2>>*/  /*<<format.ml:603:13>>*/ caml_call2
+     (Stdlib_Stack[13],
+      function(param){
+        /*<<format.ml:603:23>>*/ return pp_close_stag(state, 0);
+       /*<<format.ml:603:45>>*/ },
+      state[4]);
      /*<<format.ml:610:4>>*/ for(;;){
      if(1 >= state[14]){
       state[13] = pp_infinity;
@@ -25845,8 +25691,8 @@
     }
     /*<<format.ml:615:16>>*/ }
    function pp_print_as_size(state, size, s){
-     /*<<format.ml:625:2>>*/ var _bt_ = state[14] < state[15] ? 1 : 0;
-    return _bt_ ? enqueue_string_as(state, size, s) : _bt_;
+     /*<<format.ml:625:2>>*/ var _aX_ = state[14] < state[15] ? 1 : 0;
+    return _aX_ ? enqueue_string_as(state, size, s) : _aX_;
     /*<<format.ml:626:37>>*/ }
    function pp_print_as(state, isize, s){
      /*<<format.ml:630:2>>*/ return pp_print_as_size(state, isize, s);
@@ -25905,20 +25751,20 @@
             (state[18], 0);
     /*<<format.ml:673:69>>*/ }
    function pp_force_newline(state, param){
-     /*<<format.ml:678:2>>*/ var _bs_ = state[14] < state[15] ? 1 : 0;
-    return _bs_ ? enqueue_advance(state, [0, zero, 3, 0]) : _bs_;
+     /*<<format.ml:678:2>>*/ var _aW_ = state[14] < state[15] ? 1 : 0;
+    return _aW_ ? enqueue_advance(state, [0, zero, 3, 0]) : _aW_;
     /*<<format.ml:679:78>>*/ }
    function pp_print_if_newline(state, param){
-     /*<<format.ml:684:2>>*/ var _br_ = state[14] < state[15] ? 1 : 0;
-    return _br_ ? enqueue_advance(state, [0, zero, 4, 0]) : _br_;
+     /*<<format.ml:684:2>>*/ var _aV_ = state[14] < state[15] ? 1 : 0;
+    return _aV_ ? enqueue_advance(state, [0, zero, 4, 0]) : _aV_;
     /*<<format.ml:686:61>>*/ }
    function pp_print_custom_break(state, fits, breaks){
      /*<<format.ml:692:2>>*/ var
      after = fits[3],
      width = fits[2],
      before = fits[1],
-     _bq_ = state[14] < state[15] ? 1 : 0;
-    if(! _bq_) return _bq_;
+     _aU_ = state[14] < state[15] ? 1 : 0;
+    if(! _aU_) return _aU_;
      /*<<format.ml:695:25>>*/ var
      size = - state[13] | 0,
       /*<<format.ml:695:25>>*/ token = [1, fits, breaks],
@@ -25941,33 +25787,33 @@
     /*<<format.ml:715:52>>*/ }
    function pp_open_tbox(state, param){
      /*<<format.ml:720:2>>*/ state[14] = state[14] + 1 | 0;
-    var _bp_ = state[14] < state[15] ? 1 : 0;
-    if(! _bp_) return _bp_;
+    var _aT_ = state[14] < state[15] ? 1 : 0;
+    if(! _aT_) return _aT_;
      /*<<format.ml:723:15>>*/  /*<<format.ml:723:15>>*/ var
      elem = [0, zero, [4, [0, [0, 0]]], 0];
      /*<<format.ml:724:4>>*/ return enqueue_advance(state, elem);
     /*<<format.ml:724:30>>*/ }
    function pp_close_tbox(state, param){
-     /*<<format.ml:729:2>>*/ var _bm_ = 1 < state[14] ? 1 : 0;
-    if(_bm_){
-     var _bn_ = state[14] < state[15] ? 1 : 0;
-     if(_bn_){
+     /*<<format.ml:729:2>>*/ var _aQ_ = 1 < state[14] ? 1 : 0;
+    if(_aQ_){
+     var _aR_ = state[14] < state[15] ? 1 : 0;
+     if(_aR_){
        /*<<format.ml:732:16>>*/  /*<<format.ml:732:16>>*/ var
        elem = [0, zero, 2, 0];
        /*<<format.ml:733:5>>*/ enqueue_advance(state, elem);
       state[14] = state[14] - 1 | 0;
-      var _bo_ = 0;
+      var _aS_ = 0;
      }
      else
-      var _bo_ = _bn_;
+      var _aS_ = _aR_;
     }
     else
-     var _bo_ = _bm_;
-    return _bo_;
+     var _aS_ = _aQ_;
+    return _aS_;
     /*<<format.ml:735:5>>*/ }
    function pp_print_tbreak(state, width, offset){
-     /*<<format.ml:740:2>>*/ var _bl_ = state[14] < state[15] ? 1 : 0;
-    if(! _bl_) return _bl_;
+     /*<<format.ml:740:2>>*/ var _aP_ = state[14] < state[15] ? 1 : 0;
+    if(! _aP_) return _aP_;
      /*<<format.ml:742:15>>*/ var
      size = - state[13] | 0,
       /*<<format.ml:742:15>>*/ elem = [0, size, [2, width, offset], width];
@@ -25977,17 +25823,17 @@
      /*<<format.ml:746:28>>*/ return pp_print_tbreak(state, 0, 0);
     /*<<format.ml:746:53>>*/ }
    function pp_set_tab(state, param){
-     /*<<format.ml:749:2>>*/ var _bk_ = state[14] < state[15] ? 1 : 0;
-    if(! _bk_) return _bk_;
+     /*<<format.ml:749:2>>*/ var _aO_ = state[14] < state[15] ? 1 : 0;
+    if(! _aO_) return _aO_;
      /*<<format.ml:750:15>>*/  /*<<format.ml:750:15>>*/ var
      elem = [0, zero, 0, 0];
      /*<<format.ml:751:4>>*/ return enqueue_advance(state, elem);
     /*<<format.ml:751:30>>*/ }
    function pp_set_max_boxes(state, n){
      /*<<format.ml:761:31>>*/ var
-     _bi_ = 1 < n ? 1 : 0,
-     _bj_ = _bi_ ? (state[15] = n, 0) : _bi_;
-    return _bj_;
+     _aM_ = 1 < n ? 1 : 0,
+     _aN_ = _aM_ ? (state[15] = n, 0) : _aM_;
+    return _aN_;
     /*<<format.ml:761:68>>*/ }
    function pp_get_max_boxes(state, param){
      /*<<format.ml:764:32>>*/ return state[15];
@@ -26006,10 +25852,10 @@
      /*<<format.ml:775:2>>*/ return n < 1000000010 ? n : 1000000009;
     /*<<format.ml:775:49>>*/ }
    function pp_set_max_indent(state, n$0){
-     /*<<format.ml:791:2>>*/ var _bh_ = 1 < n$0 ? 1 : 0;
-    if(! _bh_) return _bh_;
-    var n$1 = state[6] - n$0 | 0, _bg_ = 1 <= n$1 ? 1 : 0;
-    if(! _bg_) return _bg_;
+     /*<<format.ml:791:2>>*/ var _aL_ = 1 < n$0 ? 1 : 0;
+    if(! _aL_) return _aL_;
+    var n$1 = state[6] - n$0 | 0, _aK_ = 1 <= n$1 ? 1 : 0;
+    if(! _aK_) return _aK_;
      /*<<format.ml:781:12>>*/  /*<<format.ml:781:12>>*/ var n = pp_limit(n$1);
     state[7] = n;
     state[8] = state[6] - state[7] | 0;
@@ -26019,19 +25865,19 @@
      /*<<format.ml:795:33>>*/ return state[8];
     /*<<format.ml:795:52>>*/ }
    function pp_set_margin(state, n){
-     /*<<format.ml:798:2>>*/ var _be_ = 1 <= n ? 1 : 0;
-    if(! _be_) return _be_;
+     /*<<format.ml:798:2>>*/ var _aI_ = 1 <= n ? 1 : 0;
+    if(! _aI_) return _aI_;
      /*<<format.ml:799:12>>*/  /*<<format.ml:799:12>>*/ var n$0 = pp_limit(n);
     state[6] = n$0;
     if(state[8] <= state[6])
      var new_max_indent = state[8];
     else
       /*<<format.ml:808:15>>*/ var
-       /*<<format.ml:808:15>>*/ _bf_ =
+       /*<<format.ml:808:15>>*/ _aJ_ =
          /*<<format.ml:808:15>>*/ caml_call2
          (Stdlib_Int[11], state[6] - state[7] | 0, state[6] / 2 | 0),
       new_max_indent =
-         /*<<format.ml:808:7>>*/ caml_call2(Stdlib_Int[11], _bf_, 1);
+         /*<<format.ml:808:7>>*/ caml_call2(Stdlib_Int[11], _aJ_, 1);
      /*<<format.ml:811:4>>*/ return pp_set_max_indent(state, new_max_indent);
     /*<<format.ml:811:42>>*/ }
    function validate_geometry(param){
@@ -26062,11 +25908,11 @@
       /*<<format.ml:842:4>>*/ return pp_set_full_geometry(state, geometry);
      /*<<format.ml:840:28>>*/ var
      msg = match[1],
-      /*<<format.ml:840:28>>*/ _bd_ =
+      /*<<format.ml:840:28>>*/ _aH_ =
         /*<<format.ml:840:28>>*/ caml_call2
         (Stdlib[28], cst_Format_pp_set_geometry, msg);
      /*<<format.ml:840:4>>*/ throw  /*<<format.ml:840:4>>*/ caml_maybe_attach_backtrace
-           ([0, Stdlib[6], _bd_], 1);
+           ([0, Stdlib[6], _aH_], 1);
     /*<<format.ml:842:39>>*/ }
    function pp_safe_set_geometry(state, max_indent, margin){
      /*<<format.ml:845:2>>*/  /*<<format.ml:845:17>>*/ var
@@ -26113,14 +25959,15 @@
      /*<<format.ml:891:31>>*/ return  /*<<format.ml:891:31>>*/ caml_call3
             (state[17], cst$7, 0, 1);
     /*<<format.ml:891:60>>*/ }
-    /*<<format.ml:894:17>>*/  /*<<format.ml:894:17>>*/ var
-    blank_line =
-       /*<<format.ml:894:17>>*/ caml_call2(Stdlib_String[1], 80, 32);
+    /*<<format.ml:894:17>>*/ var
+     /*<<format.ml:894:17>>*/ blank_line =
+       /*<<format.ml:894:17>>*/ caml_call2(Stdlib_String[1], 80, 32),
+    _f_ = [3, 0, 3];
    function display_blanks(state, n){
      /*<<format.ml:896:2>>*/ var n$0 = n;
      /*<<format.ml:896:2>>*/ for(;;){
-     var _bc_ = 0 < n$0 ? 1 : 0;
-     if(! _bc_) return _bc_;
+     var _aG_ = 0 < n$0 ? 1 : 0;
+     if(! _aG_) return _aG_;
      if(80 >= n$0)
        /*<<format.ml:897:18>>*/ return  /*<<format.ml:897:18>>*/ caml_call3
               (state[17], blank_line, 0, n$0);
@@ -26140,9 +25987,9 @@
               (Stdlib[63], oc);
       /*<<format.ml:911:43>>*/ };
     state[19] =
-     function(_bb_){ /*<<?>>*/ return display_newline(state, _bb_);};
-    state[20] = function(_ba_){ /*<<?>>*/ return display_blanks(state, _ba_);};
-    state[21] = function(_a$_){ /*<<?>>*/ return display_blanks(state, _a$_);};
+     function(_aF_){ /*<<?>>*/ return display_newline(state, _aF_);};
+    state[20] = function(_aE_){ /*<<?>>*/ return display_blanks(state, _aE_);};
+    state[21] = function(_aD_){ /*<<?>>*/ return display_blanks(state, _aD_);};
     return 0;
     /*<<format.ml:914:45>>*/ }
    function default_pp_mark_open_tag(param){
@@ -26150,23 +25997,23 @@
       /*<<format.ml:924:9>>*/ return cst$10;
      /*<<format.ml:923:26>>*/ var
      s = param[2],
-      /*<<format.ml:923:26>>*/ _a__ =
+      /*<<format.ml:923:26>>*/ _aC_ =
         /*<<format.ml:923:26>>*/ caml_call2(Stdlib[28], s, cst$8);
      /*<<format.ml:923:26>>*/ return  /*<<format.ml:923:26>>*/ caml_call2
-            (Stdlib[28], cst$9, _a__);
+            (Stdlib[28], cst$9, _aC_);
     /*<<format.ml:924:11>>*/ }
    function default_pp_mark_close_tag(param){
      /*<<format.ml:925:32>>*/ if(param[1] !== String_tag)
       /*<<format.ml:927:9>>*/ return cst$13;
      /*<<format.ml:926:27>>*/ var
      s = param[2],
-      /*<<format.ml:926:27>>*/ _a9_ =
+      /*<<format.ml:926:27>>*/ _aB_ =
         /*<<format.ml:926:27>>*/ caml_call2(Stdlib[28], s, cst$11);
      /*<<format.ml:926:27>>*/ return  /*<<format.ml:926:27>>*/ caml_call2
-            (Stdlib[28], cst$12, _a9_);
+            (Stdlib[28], cst$12, _aB_);
     /*<<format.ml:927:11>>*/ }
-   function default_pp_print_open_tag(_a8_){ /*<<?>>*/ return 0;}
-   function default_pp_print_close_tag(_a7_){ /*<<?>>*/ return 0;}
+   function default_pp_print_open_tag(_aA_){ /*<<?>>*/ return 0;}
+   function default_pp_print_close_tag(_az_){ /*<<?>>*/ return 0;}
    function pp_make_formatter(f, g, h, i, j){
      /*<<format.ml:936:17>>*/ var
       /*<<format.ml:936:17>>*/ pp_queue =
@@ -26181,19 +26028,19 @@
      (Stdlib_Stack[3], [0, 1, sys_tok], scan_stack);
      /*<<format.ml:942:2>>*/ var
       /*<<format.ml:942:2>>*/ pp_margin = 78,
-     _a3_ = Stdlib[19],
-      /*<<format.ml:950:20>>*/ _a4_ =
+     _av_ = Stdlib[19],
+      /*<<format.ml:950:20>>*/ _aw_ =
         /*<<format.ml:950:20>>*/ caml_call1(Stdlib_Stack[2], 0),
-      /*<<format.ml:949:19>>*/ _a5_ =
+      /*<<format.ml:949:19>>*/ _ax_ =
         /*<<format.ml:949:19>>*/ caml_call1(Stdlib_Stack[2], 0),
-      /*<<format.ml:948:20>>*/ _a6_ =
+      /*<<format.ml:948:20>>*/ _ay_ =
         /*<<format.ml:948:20>>*/ caml_call1(Stdlib_Stack[2], 0);
      /*<<format.ml:945:2>>*/ return [0,
             scan_stack,
              /*<<format.ml:947:22>>*/ caml_call1(Stdlib_Stack[2], 0),
-            _a6_,
-            _a5_,
-            _a4_,
+            _ay_,
+            _ax_,
+            _aw_,
             pp_margin,
             10,
             68,
@@ -26203,7 +26050,7 @@
             1,
             1,
             1,
-            _a3_,
+            _av_,
             cst$14,
             f,
             g,
@@ -26228,27 +26075,26 @@
        pp_make_formatter
         (output,
          flush,
-         function(_a2_){ /*<<?>>*/ return 0;},
-         function(_a1_){ /*<<?>>*/ return 0;},
-         function(_a0_){ /*<<?>>*/ return 0;});
-    ppf[19] = function(_aZ_){ /*<<?>>*/ return display_newline(ppf, _aZ_);};
-    ppf[20] = function(_aY_){ /*<<?>>*/ return display_blanks(ppf, _aY_);};
-    ppf[21] = function(_aX_){ /*<<?>>*/ return display_blanks(ppf, _aX_);};
+         function(_au_){ /*<<?>>*/ return 0;},
+         function(_at_){ /*<<?>>*/ return 0;},
+         function(_as_){ /*<<?>>*/ return 0;});
+    ppf[19] = function(_ar_){ /*<<?>>*/ return display_newline(ppf, _ar_);};
+    ppf[20] = function(_aq_){ /*<<?>>*/ return display_blanks(ppf, _aq_);};
+    ppf[21] = function(_ap_){ /*<<?>>*/ return display_blanks(ppf, _ap_);};
      /*<<format.ml:994:2>>*/ return ppf;
     /*<<format.ml:994:5>>*/ }
    function formatter_of_out_channel(oc){
-    function _aW_(param){
-      /*<<format.ml:999:50>>*/ return  /*<<format.ml:999:2>>*/ caml_call1
-             (Stdlib[63], oc);
-     /*<<format.ml:999:58>>*/ }
-     /*<<format.ml:999:39>>*/ return make_formatter
-            ( /*<<format.ml:999:17>>*/ caml_call1(Stdlib[69], oc), _aW_);
+     /*<<format.ml:999:2>>*/ return make_formatter
+            ( /*<<format.ml:999:17>>*/ caml_call1(Stdlib[69], oc),
+             function(param){
+               /*<<format.ml:999:50>>*/ return  /*<<format.ml:999:2>>*/ caml_call1
+                      (Stdlib[63], oc);
+              /*<<format.ml:999:58>>*/ });
     /*<<format.ml:999:59>>*/ }
    function formatter_of_buffer(b){
-     /*<<format.ml:1004:2>>*/ function _aU_(_aV_){ /*<<?>>*/ return 0;}
-     /*<<format.ml:1004:42>>*/ return make_formatter
+     /*<<format.ml:1004:2>>*/ return make_formatter
             ( /*<<format.ml:1004:17>>*/ caml_call1(Stdlib_Buffer[18], b),
-             _aU_);
+             function(_ao_){ /*<<?>>*/ return 0;});
     /*<<format.ml:1004:48>>*/ }
    var pp_buffer_size = 512;
    function pp_make_buffer(param){
@@ -26267,21 +26113,23 @@
        (Stdlib_Domain[10][1], 0, pp_make_buffer);
     /*<<format.ml:1026:8>>*/  /*<<format.ml:1026:8>>*/ caml_call2
     (Stdlib_Domain[10][3], stdbuf_key, stdbuf);
-   function _g_(param){
-     /*<<format.ml:1029:2>>*/ return formatter_of_buffer
-            ( /*<<format.ml:1029:22>>*/ caml_call1
-              (Stdlib_Domain[10][2], stdbuf_key));
-    /*<<format.ml:1029:42>>*/ }
     /*<<format.ml:1028:24>>*/  /*<<format.ml:1028:24>>*/ var
     str_formatter_key =
-       /*<<format.ml:1028:24>>*/ caml_call2(Stdlib_Domain[10][1], 0, _g_);
+       /*<<format.ml:1028:24>>*/ caml_call2
+       (Stdlib_Domain[10][1],
+        0,
+        function(param){
+          /*<<format.ml:1029:2>>*/ return formatter_of_buffer
+                 ( /*<<format.ml:1029:22>>*/ caml_call1
+                   (Stdlib_Domain[10][2], stdbuf_key));
+         /*<<format.ml:1029:42>>*/ });
     /*<<format.ml:1030:8>>*/  /*<<format.ml:1030:8>>*/ caml_call2
     (Stdlib_Domain[10][3], str_formatter_key, str_formatter);
     /*<<format.ml:1030:8>>*/ function buffered_out_string(key, str, ofs, len){
      /*<<format.ml:1033:2>>*/  /*<<format.ml:1033:23>>*/ var
-     _aT_ =  /*<<format.ml:1033:23>>*/ caml_call1(Stdlib_Domain[10][2], key);
+     _an_ =  /*<<format.ml:1033:23>>*/ caml_call1(Stdlib_Domain[10][2], key);
      /*<<format.ml:1033:2>>*/ return  /*<<format.ml:1033:2>>*/ caml_call4
-            (Stdlib_Buffer[18], _aT_, str, ofs, len);
+            (Stdlib_Buffer[18], _an_, str, ofs, len);
     /*<<format.ml:1033:55>>*/ }
    function buffered_out_flush(oc, key, param){
      /*<<format.ml:1036:2>>*/ var
@@ -26298,82 +26146,83 @@
      /*<<format.ml:1040:2>>*/ return  /*<<format.ml:1040:2>>*/ caml_call1
             (Stdlib_Buffer[8], buf);
     /*<<format.ml:1041:18>>*/ }
-   function _h_(param){
-     /*<<format.ml:1043:48>>*/ return caml_call1
-            (Stdlib_Buffer[1], pp_buffer_size);
-    /*<<format.ml:1043:76>>*/ }
-    /*<<format.ml:1043:18>>*/  /*<<format.ml:1043:18>>*/ var
-    std_buf_key =
-       /*<<format.ml:1043:18>>*/ caml_call2(Stdlib_Domain[10][1], 0, _h_);
-   function _i_(param){
-     /*<<format.ml:1044:48>>*/ return  /*<<format.ml:1043:18>>*/ caml_call1
-            (Stdlib_Buffer[1], pp_buffer_size);
-    /*<<format.ml:1044:76>>*/ }
-    /*<<format.ml:1044:18>>*/  /*<<format.ml:1044:18>>*/ var
-    err_buf_key =
-       /*<<format.ml:1044:18>>*/ caml_call2(Stdlib_Domain[10][1], 0, _i_);
-   function _j_(param){
-    function _aD_(_aS_){ /*<<?>>*/ return 0;}
-    function _aE_(_aR_){ /*<<?>>*/ return 0;}
-    function _aF_(_aQ_){ /*<<?>>*/ return 0;}
-     /*<<format.ml:1048:4>>*/ var
-     _aG_ = Stdlib[39],
-      /*<<format.ml:1048:4>>*/ ppf =
-       pp_make_formatter
-        (function(_aN_, _aO_, _aP_){
-           /*<<?>>*/ return buffered_out_string(std_buf_key, _aN_, _aO_, _aP_);
-         },
-         function(_aM_){
-           /*<<?>>*/ return buffered_out_flush(_aG_, std_buf_key, _aM_);
-         },
-         _aF_,
-         _aE_,
-         _aD_);
-    ppf[19] = function(_aL_){ /*<<?>>*/ return display_newline(ppf, _aL_);};
-    ppf[20] = function(_aK_){ /*<<?>>*/ return display_blanks(ppf, _aK_);};
-    ppf[21] = function(_aJ_){ /*<<?>>*/ return display_blanks(ppf, _aJ_);};
-     /*<<format.ml:1054:17>>*/ function _aH_(_aI_){
-      /*<<?>>*/ return pp_print_flush(ppf, _aI_);
-    }
-     /*<<format.ml:1054:2>>*/  /*<<format.ml:1054:2>>*/ caml_call1
-     (Stdlib_Domain[6], _aH_);
-     /*<<format.ml:1054:2>>*/ return ppf;
-    /*<<format.ml:1055:5>>*/ }
-    /*<<format.ml:1046:24>>*/  /*<<format.ml:1046:24>>*/ var
-    std_formatter_key =
-       /*<<format.ml:1046:24>>*/ caml_call2(Stdlib_Domain[10][1], 0, _j_);
+    /*<<format.ml:1043:18>>*/ var
+     /*<<format.ml:1043:18>>*/ std_buf_key =
+       /*<<format.ml:1043:18>>*/ caml_call2
+       (Stdlib_Domain[10][1],
+        0,
+        function(param){
+          /*<<format.ml:1043:48>>*/ return caml_call1
+                 (Stdlib_Buffer[1], pp_buffer_size);
+         /*<<format.ml:1043:76>>*/ }),
+     /*<<format.ml:1044:18>>*/ err_buf_key =
+       /*<<format.ml:1044:18>>*/ caml_call2
+       (Stdlib_Domain[10][1],
+        0,
+        function(param){
+          /*<<format.ml:1044:48>>*/ return  /*<<format.ml:1043:18>>*/ caml_call1
+                 (Stdlib_Buffer[1], pp_buffer_size);
+         /*<<format.ml:1044:76>>*/ }),
+     /*<<format.ml:1046:24>>*/ std_formatter_key =
+       /*<<format.ml:1046:24>>*/ caml_call2
+       (Stdlib_Domain[10][1],
+        0,
+        function(param){
+          /*<<format.ml:1047:2>>*/ var
+          _ab_ = Stdlib[39],
+           /*<<format.ml:1048:4>>*/ ppf =
+            pp_make_formatter
+             (function(_ak_, _al_, _am_){
+                /*<<?>>*/ return buffered_out_string
+                       (std_buf_key, _ak_, _al_, _am_);
+              },
+              function(_aj_){
+                /*<<?>>*/ return buffered_out_flush(_ab_, std_buf_key, _aj_);
+              },
+              function(_ai_){ /*<<?>>*/ return 0;},
+              function(_ah_){ /*<<?>>*/ return 0;},
+              function(_ag_){ /*<<?>>*/ return 0;});
+         ppf[19] =
+          function(_af_){ /*<<?>>*/ return display_newline(ppf, _af_);};
+         ppf[20] =
+          function(_ae_){ /*<<?>>*/ return display_blanks(ppf, _ae_);};
+         ppf[21] =
+          function(_ad_){ /*<<?>>*/ return display_blanks(ppf, _ad_);};
+          /*<<format.ml:1054:2>>*/  /*<<format.ml:1054:2>>*/ caml_call1
+          (Stdlib_Domain[6],
+           function(_ac_){ /*<<?>>*/ return pp_print_flush(ppf, _ac_);});
+          /*<<format.ml:1054:2>>*/ return ppf;
+         /*<<format.ml:1055:5>>*/ });
     /*<<format.ml:1056:8>>*/  /*<<format.ml:1056:8>>*/ caml_call2
     (Stdlib_Domain[10][3], std_formatter_key, std_formatter);
-   function _k_(param){
-    function _an_(_aC_){ /*<<?>>*/ return 0;}
-    function _ao_(_aB_){ /*<<?>>*/ return 0;}
-    function _ap_(_aA_){ /*<<?>>*/ return 0;}
-     /*<<format.ml:1060:4>>*/ var
-     _aq_ = Stdlib[40],
-      /*<<format.ml:1060:4>>*/ ppf =
-       pp_make_formatter
-        (function(_ax_, _ay_, _az_){
-           /*<<?>>*/ return buffered_out_string(err_buf_key, _ax_, _ay_, _az_);
-         },
-         function(_aw_){
-           /*<<?>>*/ return buffered_out_flush(_aq_, err_buf_key, _aw_);
-         },
-         _ap_,
-         _ao_,
-         _an_);
-    ppf[19] = function(_av_){ /*<<?>>*/ return display_newline(ppf, _av_);};
-    ppf[20] = function(_au_){ /*<<?>>*/ return display_blanks(ppf, _au_);};
-    ppf[21] = function(_at_){ /*<<?>>*/ return display_blanks(ppf, _at_);};
-     /*<<format.ml:1066:17>>*/ function _ar_(_as_){
-      /*<<?>>*/ return pp_print_flush(ppf, _as_);
-    }
-     /*<<format.ml:1066:2>>*/  /*<<format.ml:1066:2>>*/ caml_call1
-     (Stdlib_Domain[6], _ar_);
-     /*<<format.ml:1066:2>>*/ return ppf;
-    /*<<format.ml:1067:5>>*/ }
     /*<<format.ml:1058:24>>*/  /*<<format.ml:1058:24>>*/ var
     err_formatter_key =
-       /*<<format.ml:1058:24>>*/ caml_call2(Stdlib_Domain[10][1], 0, _k_);
+       /*<<format.ml:1058:24>>*/ caml_call2
+       (Stdlib_Domain[10][1],
+        0,
+        function(param){
+          /*<<format.ml:1059:2>>*/ var
+          _R_ = Stdlib[40],
+           /*<<format.ml:1060:4>>*/ ppf =
+            pp_make_formatter
+             (function(___, _$_, _aa_){
+                /*<<?>>*/ return buffered_out_string
+                       (err_buf_key, ___, _$_, _aa_);
+              },
+              function(_Z_){
+                /*<<?>>*/ return buffered_out_flush(_R_, err_buf_key, _Z_);
+              },
+              function(_Y_){ /*<<?>>*/ return 0;},
+              function(_X_){ /*<<?>>*/ return 0;},
+              function(_W_){ /*<<?>>*/ return 0;});
+         ppf[19] = function(_V_){ /*<<?>>*/ return display_newline(ppf, _V_);};
+         ppf[20] = function(_U_){ /*<<?>>*/ return display_blanks(ppf, _U_);};
+         ppf[21] = function(_T_){ /*<<?>>*/ return display_blanks(ppf, _T_);};
+          /*<<format.ml:1066:2>>*/  /*<<format.ml:1066:2>>*/ caml_call1
+          (Stdlib_Domain[6],
+           function(_S_){ /*<<?>>*/ return pp_print_flush(ppf, _S_);});
+          /*<<format.ml:1066:2>>*/ return ppf;
+         /*<<format.ml:1067:5>>*/ });
     /*<<format.ml:1068:8>>*/  /*<<format.ml:1068:8>>*/ caml_call2
     (Stdlib_Domain[10][3], err_formatter_key, err_formatter);
    function get_std_formatter(param){
@@ -26411,38 +26260,41 @@
             (stdbuf, str_formatter);
     /*<<format.ml:1089:45>>*/ }
    function make_synchronized_formatter(output, flush){
-    function _al_(param){
-      /*<<format.ml:1093:4>>*/ var
-       /*<<format.ml:1093:14>>*/ buf =
-         /*<<format.ml:1093:14>>*/ caml_call1
-         (Stdlib_Buffer[1], pp_buffer_size),
-       /*<<format.ml:1094:18>>*/ output$0 =
-         /*<<format.ml:1094:18>>*/ caml_call1(Stdlib_Buffer[18], buf);
-     function flush$0(param){
-       /*<<format.ml:1096:6>>*/  /*<<format.ml:1096:37>>*/ var
-       _am_ =  /*<<format.ml:1096:37>>*/ caml_call1(Stdlib_Buffer[7], buf);
-       /*<<format.ml:1096:6>>*/  /*<<format.ml:1096:6>>*/ caml_call3
-       (output,
-         /*<<format.ml:1096:13>>*/ caml_call1(Stdlib_Buffer[2], buf),
-        0,
-        _am_);
-       /*<<format.ml:1097:6>>*/  /*<<format.ml:1097:6>>*/ caml_call1
-       (Stdlib_Buffer[8], buf);
-       /*<<format.ml:1097:6>>*/ return  /*<<format.ml:1097:6>>*/ caml_call1
-              (flush, 0);
-      /*<<format.ml:1098:14>>*/ }
-      /*<<format.ml:1100:4>>*/ return make_formatter(output$0, flush$0);
-     /*<<format.ml:1100:33>>*/ }
-     /*<<format.ml:1092:14>>*/ return  /*<<format.ml:1092:14>>*/ caml_call2
-            (Stdlib_Domain[10][1], 0, _al_);
+     /*<<format.ml:1092:2>>*/ return  /*<<format.ml:1092:14>>*/ caml_call2
+            (Stdlib_Domain[10][1],
+             0,
+             function(param){
+               /*<<format.ml:1093:4>>*/ var
+                /*<<format.ml:1093:14>>*/ buf =
+                  /*<<format.ml:1093:14>>*/ caml_call1
+                  (Stdlib_Buffer[1], pp_buffer_size),
+                /*<<format.ml:1094:18>>*/ output$0 =
+                  /*<<format.ml:1094:18>>*/ caml_call1(Stdlib_Buffer[18], buf);
+              function flush$0(param){
+                /*<<format.ml:1096:6>>*/  /*<<format.ml:1096:37>>*/ var
+                _Q_ =
+                   /*<<format.ml:1096:37>>*/ caml_call1(Stdlib_Buffer[7], buf);
+                /*<<format.ml:1096:6>>*/  /*<<format.ml:1096:6>>*/ caml_call3
+                (output,
+                  /*<<format.ml:1096:13>>*/ caml_call1(Stdlib_Buffer[2], buf),
+                 0,
+                 _Q_);
+                /*<<format.ml:1097:6>>*/  /*<<format.ml:1097:6>>*/ caml_call1
+                (Stdlib_Buffer[8], buf);
+                /*<<format.ml:1097:6>>*/ return  /*<<format.ml:1097:6>>*/ caml_call1
+                       (flush, 0);
+               /*<<format.ml:1098:14>>*/ }
+               /*<<format.ml:1100:4>>*/ return make_formatter
+                      (output$0, flush$0);
+              /*<<format.ml:1100:33>>*/ });
     /*<<format.ml:1100:34>>*/ }
    function synchronized_formatter_of_out_(oc){
-    function _ak_(param){
-      /*<<format.ml:1103:63>>*/ return  /*<<format.ml:1103:2>>*/ caml_call1
-             (Stdlib[63], oc);
-     /*<<format.ml:1103:71>>*/ }
-     /*<<format.ml:1103:52>>*/ return make_synchronized_formatter
-            ( /*<<format.ml:1103:30>>*/ caml_call1(Stdlib[69], oc), _ak_);
+     /*<<format.ml:1103:2>>*/ return make_synchronized_formatter
+            ( /*<<format.ml:1103:30>>*/ caml_call1(Stdlib[69], oc),
+             function(param){
+               /*<<format.ml:1103:63>>*/ return  /*<<format.ml:1103:2>>*/ caml_call1
+                      (Stdlib[63], oc);
+              /*<<format.ml:1103:71>>*/ });
     /*<<format.ml:1103:72>>*/ }
    function make_symbolic_output_buffer(param){ /*<<format.ml:1130:2>>*/ return [0, 0];
     /*<<format.ml:1130:35>>*/ }
@@ -26471,10 +26323,10 @@
                 /*<<format.ml:1152:48>>*/ caml_call3
                 (Stdlib_String[16], s, i, n)]);
     }
-     /*<<format.ml:1159:10>>*/ function g(_aj_){
+     /*<<format.ml:1159:10>>*/ function g(_P_){
       /*<<format.ml:1148:4>>*/ return add_symbolic_output_item(sob, 0);
     }
-     /*<<format.ml:1160:10>>*/ function h(_ai_){
+     /*<<format.ml:1160:10>>*/ function h(_O_){
       /*<<format.ml:1150:4>>*/ return add_symbolic_output_item(sob, 1);
     }
      /*<<format.ml:1161:10>>*/ function i(n){
@@ -26856,8 +26708,8 @@
      /*<<format.ml:1280:31>>*/ }
     for(;;){
      if(right[1] === len){
-      var _ah_ = left[1] !== len ? 1 : 0;
-      return _ah_ ? flush(0) : _ah_;
+      var _N_ = left[1] !== len ? 1 : 0;
+      return _N_ ? flush(0) : _N_;
      }
       /*<<format.ml:1283:10>>*/  /*<<format.ml:1283:10>>*/ var
       match =  /*<<format.ml:1283:10>>*/ runtime.caml_string_get(s, right[1]);
@@ -26879,7 +26731,7 @@
     else
      var
       none =
-        function(param, _ag_){
+        function(param, _M_){
           /*<<format.ml:1295:41>>*/ return 0;
          /*<<format.ml:1295:43>>*/ };
      /*<<format.ml:1295:56>>*/ if(! param)
@@ -26978,56 +26830,56 @@
           var acc$1 = match[1];
            /*<<format.ml:1361:4>>*/ output_acc(ppf, p$0);
            /*<<format.ml:1362:43>>*/ var
-            /*<<format.ml:1362:43>>*/ _Z_ = compute_tag(output_acc, acc$1),
+            /*<<format.ml:1362:43>>*/ _D_ = compute_tag(output_acc, acc$1),
             /*<<format.ml:1362:24>>*/ match$0 =
               /*<<format.ml:1362:24>>*/ caml_call1
-              (CamlinternalFormat[20], _Z_),
+              (CamlinternalFormat[20], _D_),
            bty = match$0[2],
            indent = match$0[1];
            /*<<format.ml:1363:4>>*/ return pp_open_box_gen(ppf, indent, bty);
          case 2:
-          var ___ = acc[1];
-          if(typeof ___ !== "number" && 0 === ___[0]){
-           var _$_ = ___[2];
-           if(typeof _$_ !== "number" && 1 === _$_[0]){
-            var s$0 = acc[2], size = _$_[2], p$2 = ___[1];
+          var _E_ = acc[1];
+          if(typeof _E_ !== "number" && 0 === _E_[0]){
+           var _F_ = _E_[2];
+           if(typeof _F_ !== "number" && 1 === _F_[0]){
+            var s$0 = acc[2], size = _F_[2], p$2 = _E_[1];
             break b;
            }
           }
-          var s = acc[2], p$1 = ___;
+          var s = acc[2], p$1 = _E_;
           break a;
          case 3:
-          var _aa_ = acc[1];
-          if(typeof _aa_ !== "number" && 0 === _aa_[0]){
-           var _ab_ = _aa_[2];
-           if(typeof _ab_ !== "number" && 1 === _ab_[0]){
-            var c$0 = acc[2], size$0 = _ab_[2], p$4 = _aa_[1];
+          var _G_ = acc[1];
+          if(typeof _G_ !== "number" && 0 === _G_[0]){
+           var _H_ = _G_[2];
+           if(typeof _H_ !== "number" && 1 === _H_[0]){
+            var c$0 = acc[2], size$0 = _H_[2], p$4 = _G_[1];
             break;
            }
           }
-          var c = acc[2], p$3 = _aa_;
+          var c = acc[2], p$3 = _G_;
           break c;
          case 4:
-          var _ac_ = acc[1];
-          if(typeof _ac_ !== "number" && 0 === _ac_[0]){
-           var _ad_ = _ac_[2];
-           if(typeof _ad_ !== "number" && 1 === _ad_[0]){
-            var s$0 = acc[2], size = _ad_[2], p$2 = _ac_[1];
+          var _I_ = acc[1];
+          if(typeof _I_ !== "number" && 0 === _I_[0]){
+           var _J_ = _I_[2];
+           if(typeof _J_ !== "number" && 1 === _J_[0]){
+            var s$0 = acc[2], size = _J_[2], p$2 = _I_[1];
             break b;
            }
           }
-          var s = acc[2], p$1 = _ac_;
+          var s = acc[2], p$1 = _I_;
           break a;
          case 5:
-          var _ae_ = acc[1];
-          if(typeof _ae_ !== "number" && 0 === _ae_[0]){
-           var _af_ = _ae_[2];
-           if(typeof _af_ !== "number" && 1 === _af_[0]){
-            var c$0 = acc[2], size$0 = _af_[2], p$4 = _ae_[1];
+          var _K_ = acc[1];
+          if(typeof _K_ !== "number" && 0 === _K_[0]){
+           var _L_ = _K_[2];
+           if(typeof _L_ !== "number" && 1 === _L_[0]){
+            var c$0 = acc[2], size$0 = _L_[2], p$4 = _K_[1];
             break;
            }
           }
-          var c = acc[2], p$3 = _ae_;
+          var c = acc[2], p$3 = _K_;
           break c;
          case 6:
           var f$0 = acc[2], p$5 = acc[1];
@@ -27085,56 +26937,56 @@
           var acc$1 = match[1];
            /*<<format.ml:1396:4>>*/ strput_acc(ppf, p$0);
            /*<<format.ml:1397:43>>*/ var
-            /*<<format.ml:1397:43>>*/ _Q_ = compute_tag(strput_acc, acc$1),
+            /*<<format.ml:1397:43>>*/ _u_ = compute_tag(strput_acc, acc$1),
             /*<<format.ml:1397:24>>*/ match$0 =
               /*<<format.ml:1397:24>>*/ caml_call1
-              (CamlinternalFormat[20], _Q_),
+              (CamlinternalFormat[20], _u_),
            bty = match$0[2],
            indent = match$0[1];
            /*<<format.ml:1398:4>>*/ return pp_open_box_gen(ppf, indent, bty);
          case 2:
-          var _R_ = acc[1];
-          if(typeof _R_ !== "number" && 0 === _R_[0]){
-           var _S_ = _R_[2];
-           if(typeof _S_ !== "number" && 1 === _S_[0]){
-            var s$0 = acc[2], size = _S_[2], p$2 = _R_[1];
+          var _v_ = acc[1];
+          if(typeof _v_ !== "number" && 0 === _v_[0]){
+           var _w_ = _v_[2];
+           if(typeof _w_ !== "number" && 1 === _w_[0]){
+            var s$0 = acc[2], size = _w_[2], p$2 = _v_[1];
             break b;
            }
           }
-          var s = acc[2], p$1 = _R_;
+          var s = acc[2], p$1 = _v_;
           break a;
          case 3:
-          var _T_ = acc[1];
-          if(typeof _T_ !== "number" && 0 === _T_[0]){
-           var _U_ = _T_[2];
-           if(typeof _U_ !== "number" && 1 === _U_[0]){
-            var c$0 = acc[2], size$0 = _U_[2], p$4 = _T_[1];
+          var _x_ = acc[1];
+          if(typeof _x_ !== "number" && 0 === _x_[0]){
+           var _y_ = _x_[2];
+           if(typeof _y_ !== "number" && 1 === _y_[0]){
+            var c$0 = acc[2], size$0 = _y_[2], p$4 = _x_[1];
             break;
            }
           }
-          var c = acc[2], p$3 = _T_;
+          var c = acc[2], p$3 = _x_;
           break c;
          case 4:
-          var _V_ = acc[1];
-          if(typeof _V_ !== "number" && 0 === _V_[0]){
-           var _W_ = _V_[2];
-           if(typeof _W_ !== "number" && 1 === _W_[0]){
-            var s$0 = acc[2], size = _W_[2], p$2 = _V_[1];
+          var _z_ = acc[1];
+          if(typeof _z_ !== "number" && 0 === _z_[0]){
+           var _A_ = _z_[2];
+           if(typeof _A_ !== "number" && 1 === _A_[0]){
+            var s$0 = acc[2], size = _A_[2], p$2 = _z_[1];
             break b;
            }
           }
-          var s = acc[2], p$1 = _V_;
+          var s = acc[2], p$1 = _z_;
           break a;
          case 5:
-          var _X_ = acc[1];
-          if(typeof _X_ !== "number" && 0 === _X_[0]){
-           var _Y_ = _X_[2];
-           if(typeof _Y_ !== "number" && 1 === _Y_[0]){
-            var c$0 = acc[2], size$0 = _Y_[2], p$4 = _X_[1];
+          var _B_ = acc[1];
+          if(typeof _B_ !== "number" && 0 === _B_[0]){
+           var _C_ = _B_[2];
+           if(typeof _C_ !== "number" && 1 === _C_[0]){
+            var c$0 = acc[2], size$0 = _C_[2], p$4 = _B_[1];
             break;
            }
           }
-          var c = acc[2], p$3 = _X_;
+          var c = acc[2], p$3 = _B_;
           break c;
          case 6:
           var p$5 = acc[1];
@@ -27178,15 +27030,15 @@
      /*<<format.ml:1400:32>>*/ return pp_print_string(ppf, s);
     /*<<format.ml:1406:34>>*/ }
    function kfprintf(k, ppf, param){
-     /*<<format.ml:1415:2>>*/ var
-     fmt = param[1],
-      /*<<format.ml:1415:2>>*/ _O_ = 0;
-    function _P_(acc){
-      /*<<format.ml:1416:16>>*/ output_acc(ppf, acc);
-     return caml_call1(k, ppf);
-     /*<<format.ml:1416:41>>*/ }
+    var fmt = param[1];
      /*<<format.ml:1415:2>>*/ return  /*<<format.ml:1415:2>>*/ caml_call3
-            (CamlinternalFormat[7], _P_, _O_, fmt);
+            (CamlinternalFormat[7],
+             function(acc){
+               /*<<format.ml:1416:16>>*/ output_acc(ppf, acc);
+              return caml_call1(k, ppf);
+              /*<<format.ml:1416:41>>*/ },
+             0,
+             fmt);
    }
    function ikfprintf(k, ppf, param){
     var fmt = param[1];
@@ -27194,57 +27046,57 @@
             (CamlinternalFormat[8], k, ppf, fmt);
    }
    function ifprintf(ppf, param){
-     /*<<format.ml:1423:2>>*/ var
-     fmt = param[1],
-      /*<<format.ml:1423:2>>*/ _L_ = 0;
-    function _M_(_N_){ /*<<?>>*/ return 0;}
+    var fmt = param[1];
      /*<<format.ml:1423:2>>*/ return  /*<<format.ml:1423:2>>*/ caml_call3
-            (CamlinternalFormat[8], _M_, _L_, fmt);
+            (CamlinternalFormat[8],
+             function(_t_){ /*<<?>>*/ return 0;},
+             0,
+             fmt);
    }
    function fprintf(ppf){
-    function _I_(_K_){ /*<<?>>*/ return 0;}
-     /*<<format.ml:1425:18>>*/ return function(_J_){
-      /*<<?>>*/ return kfprintf(_I_, ppf, _J_);};
+    function _q_(_s_){ /*<<?>>*/ return 0;}
+     /*<<format.ml:1425:18>>*/ return function(_r_){
+      /*<<?>>*/ return kfprintf(_q_, ppf, _r_);};
     /*<<format.ml:1425:37>>*/ }
    function printf(param){
-     /*<<format.ml:1428:2>>*/ var
-     fmt = param[1],
-      /*<<format.ml:1428:2>>*/ _G_ = 0;
-    function _H_(acc){
-      /*<<format.ml:1429:16>>*/ return output_acc
-             ( /*<<format.ml:1429:27>>*/ caml_call1
-               (Stdlib_Domain[10][2], std_formatter_key),
-              acc);
-     /*<<format.ml:1429:58>>*/ }
+    var fmt = param[1];
      /*<<format.ml:1428:2>>*/ return  /*<<format.ml:1428:2>>*/ caml_call3
-            (CamlinternalFormat[7], _H_, _G_, fmt);
+            (CamlinternalFormat[7],
+             function(acc){
+               /*<<format.ml:1429:16>>*/ return output_acc
+                      ( /*<<format.ml:1429:27>>*/ caml_call1
+                        (Stdlib_Domain[10][2], std_formatter_key),
+                       acc);
+              /*<<format.ml:1429:58>>*/ },
+             0,
+             fmt);
    }
    function eprintf(param){
-     /*<<format.ml:1433:2>>*/ var
-     fmt = param[1],
-      /*<<format.ml:1433:2>>*/ _E_ = 0;
-    function _F_(acc){
-      /*<<format.ml:1434:16>>*/ return output_acc
-             ( /*<<format.ml:1434:27>>*/ caml_call1
-               (Stdlib_Domain[10][2], err_formatter_key),
-              acc);
-     /*<<format.ml:1434:58>>*/ }
+    var fmt = param[1];
      /*<<format.ml:1433:2>>*/ return  /*<<format.ml:1433:2>>*/ caml_call3
-            (CamlinternalFormat[7], _F_, _E_, fmt);
+            (CamlinternalFormat[7],
+             function(acc){
+               /*<<format.ml:1434:16>>*/ return output_acc
+                      ( /*<<format.ml:1434:27>>*/ caml_call1
+                        (Stdlib_Domain[10][2], err_formatter_key),
+                       acc);
+              /*<<format.ml:1434:58>>*/ },
+             0,
+             fmt);
    }
    function kdprintf(k, param){
-     /*<<format.ml:1438:2>>*/ var
-     fmt = param[1],
-      /*<<format.ml:1438:2>>*/ _C_ = 0;
-    function _D_(acc){
-      /*<<format.ml:1439:16>>*/ return  /*<<format.ml:1439:18>>*/ caml_call1
-             (k,
-              function(ppf){
-                /*<<format.ml:1439:30>>*/ return output_acc(ppf, acc);
-               /*<<format.ml:1439:48>>*/ });
-     /*<<format.ml:1439:49>>*/ }
+    var fmt = param[1];
      /*<<format.ml:1438:2>>*/ return  /*<<format.ml:1438:2>>*/ caml_call3
-            (CamlinternalFormat[7], _D_, _C_, fmt);
+            (CamlinternalFormat[7],
+             function(acc){
+               /*<<format.ml:1439:16>>*/ return  /*<<format.ml:1439:18>>*/ caml_call1
+                      (k,
+                       function(ppf){
+                         /*<<format.ml:1439:30>>*/ return output_acc(ppf, acc);
+                        /*<<format.ml:1439:48>>*/ });
+              /*<<format.ml:1439:49>>*/ },
+             0,
+             fmt);
    }
    function dprintf(fmt){
      /*<<format.ml:1442:18>>*/ return kdprintf
@@ -27297,50 +27149,44 @@
     /*<<format.ml:1470:47>>*/ }
     /*<<format.ml:1472:9>>*/  /*<<format.ml:1472:9>>*/ caml_call1
     (Stdlib[100], flush_standard_formatters);
-   function _l_(param){
-     /*<<format.ml:1475:2>>*/ flush_standard_formatters(0);
-     /*<<format.ml:1476:11>>*/ var
-      /*<<format.ml:1476:11>>*/ fs =
-       pp_get_formatter_out_functions(std_formatter, 0),
-     _m_ = fs[5],
-     _n_ = fs[4],
-     _o_ = fs[3],
-     _p_ = Stdlib[39];
-     /*<<format.ml:1477:2>>*/ pp_set_formatter_out_functions
-     (std_formatter,
-      [0,
-       function(_z_, _A_, _B_){
-         /*<<?>>*/ return buffered_out_string(std_buf_key, _z_, _A_, _B_);
-       },
-       function(_y_){
-         /*<<?>>*/ return buffered_out_flush(_p_, std_buf_key, _y_);
-       },
-       _o_,
-       _n_,
-       _m_]);
-     /*<<format.ml:1481:11>>*/ var
-      /*<<format.ml:1481:11>>*/ fs$0 =
-       pp_get_formatter_out_functions(err_formatter, 0),
-     _q_ = fs$0[5],
-     _r_ = fs$0[4],
-     _s_ = fs$0[3],
-     _t_ = Stdlib[40];
-     /*<<format.ml:1483:4>>*/ return pp_set_formatter_out_functions
-            (err_formatter,
-             [0,
-              function(_v_, _w_, _x_){
-                /*<<?>>*/ return buffered_out_string
-                       (err_buf_key, _v_, _w_, _x_);
-              },
-              function(_u_){
-                /*<<?>>*/ return buffered_out_flush(_t_, err_buf_key, _u_);
-              },
-              _s_,
-              _r_,
-              _q_]);
-    /*<<format.ml:1484:71>>*/ }
     /*<<format.ml:1474:9>>*/  /*<<format.ml:1474:9>>*/ caml_call1
-    (Stdlib_Domain[5], _l_);
+    (Stdlib_Domain[5],
+     function(param){
+       /*<<format.ml:1475:2>>*/ flush_standard_formatters(0);
+       /*<<format.ml:1476:11>>*/ var
+        /*<<format.ml:1476:11>>*/ fs =
+         pp_get_formatter_out_functions(std_formatter, 0),
+       _g_ = Stdlib[39];
+       /*<<format.ml:1477:2>>*/ pp_set_formatter_out_functions
+       (std_formatter,
+        [0,
+         function(_n_, _o_, _p_){
+           /*<<?>>*/ return buffered_out_string(std_buf_key, _n_, _o_, _p_);
+         },
+         function(_m_){
+           /*<<?>>*/ return buffered_out_flush(_g_, std_buf_key, _m_);
+         },
+         fs[3],
+         fs[4],
+         fs[5]]);
+       /*<<format.ml:1481:11>>*/ var
+        /*<<format.ml:1481:11>>*/ fs$0 =
+         pp_get_formatter_out_functions(err_formatter, 0),
+       _h_ = Stdlib[40];
+       /*<<format.ml:1483:4>>*/ return pp_set_formatter_out_functions
+              (err_formatter,
+               [0,
+                function(_j_, _k_, _l_){
+                  /*<<?>>*/ return buffered_out_string
+                         (err_buf_key, _j_, _k_, _l_);
+                },
+                function(_i_){
+                  /*<<?>>*/ return buffered_out_flush(_h_, err_buf_key, _i_);
+                },
+                fs$0[3],
+                fs$0[4],
+                fs$0[5]]);
+      /*<<format.ml:1484:71>>*/ });
    var
     Stdlib_Format =
       [0,
@@ -27556,103 +27402,9 @@
     Stdlib_Int = global_data.Stdlib__Int,
     Stdlib_Buffer = global_data.Stdlib__Buffer,
     null_char = 0,
-    _r_ = [0, 91],
-    _q_ = [0, 123],
-    cst_end_of_input_not_found = "end of input not found",
-    cst_scanf_bad_conversion_a = 'scanf: bad conversion "%a"',
-    cst_scanf_bad_conversion_t = 'scanf: bad conversion "%t"',
-    cst_scanf_missing_reader = "scanf: missing reader",
-    _s_ = [0, cst_scanf_ml, 1414, 13],
-    cst_scanf_bad_conversion_custo =
-      'scanf: bad conversion "%?" (custom converter)',
-    cst_scanf_bad_conversion = cst_scanf_bad_conversion$3,
-    cst_scanf_bad_conversion$0 = cst_scanf_bad_conversion$3,
-    cst_scanf_bad_conversion$1 = 'scanf: bad conversion "%-"',
-    cst_scanf_bad_conversion$2 = cst_scanf_bad_conversion$3,
-    _t_ = [0, [3, 0, [10, 0]], "%S%!"],
-    cst_in_format = ' in format "',
-    _p_ = [0, 37, ""],
-    _o_ =
-      [0,
-       [11,
-        "scanf: bad input at char number ",
-        [4, 3, 0, 0, [11, ": ", [2, 0, 0]]]],
-       "scanf: bad input at char number %i: %s"],
-    _n_ =
-      [0,
-       [11, "the character ", [1, [11, " cannot start a boolean", 0]]],
-       "the character %C cannot start a boolean"],
-    _m_ =
-      [0,
-       [11, "bad character hexadecimal encoding \\", [0, [0, 0]]],
-       "bad character hexadecimal encoding \\%c%c"],
-    _l_ =
-      [0,
-       [11, "bad character decimal encoding \\", [0, [0, [0, 0]]]],
-       "bad character decimal encoding \\%c%c%c"],
-    cst_an = "an",
-    cst_x = "x",
-    cst_nfinity = "nfinity",
-    cst_digits = "digits",
-    _k_ =
-      [0,
-       [11,
-        cst_character,
-        [1, [11, " is not a valid ", [2, 0, [11, " digit", 0]]]]],
-       "character %C is not a valid %s digit"],
-    cst_decimal_digits = "decimal digits",
-    _j_ =
-      [0,
-       [11, cst_character, [1, [11, " is not a decimal digit", 0]]],
-       "character %C is not a decimal digit"],
-    cst_0b = "0b",
-    cst_0o = "0o",
-    cst_0u = "0u",
-    cst_0x = "0x",
-    _i_ = [0, cst_scanf_ml, 516, 9],
-    _h_ =
-      [0,
-       [11, "invalid boolean '", [2, 0, [12, 39, 0]]],
-       "invalid boolean '%s'"],
-    _g_ =
-      [0,
-       [11, "looking for ", [1, [11, ", found ", [1, 0]]]],
-       "looking for %C, found %C"],
-    cst_not_a_valid_float_in_hexad =
-      "not a valid float in hexadecimal notation",
-    cst_no_dot_or_exponent_part_fo =
-      "no dot or exponent part found in float token",
-    _f_ =
-      [0,
-       [11,
-        cst_scanning_of,
-        [2,
-         0,
-         [11,
-          " failed: premature end of file occurred before end of token",
-          0]]],
-       "scanning of %s failed: premature end of file occurred before end of token"],
-    _e_ =
-      [0,
-       [11,
-        cst_scanning_of,
-        [2,
-         0,
-         [11, " failed: the specified length was too short for token", 0]]],
-       "scanning of %s failed: the specified length was too short for token"],
-    _d_ =
-      [0,
-       [11, "illegal escape character ", [1, 0]],
-       "illegal escape character %C"],
     cst_unnamed_function = "unnamed function",
     cst_unnamed_character_string = "unnamed character string",
-    cst_unnamed_Stdlib_input_chann = "unnamed Stdlib input channel",
-    cst_Stdlib_Scanf_Scan_failure = "Stdlib.Scanf.Scan_failure",
-    cst_binary = "binary",
-    cst_octal = "octal",
-    cst_hexadecimal = "hexadecimal",
-    cst_a_Char = "a Char",
-    cst_a_String = "a String";
+    cst_unnamed_Stdlib_input_chann = "unnamed Stdlib input channel";
    function next_char(ib){
      /*<<scanf.ml:165:4>>*/ try{
       /*<<scanf.ml:166:14>>*/  /*<<scanf.ml:166:14>>*/ var
@@ -27663,9 +27415,9 @@
      if(10 === c) ib[5] = ib[5] + 1 | 0;
       /*<<scanf.ml:171:6>>*/ return c;
     }
-    catch(_ba_){
-     var _a$_ = caml_wrap_exception(_ba_);
-     if(_a$_ !== Stdlib[12]) throw caml_maybe_attach_backtrace(_a$_, 0);
+    catch(_a8_){
+     var _a7_ = caml_wrap_exception(_a8_);
+     if(_a7_ !== Stdlib[12]) throw caml_maybe_attach_backtrace(_a7_, 0);
      ib[2] = null_char;
      ib[3] = 0;
      ib[1] = 1;
@@ -27758,10 +27510,10 @@
      /*<<scanf.ml:271:4>>*/ return create(1, next);
     /*<<scanf.ml:271:27>>*/ }
    var _a_ = 0;
-    /*<<scanf.ml:274:22>>*/ function from_function(_a__){
-     /*<<?>>*/ return create(_a_, _a__);
+    /*<<scanf.ml:274:22>>*/ function from_function(_a6_){
+     /*<<?>>*/ return create(_a_, _a6_);
    }
-    /*<<scanf.ml:274:22>>*/  /*<<scanf.ml:274:22>>*/ var len = 1024;
+   var len = 1024;
    function scan_close_at_end(ic){
      /*<<scanf.ml:320:29>>*/  /*<<scanf.ml:320:29>>*/ caml_call1
      (Stdlib[93], ic);
@@ -27806,12 +27558,12 @@
     return from_ic(scan_close_at_end, [1, fname, ic], ic);
     /*<<scanf.ml:371:53>>*/ }
    var _b_ = Stdlib[79];
-    /*<<scanf.ml:374:16>>*/ function open_in(_a9_){
-     /*<<?>>*/ return open_in_file(_b_, _a9_);
+    /*<<scanf.ml:374:16>>*/ function open_in(_a5_){
+     /*<<?>>*/ return open_in_file(_b_, _a5_);
    }
-    /*<<scanf.ml:374:16>>*/  /*<<scanf.ml:374:16>>*/ var _c_ = Stdlib[80];
-    /*<<scanf.ml:375:20>>*/ function open_in_bin(_a8_){
-     /*<<?>>*/ return open_in_file(_c_, _a8_);
+   var _c_ = Stdlib[80];
+    /*<<scanf.ml:375:20>>*/ function open_in_bin(_a4_){
+     /*<<?>>*/ return open_in_file(_c_, _a4_);
    }
    function from_channel(ic){
      /*<<scanf.ml:381:4>>*/ return from_ic(scan_raise_at_end, [0, ic], ic);
@@ -27828,9 +27580,102 @@
      /*<<scanf.ml:388:32>>*/ return  /*<<scanf.ml:388:32>>*/ caml_call1
             (Stdlib[93], ic$0);
     /*<<scanf.ml:389:39>>*/ }
-    /*<<scanf.ml:403:0>>*/  /*<<scanf.ml:403:0>>*/ var
-    Scan_failure =
-      [248, cst_Stdlib_Scanf_Scan_failure, runtime.caml_fresh_oo_id(0)];
+    /*<<scanf.ml:403:0>>*/ var
+     /*<<scanf.ml:403:0>>*/ Scan_failure =
+      [248, "Stdlib.Scanf.Scan_failure", runtime.caml_fresh_oo_id(0)],
+    _d_ =
+      [0,
+       [11, "illegal escape character ", [1, 0]],
+       "illegal escape character %C"],
+    _e_ =
+      [0,
+       [11,
+        cst_scanning_of,
+        [2,
+         0,
+         [11, " failed: the specified length was too short for token", 0]]],
+       "scanning of %s failed: the specified length was too short for token"],
+    _f_ =
+      [0,
+       [11,
+        cst_scanning_of,
+        [2,
+         0,
+         [11,
+          " failed: premature end of file occurred before end of token",
+          0]]],
+       "scanning of %s failed: premature end of file occurred before end of token"],
+    cst_no_dot_or_exponent_part_fo =
+      "no dot or exponent part found in float token",
+    cst_not_a_valid_float_in_hexad =
+      "not a valid float in hexadecimal notation",
+    _g_ =
+      [0,
+       [11, "looking for ", [1, [11, ", found ", [1, 0]]]],
+       "looking for %C, found %C"],
+    _h_ =
+      [0,
+       [11, "invalid boolean '", [2, 0, [12, 39, 0]]],
+       "invalid boolean '%s'"],
+    _i_ = [0, cst_scanf_ml, 516, 9],
+    cst_0b = "0b",
+    cst_0o = "0o",
+    cst_0u = "0u",
+    cst_0x = "0x",
+    cst_decimal_digits = "decimal digits",
+    _j_ =
+      [0,
+       [11, cst_character, [1, [11, " is not a decimal digit", 0]]],
+       "character %C is not a decimal digit"],
+    cst_digits = "digits",
+    _k_ =
+      [0,
+       [11,
+        cst_character,
+        [1, [11, " is not a valid ", [2, 0, [11, " digit", 0]]]]],
+       "character %C is not a valid %s digit"],
+    cst_binary = "binary",
+    cst_octal = "octal",
+    cst_hexadecimal = "hexadecimal",
+    cst_an = "an",
+    cst_nfinity = "nfinity",
+    cst_x = "x",
+    _l_ =
+      [0,
+       [11, "bad character decimal encoding \\", [0, [0, [0, 0]]]],
+       "bad character decimal encoding \\%c%c%c"],
+    _m_ =
+      [0,
+       [11, "bad character hexadecimal encoding \\", [0, [0, 0]]],
+       "bad character hexadecimal encoding \\%c%c"],
+    cst_a_Char = "a Char",
+    cst_a_String = "a String",
+    _n_ =
+      [0,
+       [11, "the character ", [1, [11, " cannot start a boolean", 0]]],
+       "the character %C cannot start a boolean"],
+    _o_ =
+      [0,
+       [11,
+        "scanf: bad input at char number ",
+        [4, 3, 0, 0, [11, ": ", [2, 0, 0]]]],
+       "scanf: bad input at char number %i: %s"],
+    _p_ = [0, 37, ""],
+    _q_ = [0, 123],
+    _r_ = [0, 91],
+    cst_end_of_input_not_found = "end of input not found",
+    cst_scanf_bad_conversion_a = 'scanf: bad conversion "%a"',
+    cst_scanf_bad_conversion_t = 'scanf: bad conversion "%t"',
+    cst_scanf_missing_reader = "scanf: missing reader",
+    _s_ = [0, cst_scanf_ml, 1414, 13],
+    cst_scanf_bad_conversion_custo =
+      'scanf: bad conversion "%?" (custom converter)',
+    cst_scanf_bad_conversion = cst_scanf_bad_conversion$3,
+    cst_scanf_bad_conversion$0 = cst_scanf_bad_conversion$3,
+    cst_scanf_bad_conversion$1 = 'scanf: bad conversion "%-"',
+    cst_scanf_bad_conversion$2 = cst_scanf_bad_conversion$3,
+    cst_in_format = ' in format "',
+    _t_ = [0, [3, 0, [10, 0]], "%S%!"];
    function bad_input(s){
      /*<<scanf.ml:405:18>>*/ throw  /*<<scanf.ml:405:18>>*/ caml_maybe_attach_backtrace
            ([0, Scan_failure, s], 1);
@@ -27869,15 +27714,15 @@
      /*<<scanf.ml:444:2>>*/ for(;;){
       /*<<scanf.ml:444:10>>*/ var
        /*<<scanf.ml:444:10>>*/ c = peek_char(ib),
-       /*<<scanf.ml:445:9>>*/ _a6_ = 1 - ib[1];
-     if(! _a6_)  /*<<scanf.ml:445:9>>*/ return _a6_;
-      /*<<scanf.ml:445:32>>*/  /*<<scanf.ml:445:32>>*/ var _a7_ = c - 9 | 0;
+       /*<<scanf.ml:445:9>>*/ _a2_ = 1 - ib[1];
+     if(! _a2_)  /*<<scanf.ml:445:9>>*/ return _a2_;
+      /*<<scanf.ml:445:32>>*/  /*<<scanf.ml:445:32>>*/ var _a3_ = c - 9 | 0;
      a:
      {
-      if(4 < _a7_ >>> 0){
-       if(23 === _a7_) break a;
+      if(4 < _a3_ >>> 0){
+       if(23 === _a3_) break a;
       }
-      else if(1 < _a7_ - 2 >>> 0) break a;
+      else if(1 < _a3_ - 2 >>> 0) break a;
        /*<<scanf.ml:449:11>>*/ return 0;
      }
       /*<<scanf.ml:448:6>>*/ invalidate_current_char(ib);
@@ -27928,23 +27773,23 @@
      /*<<scanf.ml:523:2>>*/ switch(conv){
       case 0:
         /*<<scanf.ml:529:29>>*/ var
-         /*<<scanf.ml:529:29>>*/ _a2_ = token_string(ib),
-        tok =  /*<<scanf.ml:529:22>>*/ caml_call2(Stdlib[28], cst_0b, _a2_);
+         /*<<scanf.ml:529:29>>*/ _aY_ = token_string(ib),
+        tok =  /*<<scanf.ml:529:22>>*/ caml_call2(Stdlib[28], cst_0b, _aY_);
        break;
       case 3:
         /*<<scanf.ml:527:29>>*/ var
-         /*<<scanf.ml:527:29>>*/ _a3_ = token_string(ib),
-        tok =  /*<<scanf.ml:527:22>>*/ caml_call2(Stdlib[28], cst_0o, _a3_);
+         /*<<scanf.ml:527:29>>*/ _aZ_ = token_string(ib),
+        tok =  /*<<scanf.ml:527:22>>*/ caml_call2(Stdlib[28], cst_0o, _aZ_);
        break;
       case 4:
         /*<<scanf.ml:526:29>>*/ var
-         /*<<scanf.ml:526:29>>*/ _a4_ = token_string(ib),
-        tok =  /*<<scanf.ml:526:22>>*/ caml_call2(Stdlib[28], cst_0u, _a4_);
+         /*<<scanf.ml:526:29>>*/ _a0_ = token_string(ib),
+        tok =  /*<<scanf.ml:526:22>>*/ caml_call2(Stdlib[28], cst_0u, _a0_);
        break;
       case 5:
         /*<<scanf.ml:528:29>>*/ var
-         /*<<scanf.ml:528:29>>*/ _a5_ = token_string(ib),
-        tok =  /*<<scanf.ml:528:22>>*/ caml_call2(Stdlib[28], cst_0x, _a5_);
+         /*<<scanf.ml:528:29>>*/ _a1_ = token_string(ib),
+        tok =  /*<<scanf.ml:528:22>>*/ caml_call2(Stdlib[28], cst_0x, _a1_);
        break;
       default: var tok = token_string(ib);
     }
@@ -28029,31 +27874,31 @@
    function is_binary_digit(param){
      /*<<scanf.ml:629:22>>*/ return 1 < param - 48 >>> 0 ? 0 : 1;
     /*<<scanf.ml:631:14>>*/ }
-    /*<<scanf.ml:634:22>>*/ function scan_binary_int(_a0_, _a1_){
-     /*<<?>>*/ return scan_digit_plus(cst_binary, is_binary_digit, _a0_, _a1_);
+    /*<<scanf.ml:634:22>>*/ function scan_binary_int(_aW_, _aX_){
+     /*<<?>>*/ return scan_digit_plus(cst_binary, is_binary_digit, _aW_, _aX_);
    }
    function is_octal_digit(param){
      /*<<scanf.ml:636:21>>*/ return 7 < param - 48 >>> 0 ? 0 : 1;
     /*<<scanf.ml:638:14>>*/ }
-    /*<<scanf.ml:641:21>>*/ function scan_octal_int(_aY_, _aZ_){
-     /*<<?>>*/ return scan_digit_plus(cst_octal, is_octal_digit, _aY_, _aZ_);
+    /*<<scanf.ml:641:21>>*/ function scan_octal_int(_aU_, _aV_){
+     /*<<?>>*/ return scan_digit_plus(cst_octal, is_octal_digit, _aU_, _aV_);
    }
    function is_hexa_digit(param){
      /*<<scanf.ml:643:20>>*/  /*<<scanf.ml:643:20>>*/ var
-     _aX_ = param - 48 | 0;
+     _aT_ = param - 48 | 0;
     a:
     {
-     if(22 < _aX_ >>> 0){
-      if(5 < _aX_ - 49 >>> 0) break a;
+     if(22 < _aT_ >>> 0){
+      if(5 < _aT_ - 49 >>> 0) break a;
      }
-     else if(6 >= _aX_ - 10 >>> 0) break a;
+     else if(6 >= _aT_ - 10 >>> 0) break a;
       /*<<scanf.ml:644:44>>*/ return 1;
     }
      /*<<scanf.ml:645:9>>*/ return 0;
     /*<<scanf.ml:645:14>>*/ }
-    /*<<scanf.ml:648:27>>*/ function scan_hexadecimal_int(_aV_, _aW_){
+    /*<<scanf.ml:648:27>>*/ function scan_hexadecimal_int(_aR_, _aS_){
      /*<<?>>*/ return scan_digit_plus
-            (cst_hexadecimal, is_hexa_digit, _aV_, _aW_);
+            (cst_hexadecimal, is_hexa_digit, _aR_, _aS_);
    }
    function scan_sign(width, ib){
      /*<<scanf.ml:654:2>>*/ var
@@ -28173,38 +28018,38 @@
       /*<<scanf.ml:785:2>>*/ len =
         /*<<scanf.ml:785:2>>*/ caml_ml_string_length(str),
       /*<<scanf.ml:786:14>>*/ width$0 = [0, width],
-      /*<<scanf.ml:787:2>>*/ _aS_ = len - 1 | 0,
-      /*<<scanf.ml:786:14>>*/ _aR_ = 0;
-    if(_aS_ >= 0){
-     var i = _aR_;
+      /*<<scanf.ml:787:2>>*/ _aO_ = len - 1 | 0,
+      /*<<scanf.ml:786:14>>*/ _aN_ = 0;
+    if(_aO_ >= 0){
+     var i = _aN_;
      for(;;){
        /*<<scanf.ml:788:12>>*/ var
         /*<<scanf.ml:788:12>>*/ c = peek_char(ib),
-        /*<<scanf.ml:789:22>>*/ _aT_ =
+        /*<<scanf.ml:789:22>>*/ _aP_ =
          lowercase( /*<<scanf.ml:789:32>>*/ caml_string_get(str, i));
-      if(lowercase(c) !== _aT_)
+      if(lowercase(c) !== _aP_)
         /*<<scanf.ml:789:45>>*/  /*<<scanf.ml:789:45>>*/ caml_call1(error, 0);
       if(0 === width$0[1])
         /*<<scanf.ml:790:23>>*/  /*<<scanf.ml:790:23>>*/ caml_call1(error, 0);
       width$0[1] = store_char(width$0[1], ib, c);
-       /*<<scanf.ml:787:2>>*/  /*<<scanf.ml:787:2>>*/ var _aU_ = i + 1 | 0;
-      if(_aS_ === i) break;
-      var i = _aU_;
+       /*<<scanf.ml:787:2>>*/  /*<<scanf.ml:787:2>>*/ var _aQ_ = i + 1 | 0;
+      if(_aO_ === i) break;
+      var i = _aQ_;
      }
     }
     return width$0[1];
     /*<<scanf.ml:793:8>>*/ }
    function scan_hex_float(width, precision, ib){
      /*<<scanf.ml:797:2>>*/ var
-     _aE_ = 0 === width ? 1 : 0,
-     _aF_ = _aE_ || end_of_input(ib);
-     /*<<scanf.ml:797:18>>*/ if(_aF_)
+     _aA_ = 0 === width ? 1 : 0,
+     _aB_ = _aA_ || end_of_input(ib);
+     /*<<scanf.ml:797:18>>*/ if(_aB_)
       /*<<scanf.ml:797:48>>*/ bad_hex_float(0);
      /*<<scanf.ml:798:14>>*/ var
       /*<<scanf.ml:798:14>>*/ width$0 = scan_sign(width, ib),
-     _aG_ = 0 === width$0 ? 1 : 0,
-     _aH_ = _aG_ || end_of_input(ib);
-     /*<<scanf.ml:799:18>>*/ if(_aH_)
+     _aC_ = 0 === width$0 ? 1 : 0,
+     _aD_ = _aC_ || end_of_input(ib);
+     /*<<scanf.ml:799:18>>*/ if(_aD_)
       /*<<scanf.ml:799:48>>*/ bad_hex_float(0);
      /*<<scanf.ml:800:8>>*/  /*<<scanf.ml:800:8>>*/ var c = peek_char(ib);
     a:
@@ -28216,9 +28061,9 @@
        if(32 <= switcher) break a;
         /*<<scanf.ml:830:16>>*/ var
          /*<<scanf.ml:830:16>>*/ width$1 = store_char(width$0, ib, c),
-        _aI_ = 0 === width$1 ? 1 : 0,
-        _aJ_ = _aI_ || end_of_input(ib);
-        /*<<scanf.ml:831:20>>*/ if(_aJ_)
+        _aE_ = 0 === width$1 ? 1 : 0,
+        _aF_ = _aE_ || end_of_input(ib);
+        /*<<scanf.ml:831:20>>*/ if(_aF_)
          /*<<scanf.ml:831:50>>*/ bad_hex_float(0);
         /*<<scanf.ml:831:50>>*/ return check_case_insensitive_string
                (width$1, ib, bad_hex_float, cst_an);
@@ -28229,24 +28074,24 @@
       if(48 === c){
         /*<<scanf.ml:802:16>>*/ var
          /*<<scanf.ml:802:16>>*/ width$3 = store_char(width$0, ib, c),
-        _aM_ = 0 === width$3 ? 1 : 0,
-        _aN_ = _aM_ || end_of_input(ib);
-        /*<<scanf.ml:803:20>>*/ if(_aN_)
+        _aI_ = 0 === width$3 ? 1 : 0,
+        _aJ_ = _aI_ || end_of_input(ib);
+        /*<<scanf.ml:803:20>>*/ if(_aJ_)
          /*<<scanf.ml:803:50>>*/ bad_hex_float(0);
         /*<<scanf.ml:804:16>>*/  /*<<scanf.ml:804:16>>*/ var
         width$4 =
           check_case_insensitive_string(width$3, ib, bad_hex_float, cst_x);
         /*<<scanf.ml:805:20>>*/ if(0 !== width$4 && ! end_of_input(ib)){
          /*<<scanf.ml:806:24>>*/  /*<<scanf.ml:806:24>>*/ var
-         _aO_ = peek_char(ib) - 46 | 0;
+         _aK_ = peek_char(ib) - 46 | 0;
         b:
         {
          c:
          {
-          if(34 < _aO_ >>> 0){
-           if(66 === _aO_) break c;
+          if(34 < _aK_ >>> 0){
+           if(66 === _aK_) break c;
           }
-          else if(32 < _aO_ - 1 >>> 0) break c;
+          else if(32 < _aK_ - 1 >>> 0) break c;
           var width$5 = scan_hexadecimal_int(width$4, ib);
           break b;
          }
@@ -28294,9 +28139,9 @@
             /*<<scanf.ml:827:17>>*/ return width$8;
            /*<<scanf.ml:824:24>>*/ var
             /*<<scanf.ml:824:24>>*/ width$9 = store_char(width$8, ib, c$1),
-           _aP_ = 0 === width$9 ? 1 : 0,
-           _aQ_ = _aP_ || end_of_input(ib);
-           /*<<scanf.ml:825:28>>*/ if(_aQ_)
+           _aL_ = 0 === width$9 ? 1 : 0,
+           _aM_ = _aL_ || end_of_input(ib);
+           /*<<scanf.ml:825:28>>*/ if(_aM_)
             /*<<scanf.ml:825:58>>*/ bad_hex_float(0);
            /*<<scanf.ml:825:58>>*/ return scan_optionally_signed_decimal
                   (width$9, ib);
@@ -28311,9 +28156,9 @@
      }
       /*<<scanf.ml:834:16>>*/ var
        /*<<scanf.ml:834:16>>*/ width$2 = store_char(width$0, ib, c),
-      _aK_ = 0 === width$2 ? 1 : 0,
-      _aL_ = _aK_ || end_of_input(ib);
-      /*<<scanf.ml:835:20>>*/ if(_aL_)
+      _aG_ = 0 === width$2 ? 1 : 0,
+      _aH_ = _aG_ || end_of_input(ib);
+      /*<<scanf.ml:835:20>>*/ if(_aH_)
        /*<<scanf.ml:835:50>>*/ bad_hex_float(0);
       /*<<scanf.ml:835:50>>*/ return check_case_insensitive_string
              (width$2, ib, bad_hex_float, cst_nfinity);
@@ -28322,14 +28167,14 @@
     /*<<scanf.ml:837:25>>*/ }
    function scan_caml_float_rest(width, precision, ib){
      /*<<scanf.ml:841:2>>*/ var
-     _aA_ = 0 === width ? 1 : 0,
-     _aB_ = _aA_ || end_of_input(ib);
-     /*<<scanf.ml:841:18>>*/ if(_aB_)  /*<<scanf.ml:841:48>>*/ bad_float(0);
+     _aw_ = 0 === width ? 1 : 0,
+     _ax_ = _aw_ || end_of_input(ib);
+     /*<<scanf.ml:841:18>>*/ if(_ax_)  /*<<scanf.ml:841:48>>*/ bad_float(0);
      /*<<scanf.ml:842:14>>*/ var
       /*<<scanf.ml:842:14>>*/ width$0 = scan_decimal_digit_star(width, ib),
-     _aC_ = 0 === width$0 ? 1 : 0,
-     _aD_ = _aC_ || end_of_input(ib);
-     /*<<scanf.ml:843:18>>*/ if(_aD_)  /*<<scanf.ml:843:48>>*/ bad_float(0);
+     _ay_ = 0 === width$0 ? 1 : 0,
+     _az_ = _ay_ || end_of_input(ib);
+     /*<<scanf.ml:843:18>>*/ if(_az_)  /*<<scanf.ml:843:48>>*/ bad_float(0);
      /*<<scanf.ml:844:10>>*/ var
       /*<<scanf.ml:844:10>>*/ c = peek_char(ib),
       /*<<scanf.ml:844:10>>*/ switcher = c - 69 | 0;
@@ -28353,22 +28198,22 @@
     /*<<scanf.ml:862:21>>*/ }
    function scan_caml_float(width, precision, ib){
      /*<<scanf.ml:866:2>>*/ var
-     _am_ = 0 === width ? 1 : 0,
-     _an_ = _am_ || end_of_input(ib);
-     /*<<scanf.ml:866:18>>*/ if(_an_)  /*<<scanf.ml:866:48>>*/ bad_float(0);
+     _ai_ = 0 === width ? 1 : 0,
+     _aj_ = _ai_ || end_of_input(ib);
+     /*<<scanf.ml:866:18>>*/ if(_aj_)  /*<<scanf.ml:866:48>>*/ bad_float(0);
      /*<<scanf.ml:867:14>>*/ var
       /*<<scanf.ml:867:14>>*/ width$0 = scan_sign(width, ib),
-     _ao_ = 0 === width$0 ? 1 : 0,
-     _ap_ = _ao_ || end_of_input(ib);
-     /*<<scanf.ml:868:18>>*/ if(_ap_)  /*<<scanf.ml:868:48>>*/ bad_float(0);
+     _ak_ = 0 === width$0 ? 1 : 0,
+     _al_ = _ak_ || end_of_input(ib);
+     /*<<scanf.ml:868:18>>*/ if(_al_)  /*<<scanf.ml:868:48>>*/ bad_float(0);
      /*<<scanf.ml:869:8>>*/  /*<<scanf.ml:869:8>>*/ var c = peek_char(ib);
     if(49 <= c){
      if(58 > c){
        /*<<scanf.ml:903:16>>*/ var
         /*<<scanf.ml:903:16>>*/ width$1 = store_char(width$0, ib, c),
-       _aq_ = 0 === width$1 ? 1 : 0,
-       _ar_ = _aq_ || end_of_input(ib);
-       /*<<scanf.ml:904:20>>*/ if(_ar_)  /*<<scanf.ml:904:50>>*/ bad_float(0);
+       _am_ = 0 === width$1 ? 1 : 0,
+       _an_ = _am_ || end_of_input(ib);
+       /*<<scanf.ml:904:20>>*/ if(_an_)  /*<<scanf.ml:904:50>>*/ bad_float(0);
        /*<<scanf.ml:904:50>>*/ return scan_caml_float_rest
               (width$1, precision, ib);
      }
@@ -28376,9 +28221,9 @@
     else if(48 <= c){
       /*<<scanf.ml:871:16>>*/ var
        /*<<scanf.ml:871:16>>*/ width$2 = store_char(width$0, ib, c),
-      _as_ = 0 === width$2 ? 1 : 0,
-      _at_ = _as_ || end_of_input(ib);
-      /*<<scanf.ml:872:20>>*/ if(_at_)  /*<<scanf.ml:872:50>>*/ bad_float(0);
+      _ao_ = 0 === width$2 ? 1 : 0,
+      _ap_ = _ao_ || end_of_input(ib);
+      /*<<scanf.ml:872:20>>*/ if(_ap_)  /*<<scanf.ml:872:50>>*/ bad_float(0);
       /*<<scanf.ml:873:10>>*/  /*<<scanf.ml:873:10>>*/ var
       c$0 = peek_char(ib);
      if(88 !== c$0 && 120 !== c$0)
@@ -28386,14 +28231,14 @@
               (width$2, precision, ib);
       /*<<scanf.ml:875:18>>*/ var
        /*<<scanf.ml:875:18>>*/ width$3 = store_char(width$2, ib, c$0),
-      _au_ = 0 === width$3 ? 1 : 0,
-      _av_ = _au_ || end_of_input(ib);
-      /*<<scanf.ml:876:22>>*/ if(_av_)  /*<<scanf.ml:876:52>>*/ bad_float(0);
+      _aq_ = 0 === width$3 ? 1 : 0,
+      _ar_ = _aq_ || end_of_input(ib);
+      /*<<scanf.ml:876:22>>*/ if(_ar_)  /*<<scanf.ml:876:52>>*/ bad_float(0);
       /*<<scanf.ml:877:18>>*/ var
        /*<<scanf.ml:877:18>>*/ width$4 = scan_hexadecimal_int(width$3, ib),
-      _aw_ = 0 === width$4 ? 1 : 0,
-      _ax_ = _aw_ || end_of_input(ib);
-      /*<<scanf.ml:878:22>>*/ if(_ax_)  /*<<scanf.ml:878:52>>*/ bad_float(0);
+      _as_ = 0 === width$4 ? 1 : 0,
+      _at_ = _as_ || end_of_input(ib);
+      /*<<scanf.ml:878:22>>*/ if(_at_)  /*<<scanf.ml:878:52>>*/ bad_float(0);
       /*<<scanf.ml:879:24>>*/ var
        /*<<scanf.ml:879:24>>*/ c$1 = peek_char(ib),
        /*<<scanf.ml:879:24>>*/ switcher = c$1 - 80 | 0;
@@ -28446,9 +28291,9 @@
       if(80 !== c$2 && 112 !== c$2)  /*<<scanf.ml:897:15>>*/ return width$8;
        /*<<scanf.ml:894:22>>*/ var
         /*<<scanf.ml:894:22>>*/ width$9 = store_char(width$8, ib, c$2),
-       _ay_ = 0 === width$9 ? 1 : 0,
-       _az_ = _ay_ || end_of_input(ib);
-       /*<<scanf.ml:895:26>>*/ if(_az_)
+       _au_ = 0 === width$9 ? 1 : 0,
+       _av_ = _au_ || end_of_input(ib);
+       /*<<scanf.ml:895:26>>*/ if(_av_)
         /*<<scanf.ml:895:56>>*/ bad_hex_float(0);
        /*<<scanf.ml:895:56>>*/ return scan_optionally_signed_decimal
               (width$9, ib);
@@ -28465,13 +28310,13 @@
       /*<<scanf.ml:923:7>>*/ if(ib[1])
        /*<<scanf.ml:923:28>>*/ return width$0;
      if(! stp){
-       /*<<scanf.ml:928:8>>*/  /*<<scanf.ml:928:8>>*/ var _al_ = c - 9 | 0;
+       /*<<scanf.ml:928:8>>*/  /*<<scanf.ml:928:8>>*/ var _ah_ = c - 9 | 0;
       a:
       {
-       if(4 < _al_ >>> 0){
-        if(23 === _al_) break a;
+       if(4 < _ah_ >>> 0){
+        if(23 === _ah_) break a;
        }
-       else if(1 < _al_ - 2 >>> 0) break a;
+       else if(1 < _ah_ - 2 >>> 0) break a;
         /*<<scanf.ml:930:20>>*/ var
          /*<<scanf.ml:930:20>>*/ width$2 = store_char(width$0, ib, c),
         width$0 = width$2;
@@ -28501,11 +28346,11 @@
                 (Stdlib_Printf[4], _f_, message))
             : c;
     /*<<scanf.ml:998:3>>*/ }
-    /*<<scanf.ml:1001:31>>*/ function check_next_char_for_char(_aj_, _ak_){
-     /*<<?>>*/ return check_next_char(cst_a_Char, _aj_, _ak_);
+    /*<<scanf.ml:1001:31>>*/ function check_next_char_for_char(_af_, _ag_){
+     /*<<?>>*/ return check_next_char(cst_a_Char, _af_, _ag_);
    }
-    /*<<scanf.ml:1002:33>>*/ function check_next_char_for_string(_ah_, _ai_){
-     /*<<?>>*/ return check_next_char(cst_a_String, _ah_, _ai_);
+    /*<<scanf.ml:1002:33>>*/ function check_next_char_for_string(_ad_, _ae_){
+     /*<<?>>*/ return check_next_char(cst_a_String, _ad_, _ae_);
    }
    function scan_backslash_char(width, ib){
      /*<<scanf.ml:1005:2>>*/  /*<<scanf.ml:1005:8>>*/ var
@@ -28531,16 +28376,16 @@
        b:
        {
         if(0 <= c && 255 >= c){
-         var _af_ =  /*<<scanf.ml:963:2>>*/ caml_call1(Stdlib[29], c);
+         var _ab_ =  /*<<scanf.ml:963:2>>*/ caml_call1(Stdlib[29], c);
          break b;
         }
         var
-         _af_ =
+         _ab_ =
            bad_input
             ( /*<<scanf.ml:961:6>>*/ caml_call4
               (Stdlib_Printf[4], _l_, c0, c1$0, c2$0));
        }
-        /*<<scanf.ml:1017:39>>*/ return store_char(width - 2 | 0, ib, _af_);
+        /*<<scanf.ml:1017:39>>*/ return store_char(width - 2 | 0, ib, _ab_);
       }
        /*<<scanf.ml:1005:8>>*/  /*<<scanf.ml:1005:8>>*/ var
        switcher = c0 - 92 | 0;
@@ -28552,34 +28397,34 @@
             function(param){
               /*<<scanf.ml:1020:6>>*/ var
                /*<<scanf.ml:1020:14>>*/ c = next_char(ib),
-               /*<<scanf.ml:1020:14>>*/ _ag_ = c - 48 | 0;
+               /*<<scanf.ml:1020:14>>*/ _ac_ = c - 48 | 0;
              a:
              {
-              if(22 < _ag_ >>> 0){
-               if(5 < _ag_ - 49 >>> 0) break a;
+              if(22 < _ac_ >>> 0){
+               if(5 < _ac_ - 49 >>> 0) break a;
               }
-              else if(6 >= _ag_ - 10 >>> 0) break a;
+              else if(6 >= _ac_ - 10 >>> 0) break a;
                /*<<scanf.ml:1022:53>>*/ return c;
              }
               /*<<scanf.ml:1023:13>>*/ return bad_input_escape(c);
              /*<<scanf.ml:1023:31>>*/ },
            /*<<scanf.ml:1024:13>>*/ c1 = get_digit(0),
            /*<<scanf.ml:1025:13>>*/ c2 = get_digit(0),
-           /*<<scanf.ml:985:9>>*/ _ac_ = hexadecimal_value_of_char(c2),
-          c$0 = (16 * hexadecimal_value_of_char(c1) | 0) + _ac_ | 0;
+           /*<<scanf.ml:985:9>>*/ ___ = hexadecimal_value_of_char(c2),
+          c$0 = (16 * hexadecimal_value_of_char(c1) | 0) + ___ | 0;
          b:
          {
           if(0 <= c$0 && 255 >= c$0){
-           var _ae_ =  /*<<scanf.ml:989:2>>*/ caml_call1(Stdlib[29], c$0);
+           var _aa_ =  /*<<scanf.ml:989:2>>*/ caml_call1(Stdlib[29], c$0);
            break b;
           }
           var
-           _ae_ =
+           _aa_ =
              bad_input
               ( /*<<scanf.ml:988:6>>*/ caml_call3
                 (Stdlib_Printf[4], _m_, c1, c2));
          }
-          /*<<scanf.ml:1026:39>>*/ return store_char(width - 2 | 0, ib, _ae_);
+          /*<<scanf.ml:1026:39>>*/ return store_char(width - 2 | 0, ib, _aa_);
         case 0:
         case 6:
         case 18:
@@ -28595,17 +28440,17 @@
        if(117 > c0)
         switch(c0 - 110 | 0){
           case 0:
-           var _ad_ = 10; break b;
+           var _$_ = 10; break b;
           case 4:
-           var _ad_ = 13; break b;
+           var _$_ = 13; break b;
           case 6:
-           var _ad_ = 9; break b;
+           var _$_ = 9; break b;
         }
       }
-      else if(98 === c0){var _ad_ = 8; break b;}
-      var _ad_ = c0;
+      else if(98 === c0){var _$_ = 8; break b;}
+      var _$_ = c0;
      }
-      /*<<scanf.ml:1007:33>>*/ return store_char(width, ib, _ad_);
+      /*<<scanf.ml:1007:33>>*/ return store_char(width, ib, _$_);
     }
      /*<<scanf.ml:1028:4>>*/ return bad_input_escape(c0);
     /*<<scanf.ml:1028:22>>*/ }
@@ -28623,24 +28468,24 @@
           check_next_char_for_string(width$1, ib);
        if(10 === match){
          /*<<scanf.ml:1071:26>>*/  /*<<scanf.ml:1071:26>>*/ var
-         _aa_ = ignore_char(width$1, ib);
+         _Y_ = ignore_char(width$1, ib);
          /*<<scanf.ml:1071:26>>*/ if(counter >= 50)
           /*<<scanf.ml:1071:26>>*/ return  /*<<scanf.ml:1071:26>>*/ caml_trampoline_return
-                 (skip_spaces, [0, _aa_]);
+                 (skip_spaces, [0, _Y_]);
         var counter$0 = counter + 1 | 0;
-         /*<<scanf.ml:1071:26>>*/ return skip_spaces(counter$0, _aa_);
+         /*<<scanf.ml:1071:26>>*/ return skip_spaces(counter$0, _Y_);
        }
        if(13 === match){
          /*<<scanf.ml:1070:27>>*/  /*<<scanf.ml:1070:27>>*/ var
          width$3 = ignore_char(width$1, ib);
         if(10 === check_next_char_for_string(width$3, ib)){
           /*<<scanf.ml:1076:26>>*/  /*<<scanf.ml:1076:26>>*/ var
-          _ab_ = ignore_char(width$3, ib);
+          _Z_ = ignore_char(width$3, ib);
           /*<<scanf.ml:1076:26>>*/ if(counter >= 50)
            /*<<scanf.ml:1076:26>>*/ return  /*<<scanf.ml:1076:26>>*/ caml_trampoline_return
-                  (skip_spaces, [0, _ab_]);
+                  (skip_spaces, [0, _Z_]);
          var counter$1 = counter + 1 | 0;
-          /*<<scanf.ml:1076:26>>*/ return skip_spaces(counter$1, _ab_);
+          /*<<scanf.ml:1076:26>>*/ return skip_spaces(counter$1, _Z_);
         }
          /*<<scanf.ml:1077:21>>*/ var
           /*<<scanf.ml:1077:21>>*/ width$5 = store_char(width$3, ib, 13),
@@ -28687,22 +28532,22 @@
       /*<<scanf.ml:1104:4>>*/ for(;;){
        /*<<scanf.ml:1104:12>>*/ var
         /*<<scanf.ml:1104:12>>*/ c = peek_char(ib),
-       _Y_ = 0 < i$0 ? 1 : 0;
-      if(_Y_){
+       _U_ = 0 < i$0 ? 1 : 0;
+      if(_U_){
         /*<<scanf.ml:1105:20>>*/  /*<<scanf.ml:1105:20>>*/ var
-        _Z_ = 1 - ib[1];
-       if(_Z_)
+        _V_ = 1 - ib[1];
+       if(_V_)
          /*<<scanf.ml:1106:7>>*/ var
-          /*<<scanf.ml:1106:7>>*/ ___ =
+          /*<<scanf.ml:1106:7>>*/ _W_ =
             /*<<scanf.ml:1106:7>>*/ caml_call2
             (CamlinternalFormat[1], char_set, c),
-          /*<<scanf.ml:1106:7>>*/ _$_ = ___ ? c !== stp ? 1 : 0 : ___;
+          /*<<scanf.ml:1106:7>>*/ _X_ = _W_ ? c !== stp ? 1 : 0 : _W_;
        else
-        var _$_ = _Z_;
+        var _X_ = _V_;
       }
       else
-       var _$_ = _Y_;
-      if(! _$_) return _$_;
+       var _X_ = _U_;
+      if(! _X_) return _X_;
        /*<<scanf.ml:1108:14>>*/ store_char(Stdlib[19], ib, c);
       var i$1 = i$0 - 1 | 0, i$0 = i$1;
      }
@@ -28710,8 +28555,8 @@
     if(! scan_indic)  /*<<scanf.ml:1111:12>>*/ return scan_chars(width, -1);
     var c = scan_indic[1];
      /*<<scanf.ml:1113:4>>*/ scan_chars(width, c);
-     /*<<scanf.ml:1114:11>>*/  /*<<scanf.ml:1114:11>>*/ var _X_ = 1 - ib[1];
-    if(! _X_)  /*<<scanf.ml:1114:11>>*/ return _X_;
+     /*<<scanf.ml:1114:11>>*/  /*<<scanf.ml:1114:11>>*/ var _T_ = 1 - ib[1];
+    if(! _T_)  /*<<scanf.ml:1114:11>>*/ return _T_;
      /*<<scanf.ml:1115:15>>*/  /*<<scanf.ml:1115:15>>*/ var
      ci = peek_char(ib);
     return c === ci ? invalidate_current_char(ib) : character_mismatch(c, ci);
@@ -28791,17 +28636,17 @@
          /*<<scanf.ml:1195:44>>*/ var
          rest$13 = fmt$0[3],
          fmtty = fmt$0[2],
-          /*<<scanf.ml:1195:44>>*/ _U_ =
+          /*<<scanf.ml:1195:44>>*/ _Q_ =
             /*<<scanf.ml:1195:44>>*/ caml_call1(CamlinternalFormat[21], fmtty),
-          /*<<scanf.ml:1195:33>>*/ _V_ =
+          /*<<scanf.ml:1195:33>>*/ _R_ =
             /*<<scanf.ml:1195:33>>*/ caml_call1
-            (CamlinternalFormatBasics[2], _U_);
+            (CamlinternalFormatBasics[2], _Q_);
          /*<<scanf.ml:1195:5>>*/ if(counter >= 50)
           /*<<scanf.ml:1195:5>>*/ return  /*<<scanf.ml:1195:5>>*/ caml_trampoline_return
-                 (take_fmtty_format_readers$0, [0, k, _V_, rest$13]);
+                 (take_fmtty_format_readers$0, [0, k, _R_, rest$13]);
         var counter$0 = counter + 1 | 0;
          /*<<scanf.ml:1195:5>>*/ return take_fmtty_format_readers$0
-                (counter$0, k, _V_, rest$13);
+                (counter$0, k, _R_, rest$13);
        case 15:
         var rest$14 = fmt$0[1], fmt$0 = rest$14; break;
        case 16:
@@ -28809,11 +28654,11 @@
        case 17:
         var rest$16 = fmt$0[2], fmt$0 = rest$16; break;
        case 18:
-        var _W_ = fmt$0[1];
-        if(0 === _W_[0])
+        var _S_ = fmt$0[1];
+        if(0 === _S_[0])
           /*<<scanf.ml:1189:28>>*/ var
           rest$17 = fmt$0[2],
-          fmt$1 = _W_[1][1],
+          fmt$1 = _S_[1][1],
            /*<<scanf.ml:1189:28>>*/ fmt$2 =
              /*<<scanf.ml:1189:28>>*/ caml_call2
              (CamlinternalFormatBasics[3], fmt$1, rest$17),
@@ -28821,7 +28666,7 @@
         else
           /*<<scanf.ml:1191:28>>*/ var
           rest$18 = fmt$0[2],
-          fmt$3 = _W_[1][1],
+          fmt$3 = _S_[1][1],
            /*<<scanf.ml:1191:28>>*/ fmt$4 =
              /*<<scanf.ml:1191:28>>*/ caml_call2
              (CamlinternalFormatBasics[3], fmt$3, rest$18),
@@ -28934,11 +28779,11 @@
          rest = fmtty$0[3],
          ty2 = fmtty$0[2],
          ty1 = fmtty$0[1],
-          /*<<scanf.ml:1227:19>>*/ _T_ =
+          /*<<scanf.ml:1227:19>>*/ _P_ =
             /*<<scanf.ml:1227:19>>*/ caml_call1(CamlinternalFormat[21], ty1),
           /*<<scanf.ml:1227:13>>*/ ty =
             /*<<scanf.ml:1227:13>>*/ caml_call2
-            (CamlinternalFormat[22], _T_, ty2),
+            (CamlinternalFormat[22], _P_, ty2),
           /*<<scanf.ml:1228:32>>*/ fmtty$10 =
             /*<<scanf.ml:1228:32>>*/ caml_call2
             (CamlinternalFormatBasics[1], ty, rest),
@@ -28989,9 +28834,8 @@
                 c$1,
                 make_scanf(ib, rest, readers)];
        case 1:
-         /*<<scanf.ml:1272:4>>*/ var
+         /*<<scanf.ml:1035:10>>*/ var
          rest$0 = fmt$0[1],
-          /*<<scanf.ml:1272:4>>*/ width$0 = 0,
          find_stop =
            function(width){
              /*<<scanf.ml:1047:4>>*/  /*<<scanf.ml:1047:10>>*/ var
@@ -29000,7 +28844,8 @@
                     ? ignore_char(width, ib)
                     : character_mismatch(39, c);
             /*<<scanf.ml:1049:36>>*/ },
-          /*<<scanf.ml:1035:10>>*/ c = checked_peek_char(ib);
+          /*<<scanf.ml:1035:10>>*/ c = checked_peek_char(ib),
+          /*<<scanf.ml:1272:4>>*/ width$0 = 0;
         if(39 === c){
           /*<<scanf.ml:1036:24>>*/ var
            /*<<scanf.ml:1036:24>>*/ width = ignore_char(width$0, ib),
@@ -29039,11 +28884,11 @@
              /*<<scanf.ml:1280:4>>*/ return pad_prec_scanf
                     (ib, str_rest, readers, pad, 0, scan$0, token_string);
            case 18:
-            var _F_ = match[1];
-            if(0 === _F_[0]){
+            var _D_ = match[1];
+            if(0 === _D_[0]){
               /*<<scanf.ml:1282:4>>*/ var
               rest$3 = match[2],
-              fmt$1 = _F_[1][1],
+              fmt$1 = _D_[1][1],
                /*<<scanf.ml:1282:4>>*/ scan$1 =
                 function(width, param, ib){
                   /*<<scanf.ml:1282:26>>*/ return scan_string(_q_, width, ib);
@@ -29060,7 +28905,7 @@
             }
              /*<<scanf.ml:1286:4>>*/ var
              rest$4 = match[2],
-             fmt$2 = _F_[1][1],
+             fmt$2 = _D_[1][1],
               /*<<scanf.ml:1286:4>>*/ scan$2 =
                function(width, param, ib){
                  /*<<scanf.ml:1286:26>>*/ return scan_string(_r_, width, ib);
@@ -29237,7 +29082,7 @@
          rest$13 = fmt$0[2],
          pad$8 = fmt$0[1],
           /*<<scanf.ml:1320:4>>*/ scan$8 =
-           function(param, _S_, ib){
+           function(param, _O_, ib){
              /*<<scanf.ml:1320:22>>*/ var
               /*<<scanf.ml:1089:10>>*/ c = checked_peek_char(ib),
               /*<<scanf.ml:1090:2>>*/ m =
@@ -29260,13 +29105,11 @@
         var fmt$0 = rest$14;
         break;
        case 11:
-         /*<<scanf.ml:1341:16>>*/ var
-         rest$15 = fmt$0[2],
-         str$0 = fmt$0[1],
-          /*<<scanf.ml:1341:16>>*/ _G_ =
-           function(_R_){ /*<<?>>*/ return check_char(ib, _R_);};
+        var rest$15 = fmt$0[2], str$0 = fmt$0[1];
          /*<<scanf.ml:1341:4>>*/  /*<<scanf.ml:1341:4>>*/ caml_call2
-         (Stdlib_String[30], _G_, str$0);
+         (Stdlib_String[30],
+          function(_N_){ /*<<?>>*/ return check_char(ib, _N_);},
+          str$0);
         var fmt$0 = rest$15;
         break;
        case 12:
@@ -29282,10 +29125,10 @@
          s = token_string(ib);
          /*<<scanf.ml:1350:4>>*/ try{
           /*<<scanf.ml:1351:10>>*/ var
-           /*<<scanf.ml:1351:10>>*/ _H_ =
+           /*<<scanf.ml:1351:10>>*/ _E_ =
              /*<<scanf.ml:1351:10>>*/ caml_call2
              (CamlinternalFormat[14], s, fmtty),
-          fmt$3 = _H_;
+          fmt$3 = _E_;
         }
         catch(exn$0){
          var exn = caml_wrap_exception(exn$0);
@@ -29311,23 +29154,23 @@
              /*<<scanf.ml:1361:27>>*/ caml_call2
               (CamlinternalFormat[13], 0, s$0)
              [1],
-           /*<<scanf.ml:1375:36>>*/ _J_ =
+           /*<<scanf.ml:1375:36>>*/ _G_ =
              /*<<scanf.ml:1375:36>>*/ caml_call1
              (CamlinternalFormat[21], fmtty$0),
-           /*<<scanf.ml:1375:25>>*/ _K_ =
+           /*<<scanf.ml:1375:25>>*/ _H_ =
              /*<<scanf.ml:1375:25>>*/ caml_call1
-             (CamlinternalFormatBasics[2], _J_),
+             (CamlinternalFormatBasics[2], _G_),
            /*<<scanf.ml:1375:8>>*/ fmt$8 =
              /*<<scanf.ml:1375:8>>*/ caml_call2
-             (CamlinternalFormat[12], fmt$7, _K_),
-           /*<<scanf.ml:1374:24>>*/ _L_ =
+             (CamlinternalFormat[12], fmt$7, _H_),
+           /*<<scanf.ml:1374:24>>*/ _I_ =
              /*<<scanf.ml:1374:24>>*/ caml_call1
              (CamlinternalFormatBasics[2], fmtty$0),
-           /*<<scanf.ml:1374:8>>*/ _M_ =
+           /*<<scanf.ml:1374:8>>*/ _J_ =
              /*<<scanf.ml:1374:8>>*/ caml_call2
-             (CamlinternalFormat[12], fmt$6, _L_),
+             (CamlinternalFormat[12], fmt$6, _I_),
           fmt$5 = fmt$8,
-          fmt$4 = _M_;
+          fmt$4 = _J_;
         }
         catch(exn){
          var exn$0 = caml_wrap_exception(exn);
@@ -29335,9 +29178,9 @@
           throw caml_maybe_attach_backtrace(exn$0, 0);
          var
           msg$0 = exn$0[2],
-          _I_ = bad_input(msg$0),
-          fmt$5 = _I_[2],
-          fmt$4 = _I_[1];
+          _F_ = bad_input(msg$0),
+          fmt$5 = _F_[2],
+          fmt$4 = _F_[1];
         }
          /*<<scanf.ml:1378:4>>*/ return [0,
                 [0, fmt$4, s$0],
@@ -29356,19 +29199,19 @@
          /*<<scanf.ml:1401:32>>*/ var
          rest$19 = fmt$0[2],
          formatting_lit = fmt$0[1],
-          /*<<scanf.ml:1401:32>>*/ _N_ =
+          /*<<scanf.ml:1401:32>>*/ _K_ =
             /*<<scanf.ml:1401:32>>*/ caml_call1
-            (CamlinternalFormat[17], formatting_lit),
-          /*<<scanf.ml:1401:16>>*/ _O_ =
-           function(_Q_){ /*<<?>>*/ return check_char(ib, _Q_);};
+            (CamlinternalFormat[17], formatting_lit);
          /*<<scanf.ml:1401:4>>*/  /*<<scanf.ml:1401:4>>*/ caml_call2
-         (Stdlib_String[30], _O_, _N_);
+         (Stdlib_String[30],
+          function(_M_){ /*<<?>>*/ return check_char(ib, _M_);},
+          _K_);
         var fmt$0 = rest$19;
         break;
        case 18:
-        var _P_ = fmt$0[1];
-        if(0 === _P_[0]){
-         var rest$20 = fmt$0[2], fmt$9 = _P_[1][1];
+        var _L_ = fmt$0[1];
+        if(0 === _L_[0]){
+         var rest$20 = fmt$0[2], fmt$9 = _L_[1][1];
           /*<<scanf.ml:1404:4>>*/ check_char(ib, 64);
           /*<<scanf.ml:1404:23>>*/ check_char(ib, 123);
           /*<<scanf.ml:1405:18>>*/ var
@@ -29378,7 +29221,7 @@
           fmt$0 = fmt$10;
         }
         else{
-         var rest$21 = fmt$0[2], fmt$11 = _P_[1][1];
+         var rest$21 = fmt$0[2], fmt$11 = _L_[1][1];
           /*<<scanf.ml:1407:4>>*/ check_char(ib, 64);
           /*<<scanf.ml:1407:23>>*/ check_char(ib, 91);
           /*<<scanf.ml:1408:18>>*/ var
@@ -29530,16 +29373,16 @@
        if(exc[1] !== Stdlib[6]) throw caml_maybe_attach_backtrace(exc, 0);
         /*<<scanf.ml:1470:45>>*/ var
         msg = exc[2],
-         /*<<scanf.ml:1470:45>>*/ _B_ =
+         /*<<scanf.ml:1470:45>>*/ _z_ =
            /*<<scanf.ml:1470:45>>*/ caml_call1(Stdlib_String[25], str),
-         /*<<scanf.ml:1470:45>>*/ _C_ =
-           /*<<scanf.ml:1470:45>>*/ caml_call2(Stdlib[28], _B_, cst$0),
-         /*<<scanf.ml:1470:27>>*/ _D_ =
-           /*<<scanf.ml:1470:27>>*/ caml_call2(Stdlib[28], cst_in_format, _C_),
-         /*<<scanf.ml:1470:20>>*/ _E_ =
-           /*<<scanf.ml:1470:20>>*/ caml_call2(Stdlib[28], msg, _D_);
+         /*<<scanf.ml:1470:45>>*/ _A_ =
+           /*<<scanf.ml:1470:45>>*/ caml_call2(Stdlib[28], _z_, cst$0),
+         /*<<scanf.ml:1470:27>>*/ _B_ =
+           /*<<scanf.ml:1470:27>>*/ caml_call2(Stdlib[28], cst_in_format, _A_),
+         /*<<scanf.ml:1470:20>>*/ _C_ =
+           /*<<scanf.ml:1470:20>>*/ caml_call2(Stdlib[28], msg, _B_);
         /*<<scanf.ml:1470:20>>*/ return  /*<<scanf.ml:1470:20>>*/ caml_call1
-               (Stdlib[1], _E_);
+               (Stdlib[1], _C_);
       }
        /*<<scanf.ml:1468:8>>*/ return  /*<<scanf.ml:1468:8>>*/ caml_call2
               (ef, ib, exc);
@@ -29572,7 +29415,7 @@
    function kscanf_opt(ib, fmt){
      /*<<scanf.ml:1480:2>>*/ return kscanf_gen
             (ib,
-             function(param, _A_){
+             function(param, _y_){
                /*<<scanf.ml:1480:28>>*/ return 0;
               /*<<scanf.ml:1480:32>>*/ },
              function(x){
@@ -29608,10 +29451,10 @@
      str = token_string(ib);
      /*<<scanf.ml:1504:4>>*/ try{
       /*<<scanf.ml:1505:10>>*/ var
-       /*<<scanf.ml:1505:10>>*/ _z_ =
+       /*<<scanf.ml:1505:10>>*/ _x_ =
          /*<<scanf.ml:1505:10>>*/ caml_call2
          (CamlinternalFormat[15], str, format),
-      fmt = _z_;
+      fmt = _x_;
     }
     catch(exn$0){
      var exn = caml_wrap_exception(exn$0);
@@ -29625,30 +29468,28 @@
      /*<<scanf.ml:1513:20>>*/ return bscanf_format(from_string(s), format, f);
     /*<<scanf.ml:1513:67>>*/ }
    function format_from_string(s, fmt){
-     /*<<scanf.ml:1517:2>>*/ function _w_(x){
-      /*<<scanf.ml:1517:63>>*/ return x;
-     /*<<scanf.ml:1517:64>>*/ }
-     /*<<scanf.ml:1517:24>>*/ var
-      /*<<scanf.ml:1517:24>>*/ _x_ =
+     /*<<scanf.ml:1517:2>>*/ var
+      /*<<scanf.ml:1517:24>>*/ _v_ =
         /*<<scanf.ml:1517:24>>*/ caml_call1(Stdlib_String[25], s),
-      /*<<scanf.ml:1517:24>>*/ _y_ =
-        /*<<scanf.ml:1517:24>>*/ caml_call2(Stdlib[28], _x_, cst$1);
+      /*<<scanf.ml:1517:24>>*/ _w_ =
+        /*<<scanf.ml:1517:24>>*/ caml_call2(Stdlib[28], _v_, cst$1);
      /*<<scanf.ml:1517:53>>*/ return sscanf_format
-            ( /*<<scanf.ml:1517:16>>*/ caml_call2(Stdlib[28], cst$2, _y_),
+            ( /*<<scanf.ml:1517:16>>*/ caml_call2(Stdlib[28], cst$2, _w_),
              fmt,
-             _w_);
+             function(x){
+               /*<<scanf.ml:1517:63>>*/ return x;
+              /*<<scanf.ml:1517:64>>*/ });
     /*<<scanf.ml:1517:65>>*/ }
    function unescaped(s){
-     /*<<scanf.ml:1521:2>>*/ function _u_(x){
-      /*<<scanf.ml:1521:44>>*/ return x;
-     /*<<scanf.ml:1521:45>>*/ }
-     /*<<scanf.ml:1521:17>>*/  /*<<scanf.ml:1521:17>>*/ var
-     _v_ =  /*<<scanf.ml:1521:17>>*/ caml_call2(Stdlib[28], s, cst$3);
+     /*<<scanf.ml:1521:2>>*/  /*<<scanf.ml:1521:17>>*/ var
+     _u_ =  /*<<scanf.ml:1521:17>>*/ caml_call2(Stdlib[28], s, cst$3);
      /*<<scanf.ml:1521:34>>*/ return  /*<<scanf.ml:1521:34>>*/ caml_call1
             (sscanf
-              ( /*<<scanf.ml:1521:9>>*/ caml_call2(Stdlib[28], cst$4, _v_),
+              ( /*<<scanf.ml:1521:9>>*/ caml_call2(Stdlib[28], cst$4, _u_),
                _t_),
-             _u_);
+             function(x){
+               /*<<scanf.ml:1521:44>>*/ return x;
+              /*<<scanf.ml:1521:45>>*/ });
     /*<<scanf.ml:1521:46>>*/ }
    var
     Stdlib_Scanf =
@@ -29756,39 +29597,30 @@
     Stdlib = global_data.Stdlib,
     Stdlib_Array = global_data.Stdlib__Array,
     Stdlib_List = global_data.Stdlib__List,
-    Stdlib_Map = global_data.Stdlib__Map,
-    _g_ = [0, cst_camlinternalOO_ml, 437, 17],
-    _f_ = [0, cst_camlinternalOO_ml, 419, 13],
-    _e_ = [0, cst_camlinternalOO_ml, 416, 13],
-    _d_ = [0, cst_camlinternalOO_ml, 413, 13],
-    _c_ = [0, cst_camlinternalOO_ml, 410, 13],
-    _b_ = [0, cst_camlinternalOO_ml, 407, 13],
-    _a_ = [0, cst_camlinternalOO_ml, 279, 50];
+    Stdlib_Map = global_data.Stdlib__Map;
    function copy(o){
      /*<<camlinternalOO.ml:23:2>>*/  /*<<camlinternalOO.ml:23:19>>*/ var
      o$0 =  /*<<camlinternalOO.ml:23:19>>*/ o.slice();
      /*<<camlinternalOO.ml:24:2>>*/ return  /*<<camlinternalOO.ml:24:2>>*/ caml_set_oo_id
             (o$0);
     /*<<camlinternalOO.ml:24:10>>*/ }
-    /*<<camlinternalOO.ml:36:13>>*/ var
-     /*<<camlinternalOO.ml:36:13>>*/ params = [0, 1, 1, 1, 3, 16],
-     /*<<camlinternalOO.ml:36:13>>*/ initial_object_size = 2,
-    dummy_item = 0;
+    /*<<camlinternalOO.ml:36:13>>*/  /*<<camlinternalOO.ml:36:13>>*/ var
+    params = [0, 1, 1, 1, 3, 16];
    function public_method_label(s){
      /*<<camlinternalOO.ml:69:2>>*/ var
       /*<<camlinternalOO.ml:69:13>>*/ accu = [0, 0],
-     _aE_ = runtime.caml_ml_string_length(s) - 1 | 0,
-      /*<<camlinternalOO.ml:69:13>>*/ _aD_ = 0;
-    if(_aE_ >= 0){
-     var i = _aD_;
+     _al_ = runtime.caml_ml_string_length(s) - 1 | 0,
+      /*<<camlinternalOO.ml:69:13>>*/ _ak_ = 0;
+    if(_al_ >= 0){
+     var i = _ak_;
      for(;;){
        /*<<camlinternalOO.ml:71:36>>*/  /*<<camlinternalOO.ml:71:36>>*/ var
-       _aF_ =  /*<<camlinternalOO.ml:71:36>>*/ runtime.caml_string_get(s, i);
-      accu[1] = (223 * accu[1] | 0) + _aF_ | 0;
+       _am_ =  /*<<camlinternalOO.ml:71:36>>*/ runtime.caml_string_get(s, i);
+      accu[1] = (223 * accu[1] | 0) + _am_ | 0;
        /*<<camlinternalOO.ml:70:2>>*/  /*<<camlinternalOO.ml:70:2>>*/ var
-       _aG_ = i + 1 | 0;
-      if(_aE_ === i) break;
-      var i = _aG_;
+       _an_ = i + 1 | 0;
+      if(_al_ === i) break;
+      var i = _an_;
      }
     }
     accu[1] = accu[1] & 2147483647;
@@ -29803,10 +29635,11 @@
     compare$1 = runtime.caml_int_compare,
     Labs = caml_call1(Stdlib_Map[1], [0, compare$1]),
      /*<<camlinternalOO.ml:107:2>>*/ dummy_table =
-      [0, 0, [0, dummy_item], Meths[1], Labs[1], 0, 0, Vars[1], 0],
+      [0, 0, [0, 0], Meths[1], Labs[1], 0, 0, Vars[1], 0],
      /*<<camlinternalOO.ml:116:18>>*/ table_count = [0, 0],
      /*<<camlinternalOO.ml:119:31>>*/ dummy_met =
-       /*<<camlinternalOO.ml:119:31>>*/ caml_obj_block(0, 0);
+       /*<<camlinternalOO.ml:119:31>>*/ caml_obj_block(0, 0),
+    initial_object_size = 2;
    function fit_size(n){
      /*<<camlinternalOO.ml:124:2>>*/ return 2 < n
             ? fit_size((n + 1 | 0) / 2 | 0) * 2 | 0
@@ -29821,32 +29654,32 @@
         ((len * 2 | 0) + 2 | 0, dummy_met);
      /*<<camlinternalOO.ml:131:2>>*/ caml_check_bound(methods, 0)[1] = len;
     var
-     _aw_ = Stdlib_Sys[9],
-     _ax_ =
+     _ad_ = Stdlib_Sys[9],
+     _ae_ =
        ( /*<<camlinternalOO.ml:132:28>>*/ runtime.caml_mul
-        (fit_size(len), _aw_)
+        (fit_size(len), _ad_)
        / 8
        | 0)
        - 1
        | 0;
-     /*<<camlinternalOO.ml:132:2>>*/ caml_check_bound(methods, 1)[2] = _ax_;
+     /*<<camlinternalOO.ml:132:2>>*/ caml_check_bound(methods, 1)[2] = _ae_;
      /*<<camlinternalOO.ml:132:2>>*/ var
-     _az_ = len - 1 | 0,
-      /*<<camlinternalOO.ml:132:2>>*/ _ay_ = 0;
-    if(_az_ >= 0){
-     var i = _ay_;
+     _ag_ = len - 1 | 0,
+      /*<<camlinternalOO.ml:132:2>>*/ _af_ = 0;
+    if(_ag_ >= 0){
+     var i = _af_;
      for(;;){
        /*<<camlinternalOO.ml:133:55>>*/ var
-       _aB_ = (i * 2 | 0) + 3 | 0,
-        /*<<camlinternalOO.ml:133:55>>*/ _aA_ =
+       _ai_ = (i * 2 | 0) + 3 | 0,
+        /*<<camlinternalOO.ml:133:55>>*/ _ah_ =
          caml_check_bound(pub_labels, i)[1 + i];
-       /*<<camlinternalOO.ml:133:26>>*/ caml_check_bound(methods, _aB_)
-       [1 + _aB_]
-      = _aA_;
+       /*<<camlinternalOO.ml:133:26>>*/ caml_check_bound(methods, _ai_)
+       [1 + _ai_]
+      = _ah_;
        /*<<camlinternalOO.ml:133:26>>*/  /*<<camlinternalOO.ml:133:26>>*/ var
-       _aC_ = i + 1 | 0;
-      if(_az_ === i) break;
-      var i = _aC_;
+       _aj_ = i + 1 | 0;
+      if(_ag_ === i) break;
+      var i = _aj_;
      }
     }
      /*<<camlinternalOO.ml:134:2>>*/ return [0,
@@ -29862,23 +29695,30 @@
    function resize(array, new_size){
      /*<<camlinternalOO.ml:144:2>>*/ var
      old_size = array[2].length - 1,
-     _au_ = old_size < new_size ? 1 : 0;
-    if(_au_){
+     _ab_ = old_size < new_size ? 1 : 0;
+    if(_ab_){
       /*<<camlinternalOO.ml:146:19>>*/  /*<<camlinternalOO.ml:146:19>>*/ var
       new_buck =
          /*<<camlinternalOO.ml:146:19>>*/ caml_make_vect(new_size, dummy_met);
       /*<<camlinternalOO.ml:147:4>>*/  /*<<camlinternalOO.ml:147:4>>*/ caml_call5
       (Stdlib_Array[8], array[2], 0, new_buck, 0, old_size);
      array[2] = new_buck;
-     var _av_ = 0;
+     var _ac_ = 0;
     }
     else
-     var _av_ = _au_;
-    return _av_;
+     var _ac_ = _ab_;
+    return _ac_;
     /*<<camlinternalOO.ml:149:4>>*/ }
     /*<<camlinternalOO.ml:157:19>>*/ var
      /*<<camlinternalOO.ml:157:19>>*/ method_count = [0, 0],
-     /*<<camlinternalOO.ml:158:21>>*/ inst_var_count = [0, 0];
+     /*<<camlinternalOO.ml:158:21>>*/ inst_var_count = [0, 0],
+    _a_ = [0, cst_camlinternalOO_ml, 279, 50],
+    _b_ = [0, cst_camlinternalOO_ml, 407, 13],
+    _c_ = [0, cst_camlinternalOO_ml, 410, 13],
+    _d_ = [0, cst_camlinternalOO_ml, 413, 13],
+    _e_ = [0, cst_camlinternalOO_ml, 416, 13],
+    _f_ = [0, cst_camlinternalOO_ml, 419, 13],
+    _g_ = [0, cst_camlinternalOO_ml, 437, 17];
    function new_method(table){
      /*<<camlinternalOO.ml:164:2>>*/ var index = table[2].length - 1;
      /*<<camlinternalOO.ml:165:2>>*/ resize(table, index + 1 | 0);
@@ -29887,13 +29727,13 @@
    function get_method_label(table, name){
      /*<<camlinternalOO.ml:169:2>>*/ try{
       /*<<camlinternalOO.ml:170:4>>*/  /*<<camlinternalOO.ml:170:4>>*/ var
-      _as_ =
+      _$_ =
          /*<<camlinternalOO.ml:170:4>>*/ caml_call2(Meths[17], name, table[3]);
-      /*<<camlinternalOO.ml:170:4>>*/ return _as_;
+      /*<<camlinternalOO.ml:170:4>>*/ return _$_;
     }
-    catch(_at_){
-     var _ar_ = caml_wrap_exception(_at_);
-     if(_ar_ !== Stdlib[8]) throw caml_maybe_attach_backtrace(_ar_, 0);
+    catch(_aa_){
+     var ___ = caml_wrap_exception(_aa_);
+     if(___ !== Stdlib[8]) throw caml_maybe_attach_backtrace(___, 0);
       /*<<camlinternalOO.ml:172:16>>*/  /*<<camlinternalOO.ml:172:16>>*/ var
       label = new_method(table);
      table[3] =
@@ -29906,11 +29746,10 @@
     }
     /*<<camlinternalOO.ml:175:9>>*/ }
    function get_method_labels(table, names){
-     /*<<camlinternalOO.ml:178:12>>*/ function _ap_(_aq_){
-      /*<<?>>*/ return get_method_label(table, _aq_);
-    }
      /*<<camlinternalOO.ml:178:2>>*/ return  /*<<camlinternalOO.ml:178:2>>*/ caml_call2
-            (Stdlib_Array[13], _ap_, names);
+            (Stdlib_Array[13],
+             function(_Z_){ /*<<?>>*/ return get_method_label(table, _Z_);},
+             names);
     /*<<camlinternalOO.ml:178:42>>*/ }
    function set_method(table, label, element){
      /*<<camlinternalOO.ml:181:2>>*/ method_count[1]++;
@@ -29925,18 +29764,18 @@
    function get_method(table, label){
      /*<<camlinternalOO.ml:188:2>>*/ try{
       /*<<camlinternalOO.ml:188:6>>*/  /*<<camlinternalOO.ml:188:6>>*/ var
-      _an_ =
+      _X_ =
          /*<<camlinternalOO.ml:188:6>>*/ caml_call2
          (Stdlib_List[49], label, table[6]);
-      /*<<camlinternalOO.ml:188:6>>*/ return _an_;
+      /*<<camlinternalOO.ml:188:6>>*/ return _X_;
     }
-    catch(_ao_){
-     var _am_ = caml_wrap_exception(_ao_);
-     if(_am_ === Stdlib[8])
+    catch(_Y_){
+     var _W_ = caml_wrap_exception(_Y_);
+     if(_W_ === Stdlib[8])
        /*<<camlinternalOO.ml:189:20>>*/ return caml_check_bound
                (table[2], label)
               [1 + label];
-     throw caml_maybe_attach_backtrace(_am_, 0);
+     throw caml_maybe_attach_backtrace(_W_, 0);
     }
     /*<<camlinternalOO.ml:189:41>>*/ }
    function to_list(arr){
@@ -29949,87 +29788,88 @@
      /*<<camlinternalOO.ml:195:2>>*/ var
       /*<<camlinternalOO.ml:195:13>>*/ vars$0 = to_list(vars),
       /*<<camlinternalOO.ml:196:19>>*/ virt_meths$0 = to_list(virt_meths),
-      /*<<camlinternalOO.ml:197:20>>*/ concr_meths$0 = to_list(concr_meths);
-     /*<<camlinternalOO.ml:198:32>>*/ function _X_(_al_){
-      /*<<?>>*/ return get_method_label(table, _al_);
-    }
-     /*<<camlinternalOO.ml:198:23>>*/  /*<<camlinternalOO.ml:198:23>>*/ var
-     virt_meth_labs =
+      /*<<camlinternalOO.ml:197:20>>*/ concr_meths$0 = to_list(concr_meths),
+      /*<<camlinternalOO.ml:198:23>>*/ virt_meth_labs =
         /*<<camlinternalOO.ml:198:23>>*/ caml_call2
-        (Stdlib_List[20], _X_, virt_meths$0);
-     /*<<camlinternalOO.ml:199:33>>*/ function _Y_(_ak_){
-      /*<<?>>*/ return get_method_label(table, _ak_);
-    }
-     /*<<camlinternalOO.ml:199:24>>*/  /*<<camlinternalOO.ml:199:24>>*/ var
-     concr_meth_labs =
+        (Stdlib_List[20],
+         function(_V_){ /*<<?>>*/ return get_method_label(table, _V_);},
+         virt_meths$0),
+      /*<<camlinternalOO.ml:199:24>>*/ concr_meth_labs =
         /*<<camlinternalOO.ml:199:24>>*/ caml_call2
-        (Stdlib_List[20], _Y_, concr_meths$0);
+        (Stdlib_List[20],
+         function(_U_){ /*<<?>>*/ return get_method_label(table, _U_);},
+         concr_meths$0);
     table[5] =
      [0,
       [0, table[3], table[4], table[6], table[7], virt_meth_labs, vars$0],
       table[5]];
-    var _Z_ = Vars[1], ___ = table[7];
-    function _$_(lab, info, tvars){
-      /*<<camlinternalOO.ml:207:8>>*/ return  /*<<camlinternalOO.ml:207:11>>*/ caml_call2
-              (Stdlib_List[37], lab, vars$0)
-             ?  /*<<camlinternalOO.ml:207:34>>*/ caml_call3
-               (Vars[2], lab, info, tvars)
-             : tvars;
-     /*<<camlinternalOO.ml:207:68>>*/ }
     table[7] =
-      /*<<camlinternalOO.ml:205:4>>*/ caml_call3(Vars[24], _$_, ___, _Z_);
+      /*<<camlinternalOO.ml:205:4>>*/ caml_call3
+      (Vars[24],
+       function(lab, info, tvars){
+         /*<<camlinternalOO.ml:207:8>>*/ return  /*<<camlinternalOO.ml:207:11>>*/ caml_call2
+                 (Stdlib_List[37], lab, vars$0)
+                ?  /*<<camlinternalOO.ml:207:34>>*/ caml_call3
+                  (Vars[2], lab, info, tvars)
+                : tvars;
+        /*<<camlinternalOO.ml:207:68>>*/ },
+       table[7],
+       Vars[1]);
      /*<<camlinternalOO.ml:209:16>>*/ var
       /*<<camlinternalOO.ml:209:16>>*/ by_name = [0, Meths[1]],
       /*<<camlinternalOO.ml:210:17>>*/ by_label = [0, Labs[1]];
-    function _aa_(met, label){
-      /*<<camlinternalOO.ml:213:7>>*/ by_name[1] =
-       /*<<camlinternalOO.ml:213:18>>*/ caml_call3
-       (Meths[2], met, label, by_name[1]);
-     var _af_ = by_label[1];
-     try{
-       /*<<camlinternalOO.ml:216:17>>*/ var
-        /*<<camlinternalOO.ml:216:17>>*/ _ai_ =
-          /*<<camlinternalOO.ml:216:17>>*/ caml_call2
-          (Labs[17], label, table[4]),
-       _ah_ = _ai_;
-     }
-     catch(_aj_){
-      var _ag_ = caml_wrap_exception(_aj_);
-      if(_ag_ !== Stdlib[8]) throw caml_maybe_attach_backtrace(_ag_, 0);
-      var _ah_ = 1;
-     }
-     by_label[1] =
-       /*<<camlinternalOO.ml:215:10>>*/ caml_call3(Labs[2], label, _ah_, _af_);
-     return 0;
-     /*<<camlinternalOO.ml:217:21>>*/ }
      /*<<camlinternalOO.ml:211:2>>*/  /*<<camlinternalOO.ml:211:2>>*/ caml_call3
-     (Stdlib_List[28], _aa_, concr_meths$0, concr_meth_labs);
-    function _ab_(met, label){
-      /*<<camlinternalOO.ml:221:7>>*/ by_name[1] =
-       /*<<camlinternalOO.ml:221:18>>*/ caml_call3
-       (Meths[2], met, label, by_name[1]);
-     by_label[1] =
-       /*<<camlinternalOO.ml:222:19>>*/ caml_call3
-       (Labs[2], label, 0, by_label[1]);
-     return 0;
-     /*<<camlinternalOO.ml:222:49>>*/ }
+     (Stdlib_List[28],
+      function(met, label){
+        /*<<camlinternalOO.ml:213:7>>*/ by_name[1] =
+         /*<<camlinternalOO.ml:213:18>>*/ caml_call3
+         (Meths[2], met, label, by_name[1]);
+       var _P_ = by_label[1];
+       try{
+         /*<<camlinternalOO.ml:216:17>>*/ var
+          /*<<camlinternalOO.ml:216:17>>*/ _S_ =
+            /*<<camlinternalOO.ml:216:17>>*/ caml_call2
+            (Labs[17], label, table[4]),
+         _R_ = _S_;
+       }
+       catch(_T_){
+        var _Q_ = caml_wrap_exception(_T_);
+        if(_Q_ !== Stdlib[8]) throw caml_maybe_attach_backtrace(_Q_, 0);
+        var _R_ = 1;
+       }
+       by_label[1] =
+         /*<<camlinternalOO.ml:215:10>>*/ caml_call3(Labs[2], label, _R_, _P_);
+       return 0;
+       /*<<camlinternalOO.ml:217:21>>*/ },
+      concr_meths$0,
+      concr_meth_labs);
      /*<<camlinternalOO.ml:219:2>>*/  /*<<camlinternalOO.ml:219:2>>*/ caml_call3
-     (Stdlib_List[28], _ab_, virt_meths$0, virt_meth_labs);
+     (Stdlib_List[28],
+      function(met, label){
+        /*<<camlinternalOO.ml:221:7>>*/ by_name[1] =
+         /*<<camlinternalOO.ml:221:18>>*/ caml_call3
+         (Meths[2], met, label, by_name[1]);
+       by_label[1] =
+         /*<<camlinternalOO.ml:222:19>>*/ caml_call3
+         (Labs[2], label, 0, by_label[1]);
+       return 0;
+       /*<<camlinternalOO.ml:222:49>>*/ },
+      virt_meths$0,
+      virt_meth_labs);
     table[3] = by_name[1];
     table[4] = by_label[1];
-     /*<<camlinternalOO.ml:226:2>>*/ var
-      /*<<camlinternalOO.ml:226:2>>*/ _ac_ = 0,
-     _ad_ = table[6];
-    function _ae_(met, hm){
-      /*<<camlinternalOO.ml:228:7>>*/ var lab = met[1];
-      /*<<camlinternalOO.ml:229:13>>*/ return  /*<<camlinternalOO.ml:229:13>>*/ caml_call2
-              (Stdlib_List[37], lab, virt_meth_labs)
-             ? hm
-             : [0, met, hm];
-     /*<<camlinternalOO.ml:229:62>>*/ }
     table[6] =
       /*<<camlinternalOO.ml:227:5>>*/ caml_call3
-      (Stdlib_List[27], _ae_, _ad_, _ac_);
+      (Stdlib_List[27],
+       function(met, hm){
+         /*<<camlinternalOO.ml:228:7>>*/ var lab = met[1];
+         /*<<camlinternalOO.ml:229:13>>*/ return  /*<<camlinternalOO.ml:229:13>>*/ caml_call2
+                 (Stdlib_List[37], lab, virt_meth_labs)
+                ? hm
+                : [0, met, hm];
+        /*<<camlinternalOO.ml:229:62>>*/ },
+       table[6],
+       0);
     return 0;
     /*<<camlinternalOO.ml:231:9>>*/ }
    function widen(table){
@@ -30044,41 +29884,44 @@
      by_name = match[1];
     table[5] =
       /*<<camlinternalOO.ml:237:27>>*/ caml_call1(Stdlib_List[7], table[5]);
-    function _T_(s, v){
-      /*<<camlinternalOO.ml:240:19>>*/  /*<<camlinternalOO.ml:240:30>>*/ var
-      _W_ =
-         /*<<camlinternalOO.ml:240:30>>*/ caml_call2(Vars[17], v, table[7]);
-      /*<<camlinternalOO.ml:240:19>>*/ return  /*<<camlinternalOO.ml:240:19>>*/ caml_call3
-             (Vars[2], v, _W_, s);
-     /*<<camlinternalOO.ml:240:56>>*/ }
     table[7] =
       /*<<camlinternalOO.ml:239:5>>*/ caml_call3
-      (Stdlib_List[26], _T_, saved_vars, vars);
+      (Stdlib_List[26],
+       function(s, v){
+         /*<<camlinternalOO.ml:240:19>>*/  /*<<camlinternalOO.ml:240:30>>*/ var
+         _O_ =
+            /*<<camlinternalOO.ml:240:30>>*/ caml_call2(Vars[17], v, table[7]);
+         /*<<camlinternalOO.ml:240:19>>*/ return  /*<<camlinternalOO.ml:240:19>>*/ caml_call3
+                (Vars[2], v, _O_, s);
+        /*<<camlinternalOO.ml:240:56>>*/ },
+       saved_vars,
+       vars);
     table[3] = by_name;
     table[4] = by_label;
-    var _U_ = table[6];
-    function _V_(met, hm){
-      /*<<camlinternalOO.ml:246:7>>*/ var lab = met[1];
-      /*<<camlinternalOO.ml:247:13>>*/ return  /*<<camlinternalOO.ml:247:13>>*/ caml_call2
-              (Stdlib_List[37], lab, virt_meths)
-             ? hm
-             : [0, met, hm];
-     /*<<camlinternalOO.ml:247:58>>*/ }
     table[6] =
       /*<<camlinternalOO.ml:245:5>>*/ caml_call3
-      (Stdlib_List[27], _V_, _U_, saved_hidden_meths);
+      (Stdlib_List[27],
+       function(met, hm){
+         /*<<camlinternalOO.ml:246:7>>*/ var lab = met[1];
+         /*<<camlinternalOO.ml:247:13>>*/ return  /*<<camlinternalOO.ml:247:13>>*/ caml_call2
+                 (Stdlib_List[37], lab, virt_meths)
+                ? hm
+                : [0, met, hm];
+        /*<<camlinternalOO.ml:247:58>>*/ },
+       table[6],
+       saved_hidden_meths);
     return 0;
     /*<<camlinternalOO.ml:249:25>>*/ }
    function new_variable(table, name){
      /*<<camlinternalOO.ml:257:2>>*/ try{
       /*<<camlinternalOO.ml:257:6>>*/  /*<<camlinternalOO.ml:257:6>>*/ var
-      _R_ =
+      _M_ =
          /*<<camlinternalOO.ml:257:6>>*/ caml_call2(Vars[17], name, table[7]);
-      /*<<camlinternalOO.ml:257:6>>*/ return _R_;
+      /*<<camlinternalOO.ml:257:6>>*/ return _M_;
     }
-    catch(_S_){
-     var _Q_ = caml_wrap_exception(_S_);
-     if(_Q_ !== Stdlib[8]) throw caml_maybe_attach_backtrace(_Q_, 0);
+    catch(_N_){
+     var _L_ = caml_wrap_exception(_N_);
+     if(_L_ !== Stdlib[8]) throw caml_maybe_attach_backtrace(_L_, 0);
      var index = table[1];
      table[1] = index + 1 | 0;
       /*<<camlinternalOO.ml:260:7>>*/ if
@@ -30102,35 +29945,35 @@
      nvals = vals.length - 1,
       /*<<camlinternalOO.ml:269:12>>*/ res =
         /*<<camlinternalOO.ml:269:12>>*/ caml_make_vect(nmeths + nvals | 0, 0),
-      /*<<camlinternalOO.ml:270:2>>*/ _I_ = nmeths - 1 | 0,
-      /*<<camlinternalOO.ml:269:12>>*/ _H_ = 0;
-    if(_I_ >= 0){
-     var i$0 = _H_;
+      /*<<camlinternalOO.ml:270:2>>*/ _D_ = nmeths - 1 | 0,
+      /*<<camlinternalOO.ml:269:12>>*/ _C_ = 0;
+    if(_D_ >= 0){
+     var i$0 = _C_;
      for(;;){
        /*<<camlinternalOO.ml:271:15>>*/  /*<<camlinternalOO.ml:271:15>>*/ var
-       _O_ = get_method_label(table, caml_check_bound(meths$0, i$0)[1 + i$0]);
-       /*<<camlinternalOO.ml:271:4>>*/ caml_check_bound(res, i$0)[1 + i$0] = _O_;
+       _J_ = get_method_label(table, caml_check_bound(meths$0, i$0)[1 + i$0]);
+       /*<<camlinternalOO.ml:271:4>>*/ caml_check_bound(res, i$0)[1 + i$0] = _J_;
        /*<<camlinternalOO.ml:271:4>>*/  /*<<camlinternalOO.ml:271:4>>*/ var
-       _P_ = i$0 + 1 | 0;
-      if(_I_ === i$0) break;
-      var i$0 = _P_;
+       _K_ = i$0 + 1 | 0;
+      if(_D_ === i$0) break;
+      var i$0 = _K_;
      }
     }
      /*<<camlinternalOO.ml:273:2>>*/ var
-     _K_ = nvals - 1 | 0,
-      /*<<camlinternalOO.ml:273:2>>*/ _J_ = 0;
-    if(_K_ >= 0){
-     var i = _J_;
+     _F_ = nvals - 1 | 0,
+      /*<<camlinternalOO.ml:273:2>>*/ _E_ = 0;
+    if(_F_ >= 0){
+     var i = _E_;
      for(;;){
        /*<<camlinternalOO.ml:274:22>>*/ var
-       _M_ = i + nmeths | 0,
-        /*<<camlinternalOO.ml:274:22>>*/ _L_ =
+       _H_ = i + nmeths | 0,
+        /*<<camlinternalOO.ml:274:22>>*/ _G_ =
          new_variable(table, caml_check_bound(vals, i)[1 + i]);
-       /*<<camlinternalOO.ml:274:4>>*/ caml_check_bound(res, _M_)[1 + _M_] = _L_;
+       /*<<camlinternalOO.ml:274:4>>*/ caml_check_bound(res, _H_)[1 + _H_] = _G_;
        /*<<camlinternalOO.ml:274:4>>*/  /*<<camlinternalOO.ml:274:4>>*/ var
-       _N_ = i + 1 | 0;
-      if(_K_ === i) break;
-      var i = _N_;
+       _I_ = i + 1 | 0;
+      if(_F_ === i) break;
+      var i = _I_;
      }
     }
      /*<<camlinternalOO.ml:276:2>>*/ return res;
@@ -30138,24 +29981,23 @@
    function get_variable(table, name){
      /*<<camlinternalOO.ml:279:2>>*/ try{
       /*<<camlinternalOO.ml:279:6>>*/  /*<<camlinternalOO.ml:279:6>>*/ var
-      _F_ =
+      _A_ =
          /*<<camlinternalOO.ml:279:6>>*/ caml_call2(Vars[17], name, table[7]);
-      /*<<camlinternalOO.ml:279:6>>*/ return _F_;
+      /*<<camlinternalOO.ml:279:6>>*/ return _A_;
     }
-    catch(_G_){
-     var _E_ = caml_wrap_exception(_G_);
-     if(_E_ === Stdlib[8])
+    catch(_B_){
+     var _z_ = caml_wrap_exception(_B_);
+     if(_z_ === Stdlib[8])
        /*<<camlinternalOO.ml:279:50>>*/ throw  /*<<camlinternalOO.ml:279:50>>*/ caml_maybe_attach_backtrace
              ([0, Assert_failure, _a_], 1);
-     throw caml_maybe_attach_backtrace(_E_, 0);
+     throw caml_maybe_attach_backtrace(_z_, 0);
     }
     /*<<camlinternalOO.ml:279:62>>*/ }
    function get_variables(table, names){
-     /*<<camlinternalOO.ml:282:12>>*/ function _C_(_D_){
-      /*<<?>>*/ return get_variable(table, _D_);
-    }
      /*<<camlinternalOO.ml:282:2>>*/ return  /*<<camlinternalOO.ml:282:2>>*/ caml_call2
-            (Stdlib_Array[13], _C_, names);
+            (Stdlib_Array[13],
+             function(_y_){ /*<<?>>*/ return get_variable(table, _y_);},
+             names);
     /*<<camlinternalOO.ml:282:38>>*/ }
    function add_initializer(table, f){
      /*<<camlinternalOO.ml:285:2>>*/ table[8] = [0, f, table[8]];
@@ -30169,17 +30011,19 @@
         /*<<camlinternalOO.ml:301:13>>*/ caml_call2
         (Stdlib_Array[13], public_method_label, public_methods),
       /*<<camlinternalOO.ml:302:14>>*/ table = new_table(tags);
-    function _B_(i, met){
-      /*<<camlinternalOO.ml:305:6>>*/ var lab = (i * 2 | 0) + 2 | 0;
-     table[3] =
-       /*<<camlinternalOO.ml:306:32>>*/ caml_call3
-       (Meths[2], met, lab, table[3]);
-     table[4] =
-       /*<<camlinternalOO.ml:307:32>>*/ caml_call3(Labs[2], lab, 1, table[4]);
-     return 0;
-     /*<<camlinternalOO.ml:307:72>>*/ }
      /*<<camlinternalOO.ml:303:2>>*/  /*<<camlinternalOO.ml:303:2>>*/ caml_call2
-     (Stdlib_Array[12], _B_, public_methods);
+     (Stdlib_Array[12],
+      function(i, met){
+        /*<<camlinternalOO.ml:305:6>>*/ var lab = (i * 2 | 0) + 2 | 0;
+       table[3] =
+         /*<<camlinternalOO.ml:306:32>>*/ caml_call3
+         (Meths[2], met, lab, table[3]);
+       table[4] =
+         /*<<camlinternalOO.ml:307:32>>*/ caml_call3
+         (Labs[2], lab, 1, table[4]);
+       return 0;
+       /*<<camlinternalOO.ml:307:72>>*/ },
+      public_methods);
      /*<<camlinternalOO.ml:303:2>>*/ return table;
     /*<<camlinternalOO.ml:309:7>>*/ }
    function init_class(table){
@@ -30188,10 +30032,10 @@
     table[8] =
       /*<<camlinternalOO.ml:313:24>>*/ caml_call1(Stdlib_List[10], table[8]);
      /*<<camlinternalOO.ml:314:2>>*/  /*<<camlinternalOO.ml:314:2>>*/ var
-     _A_ = Stdlib_Sys[9];
+     _x_ = Stdlib_Sys[9];
     return resize
             (table,
-             3 + caml_div(caml_check_bound(table[2], 1)[2] * 16 | 0, _A_) | 0);
+             3 + caml_div(caml_check_bound(table[2], 1)[2] * 16 | 0, _x_) | 0);
     /*<<camlinternalOO.ml:314:69>>*/ }
    function inherits(cla, vals, virt_meths, concr_meths, param, top){
     var env = param[4], super$0 = param[2];
@@ -30203,33 +30047,30 @@
         ?  /*<<camlinternalOO.ml:319:16>>*/ caml_call2(super$0, cla, env)
         :  /*<<camlinternalOO.ml:319:44>>*/ caml_call1(super$0, cla);
      /*<<camlinternalOO.ml:320:2>>*/ widen(cla);
-     /*<<camlinternalOO.ml:320:2>>*/ var
-      /*<<camlinternalOO.ml:320:2>>*/ _s_ = 0,
-      /*<<camlinternalOO.ml:326:7>>*/ _t_ = to_array(concr_meths);
-    function _u_(nm){
-      /*<<camlinternalOO.ml:325:18>>*/ return get_method
-             (cla, get_method_label(cla, nm));
-     /*<<camlinternalOO.ml:325:79>>*/ }
-     /*<<camlinternalOO.ml:323:45>>*/ var
-     _v_ =
+     /*<<camlinternalOO.ml:326:7>>*/ var
+      /*<<camlinternalOO.ml:326:7>>*/ _s_ = to_array(concr_meths),
+     _t_ =
        [0,
          /*<<camlinternalOO.ml:324:5>>*/ caml_call2
-         (Stdlib_Array[13], _u_, _t_),
-        _s_],
-      /*<<camlinternalOO.ml:323:45>>*/ _w_ = to_array(vals);
-     /*<<camlinternalOO.ml:323:26>>*/ function _x_(_z_){
-      /*<<?>>*/ return get_variable(cla, _z_);
-    }
-     /*<<camlinternalOO.ml:322:4>>*/  /*<<camlinternalOO.ml:322:4>>*/ var
-     _y_ =
+         (Stdlib_Array[13],
+          function(nm){
+            /*<<camlinternalOO.ml:325:18>>*/ return get_method
+                   (cla, get_method_label(cla, nm));
+           /*<<camlinternalOO.ml:325:79>>*/ },
+          _s_),
+        0],
+      /*<<camlinternalOO.ml:323:45>>*/ _u_ = to_array(vals),
+      /*<<camlinternalOO.ml:322:4>>*/ _v_ =
        [0,
         [0, init],
         [0,
           /*<<camlinternalOO.ml:323:16>>*/ caml_call2
-          (Stdlib_Array[13], _x_, _w_),
-         _v_]];
+          (Stdlib_Array[13],
+           function(_w_){ /*<<?>>*/ return get_variable(cla, _w_);},
+           _u_),
+         _t_]];
      /*<<camlinternalOO.ml:322:4>>*/ return  /*<<camlinternalOO.ml:322:4>>*/ caml_call1
-            (Stdlib_Array[4], _y_);
+            (Stdlib_Array[4], _v_);
    }
    function make_class(pub_meths, class_init){
      /*<<camlinternalOO.ml:329:2>>*/ var
@@ -30827,11 +30668,11 @@
     CamlinternalLazy = global_data.CamlinternalLazy,
     CamlinternalOO = global_data.CamlinternalOO,
     Assert_failure = global_data.Assert_failure,
+    cst_CamlinternalMod_init_mod_n = "CamlinternalMod.init_mod: not a module",
     _a_ = [0, cst_camlinternalMod_ml, 72, 5],
     _b_ = [0, cst_camlinternalMod_ml, 81, 2],
     cst_CamlinternalMod_update_mod =
-      "CamlinternalMod.update_mod: not a module",
-    cst_CamlinternalMod_init_mod_n = "CamlinternalMod.init_mod: not a module";
+      "CamlinternalMod.update_mod: not a module";
    function init_mod_block(loc, comps$0){
      /*<<camlinternalMod.ml:52:2>>*/ var
      length = comps$0.length - 1,
@@ -31015,14 +30856,14 @@
     Stdlib_Hashtbl = global_data.Stdlib__Hashtbl,
     CamlinternalLazy = global_data.CamlinternalLazy,
     Stdlib_Random = global_data.Stdlib__Random,
-    _c_ = [0, 0],
+    _a_ = [0, 0],
     _b_ = [0, 0],
-    _a_ = [0, 0];
+    _c_ = [0, 0];
    function MakeSeeded(H){
      /*<<ephemeron.ml:105:20>>*/  /*<<ephemeron.ml:105:20>>*/ var
      prng =
        [246,
-        function(_aM_){ /*<<?>>*/ return caml_call1(Stdlib_Random[15][2], 0);}];
+        function(_at_){ /*<<?>>*/ return caml_call1(Stdlib_Random[15][2], 0);}];
     function create(opt, initial_size){
       /*<<ephemeron.ml:108:6>>*/ if(opt)
       var sth = opt[1], random = sth;
@@ -31041,17 +30882,17 @@
       break a;
      }
       /*<<ephemeron.ml:109:6>>*/ if(random){
-      var _aK_ = runtime.caml_obj_tag(prng);
+      var _ar_ = runtime.caml_obj_tag(prng);
       a:
-      if(250 === _aK_)
-       var _aL_ = prng[1];
+      if(250 === _ar_)
+       var _as_ = prng[1];
       else{
-       if(246 !== _aK_ && 244 !== _aK_){var _aL_ = prng; break a;}
-       var _aL_ = caml_call1(CamlinternalLazy[2], prng);
+       if(246 !== _ar_ && 244 !== _ar_){var _as_ = prng; break a;}
+       var _as_ = caml_call1(CamlinternalLazy[2], prng);
       }
       var
        seed =
-          /*<<ephemeron.ml:109:32>>*/ caml_call1(Stdlib_Random[15][4], _aL_);
+          /*<<ephemeron.ml:109:32>>*/ caml_call1(Stdlib_Random[15][4], _as_);
      }
      else
       var seed = 0;
@@ -31065,16 +30906,16 @@
       /*<<ephemeron.ml:113:6>>*/ h[1] = 0;
       /*<<ephemeron.ml:115:6>>*/ var
       len = h[2].length - 1,
-       /*<<ephemeron.ml:115:6>>*/ _aI_ = len - 1 | 0,
-      _aH_ = 0;
-     if(_aI_ >= 0){
-      var i = _aH_;
+       /*<<ephemeron.ml:115:6>>*/ _ap_ = len - 1 | 0,
+      _ao_ = 0;
+     if(_ap_ >= 0){
+      var i = _ao_;
       for(;;){
         /*<<ephemeron.ml:116:8>>*/ caml_check_bound(h[2], i)[1 + i] = 0;
         /*<<ephemeron.ml:116:8>>*/  /*<<ephemeron.ml:116:8>>*/ var
-        _aJ_ = i + 1 | 0;
-       if(_aI_ === i) break;
-       var i = _aJ_;
+        _aq_ = i + 1 | 0;
+       if(_ap_ === i) break;
+       var i = _aq_;
       }
      }
      return 0;
@@ -31091,11 +30932,11 @@
      /*<<ephemeron.ml:126:9>>*/ }
     function copy(h){
       /*<<ephemeron.ml:128:17>>*/ var
-      _aE_ = h[4],
-      _aF_ = h[3],
-       /*<<ephemeron.ml:128:33>>*/ _aG_ =
+      _al_ = h[4],
+      _am_ = h[3],
+       /*<<ephemeron.ml:128:33>>*/ _an_ =
          /*<<ephemeron.ml:128:33>>*/ caml_call1(Stdlib_Array[6], h[2]);
-      /*<<ephemeron.ml:128:17>>*/ return [0, h[1], _aG_, _aF_, _aE_];
+      /*<<ephemeron.ml:128:17>>*/ return [0, h[1], _an_, _am_, _al_];
      /*<<ephemeron.ml:128:52>>*/ }
     function key_index(h, hkey){
       /*<<ephemeron.ml:131:6>>*/ return hkey & (h[2].length - 1 - 1 | 0);
@@ -31115,16 +30956,16 @@
        var param$0 = rest;
       }
       /*<<ephemeron.ml:141:41>>*/ }
-     var d = h[2], _aC_ = d.length - 1 - 1 | 0, _aB_ = 0;
-     if(_aC_ >= 0){
-      var i = _aB_;
+     var d = h[2], _aj_ = d.length - 1 - 1 | 0, _ai_ = 0;
+     if(_aj_ >= 0){
+      var i = _ai_;
       for(;;){
         /*<<ephemeron.ml:145:8>>*/ d[1 + i] =
         do_bucket(caml_check_bound(d, i)[1 + i]);
         /*<<ephemeron.ml:145:8>>*/  /*<<ephemeron.ml:145:8>>*/ var
-        _aD_ = i + 1 | 0;
-       if(_aC_ === i) break;
-       var i = _aD_;
+        _ak_ = i + 1 | 0;
+       if(_aj_ === i) break;
+       var i = _ak_;
       }
      }
      return 0;
@@ -31136,9 +30977,9 @@
       nsize = osize * 2 | 0;
       /*<<ephemeron.ml:172:6>>*/ clean(h);
      var
-      _av_ = nsize < Stdlib_Sys[13] ? 1 : 0,
-      _aw_ = _av_ ? (osize >>> 1 | 0) <= h[1] ? 1 : 0 : _av_;
-     if(_aw_){
+      _ac_ = nsize < Stdlib_Sys[13] ? 1 : 0,
+      _ad_ = _ac_ ? (osize >>> 1 | 0) <= h[1] ? 1 : 0 : _ac_;
+     if(_ad_){
        /*<<ephemeron.ml:174:20>>*/  /*<<ephemeron.ml:174:20>>*/ var
        ndata =  /*<<ephemeron.ml:174:20>>*/ caml_make_vect(nsize, 0);
       h[2] = ndata;
@@ -31155,24 +30996,24 @@
            [0, hkey, data, caml_check_bound(ndata, nidx)[1 + nidx]];
            /*<<ephemeron.ml:181:14>>*/ return;
           /*<<ephemeron.ml:181:60>>*/ },
-        /*<<ephemeron.ml:170:6>>*/ _ay_ = osize - 1 | 0,
-        /*<<ephemeron.ml:182:8>>*/ _ax_ = 0;
-      if(_ay_ >= 0){
-       var i = _ax_;
+        /*<<ephemeron.ml:170:6>>*/ _af_ = osize - 1 | 0,
+        /*<<ephemeron.ml:182:8>>*/ _ae_ = 0;
+      if(_af_ >= 0){
+       var i = _ae_;
        for(;;){
          /*<<ephemeron.ml:183:10>>*/ insert_bucket
          (caml_check_bound(odata, i)[1 + i]);
          /*<<ephemeron.ml:183:10>>*/  /*<<ephemeron.ml:183:10>>*/ var
-         _aA_ = i + 1 | 0;
-        if(_ay_ === i) break;
-        var i = _aA_;
+         _ah_ = i + 1 | 0;
+        if(_af_ === i) break;
+        var i = _ah_;
        }
       }
-      var _az_ = 0;
+      var _ag_ = 0;
      }
      else
-      var _az_ = _aw_;
-     return _az_;
+      var _ag_ = _ad_;
+     return _ag_;
      /*<<ephemeron.ml:185:9>>*/ }
     function add(h, key, info){
       /*<<ephemeron.ml:188:6>>*/ var
@@ -31185,8 +31026,8 @@
         [0, hkey, container, caml_check_bound(h[2], i)[1 + i]];
       /*<<ephemeron.ml:192:6>>*/ caml_check_bound(h[2], i)[1 + i] = bucket;
      h[1] = h[1] + 1 | 0;
-     var _au_ = h[2].length - 1 << 1 < h[1] ? 1 : 0;
-     return _au_ ? resize(h) : _au_;
+     var _ab_ = h[2].length - 1 << 1 < h[1] ? 1 : 0;
+     return _ab_ ? resize(h) : _ab_;
      /*<<ephemeron.ml:194:57>>*/ }
     function remove(h, key){
       /*<<ephemeron.ml:197:6>>*/  /*<<ephemeron.ml:197:17>>*/ var
@@ -31214,17 +31055,17 @@
       /*<<ephemeron.ml:210:60>>*/ }
       /*<<ephemeron.ml:211:14>>*/ var
        /*<<ephemeron.ml:211:14>>*/ i = key_index(h, hkey),
-       /*<<ephemeron.ml:212:20>>*/ _at_ =
+       /*<<ephemeron.ml:212:20>>*/ _aa_ =
         remove_bucket(caml_check_bound(h[2], i)[1 + i]);
-      /*<<ephemeron.ml:212:6>>*/ caml_check_bound(h[2], i)[1 + i] = _at_;
+      /*<<ephemeron.ml:212:6>>*/ caml_check_bound(h[2], i)[1 + i] = _aa_;
       /*<<ephemeron.ml:212:6>>*/ return 0;
      /*<<ephemeron.ml:212:44>>*/ }
     function find(h, key){
       /*<<ephemeron.ml:239:6>>*/ var
        /*<<ephemeron.ml:239:17>>*/ hkey =
          /*<<ephemeron.ml:239:17>>*/ caml_call2(H[2], h[3], key),
-       /*<<ephemeron.ml:241:33>>*/ _as_ = key_index(h, hkey),
-      param = caml_check_bound(h[2], _as_)[1 + _as_];
+       /*<<ephemeron.ml:241:33>>*/ _$_ = key_index(h, hkey),
+      param = caml_check_bound(h[2], _$_)[1 + _$_];
      for(;;){
       if(! param)
         /*<<ephemeron.ml:220:10>>*/ throw  /*<<ephemeron.ml:220:10>>*/ caml_maybe_attach_backtrace
@@ -31250,8 +31091,8 @@
       /*<<ephemeron.ml:264:6>>*/ var
        /*<<ephemeron.ml:264:17>>*/ hkey =
          /*<<ephemeron.ml:264:17>>*/ caml_call2(H[2], h[3], key),
-       /*<<ephemeron.ml:266:37>>*/ _ar_ = key_index(h, hkey),
-      param = caml_check_bound(h[2], _ar_)[1 + _ar_];
+       /*<<ephemeron.ml:266:37>>*/ ___ = key_index(h, hkey),
+      param = caml_check_bound(h[2], ___)[1 + ___];
      for(;;){
       if(! param)  /*<<ephemeron.ml:245:10>>*/ return 0;
       var hk = param[1], rest = param[3], c = param[2];
@@ -31299,9 +31140,9 @@
       }
       /*<<ephemeron.ml:284:29>>*/ }
       /*<<ephemeron.ml:285:29>>*/  /*<<ephemeron.ml:285:29>>*/ var
-      _aq_ = key_index(h, hkey);
+      _Z_ = key_index(h, hkey);
       /*<<ephemeron.ml:285:21>>*/ return find_in_bucket
-             (caml_check_bound(h[2], _aq_)[1 + _aq_]);
+             (caml_check_bound(h[2], _Z_)[1 + _Z_]);
      /*<<ephemeron.ml:285:46>>*/ }
     function replace(h, key, info){
       /*<<ephemeron.ml:289:6>>*/ var
@@ -31319,8 +31160,8 @@
        if(hkey === hk){
         if(!  /*<<ephemeron.ml:293:24>>*/ caml_call2(H[3], c, key)){
           /*<<ephemeron.ml:290:6>>*/  /*<<ephemeron.ml:290:6>>*/ var
-          _am_ =  /*<<ephemeron.ml:290:6>>*/ caml_call3(H[5], c, key, info);
-          /*<<ephemeron.ml:302:8>>*/ return _am_;
+          _V_ =  /*<<ephemeron.ml:290:6>>*/ caml_call3(H[5], c, key, info);
+          /*<<ephemeron.ml:302:8>>*/ return _V_;
         }
         var param = next;
        }
@@ -31328,23 +31169,23 @@
         var next$0 = param[3], param = next$0;
       }
      }
-     catch(_ap_){
-      var _an_ = caml_wrap_exception(_ap_);
-      if(_an_ !== Stdlib[8]) throw caml_maybe_attach_backtrace(_an_, 0);
+     catch(_Y_){
+      var _W_ = caml_wrap_exception(_Y_);
+      if(_W_ !== Stdlib[8]) throw caml_maybe_attach_backtrace(_W_, 0);
        /*<<ephemeron.ml:304:24>>*/  /*<<ephemeron.ml:304:24>>*/ var
        container =  /*<<ephemeron.ml:304:24>>*/ caml_call2(H[1], key, info);
        /*<<ephemeron.ml:305:8>>*/ caml_check_bound(h[2], i)[1 + i] = [0, hkey, container, l];
       h[1] = h[1] + 1 | 0;
-      var _ao_ = h[2].length - 1 << 1 < h[1] ? 1 : 0;
-      return _ao_ ? resize(h) : _ao_;
+      var _X_ = h[2].length - 1 << 1 < h[1] ? 1 : 0;
+      return _X_ ? resize(h) : _X_;
      }
      /*<<ephemeron.ml:307:59>>*/ }
     function mem(h, key){
       /*<<ephemeron.ml:310:6>>*/ var
        /*<<ephemeron.ml:310:17>>*/ hkey =
          /*<<ephemeron.ml:310:17>>*/ caml_call2(H[2], h[3], key),
-       /*<<ephemeron.ml:320:28>>*/ _al_ = key_index(h, hkey),
-      param = caml_check_bound(h[2], _al_)[1 + _al_];
+       /*<<ephemeron.ml:320:28>>*/ _U_ = key_index(h, hkey),
+      param = caml_check_bound(h[2], _U_)[1 + _U_];
       /*<<ephemeron.ml:311:30>>*/ for(;;){
       if(! param)  /*<<ephemeron.ml:313:10>>*/ return 0;
       var hk = param[1], rest = param[3], c = param[2];
@@ -31372,29 +31213,30 @@
      }
     }
     function stats(h){
-      /*<<ephemeron.ml:329:6>>*/ var _af_ = h[2], _ag_ = 0;
-     function _ah_(m, b){
-       /*<<ephemeron.ml:330:36>>*/  /*<<ephemeron.ml:330:46>>*/ var
-       _ak_ = bucket_length(0, b);
-       /*<<ephemeron.ml:330:46>>*/ return  /*<<ephemeron.ml:330:46>>*/ caml_call2
-              (Stdlib_Int[11], m, _ak_);
-      /*<<ephemeron.ml:330:65>>*/ }
-      /*<<ephemeron.ml:330:8>>*/ var
+      /*<<ephemeron.ml:329:6>>*/ var
        /*<<ephemeron.ml:330:8>>*/ mbl =
          /*<<ephemeron.ml:330:8>>*/ caml_call3
-         (Stdlib_Array[17], _ah_, _ag_, _af_),
+         (Stdlib_Array[17],
+          function(m, b){
+            /*<<ephemeron.ml:330:36>>*/  /*<<ephemeron.ml:330:46>>*/ var
+            _T_ = bucket_length(0, b);
+            /*<<ephemeron.ml:330:46>>*/ return  /*<<ephemeron.ml:330:46>>*/ caml_call2
+                   (Stdlib_Int[11], m, _T_);
+           /*<<ephemeron.ml:330:65>>*/ },
+          0,
+          h[2]),
        /*<<ephemeron.ml:331:18>>*/ histo =
-         /*<<ephemeron.ml:331:18>>*/ caml_make_vect(mbl + 1 | 0, 0),
-       /*<<ephemeron.ml:332:6>>*/ _ai_ = h[2];
-     function _aj_(b){
-       /*<<ephemeron.ml:334:11>>*/  /*<<ephemeron.ml:334:19>>*/ var
-       l = bucket_length(0, b);
-       /*<<ephemeron.ml:335:11>>*/ histo[1 + l] =
-       caml_check_bound(histo, l)[1 + l] + 1 | 0;
-       /*<<ephemeron.ml:335:11>>*/ return 0;
-      /*<<ephemeron.ml:335:37>>*/ }
+         /*<<ephemeron.ml:331:18>>*/ caml_make_vect(mbl + 1 | 0, 0);
       /*<<ephemeron.ml:332:6>>*/  /*<<ephemeron.ml:332:6>>*/ caml_call2
-      (Stdlib_Array[11], _aj_, _ai_);
+      (Stdlib_Array[11],
+       function(b){
+         /*<<ephemeron.ml:334:11>>*/  /*<<ephemeron.ml:334:19>>*/ var
+         l = bucket_length(0, b);
+         /*<<ephemeron.ml:335:11>>*/ histo[1 + l] =
+         caml_check_bound(histo, l)[1 + l] + 1 | 0;
+         /*<<ephemeron.ml:335:11>>*/ return 0;
+        /*<<ephemeron.ml:335:37>>*/ },
+       h[2]);
       /*<<ephemeron.ml:337:6>>*/ return [0, h[1], h[2].length - 1, mbl, histo];
      /*<<ephemeron.ml:340:34>>*/ }
     function bucket_length_alive(accu, param){
@@ -31412,31 +31254,30 @@
     function stats_alive(h){
       /*<<ephemeron.ml:349:6>>*/ var
        /*<<ephemeron.ml:349:17>>*/ size = [0, 0],
-       /*<<ephemeron.ml:350:6>>*/ _$_ = h[2],
-      _aa_ = 0;
-     function _ab_(m, b){
-       /*<<ephemeron.ml:352:22>>*/  /*<<ephemeron.ml:352:32>>*/ var
-       _ae_ = bucket_length_alive(0, b);
-       /*<<ephemeron.ml:352:32>>*/ return  /*<<ephemeron.ml:352:32>>*/ caml_call2
-              (Stdlib_Int[11], m, _ae_);
-      /*<<ephemeron.ml:352:57>>*/ }
-      /*<<ephemeron.ml:351:8>>*/ var
        /*<<ephemeron.ml:351:8>>*/ mbl =
          /*<<ephemeron.ml:351:8>>*/ caml_call3
-         (Stdlib_Array[17], _ab_, _aa_, _$_),
+         (Stdlib_Array[17],
+          function(m, b){
+            /*<<ephemeron.ml:352:22>>*/  /*<<ephemeron.ml:352:32>>*/ var
+            _S_ = bucket_length_alive(0, b);
+            /*<<ephemeron.ml:352:32>>*/ return  /*<<ephemeron.ml:352:32>>*/ caml_call2
+                   (Stdlib_Int[11], m, _S_);
+           /*<<ephemeron.ml:352:57>>*/ },
+          0,
+          h[2]),
        /*<<ephemeron.ml:354:18>>*/ histo =
-         /*<<ephemeron.ml:354:18>>*/ caml_make_vect(mbl + 1 | 0, 0),
-       /*<<ephemeron.ml:355:6>>*/ _ac_ = h[2];
-     function _ad_(b){
-       /*<<ephemeron.ml:357:11>>*/  /*<<ephemeron.ml:357:19>>*/ var
-       l = bucket_length_alive(0, b);
-      size[1] = size[1] + l | 0;
-       /*<<ephemeron.ml:359:11>>*/ histo[1 + l] =
-       caml_check_bound(histo, l)[1 + l] + 1 | 0;
-       /*<<ephemeron.ml:359:11>>*/ return 0;
-      /*<<ephemeron.ml:359:37>>*/ }
+         /*<<ephemeron.ml:354:18>>*/ caml_make_vect(mbl + 1 | 0, 0);
       /*<<ephemeron.ml:355:6>>*/  /*<<ephemeron.ml:355:6>>*/ caml_call2
-      (Stdlib_Array[11], _ad_, _ac_);
+      (Stdlib_Array[11],
+       function(b){
+         /*<<ephemeron.ml:357:11>>*/  /*<<ephemeron.ml:357:19>>*/ var
+         l = bucket_length_alive(0, b);
+        size[1] = size[1] + l | 0;
+         /*<<ephemeron.ml:359:11>>*/ histo[1 + l] =
+         caml_check_bound(histo, l)[1 + l] + 1 | 0;
+         /*<<ephemeron.ml:359:11>>*/ return 0;
+        /*<<ephemeron.ml:359:37>>*/ },
+       h[2]);
       /*<<ephemeron.ml:361:6>>*/ return [0,
              size[1],
              h[2].length - 1,
@@ -31444,20 +31285,22 @@
              histo];
      /*<<ephemeron.ml:364:34>>*/ }
     function add_seq(tbl, i){
-     function ___(param){
-       /*<<ephemeron.ml:367:15>>*/ var v = param[2], k = param[1];
-       /*<<ephemeron.ml:367:29>>*/ return add(tbl, k, v);
-      /*<<ephemeron.ml:367:41>>*/ }
       /*<<ephemeron.ml:367:6>>*/ return  /*<<ephemeron.ml:367:6>>*/ caml_call2
-             (Stdlib_Seq[4], ___, i);
+             (Stdlib_Seq[4],
+              function(param){
+                /*<<ephemeron.ml:367:15>>*/ var v = param[2], k = param[1];
+                /*<<ephemeron.ml:367:29>>*/ return add(tbl, k, v);
+               /*<<ephemeron.ml:367:41>>*/ },
+              i);
      /*<<ephemeron.ml:367:43>>*/ }
     function replace_seq(tbl, i){
-     function _Z_(param){
-       /*<<ephemeron.ml:370:15>>*/ var v = param[2], k = param[1];
-       /*<<ephemeron.ml:370:29>>*/ return replace(tbl, k, v);
-      /*<<ephemeron.ml:370:45>>*/ }
       /*<<ephemeron.ml:370:6>>*/ return  /*<<ephemeron.ml:370:6>>*/ caml_call2
-             (Stdlib_Seq[4], _Z_, i);
+             (Stdlib_Seq[4],
+              function(param){
+                /*<<ephemeron.ml:370:15>>*/ var v = param[2], k = param[1];
+                /*<<ephemeron.ml:370:29>>*/ return replace(tbl, k, v);
+               /*<<ephemeron.ml:370:45>>*/ },
+              i);
      /*<<ephemeron.ml:370:47>>*/ }
     function of_seq(i){
       /*<<ephemeron.ml:373:6>>*/  /*<<ephemeron.ml:373:16>>*/ var
@@ -31581,10 +31424,10 @@
      replace_seq = include[15],
      clean = include[17],
      stats_alive = include[18],
-     _Y_ = include[1];
+     _R_ = include[1];
     function create(sz){
       /*<<ephemeron.ml:448:20>>*/ return  /*<<ephemeron.ml:448:20>>*/ caml_call2
-             (_Y_, _a_, sz);
+             (_R_, _a_, sz);
      /*<<ephemeron.ml:448:43>>*/ }
     function of_seq(i){
       /*<<ephemeron.ml:450:6>>*/  /*<<ephemeron.ml:450:16>>*/ var
@@ -31617,8 +31460,8 @@
      /*<<ephemeron.ml:459:18>>*/ return [0, 0];
     /*<<ephemeron.ml:459:24>>*/ }
    function add(b, k, d){
-     /*<<ephemeron.ml:460:20>>*/ var _X_ = b[1];
-    b[1] = [0, make(k, d), _X_];
+     /*<<ephemeron.ml:460:20>>*/ var _Q_ = b[1];
+    b[1] = [0, make(k, d), _Q_];
     return 0;
     /*<<ephemeron.ml:460:42>>*/ }
    function test_key(k, e){
@@ -31647,13 +31490,12 @@
     }
     /*<<ephemeron.ml:474:16>>*/ }
    function find(b, k){
-     /*<<ephemeron.ml:477:6>>*/ var _U_ = b[1];
-     /*<<ephemeron.ml:477:26>>*/ function _V_(_W_){
-      /*<<?>>*/ return test_key(k, _W_);
-    }
-     /*<<ephemeron.ml:477:12>>*/  /*<<ephemeron.ml:477:12>>*/ var
+     /*<<ephemeron.ml:477:6>>*/  /*<<ephemeron.ml:477:12>>*/ var
      match =
-        /*<<ephemeron.ml:477:12>>*/ caml_call2(Stdlib_List[40], _V_, _U_);
+        /*<<ephemeron.ml:477:12>>*/ caml_call2
+        (Stdlib_List[40],
+         function(_P_){ /*<<?>>*/ return test_key(k, _P_);},
+         b[1]);
     if(! match)  /*<<ephemeron.ml:479:16>>*/ return 0;
     var e = match[1];
      /*<<ephemeron.ml:478:18>>*/ return get_data(e);
@@ -31728,11 +31570,11 @@
       /*<<ephemeron.ml:539:33>>*/ var
       k2 = param[2],
       k1 = param[1],
-       /*<<ephemeron.ml:539:33>>*/ _T_ =
+       /*<<ephemeron.ml:539:33>>*/ _O_ =
          /*<<ephemeron.ml:539:33>>*/ caml_call2(H2[2], seed, k2) * 65599 | 0;
       /*<<ephemeron.ml:539:8>>*/ return  /*<<ephemeron.ml:539:8>>*/ caml_call2
              (H1[2], seed, k1)
-            + _T_
+            + _O_
             | 0;
     }
     function equal(c, param){
@@ -31761,11 +31603,11 @@
     }
     function check_key(c){
       /*<<ephemeron.ml:551:24>>*/  /*<<ephemeron.ml:496:45>>*/ var
-      _S_ =  /*<<ephemeron.ml:496:45>>*/ caml_call2(Stdlib_Obj[24][7], c, 0);
-      /*<<ephemeron.ml:551:24>>*/ return _S_
+      _N_ =  /*<<ephemeron.ml:496:45>>*/ caml_call2(Stdlib_Obj[24][7], c, 0);
+      /*<<ephemeron.ml:551:24>>*/ return _N_
              ?  /*<<ephemeron.ml:501:45>>*/ caml_call2
                (Stdlib_Obj[24][7], c, 1)
-             : _S_;
+             : _N_;
      /*<<ephemeron.ml:551:52>>*/ }
      /*<<ephemeron.ml:530:28>>*/ return MakeSeeded
             ([0,
@@ -31782,15 +31624,14 @@
       /*<<ephemeron.ml:566:43>>*/ return  /*<<ephemeron.ml:566:43>>*/ caml_call1
              (H2[2], x);
      /*<<ephemeron.ml:566:52>>*/ }
-     /*<<ephemeron.ml:563:9>>*/ var
-     equal$0 = H1[1],
-      /*<<ephemeron.ml:563:9>>*/ _Q_ = [0, equal, seeded_hash];
+    var equal$0 = H1[1];
     function seeded_hash$0(seed, x){
       /*<<ephemeron.ml:561:43>>*/ return  /*<<ephemeron.ml:561:43>>*/ caml_call1
              (H1[2], x);
      /*<<ephemeron.ml:561:52>>*/ }
     var
-     include = MakeSeeded$1([0, equal$0, seeded_hash$0], _Q_),
+     include =
+       MakeSeeded$1([0, equal$0, seeded_hash$0], [0, equal, seeded_hash]),
      clear = include[2],
      reset = include[3],
      copy = include[4],
@@ -31807,10 +31648,10 @@
      replace_seq = include[15],
      clean = include[17],
      stats_alive = include[18],
-     _R_ = include[1];
+     _M_ = include[1];
     function create(sz){
       /*<<ephemeron.ml:568:20>>*/ return  /*<<ephemeron.ml:568:20>>*/ caml_call2
-             (_R_, _b_, sz);
+             (_M_, _b_, sz);
      /*<<ephemeron.ml:568:43>>*/ }
     function of_seq(i){
       /*<<ephemeron.ml:570:6>>*/  /*<<ephemeron.ml:570:16>>*/ var
@@ -31843,8 +31684,8 @@
      /*<<ephemeron.ml:579:18>>*/ return [0, 0];
     /*<<ephemeron.ml:579:24>>*/ }
    function add$0(b, k1, k2, d){
-     /*<<ephemeron.ml:580:24>>*/ var _P_ = b[1];
-    b[1] = [0, make$1(k1, k2, d), _P_];
+     /*<<ephemeron.ml:580:24>>*/ var _L_ = b[1];
+    b[1] = [0, make$1(k1, k2, d), _L_];
     return 0;
     /*<<ephemeron.ml:580:50>>*/ }
    function test_keys(k1, k2, e){
@@ -31874,13 +31715,12 @@
     }
     /*<<ephemeron.ml:594:16>>*/ }
    function find$0(b, k1, k2){
-     /*<<ephemeron.ml:597:6>>*/ var _M_ = b[1];
-     /*<<ephemeron.ml:597:26>>*/ function _N_(_O_){
-      /*<<?>>*/ return test_keys(k1, k2, _O_);
-    }
-     /*<<ephemeron.ml:597:12>>*/  /*<<ephemeron.ml:597:12>>*/ var
+     /*<<ephemeron.ml:597:6>>*/  /*<<ephemeron.ml:597:12>>*/ var
      match =
-        /*<<ephemeron.ml:597:12>>*/ caml_call2(Stdlib_List[40], _N_, _M_);
+        /*<<ephemeron.ml:597:12>>*/ caml_call2
+        (Stdlib_List[40],
+         function(_K_){ /*<<?>>*/ return test_keys(k1, k2, _K_);},
+         b[1]);
     if(! match)  /*<<ephemeron.ml:599:16>>*/ return 0;
     var e = match[1];
      /*<<ephemeron.ml:598:18>>*/ return get_data$0(e);
@@ -31922,17 +31762,17 @@
       /*<<ephemeron.ml:625:14>>*/ eph = create$1(l);
      /*<<ephemeron.ml:626:4>>*/ set_data$1(eph, data);
      /*<<ephemeron.ml:626:4>>*/ var
-     _K_ = l - 1 | 0,
-      /*<<ephemeron.ml:626:4>>*/ _J_ = 0;
-    if(_K_ >= 0){
-     var i = _J_;
+     _I_ = l - 1 | 0,
+      /*<<ephemeron.ml:626:4>>*/ _H_ = 0;
+    if(_I_ >= 0){
+     var i = _H_;
      for(;;){
        /*<<ephemeron.ml:627:26>>*/ set_key$0
        (eph, i, caml_check_bound(keys, i)[1 + i]);
        /*<<ephemeron.ml:627:26>>*/  /*<<ephemeron.ml:627:26>>*/ var
-       _L_ = i + 1 | 0;
-      if(_K_ === i) break;
-      var i = _L_;
+       _J_ = i + 1 | 0;
+      if(_I_ === i) break;
+      var i = _J_;
      }
     }
      /*<<ephemeron.ml:628:4>>*/ return eph;
@@ -31945,10 +31785,10 @@
        /*<<ephemeron.ml:633:37>>*/ throw  /*<<ephemeron.ml:633:37>>*/ caml_maybe_attach_backtrace
              (Stdlib[3], 1);
       /*<<ephemeron.ml:631:12>>*/ var
-       /*<<ephemeron.ml:631:12>>*/ _F_ = l - 1 | 0,
-       /*<<ephemeron.ml:634:6>>*/ _E_ = 0;
-     if(_F_ >= 0){
-      var i = _E_;
+       /*<<ephemeron.ml:631:12>>*/ _D_ = l - 1 | 0,
+       /*<<ephemeron.ml:634:6>>*/ _C_ = 0;
+     if(_D_ >= 0){
+      var i = _C_;
       for(;;){
         /*<<ephemeron.ml:635:14>>*/  /*<<ephemeron.ml:635:14>>*/ var
         match = get_key$0(eph, i);
@@ -31960,19 +31800,19 @@
          /*<<ephemeron.ml:638:20>>*/ throw  /*<<ephemeron.ml:638:20>>*/ caml_maybe_attach_backtrace
                (Stdlib[3], 1);
         /*<<ephemeron.ml:634:6>>*/  /*<<ephemeron.ml:634:6>>*/ var
-        _H_ = i + 1 | 0;
-       if(_F_ === i) break;
-       var i = _H_;
+        _F_ = i + 1 | 0;
+       if(_D_ === i) break;
+       var i = _F_;
       }
      }
       /*<<ephemeron.ml:640:6>>*/  /*<<ephemeron.ml:640:6>>*/ var
-      _G_ = get_data$1(eph);
-      /*<<ephemeron.ml:640:6>>*/ return _G_;
+      _E_ = get_data$1(eph);
+      /*<<ephemeron.ml:640:6>>*/ return _E_;
     }
-    catch(_I_){
-     var _D_ = caml_wrap_exception(_I_);
-     if(_D_ === Stdlib[3])  /*<<ephemeron.ml:641:17>>*/ return 0;
-     throw caml_maybe_attach_backtrace(_D_, 0);
+    catch(_G_){
+     var _B_ = caml_wrap_exception(_G_);
+     if(_B_ === Stdlib[3])  /*<<ephemeron.ml:641:17>>*/ return 0;
+     throw caml_maybe_attach_backtrace(_B_, 0);
     }
     /*<<ephemeron.ml:641:21>>*/ }
    function MakeSeeded$2(H){
@@ -31981,17 +31821,17 @@
       c = create$1(k.length - 1);
       /*<<ephemeron.ml:649:8>>*/ set_data$1(c, d);
       /*<<ephemeron.ml:649:8>>*/ var
-      _B_ = k.length - 1 - 1 | 0,
-       /*<<ephemeron.ml:649:8>>*/ _A_ = 0;
-     if(_B_ >= 0){
-      var i = _A_;
+      _z_ = k.length - 1 - 1 | 0,
+       /*<<ephemeron.ml:649:8>>*/ _y_ = 0;
+     if(_z_ >= 0){
+      var i = _y_;
       for(;;){
         /*<<ephemeron.ml:651:10>>*/ set_key$0
         (c, i, caml_check_bound(k, i)[1 + i]);
         /*<<ephemeron.ml:651:10>>*/  /*<<ephemeron.ml:651:10>>*/ var
-        _C_ = i + 1 | 0;
-       if(_B_ === i) break;
-       var i = _C_;
+        _A_ = i + 1 | 0;
+       if(_z_ === i) break;
+       var i = _A_;
       }
      }
       /*<<ephemeron.ml:653:8>>*/ return c;
@@ -31999,22 +31839,22 @@
     function seeded_hash(seed, k){
       /*<<ephemeron.ml:655:8>>*/ var
        /*<<ephemeron.ml:655:16>>*/ h = [0, 0],
-      _w_ = k.length - 1 - 1 | 0,
-       /*<<ephemeron.ml:655:16>>*/ _v_ = 0;
-     if(_w_ >= 0){
-      var i = _v_;
+      _u_ = k.length - 1 - 1 | 0,
+       /*<<ephemeron.ml:655:16>>*/ _t_ = 0;
+     if(_u_ >= 0){
+      var i = _t_;
       for(;;){
         /*<<ephemeron.ml:657:34>>*/ var
-        _x_ = h[1],
-         /*<<ephemeron.ml:657:34>>*/ _y_ = caml_check_bound(k, i)[1 + i];
+        _v_ = h[1],
+         /*<<ephemeron.ml:657:34>>*/ _w_ = caml_check_bound(k, i)[1 + i];
        h[1] =
-        ( /*<<ephemeron.ml:657:15>>*/ caml_call2(H[2], seed, _y_) * 65599 | 0)
-        + _x_
+        ( /*<<ephemeron.ml:657:15>>*/ caml_call2(H[2], seed, _w_) * 65599 | 0)
+        + _v_
         | 0;
         /*<<ephemeron.ml:656:8>>*/  /*<<ephemeron.ml:656:8>>*/ var
-        _z_ = i + 1 | 0;
-       if(_w_ === i) break;
-       var i = _z_;
+        _x_ = i + 1 | 0;
+       if(_u_ === i) break;
+       var i = _x_;
       }
      }
      return h[1];
@@ -32034,9 +31874,9 @@
       if(! match)  /*<<ephemeron.ml:669:24>>*/ return 2;
        /*<<ephemeron.ml:671:29>>*/ var
        ki = match[1],
-        /*<<ephemeron.ml:671:29>>*/ _u_ = caml_check_bound(k, i)[1 + i];
+        /*<<ephemeron.ml:671:29>>*/ _s_ = caml_check_bound(k, i)[1 + i];
        /*<<ephemeron.ml:671:21>>*/ if
-       (!  /*<<ephemeron.ml:671:21>>*/ caml_call2(H[1], _u_, ki))
+       (!  /*<<ephemeron.ml:671:21>>*/ caml_call2(H[1], _s_, ki))
         /*<<ephemeron.ml:673:23>>*/ return 1;
        /*<<ephemeron.ml:672:23>>*/ var
         /*<<ephemeron.ml:672:23>>*/ i$0 = i - 1 | 0,
@@ -32047,17 +31887,17 @@
       /*<<ephemeron.ml:678:8>>*/  /*<<ephemeron.ml:621:40>>*/ caml_call1
       (Stdlib_Obj[24][12], c);
       /*<<ephemeron.ml:678:8>>*/ var
-      _s_ = k.length - 1 - 1 | 0,
-       /*<<ephemeron.ml:678:8>>*/ _r_ = 0;
-     if(_s_ >= 0){
-      var i = _r_;
+      _q_ = k.length - 1 - 1 | 0,
+       /*<<ephemeron.ml:678:8>>*/ _p_ = 0;
+     if(_q_ >= 0){
+      var i = _p_;
       for(;;){
         /*<<ephemeron.ml:680:10>>*/ set_key$0
         (c, i, caml_check_bound(k, i)[1 + i]);
         /*<<ephemeron.ml:680:10>>*/  /*<<ephemeron.ml:680:10>>*/ var
-        _t_ = i + 1 | 0;
-       if(_s_ === i) break;
-       var i = _t_;
+        _r_ = i + 1 | 0;
+       if(_q_ === i) break;
+       var i = _r_;
       }
      }
       /*<<ephemeron.ml:682:8>>*/ return set_data$1(c, d);
@@ -32067,19 +31907,19 @@
        /*<<ephemeron.ml:686:17>>*/ i$1 = length$1(c) - 1 | 0,
       i = i$1;
       /*<<ephemeron.ml:685:10>>*/ for(;;){
-      var _p_ = i < 0 ? 1 : 0;
-      if(_p_)
-       var _q_ = _p_;
+      var _n_ = i < 0 ? 1 : 0;
+      if(_n_)
+       var _o_ = _n_;
       else{
         /*<<ephemeron.ml:617:47>>*/  /*<<ephemeron.ml:617:47>>*/ var
-        _o_ =  /*<<ephemeron.ml:617:47>>*/ caml_call2(Stdlib_Obj[24][7], c, i);
-        /*<<ephemeron.ml:685:20>>*/ if(_o_){
+        _m_ =  /*<<ephemeron.ml:617:47>>*/ caml_call2(Stdlib_Obj[24][7], c, i);
+        /*<<ephemeron.ml:685:20>>*/ if(_m_){
         var i$0 = i - 1 | 0, i = i$0;
         continue;
        }
-       var _q_ = _o_;
+       var _o_ = _m_;
       }
-      return _q_;
+      return _o_;
      }
      /*<<ephemeron.ml:686:30>>*/ }
      /*<<ephemeron.ml:644:28>>*/ return MakeSeeded
@@ -32115,10 +31955,10 @@
      replace_seq = include[15],
      clean = include[17],
      stats_alive = include[18],
-     _n_ = include[1];
+     _l_ = include[1];
     function create(sz){
       /*<<ephemeron.ml:696:20>>*/ return  /*<<ephemeron.ml:696:20>>*/ caml_call2
-             (_n_, _c_, sz);
+             (_l_, _c_, sz);
      /*<<ephemeron.ml:696:43>>*/ }
     function of_seq(i){
       /*<<ephemeron.ml:698:6>>*/  /*<<ephemeron.ml:698:16>>*/ var
@@ -32151,8 +31991,8 @@
      /*<<ephemeron.ml:707:18>>*/ return [0, 0];
     /*<<ephemeron.ml:707:24>>*/ }
    function add$1(b, k, d){
-     /*<<ephemeron.ml:708:20>>*/ var _m_ = b[1];
-    b[1] = [0, make$3(k, d), _m_];
+     /*<<ephemeron.ml:708:20>>*/ var _k_ = b[1];
+    b[1] = [0, make$3(k, d), _k_];
     return 0;
     /*<<ephemeron.ml:708:42>>*/ }
    function test_keys$0(k, e){
@@ -32161,10 +32001,10 @@
        /*<<ephemeron.ml:712:43>>*/ throw  /*<<ephemeron.ml:712:43>>*/ caml_maybe_attach_backtrace
              (Stdlib[3], 1);
       /*<<ephemeron.ml:713:8>>*/ var
-      _i_ = k.length - 1 - 1 | 0,
-       /*<<ephemeron.ml:713:8>>*/ _h_ = 0;
-     if(_i_ >= 0){
-      var i = _h_;
+      _g_ = k.length - 1 - 1 | 0,
+       /*<<ephemeron.ml:713:8>>*/ _f_ = 0;
+     if(_g_ >= 0){
+      var i = _f_;
       for(;;){
         /*<<ephemeron.ml:714:16>>*/  /*<<ephemeron.ml:714:16>>*/ var
         match = get_key$0(e, i);
@@ -32172,9 +32012,9 @@
         var x = match[1];
         if(x === caml_check_bound(k, i)[1 + i]){
           /*<<ephemeron.ml:713:8>>*/  /*<<ephemeron.ml:713:8>>*/ var
-          _k_ = i + 1 | 0;
-         if(_i_ === i) break;
-         var i = _k_;
+          _i_ = i + 1 | 0;
+         if(_g_ === i) break;
+         var i = _i_;
          continue;
         }
        }
@@ -32182,13 +32022,13 @@
               (Stdlib[3], 1);
       }
      }
-      /*<<ephemeron.ml:718:8>>*/  /*<<ephemeron.ml:718:8>>*/ var _j_ = 1;
-      /*<<ephemeron.ml:718:8>>*/ return _j_;
+      /*<<ephemeron.ml:718:8>>*/  /*<<ephemeron.ml:718:8>>*/ var _h_ = 1;
+      /*<<ephemeron.ml:718:8>>*/ return _h_;
     }
-    catch(_l_){
-     var _g_ = caml_wrap_exception(_l_);
-     if(_g_ === Stdlib[3])  /*<<ephemeron.ml:719:19>>*/ return 0;
-     throw caml_maybe_attach_backtrace(_g_, 0);
+    catch(_j_){
+     var _e_ = caml_wrap_exception(_j_);
+     if(_e_ === Stdlib[3])  /*<<ephemeron.ml:719:19>>*/ return 0;
+     throw caml_maybe_attach_backtrace(_e_, 0);
     }
     /*<<ephemeron.ml:719:24>>*/ }
    function remove$1(b, k){
@@ -32208,13 +32048,12 @@
     }
     /*<<ephemeron.ml:728:16>>*/ }
    function find$1(b, k){
-     /*<<ephemeron.ml:731:6>>*/ var _d_ = b[1];
-     /*<<ephemeron.ml:731:26>>*/ function _e_(_f_){
-      /*<<?>>*/ return test_keys$0(k, _f_);
-    }
-     /*<<ephemeron.ml:731:12>>*/  /*<<ephemeron.ml:731:12>>*/ var
+     /*<<ephemeron.ml:731:6>>*/  /*<<ephemeron.ml:731:12>>*/ var
      match =
-        /*<<ephemeron.ml:731:12>>*/ caml_call2(Stdlib_List[40], _e_, _d_);
+        /*<<ephemeron.ml:731:12>>*/ caml_call2
+        (Stdlib_List[40],
+         function(_d_){ /*<<?>>*/ return test_keys$0(k, _d_);},
+         b[1]);
     if(! match)  /*<<ephemeron.ml:733:16>>*/ return 0;
     var e = match[1];
      /*<<ephemeron.ml:732:18>>*/ return get_data$1(e);
@@ -32345,20 +32184,7 @@
     Stdlib_String = global_data.Stdlib__String,
     Stdlib_List = global_data.Stdlib__List,
     Stdlib_Buffer = global_data.Stdlib__Buffer,
-    Stdlib_Sys = global_data.Stdlib__Sys,
-    _j_ = [0, 7, 0],
-    _i_ = [0, 1, [0, 3, [0, 5, 0]]],
-    _f_ = [0, [2, 0, [4, 6, [0, 2, 6], 0, [2, 0, 0]]], "%s%06x%s"],
-    cst_Filename_chop_extension = "Filename.chop_extension",
-    cst_Filename_chop_suffix = "Filename.chop_suffix",
-    _d_ = [0, cst$20, 0],
-    cst_2_1$0 = cst_2_1$1,
-    cst_2$0 = cst_2$1,
-    cst_Filename_quote_command_bad = "Filename.quote_command: bad file name ",
-    _c_ = [0, cst$20, 0],
-    cst_2_1 = cst_2_1$1,
-    cst_2 = cst_2$1,
-    cst_tmp = "/tmp";
+    Stdlib_Sys = global_data.Stdlib__Sys;
    function generic_basename(is_dir_sep, current_dir_name, name){
      /*<<filename.ml:37:2>>*/ if
      ( /*<<filename.ml:46:5>>*/ caml_string_equal(name, cst$19))
@@ -32437,39 +32263,39 @@
     /*<<filename.ml:96:34>>*/ }
    function is_relative(n){
      /*<<filename.ml:97:22>>*/ var
-     _aM_ = caml_ml_string_length(n) < 1 ? 1 : 0,
-     _aN_ =
-       _aM_
+     _aH_ = caml_ml_string_length(n) < 1 ? 1 : 0,
+     _aI_ =
+       _aH_
        || (47 !==  /*<<filename.ml:97:45>>*/ caml_string_get(n, 0) ? 1 : 0);
-    return _aN_;
+    return _aI_;
     /*<<filename.ml:97:57>>*/ }
    function is_implicit(n){
      /*<<filename.ml:99:4>>*/  /*<<filename.ml:99:4>>*/ var
-     _aH_ = is_relative(n);
-     /*<<filename.ml:99:4>>*/ if(_aH_){
+     _aC_ = is_relative(n);
+     /*<<filename.ml:99:4>>*/ if(_aC_){
      var
-      _aI_ = caml_ml_string_length(n) < 2 ? 1 : 0,
-      _aJ_ =
-        _aI_
+      _aD_ = caml_ml_string_length(n) < 2 ? 1 : 0,
+      _aE_ =
+        _aD_
         ||
           /*<<filename.ml:100:31>>*/ caml_string_notequal
           ( /*<<filename.ml:100:31>>*/ caml_call3(Stdlib_String[16], n, 0, 2),
            cst$27);
-      /*<<filename.ml:100:31>>*/ if(_aJ_)
+      /*<<filename.ml:100:31>>*/ if(_aE_)
       var
-       _aK_ = caml_ml_string_length(n) < 3 ? 1 : 0,
-       _aL_ =
-         _aK_
+       _aF_ = caml_ml_string_length(n) < 3 ? 1 : 0,
+       _aG_ =
+         _aF_
          ||
            /*<<filename.ml:101:31>>*/ caml_string_notequal
            ( /*<<filename.ml:101:31>>*/ caml_call3(Stdlib_String[16], n, 0, 3),
             cst$28);
      else
-      var _aL_ = _aJ_;
+      var _aG_ = _aE_;
     }
     else
-     var _aL_ = _aH_;
-     /*<<filename.ml:101:31>>*/ return _aL_;
+     var _aG_ = _aC_;
+     /*<<filename.ml:101:31>>*/ return _aG_;
     /*<<filename.ml:101:57>>*/ }
    function check_suffix(name, suff){
      /*<<filename.ml:103:4>>*/ return  /*<<filename.ml:103:4>>*/ caml_call2
@@ -32491,14 +32317,28 @@
                (Stdlib_String[16], filename, 0, len_f - len_s | 0)]
             : 0;
     /*<<filename.ml:114:10>>*/ }
+   var
+    _h_ = [0, 7, 0],
+    _g_ = [0, 1, [0, 3, [0, 5, 0]]],
+    _f_ = [0, [2, 0, [4, 6, [0, 2, 6], 0, [2, 0, 0]]], "%s%06x%s"],
+    cst_Filename_chop_extension = "Filename.chop_extension",
+    cst_Filename_chop_suffix = "Filename.chop_suffix",
+    _d_ = [0, cst$20, 0],
+    cst_2_1$0 = cst_2_1$1,
+    cst_2$0 = cst_2$1,
+    cst_Filename_quote_command_bad = "Filename.quote_command: bad file name ",
+    _c_ = [0, cst$20, 0],
+    cst_2_1 = cst_2_1$1,
+    cst_2 = cst_2$1,
+    cst_tmp = "/tmp";
    try{
      /*<<filename.ml:117:8>>*/ var
-      /*<<filename.ml:117:8>>*/ _l_ =
+      /*<<filename.ml:117:8>>*/ _j_ =
         /*<<filename.ml:117:8>>*/ caml_sys_getenv("TMPDIR"),
-     temp_dir_name = _l_;
+     temp_dir_name = _j_;
    }
-   catch(_aG_){
-    var _a_ = caml_wrap_exception(_aG_);
+   catch(_aB_){
+    var _a_ = caml_wrap_exception(_aB_);
     if(_a_ !== Stdlib[8]) throw caml_maybe_attach_backtrace(_a_, 0);
     var temp_dir_name = cst_tmp;
    }
@@ -32510,10 +32350,10 @@
      /*<<filename.ml:19:2>>*/  /*<<filename.ml:19:2>>*/ caml_call2
      (Stdlib_Buffer[12], b, 39);
      /*<<filename.ml:19:2>>*/ var
-     _aD_ = l - 1 | 0,
-      /*<<filename.ml:19:2>>*/ _aC_ = 0;
-    if(_aD_ >= 0){
-     var i = _aC_;
+     _ay_ = l - 1 | 0,
+      /*<<filename.ml:19:2>>*/ _ax_ = 0;
+    if(_ay_ >= 0){
+     var i = _ax_;
      for(;;){
        /*<<filename.ml:21:7>>*/ if
        (39 ===  /*<<filename.ml:21:7>>*/ caml_string_get(s, i))
@@ -32521,14 +32361,14 @@
         (Stdlib_Buffer[16], b, quotequote);
       else{
         /*<<filename.ml:23:28>>*/  /*<<filename.ml:23:28>>*/ var
-        _aF_ =  /*<<filename.ml:23:28>>*/ caml_string_get(s, i);
+        _aA_ =  /*<<filename.ml:23:28>>*/ caml_string_get(s, i);
         /*<<filename.ml:23:9>>*/  /*<<filename.ml:23:9>>*/ caml_call2
-        (Stdlib_Buffer[12], b, _aF_);
+        (Stdlib_Buffer[12], b, _aA_);
       }
        /*<<filename.ml:23:9>>*/  /*<<filename.ml:23:9>>*/ var
-       _aE_ = i + 1 | 0;
-      if(_aD_ === i) break;
-      var i = _aE_;
+       _az_ = i + 1 | 0;
+      if(_ay_ === i) break;
+      var i = _az_;
      }
     }
      /*<<filename.ml:25:2>>*/  /*<<filename.ml:25:2>>*/ caml_call2
@@ -32541,47 +32381,47 @@
      var f = stderr[1];
       /*<<filename.ml:123:51>>*/ if
       ( /*<<filename.ml:123:51>>*/ caml_equal(stderr, stdout))
-      var _ar_ = cst_2_1;
+      var _am_ = cst_2_1;
      else
        /*<<filename.ml:125:61>>*/ var
-        /*<<filename.ml:125:61>>*/ _aB_ = quote(f),
-       _ar_ =  /*<<filename.ml:125:53>>*/ caml_call2(Stdlib[28], cst_2, _aB_);
-     var _as_ = _ar_;
+        /*<<filename.ml:125:61>>*/ _aw_ = quote(f),
+       _am_ =  /*<<filename.ml:125:53>>*/ caml_call2(Stdlib[28], cst_2, _aw_);
+     var _an_ = _am_;
     }
     else
-     var _as_ = cst$4;
+     var _an_ = cst$4;
     if(stdout)
       /*<<filename.ml:122:55>>*/ var
       f$0 = stdout[1],
-       /*<<filename.ml:122:55>>*/ _at_ = quote(f$0),
-      _au_ =  /*<<filename.ml:122:48>>*/ caml_call2(Stdlib[28], cst, _at_);
+       /*<<filename.ml:122:55>>*/ _ao_ = quote(f$0),
+      _ap_ =  /*<<filename.ml:122:48>>*/ caml_call2(Stdlib[28], cst, _ao_);
     else
-     var _au_ = cst$3;
+     var _ap_ = cst$3;
      /*<<filename.ml:122:6>>*/  /*<<filename.ml:122:6>>*/ var
-     _av_ =  /*<<filename.ml:122:6>>*/ caml_call2(Stdlib[28], _au_, _as_);
+     _aq_ =  /*<<filename.ml:122:6>>*/ caml_call2(Stdlib[28], _ap_, _an_);
     if(stdin)
       /*<<filename.ml:121:55>>*/ var
       f$1 = stdin[1],
-       /*<<filename.ml:121:55>>*/ _aw_ = quote(f$1),
-      _ax_ =  /*<<filename.ml:121:48>>*/ caml_call2(Stdlib[28], cst$0, _aw_);
+       /*<<filename.ml:121:55>>*/ _ar_ = quote(f$1),
+      _as_ =  /*<<filename.ml:121:48>>*/ caml_call2(Stdlib[28], cst$0, _ar_);
     else
-     var _ax_ = cst$2;
+     var _as_ = cst$2;
      /*<<filename.ml:121:6>>*/ var
-      /*<<filename.ml:121:6>>*/ _ay_ =
-        /*<<filename.ml:121:6>>*/ caml_call2(Stdlib[28], _ax_, _av_),
-      /*<<filename.ml:120:22>>*/ _az_ =
+      /*<<filename.ml:121:6>>*/ _at_ =
+        /*<<filename.ml:121:6>>*/ caml_call2(Stdlib[28], _as_, _aq_),
+      /*<<filename.ml:120:22>>*/ _au_ =
         /*<<filename.ml:120:22>>*/ caml_call2
         (Stdlib_List[20], quote, [0, cmd, args]),
-      /*<<filename.ml:120:4>>*/ _aA_ =
-        /*<<filename.ml:120:4>>*/ caml_call2(Stdlib_String[7], cst$1, _az_);
+      /*<<filename.ml:120:4>>*/ _av_ =
+        /*<<filename.ml:120:4>>*/ caml_call2(Stdlib_String[7], cst$1, _au_);
      /*<<filename.ml:121:6>>*/ return  /*<<filename.ml:121:6>>*/ caml_call2
-            (Stdlib[28], _aA_, _ay_);
+            (Stdlib[28], _av_, _at_);
     /*<<filename.ml:125:69>>*/ }
-    /*<<filename.ml:126:17>>*/ function basename(_aq_){
-     /*<<?>>*/ return generic_basename(is_dir_sep, current_dir_name, _aq_);
+    /*<<filename.ml:126:17>>*/ function basename(_al_){
+     /*<<?>>*/ return generic_basename(is_dir_sep, current_dir_name, _al_);
    }
-    /*<<filename.ml:127:16>>*/ function dirname(_ap_){
-     /*<<?>>*/ return generic_dirname(is_dir_sep, current_dir_name, _ap_);
+    /*<<filename.ml:127:16>>*/ function dirname(_ak_){
+     /*<<?>>*/ return generic_dirname(is_dir_sep, current_dir_name, _ak_);
    }
     /*<<filename.ml:91:24>>*/  /*<<filename.ml:91:24>>*/ var
     Unix =
@@ -32604,96 +32444,96 @@
      /*<<filename.ml:135:23>>*/ var
       /*<<filename.ml:135:31>>*/ c =
         /*<<filename.ml:135:31>>*/ caml_string_get(s, i),
-     _am_ = 47 === c ? 1 : 0;
-    if(_am_)
-     var _an_ = _am_;
+     _ah_ = 47 === c ? 1 : 0;
+    if(_ah_)
+     var _ai_ = _ah_;
     else
-     var _ao_ = 92 === c ? 1 : 0, _an_ = _ao_ || (58 === c ? 1 : 0);
-    return _an_;
+     var _aj_ = 92 === c ? 1 : 0, _ai_ = _aj_ || (58 === c ? 1 : 0);
+    return _ai_;
     /*<<filename.ml:135:70>>*/ }
    function is_relative$0(n){
      /*<<filename.ml:137:4>>*/ var
-     _ag_ = caml_ml_string_length(n) < 1 ? 1 : 0,
-     _ah_ =
-       _ag_
+     _ab_ = caml_ml_string_length(n) < 1 ? 1 : 0,
+     _ac_ =
+       _ab_
        || (47 !==  /*<<filename.ml:137:28>>*/ caml_string_get(n, 0) ? 1 : 0);
-    if(_ah_){
+    if(_ac_){
      var
-      _ai_ = caml_ml_string_length(n) < 1 ? 1 : 0,
-      _aj_ =
-        _ai_
+      _ad_ = caml_ml_string_length(n) < 1 ? 1 : 0,
+      _ae_ =
+        _ad_
         || (92 !==  /*<<filename.ml:138:31>>*/ caml_string_get(n, 0) ? 1 : 0);
-     if(_aj_)
+     if(_ae_)
       var
-       _ak_ = caml_ml_string_length(n) < 2 ? 1 : 0,
-       _al_ =
-         _ak_
+       _af_ = caml_ml_string_length(n) < 2 ? 1 : 0,
+       _ag_ =
+         _af_
          || (58 !==  /*<<filename.ml:139:31>>*/ caml_string_get(n, 1) ? 1 : 0);
      else
-      var _al_ = _aj_;
+      var _ag_ = _ae_;
     }
     else
-     var _al_ = _ah_;
-    return _al_;
+     var _ag_ = _ac_;
+    return _ag_;
     /*<<filename.ml:139:44>>*/ }
    function is_implicit$0(n){
      /*<<filename.ml:141:4>>*/  /*<<filename.ml:141:4>>*/ var
-     _Z_ = is_relative$0(n);
-     /*<<filename.ml:141:4>>*/ if(_Z_){
+     _U_ = is_relative$0(n);
+     /*<<filename.ml:141:4>>*/ if(_U_){
      var
-      ___ = caml_ml_string_length(n) < 2 ? 1 : 0,
-      _$_ =
-        ___
+      _V_ = caml_ml_string_length(n) < 2 ? 1 : 0,
+      _W_ =
+        _V_
         ||
           /*<<filename.ml:142:31>>*/ caml_string_notequal
           ( /*<<filename.ml:142:31>>*/ caml_call3(Stdlib_String[16], n, 0, 2),
            cst$27);
-      /*<<filename.ml:142:31>>*/ if(_$_){
+      /*<<filename.ml:142:31>>*/ if(_W_){
       var
-       _aa_ = caml_ml_string_length(n) < 2 ? 1 : 0,
-       _ab_ =
-         _aa_
+       _X_ = caml_ml_string_length(n) < 2 ? 1 : 0,
+       _Y_ =
+         _X_
          ||
            /*<<filename.ml:143:31>>*/ caml_string_notequal
            ( /*<<filename.ml:143:31>>*/ caml_call3(Stdlib_String[16], n, 0, 2),
             ".\\");
-       /*<<filename.ml:143:31>>*/ if(_ab_){
+       /*<<filename.ml:143:31>>*/ if(_Y_){
        var
-        _ac_ = caml_ml_string_length(n) < 3 ? 1 : 0,
-        _ad_ =
-          _ac_
+        _Z_ = caml_ml_string_length(n) < 3 ? 1 : 0,
+        ___ =
+          _Z_
           ||
             /*<<filename.ml:144:31>>*/ caml_string_notequal
             ( /*<<filename.ml:144:31>>*/ caml_call3
               (Stdlib_String[16], n, 0, 3),
              cst$28);
-        /*<<filename.ml:144:31>>*/ if(_ad_)
+        /*<<filename.ml:144:31>>*/ if(___)
         var
-         _ae_ = caml_ml_string_length(n) < 3 ? 1 : 0,
-         _af_ =
-           _ae_
+         _$_ = caml_ml_string_length(n) < 3 ? 1 : 0,
+         _aa_ =
+           _$_
            ||
              /*<<filename.ml:145:31>>*/ caml_string_notequal
              ( /*<<filename.ml:145:31>>*/ caml_call3
                (Stdlib_String[16], n, 0, 3),
               "..\\");
        else
-        var _af_ = _ad_;
+        var _aa_ = ___;
       }
       else
-       var _af_ = _ab_;
+       var _aa_ = _Y_;
      }
      else
-      var _af_ = _$_;
+      var _aa_ = _W_;
     }
     else
-     var _af_ = _Z_;
-     /*<<filename.ml:145:31>>*/ return _af_;
+     var _aa_ = _U_;
+     /*<<filename.ml:145:31>>*/ return _aa_;
     /*<<filename.ml:145:58>>*/ }
    function check_suffix$0(name, suff){
      /*<<filename.ml:147:3>>*/ var
-     _W_ = caml_ml_string_length(suff) <= caml_ml_string_length(name) ? 1 : 0;
-    if(_W_)
+     _R_ = caml_ml_string_length(suff) <= caml_ml_string_length(name) ? 1 : 0;
+    if(_R_)
       /*<<filename.ml:148:12>>*/ var
        /*<<filename.ml:148:12>>*/ s =
          /*<<filename.ml:148:12>>*/ caml_call3
@@ -32701,14 +32541,14 @@
           name,
           caml_ml_string_length(name) - caml_ml_string_length(suff) | 0,
           caml_ml_string_length(suff)),
-       /*<<filename.ml:150:31>>*/ _X_ =
+       /*<<filename.ml:150:31>>*/ _S_ =
          /*<<filename.ml:150:31>>*/ caml_call1(Stdlib_String[27], suff),
-      _Y_ =
+      _T_ =
          /*<<filename.ml:150:4>>*/ caml_string_equal
-         ( /*<<filename.ml:150:4>>*/ caml_call1(Stdlib_String[27], s), _X_);
+         ( /*<<filename.ml:150:4>>*/ caml_call1(Stdlib_String[27], s), _S_);
     else
-     var _Y_ = _W_;
-     /*<<filename.ml:150:4>>*/ return _Y_;
+     var _T_ = _R_;
+     /*<<filename.ml:150:4>>*/ return _T_;
     /*<<filename.ml:150:59>>*/ }
    function chop_suffix_opt$0(suffix, filename){
      /*<<filename.ml:153:4>>*/ var
@@ -32719,11 +32559,11 @@
       /*<<filename.ml:155:14>>*/ r =
         /*<<filename.ml:155:14>>*/ caml_call3
         (Stdlib_String[16], filename, len_f - len_s | 0, len_s),
-      /*<<filename.ml:156:36>>*/ _V_ =
+      /*<<filename.ml:156:36>>*/ _Q_ =
         /*<<filename.ml:156:36>>*/ caml_call1(Stdlib_String[27], suffix);
      /*<<filename.ml:156:9>>*/ return  /*<<filename.ml:156:9>>*/ caml_string_equal
              ( /*<<filename.ml:156:9>>*/ caml_call1(Stdlib_String[27], r),
-              _V_)
+              _Q_)
             ? [0,
                /*<<filename.ml:157:13>>*/ caml_call3
                (Stdlib_String[16], filename, 0, len_f - len_s | 0)]
@@ -32731,12 +32571,12 @@
     /*<<filename.ml:161:10>>*/ }
    try{
      /*<<filename.ml:165:8>>*/ var
-      /*<<filename.ml:165:8>>*/ _k_ =
+      /*<<filename.ml:165:8>>*/ _i_ =
         /*<<filename.ml:165:8>>*/ caml_sys_getenv("TEMP"),
-     temp_dir_name$0 = _k_;
+     temp_dir_name$0 = _i_;
    }
-   catch(_U_){
-    var _b_ = caml_wrap_exception(_U_);
+   catch(_P_){
+    var _b_ = caml_wrap_exception(_P_);
     if(_b_ !== Stdlib[8]) throw caml_maybe_attach_backtrace(_b_, 0);
     var temp_dir_name$0 = cst$5;
    }
@@ -32756,20 +32596,20 @@
        /*<<filename.ml:172:12>>*/  /*<<filename.ml:172:12>>*/ var
        c =  /*<<filename.ml:172:12>>*/ caml_string_get(s, i$0);
       if(34 === c){
-       var _S_ = 0;
+       var _N_ = 0;
         /*<<filename.ml:173:16>>*/ if(counter >= 50)
          /*<<filename.ml:173:16>>*/ return  /*<<filename.ml:173:16>>*/ caml_trampoline_return
-                (loop_bs, [0, _S_, i$0]);
+                (loop_bs, [0, _N_, i$0]);
        var counter$1 = counter + 1 | 0;
-        /*<<filename.ml:173:16>>*/ return loop_bs(counter$1, _S_, i$0);
+        /*<<filename.ml:173:16>>*/ return loop_bs(counter$1, _N_, i$0);
       }
       if(92 === c){
-       var _T_ = 0;
+       var _O_ = 0;
         /*<<filename.ml:174:16>>*/ if(counter >= 50)
          /*<<filename.ml:174:16>>*/ return  /*<<filename.ml:174:16>>*/ caml_trampoline_return
-                (loop_bs, [0, _T_, i$0]);
+                (loop_bs, [0, _O_, i$0]);
        var counter$0 = counter + 1 | 0;
-        /*<<filename.ml:174:16>>*/ return loop_bs(counter$0, _T_, i$0);
+        /*<<filename.ml:174:16>>*/ return loop_bs(counter$0, _O_, i$0);
       }
        /*<<filename.ml:175:16>>*/  /*<<filename.ml:175:16>>*/ caml_call2
        (Stdlib_Buffer[12], b, c);
@@ -32794,12 +32634,12 @@
         /*<<filename.ml:182:34>>*/  /*<<filename.ml:182:34>>*/ caml_call2
         (Stdlib_Buffer[12], b, 34);
         /*<<filename.ml:182:34>>*/  /*<<filename.ml:182:34>>*/ var
-        _R_ = i$0 + 1 | 0;
+        _M_ = i$0 + 1 | 0;
         /*<<filename.ml:182:34>>*/ if(counter >= 50)
          /*<<filename.ml:182:34>>*/ return  /*<<filename.ml:182:34>>*/ caml_trampoline_return
-                (loop$0, [0, _R_]);
+                (loop$0, [0, _M_]);
        var counter$1 = counter + 1 | 0;
-        /*<<filename.ml:182:34>>*/ return loop$0(counter$1, _R_);
+        /*<<filename.ml:182:34>>*/ return loop$0(counter$1, _M_);
       }
       if(92 !== match){
         /*<<filename.ml:184:18>>*/ add_bs(n$0);
@@ -32817,16 +32657,16 @@
      }
      /*<<filename.ml:185:9>>*/ }
     function add_bs(n){
-      /*<<filename.ml:186:19>>*/  /*<<filename.ml:186:19>>*/ var _P_ = 1;
+      /*<<filename.ml:186:19>>*/  /*<<filename.ml:186:19>>*/ var _K_ = 1;
      if(n >= 1){
-      var j = _P_;
+      var j = _K_;
       for(;;){
         /*<<filename.ml:186:38>>*/  /*<<filename.ml:186:38>>*/ caml_call2
         (Stdlib_Buffer[12], b, 92);
         /*<<filename.ml:186:38>>*/  /*<<filename.ml:186:38>>*/ var
-        _Q_ = j + 1 | 0;
+        _L_ = j + 1 | 0;
        if(n === j) break;
-       var j = _Q_;
+       var j = _L_;
       }
      }
      return;
@@ -32836,104 +32676,112 @@
             (Stdlib_Buffer[2], b);
     /*<<filename.ml:189:21>>*/ }
    function quote_cmd_filename(f){
-    function _N_(param){
-      /*<<filename.ml:222:21>>*/ if(34 !== param && 37 !== param)
-       /*<<filename.ml:222:57>>*/ return 0;
-      /*<<filename.ml:222:45>>*/ return 1;
-     /*<<filename.ml:222:63>>*/ }
-     /*<<filename.ml:222:7>>*/ if
-     (!  /*<<filename.ml:222:7>>*/ caml_call2(Stdlib_String[23], _N_, f))
+     /*<<filename.ml:222:4>>*/ if
+     (!
+       /*<<filename.ml:222:7>>*/ caml_call2
+       (Stdlib_String[23],
+        function(param){
+          /*<<filename.ml:222:21>>*/ if(34 !== param && 37 !== param)
+           /*<<filename.ml:222:57>>*/ return 0;
+          /*<<filename.ml:222:45>>*/ return 1;
+         /*<<filename.ml:222:63>>*/ },
+        f))
       /*<<filename.ml:224:12>>*/ return  /*<<filename.ml:224:12>>*/ caml_call2
               (Stdlib_String[15], f, 32)
              ?  /*<<filename.ml:225:23>>*/ caml_call2
                (Stdlib_String[7], cst$7, [0, cst$6, [0, f, _c_]])
              : f;
      /*<<filename.ml:223:15>>*/  /*<<filename.ml:223:15>>*/ var
-     _O_ =
+     _J_ =
         /*<<filename.ml:223:15>>*/ caml_call2
         (Stdlib[28], cst_Filename_quote_command_bad, f);
      /*<<filename.ml:223:15>>*/ return  /*<<filename.ml:223:15>>*/ caml_call1
-            (Stdlib[2], _O_);
+            (Stdlib[2], _J_);
     /*<<filename.ml:227:7>>*/ }
    function quote_command$0(cmd, stdin, stdout, stderr, args){
      /*<<filename.ml:232:4>>*/ if(stderr){
      var f = stderr[1];
       /*<<filename.ml:240:43>>*/ if
       ( /*<<filename.ml:240:43>>*/ caml_equal(stderr, stdout))
-      var _z_ = cst_2_1$0;
+      var _w_ = cst_2_1$0;
      else
        /*<<filename.ml:242:53>>*/ var
-        /*<<filename.ml:242:53>>*/ _L_ = quote_cmd_filename(f),
-       _z_ =  /*<<filename.ml:242:45>>*/ caml_call2(Stdlib[28], cst_2$0, _L_);
-     var _A_ = _z_;
+        /*<<filename.ml:242:53>>*/ _H_ = quote_cmd_filename(f),
+       _w_ =  /*<<filename.ml:242:45>>*/ caml_call2(Stdlib[28], cst_2$0, _H_);
+     var _x_ = _w_;
     }
     else
-     var _A_ = cst$16;
-    var _B_ = [0, _A_, _d_];
+     var _x_ = cst$16;
+    var _y_ = [0, _x_, _d_];
     if(stdout)
       /*<<filename.ml:238:55>>*/ var
       f$0 = stdout[1],
-       /*<<filename.ml:238:55>>*/ _C_ = quote_cmd_filename(f$0),
-      _D_ =  /*<<filename.ml:238:48>>*/ caml_call2(Stdlib[28], cst$8, _C_);
+       /*<<filename.ml:238:55>>*/ _z_ = quote_cmd_filename(f$0),
+      _A_ =  /*<<filename.ml:238:48>>*/ caml_call2(Stdlib[28], cst$8, _z_);
     else
-     var _D_ = cst$15;
-    var _E_ = [0, _D_, _B_];
+     var _A_ = cst$15;
+    var _B_ = [0, _A_, _y_];
     if(stdin)
       /*<<filename.ml:237:55>>*/ var
       f$1 = stdin[1],
-       /*<<filename.ml:237:55>>*/ _F_ = quote_cmd_filename(f$1),
-      _G_ =  /*<<filename.ml:237:48>>*/ caml_call2(Stdlib[28], cst$9, _F_);
+       /*<<filename.ml:237:55>>*/ _C_ = quote_cmd_filename(f$1),
+      _D_ =  /*<<filename.ml:237:48>>*/ caml_call2(Stdlib[28], cst$9, _C_);
     else
-     var _G_ = cst$14;
+     var _D_ = cst$14;
      /*<<filename.ml:236:35>>*/ var
-      /*<<filename.ml:236:35>>*/ _I_ =
+      /*<<filename.ml:236:35>>*/ _E_ =
         /*<<filename.ml:236:35>>*/ caml_call2(Stdlib_List[20], quote$0, args),
       /*<<filename.ml:236:16>>*/ s =
-        /*<<filename.ml:236:16>>*/ caml_call2(Stdlib_String[7], cst$10, _I_),
+        /*<<filename.ml:236:16>>*/ caml_call2(Stdlib_String[7], cst$10, _E_),
       /*<<filename.ml:211:12>>*/ b =
         /*<<filename.ml:211:12>>*/ caml_call1
-        (Stdlib_Buffer[1], caml_ml_string_length(s) + 20 | 0),
-     _H_ = [0, _G_, _E_];
-    function _y_(c){
-      /*<<filename.ml:214:8>>*/ a:
-     {
-      if(62 <= c){
-       var _M_ = c - 63 | 0;
-       if(60 < _M_ >>> 0){if(62 <= _M_) break a;} else if(31 !== _M_) break a;
-      }
-      else
-       if(42 <= c){
-        if(60 !== c) break a;
-       }
-       else{
-        if(33 > c) break a;
-        switch(c - 33 | 0){case 2:case 3:case 6: break a;
-        }
-       }
-       /*<<filename.ml:216:12>>*/  /*<<filename.ml:216:12>>*/ caml_call2
-       (Stdlib_Buffer[12], b, 94);
-       /*<<filename.ml:216:12>>*/ return  /*<<filename.ml:216:12>>*/ caml_call2
-              (Stdlib_Buffer[12], b, c);
-     }
-      /*<<filename.ml:218:12>>*/ return  /*<<filename.ml:218:12>>*/ caml_call2
-             (Stdlib_Buffer[12], b, c);
-     /*<<filename.ml:218:31>>*/ }
+        (Stdlib_Buffer[1], caml_ml_string_length(s) + 20 | 0);
      /*<<filename.ml:212:4>>*/  /*<<filename.ml:212:4>>*/ caml_call2
-     (Stdlib_String[30], _y_, s);
+     (Stdlib_String[30],
+      function(c){
+        /*<<filename.ml:214:8>>*/ a:
+       {
+        if(62 <= c){
+         var _I_ = c - 63 | 0;
+         if(60 < _I_ >>> 0){
+          if(62 <= _I_) break a;
+         }
+         else if(31 !== _I_) break a;
+        }
+        else
+         if(42 <= c){
+          if(60 !== c) break a;
+         }
+         else{
+          if(33 > c) break a;
+          switch(c - 33 | 0){case 2:case 3:case 6: break a;
+          }
+         }
+         /*<<filename.ml:216:12>>*/  /*<<filename.ml:216:12>>*/ caml_call2
+         (Stdlib_Buffer[12], b, 94);
+         /*<<filename.ml:216:12>>*/ return  /*<<filename.ml:216:12>>*/ caml_call2
+                (Stdlib_Buffer[12], b, c);
+       }
+        /*<<filename.ml:218:12>>*/ return  /*<<filename.ml:218:12>>*/ caml_call2
+               (Stdlib_Buffer[12], b, c);
+       /*<<filename.ml:218:31>>*/ },
+      s);
      /*<<filename.ml:232:21>>*/ var
-     _J_ =
+     _F_ =
        [0,
         cst$11,
-        [0,  /*<<filename.ml:212:4>>*/ caml_call1(Stdlib_Buffer[2], b), _H_]],
-      /*<<filename.ml:232:21>>*/ _K_ =
-       [0, cst$12, [0, quote_cmd_filename(cmd), _J_]];
+        [0,
+          /*<<filename.ml:212:4>>*/ caml_call1(Stdlib_Buffer[2], b),
+         [0, _D_, _B_]]],
+      /*<<filename.ml:232:21>>*/ _G_ =
+       [0, cst$12, [0, quote_cmd_filename(cmd), _F_]];
      /*<<filename.ml:232:21>>*/ return  /*<<filename.ml:232:21>>*/ caml_call2
-            (Stdlib_String[7], cst$13, _K_);
+            (Stdlib_String[7], cst$13, _G_);
     /*<<filename.ml:244:5>>*/ }
    function drive_and_path(s){
      /*<<filename.ml:252:4>>*/ var
-     _u_ = 2 <=  /*<<filename.ml:250:4>>*/ caml_ml_string_length(s) ? 1 : 0;
-    if(_u_){
+     _s_ = 2 <=  /*<<filename.ml:250:4>>*/ caml_ml_string_length(s) ? 1 : 0;
+    if(_s_){
       /*<<filename.ml:250:38>>*/  /*<<filename.ml:250:38>>*/ var
       param =  /*<<filename.ml:250:38>>*/ caml_string_get(s, 0);
      a:
@@ -32944,28 +32792,28 @@
         if(25 < param - 97 >>> 0) break b;
        }
        else if(65 > param) break b;
-       var _v_ = 1;
+       var _t_ = 1;
        break a;
       }
-      var _v_ = 0;
+      var _t_ = 0;
      }
       /*<<filename.ml:250:28>>*/  /*<<filename.ml:250:28>>*/ var
-      _w_ =
-        _v_
+      _u_ =
+        _t_
          ? 58 ===  /*<<filename.ml:250:47>>*/ caml_string_get(s, 1) ? 1 : 0
-         : _v_;
+         : _t_;
     }
     else
-     var _w_ = _u_;
-     /*<<filename.ml:252:7>>*/ if(! _w_)
+     var _u_ = _s_;
+     /*<<filename.ml:252:7>>*/ if(! _u_)
       /*<<filename.ml:254:9>>*/ return [0, cst$17, s];
      /*<<filename.ml:253:28>>*/  /*<<filename.ml:253:28>>*/ var
-     _x_ =
+     _v_ =
         /*<<filename.ml:253:28>>*/ caml_call3
         (Stdlib_String[16], s, 2, caml_ml_string_length(s) - 2 | 0);
      /*<<filename.ml:253:9>>*/ return [0,
              /*<<filename.ml:253:10>>*/ caml_call3(Stdlib_String[16], s, 0, 2),
-            _x_];
+            _v_];
     /*<<filename.ml:254:16>>*/ }
    function dirname$0(s){
      /*<<filename.ml:256:4>>*/ var
@@ -32999,11 +32847,11 @@
        quote_command$0,
        basename$0,
        dirname$0];
-    /*<<filename.ml:277:17>>*/ function basename$1(_t_){
-     /*<<?>>*/ return generic_basename(is_dir_sep$0, current_dir_name$1, _t_);
+    /*<<filename.ml:277:17>>*/ function basename$1(_r_){
+     /*<<?>>*/ return generic_basename(is_dir_sep$0, current_dir_name$1, _r_);
    }
-    /*<<filename.ml:278:16>>*/ function dirname$1(_s_){
-     /*<<?>>*/ return generic_dirname(is_dir_sep$0, current_dir_name$1, _s_);
+    /*<<filename.ml:278:16>>*/ function dirname$1(_q_){
+     /*<<?>>*/ return generic_dirname(is_dir_sep$0, current_dir_name$1, _q_);
    }
     /*<<filename.ml:264:26>>*/ var
      /*<<filename.ml:264:26>>*/ Cygwin =
@@ -33046,11 +32894,11 @@
      /*<<filename.ml:291:14>>*/ if
      (0 !== l && ! is_dir_sep$1(dirname, l - 1 | 0)){
       /*<<filename.ml:293:17>>*/  /*<<filename.ml:293:17>>*/ var
-      _r_ =
+      _p_ =
          /*<<filename.ml:293:17>>*/ caml_call2
          (Stdlib[28], dir_sep$2, filename);
       /*<<filename.ml:293:17>>*/ return  /*<<filename.ml:293:17>>*/ caml_call2
-             (Stdlib[28], dirname, _r_);
+             (Stdlib[28], dirname, _p_);
     }
      /*<<filename.ml:292:7>>*/ return  /*<<filename.ml:292:7>>*/ caml_call2
             (Stdlib[28], dirname, filename);
@@ -33148,14 +32996,14 @@
               /*<<filename.ml:335:18>>*/ caml_call4
               (Stdlib_Printf[4], _f_, prefix, rnd, suffix));
     /*<<filename.ml:335:63>>*/ }
-   function _g_(param){
-     /*<<filename.ml:338:58>>*/ return temp_dir_name$1;
-    /*<<filename.ml:338:71>>*/ }
-    /*<<filename.ml:338:40>>*/ var
-     /*<<filename.ml:338:40>>*/ _h_ =
-      [0, function(_q_){ /*<<?>>*/ return _q_;}],
-     /*<<filename.ml:338:2>>*/ current_temp_dir_name =
-       /*<<filename.ml:338:2>>*/ caml_call2(Stdlib_Domain[10][1], _h_, _g_);
+    /*<<filename.ml:338:2>>*/  /*<<filename.ml:338:2>>*/ var
+    current_temp_dir_name =
+       /*<<filename.ml:338:2>>*/ caml_call2
+       (Stdlib_Domain[10][1],
+        [0, function(_o_){ /*<<?>>*/ return _o_;}],
+        function(param){
+          /*<<filename.ml:338:58>>*/ return temp_dir_name$1;
+         /*<<filename.ml:338:71>>*/ });
    function set_temp_dir_name(s){
      /*<<filename.ml:340:26>>*/ return  /*<<filename.ml:340:26>>*/ caml_call2
             (Stdlib_Domain[10][3], current_temp_dir_name, s);
@@ -33178,7 +33026,7 @@
       name = temp_file_name(temp_dir, prefix, suffix);
       /*<<filename.ml:346:4>>*/ try{
        /*<<filename.ml:347:6>>*/  /*<<filename.ml:347:6>>*/ runtime.caml_sys_close
-       ( /*<<filename.ml:347:16>>*/ runtime.caml_sys_open(name, _i_, 384));
+       ( /*<<filename.ml:347:16>>*/ runtime.caml_sys_open(name, _g_, 384));
        /*<<filename.ml:347:6>>*/ return name;
      }
      catch(e$0){
@@ -33193,17 +33041,17 @@
      }
     }
     /*<<filename.ml:351:15>>*/ }
-   function open_temp_file(opt, _o_, _n_, prefix, suffix){
+   function open_temp_file(opt, _m_, _l_, prefix, suffix){
      /*<<filename.ml:356:2>>*/ if(opt)
      var sth = opt[1], mode = sth;
     else
-     var mode = _j_;
-     /*<<filename.ml:356:2>>*/ if(_o_)
-     var sth$0 = _o_[1], perms = sth$0;
+     var mode = _h_;
+     /*<<filename.ml:356:2>>*/ if(_m_)
+     var sth$0 = _m_[1], perms = sth$0;
     else
      var perms = 384;
-     /*<<filename.ml:356:2>>*/ if(_n_)
-     var sth$1 = _n_[1], temp_dir = sth$1;
+     /*<<filename.ml:356:2>>*/ if(_l_)
+     var sth$1 = _l_[1], temp_dir = sth$1;
     else
      var
       temp_dir =
@@ -33215,12 +33063,12 @@
       name = temp_file_name(temp_dir, prefix, suffix);
       /*<<filename.ml:358:4>>*/ try{
        /*<<filename.ml:359:6>>*/  /*<<filename.ml:359:6>>*/ var
-       _p_ =
+       _n_ =
          [0,
           name,
            /*<<filename.ml:360:7>>*/ caml_call3
            (Stdlib[62], [0, 1, [0, 3, [0, 5, mode]]], perms, name)];
-       /*<<filename.ml:359:6>>*/ return _p_;
+       /*<<filename.ml:359:6>>*/ return _n_;
      }
      catch(e$0){
       var e = caml_wrap_exception(e$0);
@@ -33234,7 +33082,7 @@
      }
     }
     /*<<filename.ml:363:15>>*/ }
-   function temp_dir(opt, _m_, prefix, suffix){
+   function temp_dir(opt, _k_, prefix, suffix){
      /*<<filename.ml:367:2>>*/ if(opt)
      var sth = opt[1], temp_dir = sth;
     else
@@ -33242,8 +33090,8 @@
       temp_dir =
          /*<<filename.ml:365:26>>*/ caml_call1
          (Stdlib_Domain[10][2], current_temp_dir_name);
-     /*<<filename.ml:367:2>>*/ if(_m_)
-     var sth$0 = _m_[1], perms = sth$0;
+     /*<<filename.ml:367:2>>*/ if(_k_)
+     var sth$0 = _k_[1], perms = sth$0;
     else
      var perms = 448;
     var counter = 0;
@@ -34079,23 +33927,20 @@
     stdin = Stdlib[38],
     open_bin = Stdlib[80],
     open_text = Stdlib[79],
-    open_gen = Stdlib[81],
-    cst_In_channel_input_all_chann =
-      "In_channel.input_all: channel content is larger than maximum string length",
-    _a_ = [0, 0];
+    open_gen = Stdlib[81];
    function with_open(openfun, s, f){
      /*<<in_channel.ml:35:2>>*/  /*<<in_channel.ml:35:11>>*/ var
      ic =  /*<<in_channel.ml:35:11>>*/ caml_call1(openfun, s);
-    function _x_(param){
-      /*<<in_channel.ml:37:15>>*/ return  /*<<in_channel.ml:36:2>>*/ caml_call1
-             (f, ic);
-     /*<<in_channel.ml:37:19>>*/ }
-    function _y_(param){
-      /*<<in_channel.ml:36:34>>*/ return  /*<<in_channel.ml:37:4>>*/ caml_call1
-             (Stdlib[94], ic);
-     /*<<in_channel.ml:36:58>>*/ }
      /*<<in_channel.ml:37:4>>*/ return  /*<<in_channel.ml:37:4>>*/ caml_call2
-            (Stdlib_Fun[4], _y_, _x_);
+            (Stdlib_Fun[4],
+             function(param){
+               /*<<in_channel.ml:36:34>>*/ return  /*<<in_channel.ml:37:4>>*/ caml_call1
+                      (Stdlib[94], ic);
+              /*<<in_channel.ml:36:58>>*/ },
+             function(param){
+               /*<<in_channel.ml:37:15>>*/ return  /*<<in_channel.ml:36:2>>*/ caml_call1
+                      (f, ic);
+              /*<<in_channel.ml:37:19>>*/ });
     /*<<in_channel.ml:37:20>>*/ }
    function with_open_bin(s, f){
      /*<<in_channel.ml:40:2>>*/ return with_open(Stdlib[80], s, f);
@@ -34151,7 +33996,11 @@
     }
      /*<<in_channel.ml:66:9>>*/ return [0, s];
     /*<<in_channel.ml:67:33>>*/ }
-   var input = Stdlib[84];
+   var
+    input = Stdlib[84],
+    _a_ = [0, 0],
+    cst_In_channel_input_all_chann =
+      "In_channel.input_all: channel content is larger than maximum string length";
    function really_input(ic, buf, pos, len){
      /*<<in_channel.ml:72:2>>*/ try{
       /*<<in_channel.ml:72:8>>*/  /*<<in_channel.ml:72:8>>*/ caml_call4
@@ -34388,16 +34237,16 @@
    function with_open(openfun, s, f){
      /*<<out_channel.ml:36:2>>*/  /*<<out_channel.ml:36:11>>*/ var
      oc =  /*<<out_channel.ml:36:11>>*/ caml_call1(openfun, s);
-    function _a_(param){
-      /*<<out_channel.ml:38:15>>*/ return  /*<<out_channel.ml:37:2>>*/ caml_call1
-             (f, oc);
-     /*<<out_channel.ml:38:19>>*/ }
-    function _b_(param){
-      /*<<out_channel.ml:37:34>>*/ return  /*<<out_channel.ml:38:4>>*/ caml_call1
-             (Stdlib[77], oc);
-     /*<<out_channel.ml:37:59>>*/ }
      /*<<out_channel.ml:38:4>>*/ return  /*<<out_channel.ml:38:4>>*/ caml_call2
-            (Stdlib_Fun[4], _b_, _a_);
+            (Stdlib_Fun[4],
+             function(param){
+               /*<<out_channel.ml:37:34>>*/ return  /*<<out_channel.ml:38:4>>*/ caml_call1
+                      (Stdlib[77], oc);
+              /*<<out_channel.ml:37:59>>*/ },
+             function(param){
+               /*<<out_channel.ml:38:15>>*/ return  /*<<out_channel.ml:37:2>>*/ caml_call1
+                      (f, oc);
+              /*<<out_channel.ml:38:19>>*/ });
     /*<<out_channel.ml:38:20>>*/ }
    function with_open_bin(s, f){
      /*<<out_channel.ml:41:2>>*/ return with_open(Stdlib[61], s, f);
@@ -34493,16 +34342,10 @@
       [248, "Stdlib.Effect.Unhandled", caml_fresh_oo_id(0)],
      /*<<effect.ml:19:0>>*/ Continuation_already_resumed =
       [248, "Stdlib.Effect.Continuation_already_resumed", caml_fresh_oo_id(0)],
-    cst_impossible = "impossible",
-    cst_Initial_setup = "Initial_setup__",
-    cst_E = "E",
     _a_ =
       [0,
        [11, "Stdlib.Effect.Unhandled(", [2, 0, [12, 41, 0]]],
-       "Stdlib.Effect.Unhandled(%s)"],
-    cst_Stdlib_Effect_Should_not_s = "Stdlib.Effect.Should_not_see_this__",
-    cst_Effect_Unhandled = "Effect.Unhandled",
-    cst_Effect_Continuation_alread = "Effect.Continuation_already_resumed";
+       "Stdlib.Effect.Unhandled(%s)"];
    function printer(param){
      /*<<effect.ml:22:16>>*/ if(param[1] !== Unhandled)
       /*<<effect.ml:28:11>>*/ return 0;
@@ -34518,42 +34361,42 @@
     (Stdlib_Printexc[9], printer);
     /*<<effect.ml:33:12>>*/  /*<<effect.ml:33:12>>*/ var
     Should_not_see_this =
-      [248, cst_Stdlib_Effect_Should_not_s, caml_fresh_oo_id(0)];
+      [248, "Stdlib.Effect.Should_not_see_this__", caml_fresh_oo_id(0)];
     /*<<effect.ml:34:8>>*/  /*<<effect.ml:34:8>>*/ caml_call2
     (Stdlib_Callback[2],
-     cst_Effect_Unhandled,
+     "Effect.Unhandled",
      [0, Unhandled, Should_not_see_this]);
     /*<<effect.ml:36:8>>*/  /*<<effect.ml:36:8>>*/ caml_call2
     (Stdlib_Callback[2],
-     cst_Effect_Continuation_alread,
+     "Effect.Continuation_already_resumed",
      Continuation_already_resumed);
     /*<<effect.ml:36:8>>*/ function continue$0(k, v){
+     /*<<effect.ml:57:21>>*/  /*<<effect.ml:57:28>>*/ var
+     _h_ =  /*<<effect.ml:57:28>>*/ caml_continuation_use_noexc(k);
     function _g_(x){
       /*<<effect.ml:57:58>>*/ return x;
      /*<<effect.ml:57:59>>*/ }
-     /*<<effect.ml:57:28>>*/  /*<<effect.ml:57:28>>*/ var
-     _h_ =  /*<<effect.ml:57:28>>*/ caml_continuation_use_noexc(k);
      /*<<effect.ml:57:28>>*/ return  /*<<effect.ml:57:28>>*/ jsoo_effect_not_supported
             ();
     /*<<effect.ml:57:62>>*/ }
    function discontinue(k, e){
+     /*<<effect.ml:59:24>>*/  /*<<effect.ml:59:31>>*/ var
+     _f_ =  /*<<effect.ml:59:31>>*/ caml_continuation_use_noexc(k);
     function _e_(e){
       /*<<effect.ml:59:61>>*/ throw  /*<<effect.ml:59:61>>*/ caml_maybe_attach_backtrace
             (e, 1);
      /*<<effect.ml:59:68>>*/ }
-     /*<<effect.ml:59:31>>*/  /*<<effect.ml:59:31>>*/ var
-     _f_ =  /*<<effect.ml:59:31>>*/ caml_continuation_use_noexc(k);
      /*<<effect.ml:59:31>>*/ return  /*<<effect.ml:59:31>>*/ jsoo_effect_not_supported
             ();
     /*<<effect.ml:59:71>>*/ }
    function discontinue_with_backtrace(k, e, bt){
+     /*<<effect.ml:61:42>>*/  /*<<effect.ml:61:49>>*/ var
+     _d_ =  /*<<effect.ml:61:49>>*/ caml_continuation_use_noexc(k);
     function _c_(e){
       /*<<effect.ml:62:4>>*/ caml_restore_raw_backtrace(e, bt);
       /*<<effect.ml:62:4>>*/ throw  /*<<effect.ml:62:4>>*/ caml_maybe_attach_backtrace
             (e, 0);
      /*<<effect.ml:62:38>>*/ }
-     /*<<effect.ml:61:49>>*/  /*<<effect.ml:61:49>>*/ var
-     _d_ =  /*<<effect.ml:61:49>>*/ caml_continuation_use_noexc(k);
      /*<<effect.ml:61:49>>*/ return  /*<<effect.ml:61:49>>*/ jsoo_effect_not_supported
             ();
     /*<<effect.ml:62:41>>*/ }
@@ -34597,14 +34440,17 @@
      /*<<effect.ml:91:4>>*/ return  /*<<effect.ml:91:4>>*/ jsoo_effect_not_supported
             ();
     /*<<effect.ml:91:23>>*/ }
-    /*<<effect.ml:44:14>>*/  /*<<effect.ml:44:14>>*/ var
-    Deep =
+    /*<<effect.ml:44:14>>*/ var
+     /*<<effect.ml:44:14>>*/ Deep =
       [0,
        continue$0,
        discontinue,
        discontinue_with_backtrace,
        match_with,
-       try_with];
+       try_with],
+    cst_Initial_setup = "Initial_setup__",
+    cst_E = "E",
+    cst_impossible = "impossible";
    function fiber(f){
      /*<<effect.ml:111:4>>*/ var
       /*<<effect.ml:111:38>>*/ Initial_setup =

--- a/compiler/tests-full/stdlib.cma.expected.js
+++ b/compiler/tests-full/stdlib.cma.expected.js
@@ -843,16 +843,16 @@
       /*<<stdlib.ml:563:21>>*/ var
        /*<<stdlib.ml:563:21>>*/ f_yet_to_run = [0, 1],
        /*<<stdlib.ml:564:2>>*/ old_exit =
-         /*<<stdlib.ml:564:2>>*/ caml_atomic_load(exit_function),
+         /*<<stdlib.ml:564:2>>*/ caml_atomic_load(exit_function);
+     let f_yet_to_run$0 = f_yet_to_run, old_exit$0 = old_exit;
+      /*<<stdlib.ml:570:2>>*/ var
       new_exit =
         function(param){
           /*<<stdlib.ml:566:4>>*/ if(caml_atomic_cas(f_yet_to_run$0, 1, 0))
            /*<<stdlib.ml:566:59>>*/  /*<<stdlib.ml:566:59>>*/ caml_call1(f, 0);
           /*<<stdlib.ml:566:59>>*/ return  /*<<stdlib.ml:566:59>>*/ caml_call1
                  (old_exit$0, 0);
-         /*<<stdlib.ml:567:15>>*/ };
-     let f_yet_to_run$0 = f_yet_to_run, old_exit$0 = old_exit;
-      /*<<stdlib.ml:570:2>>*/ var
+         /*<<stdlib.ml:567:15>>*/ },
       success = caml_atomic_cas(exit_function, old_exit, new_exit),
        /*<<stdlib.ml:570:2>>*/ _g_ = 1 - success;
      if(! _g_)  /*<<stdlib.ml:570:2>>*/ return _g_;
@@ -14445,11 +14445,13 @@
                        : buffer_add_char(buf, c);
              /*<<camlinternalFormat.ml:361:35>>*/ };
           /*<<camlinternalFormat.ml:363:2>>*/ buffer_add_char(buf, 91);
-          /*<<camlinternalFormat.ml:365:7>>*/ var
-           /*<<camlinternalFormat.ml:365:7>>*/ set =
+          /*<<camlinternalFormat.ml:365:7>>*/  /*<<camlinternalFormat.ml:365:7>>*/ var
+          set =
             is_in_char_set(char_set, 0)
              ? (buffer_add_char(buf, 94), rev_char_set(char_set))
-             : char_set,
+             : char_set;
+         let set$0 = set;
+         var
           is_alone =
             function(c){
               /*<<camlinternalFormat.ml:316:6>>*/ var
@@ -14472,7 +14474,6 @@
               var _dl_ = _di_;
               /*<<camlinternalFormat.ml:318:43>>*/ return _dl_;
              /*<<camlinternalFormat.ml:318:68>>*/ };
-         let set$0 = set;
           /*<<camlinternalFormat.ml:319:7>>*/ if(is_alone(93))
            /*<<camlinternalFormat.ml:319:25>>*/ buffer_add_char(buf, 93);
          a:
@@ -17422,28 +17423,30 @@
        case 18:
         var _cO_ = fmt$0[1];
         if(0 === _cO_[0]){
+         var rest$17 = fmt$0[2], fmt$1 = _cO_[1][1];
+         let acc = acc$0, k = k$0, rest = rest$17;
          var
-          rest$17 = fmt$0[2],
-          fmt$1 = _cO_[1][1],
           k$1 =
             function(kacc){
               /*<<camlinternalFormat.ml:1597:6>>*/ return make_printf
                      (k, [1, acc, [0, kacc]], rest);
-             /*<<camlinternalFormat.ml:1597:70>>*/ };
-         let acc = acc$0, k = k$0, rest = rest$17;
-         var k$0 = k$1, acc$0 = 0, fmt$0 = fmt$1;
+             /*<<camlinternalFormat.ml:1597:70>>*/ },
+          k$0 = k$1,
+          acc$0 = 0,
+          fmt$0 = fmt$1;
         }
         else{
+         var rest$18 = fmt$0[2], fmt$2 = _cO_[1][1];
+         let acc = acc$0, k = k$0, rest = rest$18;
          var
-          rest$18 = fmt$0[2],
-          fmt$2 = _cO_[1][1],
           k$2 =
             function(kacc){
               /*<<camlinternalFormat.ml:1601:6>>*/ return make_printf
                      (k, [1, acc, [1, kacc]], rest);
-             /*<<camlinternalFormat.ml:1601:70>>*/ };
-         let acc = acc$0, k = k$0, rest = rest$18;
-         var k$0 = k$2, acc$0 = 0, fmt$0 = fmt$2;
+             /*<<camlinternalFormat.ml:1601:70>>*/ },
+          k$0 = k$2,
+          acc$0 = 0,
+          fmt$0 = fmt$2;
         }
         break;
        case 19:
@@ -18068,28 +18071,28 @@
        case 18:
         var _cl_ = fmt$0[1];
         if(0 === _cl_[0]){
+         var rest$23 = fmt$0[2], fmt$1 = _cl_[1][1];
+         let k = k$0, rest = rest$23;
          var
-          rest$23 = fmt$0[2],
-          fmt$1 = _cl_[1][1],
           k$1 =
             function(koc){
               /*<<camlinternalFormat.ml:1854:33>>*/ return make_iprintf
                      (k, koc, rest);
-             /*<<camlinternalFormat.ml:1854:56>>*/ };
-         let k = k$0, rest = rest$23;
-         var k$0 = k$1, fmt$0 = fmt$1;
+             /*<<camlinternalFormat.ml:1854:56>>*/ },
+          k$0 = k$1,
+          fmt$0 = fmt$1;
         }
         else{
+         var rest$24 = fmt$0[2], fmt$2 = _cl_[1][1];
+         let k = k$0, rest = rest$24;
          var
-          rest$24 = fmt$0[2],
-          fmt$2 = _cl_[1][1],
           k$2 =
             function(koc){
               /*<<camlinternalFormat.ml:1856:33>>*/ return make_iprintf
                      (k, koc, rest);
-             /*<<camlinternalFormat.ml:1856:56>>*/ };
-         let k = k$0, rest = rest$24;
-         var k$0 = k$2, fmt$0 = fmt$2;
+             /*<<camlinternalFormat.ml:1856:56>>*/ },
+          k$0 = k$2,
+          fmt$0 = fmt$2;
         }
         break;
        case 19:
@@ -20842,6 +20845,7 @@
          throw caml_maybe_attach_backtrace(_X_, 0);
         }
        }
+       let s$0 = s, follow$2 = follow$0;
        var
         no_arg =
           function(param){
@@ -21044,8 +21048,6 @@
            }
            /*<<arg.ml:276:54>>*/ };
        let
-        s$0 = s,
-        follow$2 = follow$0,
         no_arg$0 = no_arg,
         get_arg$0 = get_arg,
         consume_arg$0 = consume_arg,
@@ -25054,15 +25056,15 @@
           /*<<weak.ml:164:6>>*/ for(;;){
           if(length(ob) <= oi)  /*<<weak.ml:164:28>>*/ return 0;
           if(check(ob, oi)){
-            /*<<weak.ml:166:20>>*/ var
-             /*<<weak.ml:166:20>>*/ oh = caml_check_bound(t[2], j)[1 + j],
+            /*<<weak.ml:166:20>>*/  /*<<weak.ml:166:20>>*/ var
+            oh = caml_check_bound(t[2], j)[1 + j];
+           let oi$0 = oi;
+            /*<<weak.ml:223:16>>*/ var
             setter =
               function(nb, ni, param){
                 /*<<weak.ml:222:29>>*/ return blit(ob, oi$0, nb, ni, 1);
-               /*<<weak.ml:222:47>>*/ };
-           let oi$0 = oi;
-            /*<<weak.ml:223:16>>*/  /*<<weak.ml:223:16>>*/ var
-            h = caml_check_bound(oh, oi)[1 + oi];
+               /*<<weak.ml:222:47>>*/ },
+             /*<<weak.ml:223:16>>*/ h = caml_check_bound(oh, oi)[1 + oi];
             /*<<weak.ml:224:35>>*/ add_aux
             (newt, setter, 0, h, get_index(newt, h));
            var i$0 = oi + 1 | 0, oi = i$0;
@@ -30766,6 +30768,7 @@
       if(typeof shape === "number")
        switch(shape){
          case 0:
+          let i$1 = i;
           var
            fn =
              function(x){
@@ -30777,7 +30780,7 @@
                /*<<camlinternalMod.ml:32:11>>*/ return  /*<<camlinternalMod.ml:32:11>>*/ caml_call1
                       (fn, x);
               /*<<camlinternalMod.ml:32:16>>*/ };
-          let fn$0 = fn, i$1 = i;
+          let fn$0 = fn;
           var init = fn;
           break;
          case 1:

--- a/compiler/tests-full/stdlib.cma.expected.js
+++ b/compiler/tests-full/stdlib.cma.expected.js
@@ -843,16 +843,16 @@
       /*<<stdlib.ml:563:21>>*/ var
        /*<<stdlib.ml:563:21>>*/ f_yet_to_run = [0, 1],
        /*<<stdlib.ml:564:2>>*/ old_exit =
-         /*<<stdlib.ml:564:2>>*/ caml_atomic_load(exit_function);
-     let f_yet_to_run$0 = f_yet_to_run, old_exit$0 = old_exit;
-      /*<<stdlib.ml:570:2>>*/ var
+         /*<<stdlib.ml:564:2>>*/ caml_atomic_load(exit_function),
       new_exit =
         function(param){
           /*<<stdlib.ml:566:4>>*/ if(caml_atomic_cas(f_yet_to_run$0, 1, 0))
            /*<<stdlib.ml:566:59>>*/  /*<<stdlib.ml:566:59>>*/ caml_call1(f, 0);
           /*<<stdlib.ml:566:59>>*/ return  /*<<stdlib.ml:566:59>>*/ caml_call1
                  (old_exit$0, 0);
-         /*<<stdlib.ml:567:15>>*/ },
+         /*<<stdlib.ml:567:15>>*/ };
+     let f_yet_to_run$0 = f_yet_to_run, old_exit$0 = old_exit;
+      /*<<stdlib.ml:570:2>>*/ var
       success = caml_atomic_cas(exit_function, old_exit, new_exit),
        /*<<stdlib.ml:570:2>>*/ _g_ = 1 - success;
      if(! _g_)  /*<<stdlib.ml:570:2>>*/ return _g_;
@@ -14445,13 +14445,11 @@
                        : buffer_add_char(buf, c);
              /*<<camlinternalFormat.ml:361:35>>*/ };
           /*<<camlinternalFormat.ml:363:2>>*/ buffer_add_char(buf, 91);
-          /*<<camlinternalFormat.ml:365:7>>*/  /*<<camlinternalFormat.ml:365:7>>*/ var
-          set =
+          /*<<camlinternalFormat.ml:365:7>>*/ var
+           /*<<camlinternalFormat.ml:365:7>>*/ set =
             is_in_char_set(char_set, 0)
              ? (buffer_add_char(buf, 94), rev_char_set(char_set))
-             : char_set;
-         let set$0 = set;
-         var
+             : char_set,
           is_alone =
             function(c){
               /*<<camlinternalFormat.ml:316:6>>*/ var
@@ -14474,6 +14472,7 @@
               var _dl_ = _di_;
               /*<<camlinternalFormat.ml:318:43>>*/ return _dl_;
              /*<<camlinternalFormat.ml:318:68>>*/ };
+         let set$0 = set;
           /*<<camlinternalFormat.ml:319:7>>*/ if(is_alone(93))
            /*<<camlinternalFormat.ml:319:25>>*/ buffer_add_char(buf, 93);
          a:
@@ -17423,30 +17422,28 @@
        case 18:
         var _cO_ = fmt$0[1];
         if(0 === _cO_[0]){
-         var rest$17 = fmt$0[2], fmt$1 = _cO_[1][1];
-         let acc = acc$0, k = k$0, rest = rest$17;
          var
+          rest$17 = fmt$0[2],
+          fmt$1 = _cO_[1][1],
           k$1 =
             function(kacc){
               /*<<camlinternalFormat.ml:1597:6>>*/ return make_printf
                      (k, [1, acc, [0, kacc]], rest);
-             /*<<camlinternalFormat.ml:1597:70>>*/ },
-          k$0 = k$1,
-          acc$0 = 0,
-          fmt$0 = fmt$1;
+             /*<<camlinternalFormat.ml:1597:70>>*/ };
+         let acc = acc$0, k = k$0, rest = rest$17;
+         var k$0 = k$1, acc$0 = 0, fmt$0 = fmt$1;
         }
         else{
-         var rest$18 = fmt$0[2], fmt$2 = _cO_[1][1];
-         let acc = acc$0, k = k$0, rest = rest$18;
          var
+          rest$18 = fmt$0[2],
+          fmt$2 = _cO_[1][1],
           k$2 =
             function(kacc){
               /*<<camlinternalFormat.ml:1601:6>>*/ return make_printf
                      (k, [1, acc, [1, kacc]], rest);
-             /*<<camlinternalFormat.ml:1601:70>>*/ },
-          k$0 = k$2,
-          acc$0 = 0,
-          fmt$0 = fmt$2;
+             /*<<camlinternalFormat.ml:1601:70>>*/ };
+         let acc = acc$0, k = k$0, rest = rest$18;
+         var k$0 = k$2, acc$0 = 0, fmt$0 = fmt$2;
         }
         break;
        case 19:
@@ -18071,28 +18068,28 @@
        case 18:
         var _cl_ = fmt$0[1];
         if(0 === _cl_[0]){
-         var rest$23 = fmt$0[2], fmt$1 = _cl_[1][1];
-         let k = k$0, rest = rest$23;
          var
+          rest$23 = fmt$0[2],
+          fmt$1 = _cl_[1][1],
           k$1 =
             function(koc){
               /*<<camlinternalFormat.ml:1854:33>>*/ return make_iprintf
                      (k, koc, rest);
-             /*<<camlinternalFormat.ml:1854:56>>*/ },
-          k$0 = k$1,
-          fmt$0 = fmt$1;
+             /*<<camlinternalFormat.ml:1854:56>>*/ };
+         let k = k$0, rest = rest$23;
+         var k$0 = k$1, fmt$0 = fmt$1;
         }
         else{
-         var rest$24 = fmt$0[2], fmt$2 = _cl_[1][1];
-         let k = k$0, rest = rest$24;
          var
+          rest$24 = fmt$0[2],
+          fmt$2 = _cl_[1][1],
           k$2 =
             function(koc){
               /*<<camlinternalFormat.ml:1856:33>>*/ return make_iprintf
                      (k, koc, rest);
-             /*<<camlinternalFormat.ml:1856:56>>*/ },
-          k$0 = k$2,
-          fmt$0 = fmt$2;
+             /*<<camlinternalFormat.ml:1856:56>>*/ };
+         let k = k$0, rest = rest$24;
+         var k$0 = k$2, fmt$0 = fmt$2;
         }
         break;
        case 19:
@@ -20845,7 +20842,6 @@
          throw caml_maybe_attach_backtrace(_X_, 0);
         }
        }
-       let s$0 = s, follow$2 = follow$0;
        var
         no_arg =
           function(param){
@@ -20854,9 +20850,7 @@
            var arg = follow$2[1];
             /*<<arg.ml:180:24>>*/ throw  /*<<arg.ml:180:24>>*/ caml_maybe_attach_backtrace
                   ([0, Stop, [1, s$0, arg, cst_no_argument]], 1);
-           /*<<arg.ml:180:68>>*/ };
-       let no_arg$0 = no_arg;
-       var
+           /*<<arg.ml:180:68>>*/ },
         get_arg =
           function(param){
             /*<<arg.ml:182:10>>*/ if(follow$2){
@@ -20869,15 +20863,11 @@
            var _af_ = current[1] + 1 | 0;
             /*<<arg.ml:184:58>>*/ return caml_check_bound(argv[1], _af_)
                    [1 + _af_];
-           /*<<arg.ml:186:27>>*/ };
-       let get_arg$0 = get_arg;
-       var
+           /*<<arg.ml:186:27>>*/ },
         consume_arg =
           function(param){
             /*<<arg.ml:189:10>>*/ return follow$2 ? 0 : (current[1]++, 0);
-           /*<<arg.ml:191:24>>*/ };
-       let consume_arg$0 = consume_arg;
-       var
+           /*<<arg.ml:191:24>>*/ },
         treat_action =
           function(param){
             /*<<arg.ml:193:31>>*/ switch(param[0]){
@@ -21053,7 +21043,13 @@
               return 0;
            }
            /*<<arg.ml:276:54>>*/ };
-       let treat_action$0 = treat_action;
+       let
+        s$0 = s,
+        follow$2 = follow$0,
+        no_arg$0 = no_arg,
+        get_arg$0 = get_arg,
+        consume_arg$0 = consume_arg,
+        treat_action$0 = treat_action;
         /*<<arg.ml:278:8>>*/ treat_action(action);
       }
       else
@@ -25058,15 +25054,15 @@
           /*<<weak.ml:164:6>>*/ for(;;){
           if(length(ob) <= oi)  /*<<weak.ml:164:28>>*/ return 0;
           if(check(ob, oi)){
-            /*<<weak.ml:166:20>>*/  /*<<weak.ml:166:20>>*/ var
-            oh = caml_check_bound(t[2], j)[1 + j];
-           let oi$0 = oi;
-            /*<<weak.ml:223:16>>*/ var
+            /*<<weak.ml:166:20>>*/ var
+             /*<<weak.ml:166:20>>*/ oh = caml_check_bound(t[2], j)[1 + j],
             setter =
               function(nb, ni, param){
                 /*<<weak.ml:222:29>>*/ return blit(ob, oi$0, nb, ni, 1);
-               /*<<weak.ml:222:47>>*/ },
-             /*<<weak.ml:223:16>>*/ h = caml_check_bound(oh, oi)[1 + oi];
+               /*<<weak.ml:222:47>>*/ };
+           let oi$0 = oi;
+            /*<<weak.ml:223:16>>*/  /*<<weak.ml:223:16>>*/ var
+            h = caml_check_bound(oh, oi)[1 + oi];
             /*<<weak.ml:224:35>>*/ add_aux
             (newt, setter, 0, h, get_index(newt, h));
            var i$0 = oi + 1 | 0, oi = i$0;
@@ -30770,7 +30766,6 @@
       if(typeof shape === "number")
        switch(shape){
          case 0:
-          let i$1 = i;
           var
            fn =
              function(x){
@@ -30782,7 +30777,7 @@
                /*<<camlinternalMod.ml:32:11>>*/ return  /*<<camlinternalMod.ml:32:11>>*/ caml_call1
                       (fn, x);
               /*<<camlinternalMod.ml:32:16>>*/ };
-          let fn$0 = fn;
+          let fn$0 = fn, i$1 = i;
           var init = fn;
           break;
          case 1:

--- a/compiler/tests-sourcemap/dune
+++ b/compiler/tests-sourcemap/dune
@@ -21,7 +21,7 @@
 (rule
  (target dump)
  (enabled_if
-  (<> %{profile} using-effects))
+  (= %{profile} dev))
  (action
   (with-stdout-to
    %{target}
@@ -30,7 +30,7 @@
 (rule
  (alias runtest)
  (enabled_if
-  (<> %{profile} using-effects))
+  (= %{profile} dev))
  (deps dump.reference dump)
  (action
   (diff dump.reference dump)))


### PR DESCRIPTION
following the previous broken attempt in #1565.

Also
- It revert the fix in https://github.com/ocsigen/js_of_ocaml/pull/1561 which is no longer needed. @rickyvetter, can you confirm the PR still works for you ?