### PR TITLE
Lib: fix paragraph construction and coercion

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 ## Bug fixes
 * Compiler: fix --enable=vardecl
+* Lib: fix paragraph construction and coercion
 
 # 5.7.0 (2024-02-16) - Lille
 

--- a/lib/js_of_ocaml/dom_html.ml
+++ b/lib/js_of_ocaml/dom_html.ml
@@ -3417,7 +3417,7 @@ type taggedElement =
   | Ol of oListElement t
   | Optgroup of optGroupElement t
   | Option of optionElement t
-  | P of paramElement t
+  | P of paragraphElement t
   | Param of paramElement t
   | Pre of preElement t
   | Q of quoteElement t

--- a/lib/js_of_ocaml/dom_html.mli
+++ b/lib/js_of_ocaml/dom_html.mli
@@ -2976,7 +2976,7 @@ type taggedElement =
   | Ol of oListElement t
   | Optgroup of optGroupElement t
   | Option of optionElement t
-  | P of paramElement t
+  | P of paragraphElement t
   | Param of paramElement t
   | Pre of preElement t
   | Q of quoteElement t
@@ -3108,7 +3108,7 @@ module CoerceTo : sig
 
   val option : #element t -> optionElement t opt
 
-  val p : #element t -> paramElement t opt
+  val p : #element t -> paragraphElement t opt
 
   val param : #element t -> paramElement t opt
 


### PR DESCRIPTION
Some annoying bug I found while trying to coerce some elt with `Html.CoerceTo.p`.