### PR TITLE
Stop exposing numbers as floats in the Js_of_ocaml library

### DIFF
--- a/lib/js_of_ocaml/js.ml
+++ b/lib/js_of_ocaml/js.ml
@@ -246,8 +246,6 @@ module Js = struct
 
   type string_array
 
-  type number_t = float
-
   class type number = object
     method toString : js_string t meth
 
@@ -271,7 +269,7 @@ module Js = struct
 
     method charAt : int -> js_string t meth
 
-    method charCodeAt : int -> number_t meth
+    method charCodeAt : int -> number t meth
 
     (* This may return NaN... *)
     method concat : js_string t -> js_string t meth
@@ -291,7 +289,7 @@ module Js = struct
 
     method lastIndexOf_from : js_string t -> int -> int meth
 
-    method localeCompare : js_string t -> number_t meth
+    method localeCompare : js_string t -> number t meth
 
     method _match : regExp t -> match_result_handle t opt meth
 
@@ -353,6 +351,8 @@ module Js = struct
   end
 
   and normalization = js_string
+
+  type number_t = number t
 
   (* string is used by ppx_js, it needs to come before any use of the
      new syntax in this file *)

--- a/lib/js_of_ocaml/js.mli
+++ b/lib/js_of_ocaml/js.mli
@@ -219,8 +219,6 @@ val nfkc : normalization t
 
 (** Specification of Javascript number objects. *)
 
-type number_t = float
-
 class type number = object
   method toString : js_string t meth
 
@@ -245,7 +243,7 @@ and js_string = object
 
   method charAt : int -> js_string t meth
 
-  method charCodeAt : int -> number_t meth
+  method charCodeAt : int -> number t meth
 
   (* This may return NaN... *)
   method concat : js_string t -> js_string t meth
@@ -265,7 +263,7 @@ and js_string = object
 
   method lastIndexOf_from : js_string t -> int -> int meth
 
-  method localeCompare : js_string t -> number_t meth
+  method localeCompare : js_string t -> number t meth
 
   method _match : regExp t -> match_result_handle t opt meth
 
@@ -327,6 +325,8 @@ and regExp = object
 
   method lastIndex : int prop
 end
+
+type number_t = number t
 
 (** Specification of the string constructor, considered as an object. *)
 class type string_constr = object


### PR DESCRIPTION
This is for compatibility with wasm_of_ocaml, in which Javascript numbers and floats cannot be manipulated using the same functions and require conversions.

I open this as a draft PR because it will likely break a number of packages; in particular, before merging, we should wait for Jane Street to release a version of their packages with the missing explicit float conversions.