### PR TITLE
Don't leak channels.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 
 ## Bug fixes
 * Fix small bug in global data flow analysis (#1768)
+* Runtime: no longer leak channels
 
 # 5.9.1 (02-12-2024) - Lille
 

--- a/compiler/bin-js_of_ocaml/compile.ml
+++ b/compiler/bin-js_of_ocaml/compile.ml
@@ -181,7 +181,7 @@ let run
     | None -> None
     | Some file ->
         if not (Sys.file_exists file)
-        then failwith (Printf.sprintf "export file %S does not exists" file);
+        then failwith (Printf.sprintf "export file %S does not exist" file);
         let ic = open_in file in
         let t = Hashtbl.create 17 in
         (try

--- a/dune-project
+++ b/dune-project
@@ -20,7 +20,7 @@
  (depends
   (ocaml (and (>= 4.08) (< 5.4)))
   (num :with-test)
-  (ppx_expect (and (>= v0.14.2) :with-test))
+  (ppx_expect (and (>= v0.16.1) :with-test))
   (ppxlib (>= 0.15.0))
   (re :with-test)
   (cmdliner (>= 1.1.0))

--- a/js_of_ocaml-compiler.opam
+++ b/js_of_ocaml-compiler.opam
@@ -15,7 +15,7 @@ depends: [
   "dune" {>= "3.17"}
   "ocaml" {>= "4.08" & < "5.4"}
   "num" {with-test}
-  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppx_expect" {>= "v0.16.1" & with-test}
   "ppxlib" {>= "0.15.0"}
   "re" {with-test}
   "cmdliner" {>= "1.1.0"}

--- a/runtime/js/parsing.js
+++ b/runtime/js/parsing.js
@@ -24,6 +24,7 @@ var caml_parser_trace = 0;
 //Requires: caml_lex_array, caml_parser_trace,caml_jsstring_of_string
 //Requires: caml_ml_output, caml_ml_string_length, caml_string_of_jsbytes
 //Requires: caml_jsbytes_of_string, MlBytes
+//Requires: caml_sys_fds
 function caml_parse_engine(tables, env, cmd, arg) {
   var ERRCODE = 256;
 
@@ -82,7 +83,7 @@ function caml_parse_engine(tables, env, cmd, arg) {
 
   function log(x) {
     var s = caml_string_of_jsbytes(x + "\n");
-    caml_ml_output(2, s, 0, caml_ml_string_length(s));
+    caml_ml_output(caml_sys_fds[2].chanid, s, 0, caml_ml_string_length(s));
   }
 
   function token_name(names, number) {


### PR DESCRIPTION
Alternative to #1578 and #1577.
This PR requires ppx_expect and alcotest to be changed.

Because the jsoo codebase rely on ppx_expect for its tests, we have a Chicken-and-egg situation.

I can make a minor release of jsoo that would include new runtime function while keeping the existing storage mechanism.
Once jsoo is released, ppx_expect can rely on the new runtime functions.
After ppx_expect is released, we can merge this PR. 

@tkluck-janestreet, how does that sound ?
