### PR TITLE
Dom_html.html_entities: move error handling to the ML side

### DIFF
--- a/lib/js_of_ocaml/dom_html.ml
+++ b/lib/js_of_ocaml/dom_html.ml
@@ -27,7 +27,10 @@ let onIE = Js.to_bool (caml_js_on_ie ())
 
 external html_escape : js_string t -> js_string t = "caml_js_html_escape"
 
-external decode_html_entities : js_string t -> js_string t = "caml_js_html_entities"
+external html_entities : js_string t -> js_string t opt = "caml_js_html_entities"
+
+let decode_html_entities s =
+  Js.Opt.get (html_entities s) (fun () -> failwith ("Invalid entity " ^ Js.to_string s))
 
 class type cssStyleDeclaration = object
   method setProperty :

--- a/runtime/jslib_js_of_ocaml.js
+++ b/runtime/jslib_js_of_ocaml.js
@@ -37,7 +37,6 @@ function caml_js_html_escape (s) {
 }
 
 //Provides: caml_js_html_entities
-//Requires: caml_failwith
 function caml_js_html_entities(s) {
   var entity = /^&#?[0-9a-zA-Z]+;$/
   if(s.match(entity))
@@ -49,7 +48,7 @@ function caml_js_html_entities(s) {
     return str;
   }
   else {
-    caml_failwith("Invalid entity " + s);
+    return null;
   }
 }
 


### PR DESCRIPTION
This is part of a series of PRs intending to reduce the diff between js_of_ocaml and wasm_of_ocaml (see https://github.com/ocaml-wasm/wasm_of_ocaml/issues/47).