### PR TITLE
Add Typed_array.Bytes module

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# dev
+
+## Features/Changes
+
+* Library: new Typed_array.Bytes module.
+
 # 5.8.0 (2024-04-20) - Lille
 
 ## Features/Changes

--- a/lib/js_of_ocaml/js_of_ocaml_stubs.c
+++ b/lib/js_of_ocaml/js_of_ocaml_stubs.c
@@ -1,5 +1,9 @@
 #include <caml/misc.h>
 
+void caml_bytes_of_array () {
+  caml_fatal_error("Unimplemented Javascript primitive caml_bytes_of_array!");
+}
+
 void caml_js_error_of_exception () {
   caml_fatal_error("Unimplemented Javascript primitive caml_js_error_of_exception!");
 }
@@ -18,6 +22,10 @@ void caml_js_html_escape () {
 
 void caml_js_on_ie () {
   caml_fatal_error("Unimplemented Javascript primitive caml_js_on_ie!");
+}
+
+void caml_uint8_array_of_bytes () {
+  caml_fatal_error("Unimplemented Javascript primitive caml_uint8_array_of_bytes!");
 }
 
 void caml_xmlhttprequest_create () {

--- a/lib/js_of_ocaml/typed_array.ml
+++ b/lib/js_of_ocaml/typed_array.ml
@@ -261,3 +261,13 @@ module String = struct
     let uint8 = new%js uint8Array_fromBuffer ab in
     of_uint8Array uint8
 end
+
+module Bytes = struct
+  external of_uint8Array : uint8Array Js.t -> bytes = "caml_bytes_of_array"
+
+  external to_uint8Array : bytes -> uint8Array Js.t = "caml_uint8_array_of_bytes"
+
+  let of_arrayBuffer ab =
+    let uint8 = new%js uint8Array_fromBuffer ab in
+    of_uint8Array uint8
+end

--- a/lib/js_of_ocaml/typed_array.mli
+++ b/lib/js_of_ocaml/typed_array.mli
@@ -256,6 +256,13 @@ module String : sig
 end
 
 module Bytes : sig
+  (** These functions offer an efficient way to convert typed arrays to and from
+      [bytes] because they will not usually copy their input.
+
+      Modifying their input may also modify their corresponding output, and vice
+      versa when modifying their output. This is not a guarantee, however, since
+      certain [bytes] operations may require the runtime to make a copy. *)
+
   val of_arrayBuffer : arrayBuffer Js.t -> bytes
 
   val of_uint8Array : uint8Array Js.t -> bytes

--- a/lib/js_of_ocaml/typed_array.mli
+++ b/lib/js_of_ocaml/typed_array.mli
@@ -254,3 +254,11 @@ module String : sig
 
   val of_uint8Array : uint8Array Js.t -> string
 end
+
+module Bytes : sig
+  val of_arrayBuffer : arrayBuffer Js.t -> bytes
+
+  val of_uint8Array : uint8Array Js.t -> bytes
+
+  val to_uint8Array : bytes -> uint8Array Js.t
+end

--- a/lib/js_of_ocaml/typed_array.mli
+++ b/lib/js_of_ocaml/typed_array.mli
@@ -257,13 +257,13 @@ end
 
 module Bytes : sig
   val of_uint8Array : uint8Array Js.t -> bytes
-  (** This offers an efficient way to convert typed arrays to [bytes] because it
-      will not usually copy its input.
+  (** This efficiently converts a typed array to [bytes] because it will usually
+      not copy its input.
 
       Modifying its input may also modify its output, and vice versa when
       modifying its output. This is not a guarantee, however, since certain
       [bytes] operations may require the runtime to make a copy. One should not
-      use on inputs that are sensitive to modification. *)
+      use this on input that is sensitive to modification. *)
 
   val to_uint8Array : bytes -> uint8Array Js.t
   (** See the words of caution for {!of_uint8Array}. *)

--- a/lib/js_of_ocaml/typed_array.mli
+++ b/lib/js_of_ocaml/typed_array.mli
@@ -256,16 +256,18 @@ module String : sig
 end
 
 module Bytes : sig
-  (** These functions offer an efficient way to convert typed arrays to and from
-      [bytes] because they will not usually copy their input.
-
-      Modifying their input may also modify their corresponding output, and vice
-      versa when modifying their output. This is not a guarantee, however, since
-      certain [bytes] operations may require the runtime to make a copy. *)
-
-  val of_arrayBuffer : arrayBuffer Js.t -> bytes
-
   val of_uint8Array : uint8Array Js.t -> bytes
+  (** This offers an efficient way to convert typed arrays to [bytes] because it
+      will not usually copy its input.
+
+      Modifying its input may also modify its output, and vice versa when
+      modifying its output. This is not a guarantee, however, since certain
+      [bytes] operations may require the runtime to make a copy. One should not
+      use on inputs that are sensitive to modification. *)
 
   val to_uint8Array : bytes -> uint8Array Js.t
+  (** See the words of caution for {!of_uint8Array}. *)
+
+  val of_arrayBuffer : arrayBuffer Js.t -> bytes
+  (** See the words of caution for {!of_uint8Array}. *)
 end


### PR DESCRIPTION
This adds an API in `Typed_array` for converting uint8Array values into bytes. Because the runtime uses uint8Array internally to represent bytes, this doesn't need to copy anything. Modifying the resulting bytes will also modify the original uint8Array.