### PR TITLE
Runtime: abort instead of exit on unimplemented js primitives

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,9 @@
 * Compiler: codegen: more specialization for %int_add, %int_sub
 * Compiler: recognize and optimize String.concat
 * Compiler: more inlining - duplicate small function.
+* Runtime: abort instead of exit when calling unimplemented
+  js primitives in bytecode/native. It should help if one tries
+  to understand the source of the call with gdb (see #677)
 
 ## Bug fixes
 

--- a/lib/gen_stubs/gen_stubs.ml
+++ b/lib/gen_stubs/gen_stubs.ml
@@ -20,10 +20,12 @@ module String_set = Set.Make (String)
 
 let print_stub s =
   Printf.printf
-    "void %s () {\n\
-    \  fprintf(stderr, \"Unimplemented Javascript primitive %s!\\n\");\n\
-    \  exit(1);\n\
-     }\n"
+    {|
+void %s () {
+  fprintf(stderr, "Unimplemented Javascript primitive %s!\n");
+  abort();
+}
+|}
     s
     s
 

--- a/lib/js_of_ocaml/js_of_ocaml_stubs.c
+++ b/lib/js_of_ocaml/js_of_ocaml_stubs.c
@@ -1,26 +1,32 @@
 #include <stdlib.h>
 #include <stdio.h>
+
 void caml_js_error_of_exception () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_error_of_exception!\n");
-  exit(1);
+  abort();
 }
+
 void caml_js_get_console () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_get_console!\n");
-  exit(1);
+  abort();
 }
+
 void caml_js_html_entities () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_html_entities!\n");
-  exit(1);
+  abort();
 }
+
 void caml_js_html_escape () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_html_escape!\n");
-  exit(1);
+  abort();
 }
+
 void caml_js_on_ie () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_on_ie!\n");
-  exit(1);
+  abort();
 }
+
 void caml_xmlhttprequest_create () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_xmlhttprequest_create!\n");
-  exit(1);
+  abort();
 }

--- a/lib/lwt/graphics/graphics_js_stubs.c
+++ b/lib/lwt/graphics/graphics_js_stubs.c
@@ -1,18 +1,22 @@
 #include <stdlib.h>
 #include <stdio.h>
+
 void caml_gr_doc_of_state () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_gr_doc_of_state!\n");
-  exit(1);
+  abort();
 }
+
 void caml_gr_state_create () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_gr_state_create!\n");
-  exit(1);
+  abort();
 }
+
 void caml_gr_state_get () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_gr_state_get!\n");
-  exit(1);
+  abort();
 }
+
 void caml_gr_state_set () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_gr_state_set!\n");
-  exit(1);
+  abort();
 }

--- a/lib/runtime/js_of_ocaml_runtime_stubs.c
+++ b/lib/runtime/js_of_ocaml_runtime_stubs.c
@@ -1,266 +1,332 @@
 #include <stdlib.h>
 #include <stdio.h>
+
 void bigstring_of_array_buffer () {
   fprintf(stderr, "Unimplemented Javascript primitive bigstring_of_array_buffer!\n");
-  exit(1);
+  abort();
 }
+
 void bigstring_of_typed_array () {
   fprintf(stderr, "Unimplemented Javascript primitive bigstring_of_typed_array!\n");
-  exit(1);
+  abort();
 }
+
 void bigstring_to_array_buffer () {
   fprintf(stderr, "Unimplemented Javascript primitive bigstring_to_array_buffer!\n");
-  exit(1);
+  abort();
 }
+
 void bigstring_to_typed_array () {
   fprintf(stderr, "Unimplemented Javascript primitive bigstring_to_typed_array!\n");
-  exit(1);
+  abort();
 }
+
 void caml_ba_from_typed_array () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_ba_from_typed_array!\n");
-  exit(1);
+  abort();
 }
+
 void caml_ba_kind_of_typed_array () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_ba_kind_of_typed_array!\n");
-  exit(1);
+  abort();
 }
+
 void caml_ba_to_typed_array () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_ba_to_typed_array!\n");
-  exit(1);
+  abort();
 }
+
 void caml_create_file () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_create_file!\n");
-  exit(1);
+  abort();
 }
+
 void caml_exn_with_js_backtrace () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_exn_with_js_backtrace!\n");
-  exit(1);
+  abort();
 }
+
 void caml_int64_create_lo_mi_hi () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_int64_create_lo_mi_hi!\n");
-  exit(1);
+  abort();
 }
+
 void caml_js_call () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_call!\n");
-  exit(1);
+  abort();
 }
+
 void caml_js_delete () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_delete!\n");
-  exit(1);
+  abort();
 }
+
 void caml_js_equals () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_equals!\n");
-  exit(1);
+  abort();
 }
+
 void caml_js_error_option_of_exception () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_error_option_of_exception!\n");
-  exit(1);
+  abort();
 }
+
 void caml_js_eval_string () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_eval_string!\n");
-  exit(1);
+  abort();
 }
+
 void caml_js_expr () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_expr!\n");
-  exit(1);
+  abort();
 }
+
 void caml_js_from_array () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_from_array!\n");
-  exit(1);
+  abort();
 }
+
 void caml_js_from_bool () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_from_bool!\n");
-  exit(1);
+  abort();
 }
+
 void caml_js_from_float () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_from_float!\n");
-  exit(1);
+  abort();
 }
+
 void caml_js_from_int32 () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_from_int32!\n");
-  exit(1);
+  abort();
 }
