### PR TITLE
Test marshalling compression only when enabled

### DIFF
--- a/compiler/tests-jsoo/dune
+++ b/compiler/tests-jsoo/dune
@@ -10,9 +10,20 @@
   (pps ppx_expect)))
 
 (library
+ (name jsoo_testsuite_compression)
+ (modules test_marshal_compressed)
+ (libraries unix compiler-libs.common js_of_ocaml-compiler)
+ (enabled_if
+  (>= %{ocaml_version} 5.1.1))
+ (inline_tests
+  (modes js best))
+ (preprocess
+  (pps ppx_expect)))
+
+(library
  (name jsoo_testsuite)
  (modules
-  (:standard \ test_io test_floats))
+  (:standard \ test_io test_floats test_marshal_compressed))
  (libraries unix compiler-libs.common js_of_ocaml-compiler)
  (foreign_stubs
   (language c)

--- a/compiler/tests-jsoo/test_marshal.ml
+++ b/compiler/tests-jsoo/test_marshal.ml
@@ -134,28 +134,6 @@ let%expect_test _ =
   [%expect
     {| "\132\149\166\190\000\000\000'\000\000\000\001\000\000\000\007\000\000\000\007\024_bigarr02\000\000\000\000\020\000\000\000\000\000\000\000(\000\000\000\001\000\000\000\005\000\003\000\003\000\001\000\002" |}]
 
-let%expect_test _ =
-  let data =
-    "\132\149\166\189\r\022\206\021\001\147F\137d(\181/\253\000Xm\000\0000\n\
-     \000\000'\016c\001\000\012\135\007E"
-  in
-  let ocaml_5_1 =
-    match String.split_on_char '.' Sys.ocaml_version with
-    | major :: minor :: _ ->
-        let major = int_of_string major and minor = int_of_string minor in
-        major > 5 || (major = 5 && minor >= 1)
-    | _ -> assert false
-  in
-  let s =
-    (* This would only work on OCaml 5.1.0 if we were not linking
-       against compiler-libs *)
-    if ocaml_5_1 && not (Sys.win32 || Sys.cygwin)
-    then Marshal.from_string data 0
-    else String.make 10000 'c'
-  in
-  Printf.printf "%s ... (%d)\n" (String.sub s 0 20) (String.length s);
-  [%expect {| cccccccccccccccccccc ... (10000) |}]
-
 let%expect_test "test sharing of string" =
   let s = "AString" in
   let p = s, s in

--- a/compiler/tests-jsoo/test_marshal_compressed.ml
+++ b/compiler/tests-jsoo/test_marshal_compressed.ml
@@ -1,0 +1,31 @@
+(* Js_of_ocaml tests
+ * http://www.ocsigen.org/js_of_ocaml/
+ * Copyright (C) 2019 Shachar Itzhaky
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+
+let%expect_test _ =
+  let data =
+    "\132\149\166\189\r\022\206\021\001\147F\137d(\181/\253\000Xm\000\0000\n\
+     \000\000'\016c\001\000\012\135\007E"
+  in
+  let s =
+    if Compression.compression_supported
+    then Marshal.from_string data 0
+    else String.make 10000 'c'
+  in
+  Printf.printf "%s ... (%d)\n" (String.sub s 0 20) (String.length s);
+  [%expect {| cccccccccccccccccccc ... (10000) |}]


### PR DESCRIPTION
This is a better #1620: testing of Marshal with compression is enabled on 5.1.1 and higher, and tests for `Compression.compression_supported`.