### PR TITLE
Compiler: Fix renaming for object partterns and assignment targets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@
 
 ## Bug fixes
 
+* Compiler: fix variable renaming for property binding and assignment target
+
 # 5.7.1 (2024-03-05) - Lille
 
 ## Features/Changes

--- a/compiler/lib/javascript.ml
+++ b/compiler/lib/javascript.ml
@@ -425,7 +425,7 @@ and binding_pattern =
 
 and object_target_elt =
   | TargetPropertyId of ident * initialiser option
-  | TargetProperty of property_name * expression
+  | TargetProperty of property_name * expression * initialiser option
   | TargetPropertySpread of expression
   | TargetPropertyMethod of property_name * method_
 
@@ -589,7 +589,13 @@ let rec assignment_target_of_expr' x =
         List.map l ~f:(function
             | Property (PNI n, EVar (S { name = n'; _ } as id))
               when Utf8_string.equal n n' -> TargetPropertyId (id, None)
-            | Property (n, e) -> TargetProperty (n, assignment_target_of_expr' e)
+            | Property (n, e) ->
+                let e, i =
+                  match e with
+                  | EBin (Eq, e, i) -> e, Some (i, N)
+                  | _ -> e, None
+                in
+                TargetProperty (n, assignment_target_of_expr' e, i)
             | CoverInitializedName (_, i, (e, loc)) ->
                 TargetPropertyId (i, Some (assignment_target_of_expr' e, loc))
             | PropertySpread e -> TargetPropertySpread (assignment_target_of_expr' e)

--- a/compiler/lib/javascript.mli
+++ b/compiler/lib/javascript.mli
@@ -343,7 +343,7 @@ and binding_pattern =
 
 and object_target_elt =
   | TargetPropertyId of ident * initialiser option
-  | TargetProperty of property_name * expression
+  | TargetProperty of property_name * expression * initialiser option
   | TargetPropertySpread of expression
   | TargetPropertyMethod of property_name * method_
 

--- a/compiler/lib/javascript.mli
+++ b/compiler/lib/javascript.mli
@@ -285,7 +285,7 @@ and block = statement_list
 and statement_list = (statement * location) list
 
 and variable_declaration =
-  | DeclIdent of binding_ident * initialiser option
+  | DeclIdent of ident * initialiser option
   | DeclPattern of binding_pattern * initialiser
 
 and variable_declaration_kind =
@@ -334,15 +334,15 @@ and for_binding = binding
 and binding_element = binding * initialiser option
 
 and binding =
-  | BindingIdent of binding_ident
+  | BindingIdent of ident
   | BindingPattern of binding_pattern
 
 and binding_pattern =
-  | ObjectBinding of (binding_property, binding_ident) list_with_rest
+  | ObjectBinding of (binding_property, ident) list_with_rest
   | ArrayBinding of (binding_element option, binding) list_with_rest
 
 and object_target_elt =
-  | TargetPropertyId of ident * initialiser option
+  | TargetPropertyId of ident_prop * initialiser option
   | TargetProperty of property_name * expression * initialiser option
   | TargetPropertySpread of expression
   | TargetPropertyMethod of property_name * method_
@@ -357,11 +357,11 @@ and assignment_target =
   | ObjectTarget of object_target_elt list
   | ArrayTarget of array_target_elt list
 
-and binding_ident = ident
+and ident_prop = Prop_and_ident of ident
 
 and binding_property =
   | Prop_binding of property_name * binding_element
-  | Prop_ident of binding_ident * initialiser option
+  | Prop_ident of ident_prop * initialiser option
 
 and function_body = statement_list
 

--- a/compiler/lib/js_output.ml
+++ b/compiler/lib/js_output.ml
@@ -740,8 +740,8 @@ struct
     | EAssignTarget t -> (
         let property f p =
           match p with
-          | TargetPropertyId (id, None) -> ident f id
-          | TargetPropertyId (id, Some (e, _)) ->
+          | TargetPropertyId (Prop_and_ident id, None) -> ident f id
+          | TargetPropertyId (Prop_and_ident id, Some (e, _)) ->
               ident f id;
               PP.space f;
               PP.string f "=";
@@ -1123,8 +1123,8 @@ struct
         PP.string f ":";
         PP.space f;
         binding_element f e
-    | Prop_ident (i, None) -> ident f i
-    | Prop_ident (i, Some (e, loc)) ->
+    | Prop_ident (Prop_and_ident i, None) -> ident f i
+    | Prop_ident (Prop_and_ident i, Some (e, loc)) ->
         ident f i;
         PP.space f;
         PP.string f "=";

--- a/compiler/lib/js_output.ml
+++ b/compiler/lib/js_output.ml
@@ -747,12 +747,23 @@ struct
               PP.string f "=";
               PP.space f;
               expression AssignementExpression f e
-          | TargetProperty (pn, e) ->
+          | TargetProperty (pn, e, None) ->
               PP.start_group f 0;
               property_name f pn;
               PP.string f ":";
               PP.space f;
               expression AssignementExpression f e;
+              PP.end_group f
+          | TargetProperty (pn, e, Some (ini, _)) ->
+              PP.start_group f 0;
+              property_name f pn;
+              PP.string f ":";
+              PP.space f;
+              expression AssignementExpression f e;
+              PP.space f;
+              PP.string f "=";
+              PP.space f;
+              expression AssignementExpression f ini;
               PP.end_group f
           | TargetPropertySpread e ->
               PP.string f "...";

--- a/compiler/lib/js_parser.mly
+++ b/compiler/lib/js_parser.mly
@@ -503,7 +503,7 @@ object_binding_pattern:
     { ObjectBinding {list=l;rest= Some r} }
 
 binding_property:
-  | i=ident e=initializer_? { Prop_ident (i, e) }
+  | i=ident e=initializer_? { Prop_ident (Prop_and_ident i, e) }
   | pn=property_name ":" e=binding_element { Prop_binding (pn, e) }
 
 binding_property_rest:

--- a/compiler/lib/js_traverse.ml
+++ b/compiler/lib/js_traverse.ml
@@ -299,8 +299,9 @@ class map : mapper =
                    (List.map l ~f:(function
                        | TargetPropertyId (i, e) ->
                            TargetPropertyId (m#ident i, m#initialiser_o e)
-                       | TargetProperty (i, e) ->
-                           TargetProperty (m#property_name i, m#expression e)
+                       | TargetProperty (n, e, i) ->
+                           TargetProperty
+                             (m#property_name n, m#expression e, m#initialiser_o i)
                        | TargetPropertyMethod (n, x) ->
                            TargetPropertyMethod (m#property_name n, m#method_ x)
                        | TargetPropertySpread e -> TargetPropertySpread (m#expression e))))
@@ -646,9 +647,10 @@ class iter : iterator =
                   | TargetPropertyId (i, e) ->
                       m#ident i;
                       m#initialiser_o e
-                  | TargetProperty (i, e) ->
-                      m#property_name i;
-                      m#expression e
+                  | TargetProperty (n, e, i) ->
+                      m#property_name n;
+                      m#expression e;
+                      m#initialiser_o i
                   | TargetPropertyMethod (n, x) ->
                       m#property_name n;
                       m#method_ x
@@ -1369,11 +1371,8 @@ class rename_variable ~esm =
             List.map2 l_old l_new ~f:(fun a b ->
                 match a, b with
                 | ( TargetPropertyId (S { name = old_name; _ }, _)
-                  , TargetPropertyId (V v, rhs) ) -> (
-                    match rhs with
-                    | None -> TargetProperty (PNI old_name, EVar (V v))
-                    | Some (e, _) ->
-                        TargetProperty (PNI old_name, EBin (Eq, EVar (V v), e)))
+                  , TargetPropertyId (V v, rhs) ) ->
+                    TargetProperty (PNI old_name, EVar (V v), rhs)
                 | _, b -> b)
           in
           EAssignTarget (ObjectTarget l_res)

--- a/compiler/lib/js_traverse.mli
+++ b/compiler/lib/js_traverse.mli
@@ -47,6 +47,8 @@ class type mapper = object
     -> Javascript.for_binding
     -> Javascript.for_binding
 
+  method binding_property : Javascript.binding_property -> Javascript.binding_property
+
   method variable_declaration :
        Javascript.variable_declaration_kind
     -> Javascript.variable_declaration

--- a/compiler/tests-compiler/minify.ml
+++ b/compiler/tests-compiler/minify.ml
@@ -420,66 +420,52 @@ test()
 
 let%expect_test _ =
   with_temp_dir ~f:(fun () ->
-      let js_prog =
-        {|
+      let minify js_prog =
+        let js_file =
+          js_prog |> Filetype.js_text_of_string |> Filetype.write_js ~name:"test.js"
+        in
+        let js_min_file =
+          js_file |> jsoo_minify ~flags:[ "--enable"; "shortvar" ] ~pretty:false
+        in
+        print_file (Filetype.path_of_js_file js_min_file)
+      in
+      minify {|
 function f (x) {
   let {toto} = x;
   return toto;
 }
-
+|};
+      [%expect {|
+        $ cat "test.min.js"
+          1: function
+          2: f(a){let{toto:b}=a;return b} |}];
+      minify
+        {|
 function g(x) {
   var toto, test, tata; 
   for( { toto : tata = test } in x ) {
     console.log(tata);
   }
 }
-
+|};
+      [%expect {|
+        $ cat "test.min.js"
+          1: function
+          2: g(a){var
+          3: d,c,b;for({toto:b=c}in
+          4: a)console.log(b)} |}];
+      minify
+        {|
 function h(x) {
   var toto;
   for( { toto } in x ) {
     console.log(toto);
   }
 }
-|}
-      in
-      let js_file =
-        js_prog |> Filetype.js_text_of_string |> Filetype.write_js ~name:"test.js"
-      in
-      let js_min_file =
-        js_file |> jsoo_minify ~flags:[ "--enable"; "shortvar" ] ~pretty:false
-      in
-      print_file (Filetype.path_of_js_file js_file);
-      print_file (Filetype.path_of_js_file js_min_file);
-      [%expect
-        {|
-        $ cat "test.js"
-          1:
-          2: function f (x) {
-          3:   let {toto} = x;
-          4:   return toto;
-          5: }
-          6:
-          7: function g(x) {
-          8:   var toto, test, tata;
-          9:   for( { toto : tata = test } in x ) {
-         10:     console.log(tata);
-         11:   }
-         12: }
-         13:
-         14: function h(x) {
-         15:   var toto;
-         16:   for( { toto } in x ) {
-         17:     console.log(toto);
-         18:   }
-         19: }
+|};
+      [%expect {|
         $ cat "test.min.js"
           1: function
-          2: f(a){let{toto:b}=a;return b}function
-          3: g(a){var
-          4: d,c,b;for({toto:b=c}in
-          5: a)console.log(b)}function
-          6: h(a){var
-          7: b;for({toto:b}in
-          8: a)console.log(b)} |}];
-      print_endline (run_javascript js_min_file);
-      [%expect {||}])
+          2: h(a){var
+          3: b;for({toto:b}in
+          4: a)console.log(b)} |}])

--- a/compiler/tests-compiler/minify.ml
+++ b/compiler/tests-compiler/minify.ml
@@ -435,7 +435,8 @@ function f (x) {
   return toto;
 }
 |};
-      [%expect {|
+      [%expect
+        {|
         $ cat "test.min.js"
           1: function
           2: f(a){let{toto:b}=a;return b} |}];
@@ -448,7 +449,8 @@ function g(x) {
   }
 }
 |};
-      [%expect {|
+      [%expect
+        {|
         $ cat "test.min.js"
           1: function
           2: g(a){var
@@ -463,7 +465,8 @@ function h(x) {
   }
 }
 |};
-      [%expect {|
+      [%expect
+        {|
         $ cat "test.min.js"
           1: function
           2: h(a){var


### PR DESCRIPTION
fixing #1586 