+
 void caml_js_from_nativeint () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_from_nativeint!\n");
-  exit(1);
+  abort();
 }
+
 void caml_js_from_string () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_from_string!\n");
-  exit(1);
+  abort();
 }
+
 void caml_js_fun_call () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_fun_call!\n");
-  exit(1);
+  abort();
 }
+
 void caml_js_get () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_get!\n");
-  exit(1);
+  abort();
 }
+
 void caml_js_instanceof () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_instanceof!\n");
-  exit(1);
+  abort();
 }
+
 void caml_js_meth_call () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_meth_call!\n");
-  exit(1);
+  abort();
 }
+
 void caml_js_new () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_new!\n");
-  exit(1);
+  abort();
 }
+
 void caml_js_object () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_object!\n");
-  exit(1);
+  abort();
 }
+
 void caml_js_pure_expr () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_pure_expr!\n");
-  exit(1);
+  abort();
 }
+
 void caml_js_set () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_set!\n");
-  exit(1);
+  abort();
 }
+
 void caml_js_strict_equals () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_strict_equals!\n");
-  exit(1);
+  abort();
 }
+
 void caml_js_to_array () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_to_array!\n");
-  exit(1);
+  abort();
 }
+
 void caml_js_to_bool () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_to_bool!\n");
-  exit(1);
+  abort();
 }
+
 void caml_js_to_byte_string () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_to_byte_string!\n");
-  exit(1);
+  abort();
 }
+
 void caml_js_to_float () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_to_float!\n");
-  exit(1);
+  abort();
 }
+
 void caml_js_to_int32 () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_to_int32!\n");
-  exit(1);
+  abort();
 }
+
 void caml_js_to_nativeint () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_to_nativeint!\n");
-  exit(1);
+  abort();
 }
+
 void caml_js_to_string () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_to_string!\n");
-  exit(1);
+  abort();
 }
+
 void caml_js_typeof () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_typeof!\n");
-  exit(1);
+  abort();
 }
+
 void caml_js_var () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_var!\n");
-  exit(1);
+  abort();
 }
+
 void caml_js_wrap_callback () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_wrap_callback!\n");
-  exit(1);
+  abort();
 }
+
 void caml_js_wrap_callback_arguments () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_wrap_callback_arguments!\n");
-  exit(1);
+  abort();
 }
+
 void caml_js_wrap_callback_strict () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_wrap_callback_strict!\n");
-  exit(1);
+  abort();
 }
+
 void caml_js_wrap_callback_unsafe () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_wrap_callback_unsafe!\n");
-  exit(1);
+  abort();
 }
+
 void caml_js_wrap_meth_callback () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_wrap_meth_callback!\n");
-  exit(1);
+  abort();
 }
+
 void caml_js_wrap_meth_callback_arguments () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_wrap_meth_callback_arguments!\n");
-  exit(1);
+  abort();
 }
+
 void caml_js_wrap_meth_callback_strict () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_wrap_meth_callback_strict!\n");
-  exit(1);
+  abort();
 }
+
 void caml_js_wrap_meth_callback_unsafe () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_js_wrap_meth_callback_unsafe!\n");
-  exit(1);
+  abort();
 }
+
 void caml_jsbytes_of_string () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_jsbytes_of_string!\n");
-  exit(1);
+  abort();
 }
+
 void caml_jsoo_flags_effects () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_jsoo_flags_effects!\n");
-  exit(1);
+  abort();
 }
+
 void caml_jsoo_flags_use_js_string () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_jsoo_flags_use_js_string!\n");
-  exit(1);
+  abort();
 }
+
 void caml_jsstring_of_string () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_jsstring_of_string!\n");
-  exit(1);
+  abort();
 }
+
 void caml_list_mount_point () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_list_mount_point!\n");
-  exit(1);
+  abort();
 }
+
 void caml_list_of_js_array () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_list_of_js_array!\n");
-  exit(1);
+  abort();
 }
+
 void caml_list_to_js_array () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_list_to_js_array!\n");
-  exit(1);
+  abort();
 }
+
 void caml_ml_set_channel_output () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_ml_set_channel_output!\n");
-  exit(1);
+  abort();
 }
+
 void caml_ml_set_channel_refill () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_ml_set_channel_refill!\n");
-  exit(1);
+  abort();
 }
+
 void caml_mount_autoload () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_mount_autoload!\n");
-  exit(1);
+  abort();
 }
+
 void caml_ojs_new_arr () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_ojs_new_arr!\n");
-  exit(1);
+  abort();
 }
+
 void caml_pure_js_expr () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_pure_js_expr!\n");
-  exit(1);
+  abort();
 }
+
 void caml_read_file_content () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_read_file_content!\n");
-  exit(1);
+  abort();
 }
+
 void caml_string_of_array () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_string_of_array!\n");
-  exit(1);
+  abort();
 }
+
 void caml_string_of_jsbytes () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_string_of_jsbytes!\n");
-  exit(1);
+  abort();
 }
+
 void caml_string_of_jsstring () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_string_of_jsstring!\n");
-  exit(1);
+  abort();
 }
+
 void caml_unmount () {
   fprintf(stderr, "Unimplemented Javascript primitive caml_unmount!\n");
-  exit(1);
+  abort();
 }
+
 void debugger () {
   fprintf(stderr, "Unimplemented Javascript primitive debugger!\n");
-  exit(1);
+  abort();
 }


### PR DESCRIPTION
fix #677 