### PR TITLE
Runtime: re-support marshaling floats

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 * Runtime: abort instead of exit when calling unimplemented
   js primitives in bytecode/native. It should help if one tries
   to understand the source of the call with gdb (see #677)
+* Runtime: re-enable marshalling of floats, disabled in jsoo 2.0
 
 ## Bug fixes
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ bits (rather than 31 bits or 63 bits), which is their natural size in
 JavaScript, and floats are not boxed. As a consequence, marshalling, polymorphic
 comparison, and hashing functions can yield results different from usual:
 
-- marshalling of floats is not supported (unmarshalling works);
+- marshalling floats might generate different output. Such output should not be
+  unmarshalled using the standard ocaml runtime (native or bytecode).
 - the polymorphic hash function will not give the same results on datastructures
   containing floats;
 - these functions may be more prone to stack overflow.

--- a/compiler/tests-jsoo/test_marshal.ml
+++ b/compiler/tests-jsoo/test_marshal.ml
@@ -166,3 +166,27 @@ let%expect_test "test sharing of string" =
   Printf.printf "%S" (Marshal.to_string obj []);
   [%expect
     {| "\132\149\166\190\000\000\000\016\000\000\000\004\000\000\000\012\000\000\000\011\160\160'AString\004\001\160\004\003@" |}]
+
+let%expect_test "test float" =
+  let s = 3.14 in
+  let p = s, s in
+  let obj = [ p; p ] in
+  let r1 = Marshal.to_string s [ No_sharing ] in
+  Printf.printf "%S\n" r1;
+  Printf.printf "%f" (Marshal.from_string r1 0);
+  [%expect
+    {|
+      "\132\149\166\190\000\000\000\t\000\000\000\000\000\000\000\003\000\000\000\002\012\031\133\235Q\184\030\t@"
+      3.140000 |}];
+  let r2 = Marshal.to_string obj [] in
+  Printf.printf "%S\n" r2;
+  let a, b, c, d =
+    match Marshal.from_string r2 0 with
+    | [ (a, b); (c, d) ] -> a, b, c, d
+    | _ -> assert false
+  in
+  Printf.printf "%f %f %f %f" a b c d;
+  [%expect
+    {|
+    "\132\149\166\190\000\000\000\017\000\000\000\004\000\000\000\012\000\000\000\011\160\160\012\031\133\235Q\184\030\t@\004\001\160\004\003@"
+    3.140000 3.140000 3.140000 3.140000 |}]

--- a/manual/overview.wiki
+++ b/manual/overview.wiki
@@ -91,7 +91,8 @@ integers are 32 bits (rather than 31 bits or 63 bits), which is their
 natural size in JavaScript, and floats are not boxed.  As a
 consequence, marshalling, polymorphic comparison, and hashing
 functions can yield results different from usual:
-  * marshalling of floats is not supported (unmarshalling works);
+  * marshalling floats might generate different output. Such output should not be
+    unmarshalled using the standard ocaml runtime (native or bytecode);
   * the polymorphic hash function will not give the same results on
     datastructures containing floats;
   * these functions may be more prone to stack overflow.

--- a/runtime/marshal.js
+++ b/runtime/marshal.js
@@ -736,6 +736,10 @@ var caml_output_val = function (){
           var type_of_v = typeof v;
           if(type_of_v != "number")
             caml_failwith("output_value: abstract value ("+type_of_v+")");
+          // If a float happens to be an integer it is serialized as an integer
+          // (Js_of_ocaml cannot tell whether the type of an integer number is
+          // float or integer.) This can result in unexpected crashes when
+          // unmarshalling using the standard runtime.
           if (memo(v)) return;
           var t = caml_int64_to_bytes(caml_int64_bits_of_float(v));
           writer.write (8, 0x0C /*cst.CODE_DOUBLE_LITTLE*/);

--- a/runtime/marshal.js
+++ b/runtime/marshal.js
@@ -734,18 +734,14 @@ var caml_output_val = function (){
       } else {
         if (v != (v|0)){
           var type_of_v = typeof v;
-          //
-          // If a float happens to be an integer it is serialized as an integer
-          // (Js_of_ocaml cannot tell whether the type of an integer number is
-          // float or integer.) This can result in unexpected crashes when
-          // unmarshalling using the standard runtime. It seems better to
-          // systematically fail on marshalling.
-          //
-          //          if(type_of_v != "number")
-          caml_failwith("output_value: abstract value ("+type_of_v+")");
-          //          var t = caml_int64_to_bytes(caml_int64_bits_of_float(v));
-          //          writer.write (8, 0x0B /*cst.CODE_DOUBLE_BIG*/);
-          //          for(var i = 0; i<8; i++){writer.write(8,t[i])}
+          if(type_of_v != "number")
+            caml_failwith("output_value: abstract value ("+type_of_v+")");
+          if (memo(v)) return;
+          var t = caml_int64_to_bytes(caml_int64_bits_of_float(v));
+          writer.write (8, 0x0C /*cst.CODE_DOUBLE_LITTLE*/);
+          for(var i = 0; i<8; i++){writer.write(8,t[7 - i])}
+          writer.size_32 += 3
+          writer.size_64 += 2
         }
         else if (v >= 0 && v < 0x40) {
           writer.write (8, 0X40 /*cst.PREFIX_SMALL_INT*/ + v);


### PR DESCRIPTION
Re-enable marshalling of floats that were disabled in js_of_ocaml 2.0.
This is necessary to have ocamlc compiled to js working again with OCaml 5.1 due to https://github.com/ocaml/ocaml/pull/11997.

Before this PR, one could successfully generate marshalled data containing floats that SHOULD NOT be unmarshalled with the standard runtime. I now find it better to allow marshaling floats and document that the result should not be used in native/bytecode.   