### PR TITLE
Update typing of typed arrays to support Wasm, and test Typed_array.Bytes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 * Runtime: change Sys.os_type on windows (Cygwin -> Win32)
 * Runtime: backtraces are really expensive, they need to be be explicitly
   requested at compile time (--enable with-js-error) or at startup (OCAMLRUNPARAM=b=1)
+* Lib: Modify Typed_array API for compatibility with WebAssembly
 
 
 ## Bug fixes

--- a/lib/js_of_ocaml/typed_array.ml
+++ b/lib/js_of_ocaml/typed_array.ml
@@ -79,7 +79,6 @@ type float32Array = (number_t, float, Bigarray.float32_elt) typedArray
 type float64Array = (number_t, float, Bigarray.float64_elt) typedArray
 
 type ('bigarray, 'typed_array, 'elt) kind =
-  | Char : (int, char, Bigarray.int8_unsigned_elt) kind
   | Int8_signed : (int, int, Bigarray.int8_signed_elt) kind
   | Int8_unsigned : (int, int, Bigarray.int8_unsigned_elt) kind
   | Int16_signed : (int, int, Bigarray.int16_signed_elt) kind

--- a/lib/js_of_ocaml/typed_array.ml
+++ b/lib/js_of_ocaml/typed_array.ml
@@ -204,9 +204,9 @@ class type dataView = object
 
   method getUint16_ : int -> bool t -> int meth
 
-  method getInt32 : int -> int32 meth
+  method getInt32 : int -> number_t meth
 
-  method getInt32_ : int -> bool t -> int32 meth
+  method getInt32_ : int -> bool t -> number_t meth
 
   method getUint32 : int -> number_t meth
 
@@ -232,9 +232,9 @@ class type dataView = object
 
   method setUint16_ : int -> int -> bool t -> unit meth
 
-  method setInt32 : int -> int32 -> unit meth
+  method setInt32 : int -> number_t -> unit meth
 
-  method setInt32_ : int -> int32 -> bool t -> unit meth
+  method setInt32_ : int -> number_t -> bool t -> unit meth
 
   method setUint32 : int -> number_t -> unit meth
 

--- a/lib/js_of_ocaml/typed_array.ml
+++ b/lib/js_of_ocaml/typed_array.ml
@@ -20,10 +20,6 @@
 open! Import
 open Js
 
-type int32 = number_t
-
-type uint32 = number_t
-
 class type arrayBuffer = object
   method byteLength : int readonly_prop
 
@@ -74,9 +70,9 @@ type int16Array = (int, int, Bigarray.int16_signed_elt) typedArray
 
 type uint16Array = (int, int, Bigarray.int16_unsigned_elt) typedArray
 
-type int32Array = (int32, Int32.t, Bigarray.int32_elt) typedArray
+type int32Array = (number_t, Int32.t, Bigarray.int32_elt) typedArray
 
-type uint32Array = (uint32, Int32.t, Bigarray.int32_elt) typedArray
+type uint32Array = (number_t, Int32.t, Bigarray.int32_elt) typedArray
 
 type float32Array = (number_t, float, Bigarray.float32_elt) typedArray
 
@@ -88,8 +84,8 @@ type ('bigarray, 'typed_array, 'elt) kind =
   | Int8_unsigned : (int, int, Bigarray.int8_unsigned_elt) kind
   | Int16_signed : (int, int, Bigarray.int16_signed_elt) kind
   | Int16_unsigned : (int, int, Bigarray.int16_unsigned_elt) kind
-  | Int32_signed : (int32, Int32.t, Bigarray.int32_elt) kind
-  | Int32_unsigned : (uint32, Int32.t, Bigarray.int32_elt) kind
+  | Int32_signed : (number_t, Int32.t, Bigarray.int32_elt) kind
+  | Int32_unsigned : (number_t, Int32.t, Bigarray.int32_elt) kind
   | Float32 : (number_t, float, Bigarray.float32_elt) kind
   | Float64 : (number_t, float, Bigarray.float64_elt) kind
 
@@ -213,9 +209,9 @@ class type dataView = object
 
   method getInt32_ : int -> bool t -> int32 meth
 
-  method getUint32 : int -> uint32 meth
+  method getUint32 : int -> number_t meth
 
-  method getUint32_ : int -> bool t -> uint32 meth
+  method getUint32_ : int -> bool t -> number_t meth
 
   method getFloat32 : int -> number_t meth
 
@@ -241,9 +237,9 @@ class type dataView = object
 
   method setInt32_ : int -> int32 -> bool t -> unit meth
 
-  method setUint32 : int -> uint32 -> unit meth
+  method setUint32 : int -> number_t -> unit meth
 
-  method setUint32_ : int -> uint32 -> bool t -> unit meth
+  method setUint32_ : int -> number_t -> bool t -> unit meth
 
   method setFloat32 : int -> number_t -> unit meth
 

--- a/lib/js_of_ocaml/typed_array.ml
+++ b/lib/js_of_ocaml/typed_array.ml
@@ -79,7 +79,7 @@ type float32Array = (number_t, float, Bigarray.float32_elt) typedArray
 type float64Array = (number_t, float, Bigarray.float64_elt) typedArray
 
 type ('bigarray, 'typed_array, 'elt) kind =
-  | Char : (char, char, Bigarray.int8_unsigned_elt) kind
+  | Char : (int, char, Bigarray.int8_unsigned_elt) kind
   | Int8_signed : (int, int, Bigarray.int8_signed_elt) kind
   | Int8_unsigned : (int, int, Bigarray.int8_unsigned_elt) kind
   | Int16_signed : (int, int, Bigarray.int16_signed_elt) kind

--- a/lib/js_of_ocaml/typed_array.ml
+++ b/lib/js_of_ocaml/typed_array.ml
@@ -79,7 +79,7 @@ type float32Array = (number_t, float, Bigarray.float32_elt) typedArray
 type float64Array = (number_t, float, Bigarray.float64_elt) typedArray
 
 type ('bigarray, 'typed_array, 'elt) kind =
-  | Char : (int, char, Bigarray.int8_unsigned_elt) kind
+  | Char : (char, char, Bigarray.int8_unsigned_elt) kind
   | Int8_signed : (int, int, Bigarray.int8_signed_elt) kind
   | Int8_unsigned : (int, int, Bigarray.int8_unsigned_elt) kind
   | Int16_signed : (int, int, Bigarray.int16_signed_elt) kind

--- a/lib/js_of_ocaml/typed_array.ml
+++ b/lib/js_of_ocaml/typed_array.ml
@@ -78,7 +78,7 @@ type float32Array = (number_t, float, Bigarray.float32_elt) typedArray
 
 type float64Array = (number_t, float, Bigarray.float64_elt) typedArray
 
-type ('bigarray, 'typed_array, 'elt) kind =
+type (_, _, _) kind =
   | Int8_signed : (int, int, Bigarray.int8_signed_elt) kind
   | Int8_unsigned : (int, int, Bigarray.int8_unsigned_elt) kind
   | Int16_signed : (int, int, Bigarray.int16_signed_elt) kind

--- a/lib/js_of_ocaml/typed_array.ml
+++ b/lib/js_of_ocaml/typed_array.ml
@@ -105,7 +105,7 @@ external to_genarray :
      ('typed_array, 'bigarray, 'elt) typedArray t
   -> ('bigarray, 'elt, Bigarray.c_layout) Bigarray.Genarray.t = "caml_ba_from_typed_array"
 
-let from_genarray _ a = from_genarray_impl a
+let from_genarray (_ : ('typed_array, 'bigarray, 'elt) kind) a = from_genarray_impl a
 
 let int8Array = Js.Unsafe.global##._Int8Array
 

--- a/lib/js_of_ocaml/typed_array.ml
+++ b/lib/js_of_ocaml/typed_array.ml
@@ -82,16 +82,16 @@ type float32Array = (number_t, float, Bigarray.float32_elt) typedArray
 
 type float64Array = (number_t, float, Bigarray.float64_elt) typedArray
 
-type ('bigarray, 'typed_array, 'elt) type' =
-  | Char : (int, char, Bigarray.int8_unsigned_elt) type'
-  | Int8_signed : (int, int, Bigarray.int8_signed_elt) type'
-  | Int8_unsigned : (int, int, Bigarray.int8_unsigned_elt) type'
-  | Int16_signed : (int, int, Bigarray.int16_signed_elt) type'
-  | Int16_unsigned : (int, int, Bigarray.int16_unsigned_elt) type'
-  | Int32_signed : (int32, Int32.t, Bigarray.int32_elt) type'
-  | Int32_unsigned : (uint32, Int32.t, Bigarray.int32_elt) type'
-  | Float32 : (number_t, float, Bigarray.float32_elt) type'
-  | Float64 : (number_t, float, Bigarray.float64_elt) type'
+type ('bigarray, 'typed_array, 'elt) kind =
+  | Char : (int, char, Bigarray.int8_unsigned_elt) kind
+  | Int8_signed : (int, int, Bigarray.int8_signed_elt) kind
+  | Int8_unsigned : (int, int, Bigarray.int8_unsigned_elt) kind
+  | Int16_signed : (int, int, Bigarray.int16_signed_elt) kind
+  | Int16_unsigned : (int, int, Bigarray.int16_unsigned_elt) kind
+  | Int32_signed : (int32, Int32.t, Bigarray.int32_elt) kind
+  | Int32_unsigned : (uint32, Int32.t, Bigarray.int32_elt) kind
+  | Float32 : (number_t, float, Bigarray.float32_elt) kind
+  | Float64 : (number_t, float, Bigarray.float64_elt) kind
 
 external kind :
   ('typed_array, 'bigarray, 'elt) typedArray t -> ('bigarray, 'elt) Bigarray.kind

--- a/lib/js_of_ocaml/typed_array.mli
+++ b/lib/js_of_ocaml/typed_array.mli
@@ -202,9 +202,9 @@ class type dataView = object
 
   method getUint16_ : int -> bool t -> int meth
 
-  method getInt32 : int -> int32 meth
+  method getInt32 : int -> number_t meth
 
-  method getInt32_ : int -> bool t -> int32 meth
+  method getInt32_ : int -> bool t -> number_t meth
 
   method getUint32 : int -> number_t meth
 
@@ -230,9 +230,9 @@ class type dataView = object
 
   method setUint16_ : int -> int -> bool t -> unit meth
 
-  method setInt32 : int -> int32 -> unit meth
+  method setInt32 : int -> number_t -> unit meth
 
-  method setInt32_ : int -> int32 -> bool t -> unit meth
+  method setInt32_ : int -> number_t -> bool t -> unit meth
 
   method setUint32 : int -> number_t -> unit meth
 

--- a/lib/js_of_ocaml/typed_array.mli
+++ b/lib/js_of_ocaml/typed_array.mli
@@ -81,7 +81,7 @@ type float32Array = (number_t, float, Bigarray.float32_elt) typedArray
 type float64Array = (number_t, float, Bigarray.float64_elt) typedArray
 
 type ('bigarray, 'typed_array, 'elt) kind =
-  | Char : (int, char, Bigarray.int8_unsigned_elt) kind
+  | Char : (char, char, Bigarray.int8_unsigned_elt) kind
   | Int8_signed : (int, int, Bigarray.int8_signed_elt) kind
   | Int8_unsigned : (int, int, Bigarray.int8_unsigned_elt) kind
   | Int16_signed : (int, int, Bigarray.int16_signed_elt) kind

--- a/lib/js_of_ocaml/typed_array.mli
+++ b/lib/js_of_ocaml/typed_array.mli
@@ -81,7 +81,6 @@ type float32Array = (number_t, float, Bigarray.float32_elt) typedArray
 type float64Array = (number_t, float, Bigarray.float64_elt) typedArray
 
 type ('bigarray, 'typed_array, 'elt) kind =
-  | Char : (int, char, Bigarray.int8_unsigned_elt) kind
   | Int8_signed : (int, int, Bigarray.int8_signed_elt) kind
   | Int8_unsigned : (int, int, Bigarray.int8_unsigned_elt) kind
   | Int16_signed : (int, int, Bigarray.int16_signed_elt) kind

--- a/lib/js_of_ocaml/typed_array.mli
+++ b/lib/js_of_ocaml/typed_array.mli
@@ -84,21 +84,21 @@ type float32Array = (number_t, float, Bigarray.float32_elt) typedArray
 
 type float64Array = (number_t, float, Bigarray.float64_elt) typedArray
 
-type ('bigarray, 'typed_array, 'elt) type' =
-  | Char : (int, char, Bigarray.int8_unsigned_elt) type'
-  | Int8_signed : (int, int, Bigarray.int8_signed_elt) type'
-  | Int8_unsigned : (int, int, Bigarray.int8_unsigned_elt) type'
-  | Int16_signed : (int, int, Bigarray.int16_signed_elt) type'
-  | Int16_unsigned : (int, int, Bigarray.int16_unsigned_elt) type'
-  | Int32_signed : (int32, Int32.t, Bigarray.int32_elt) type'
-  | Int32_unsigned : (uint32, Int32.t, Bigarray.int32_elt) type'
-  | Float32 : (number_t, float, Bigarray.float32_elt) type'
-  | Float64 : (number_t, float, Bigarray.float64_elt) type'
+type ('bigarray, 'typed_array, 'elt) kind =
+  | Char : (int, char, Bigarray.int8_unsigned_elt) kind
+  | Int8_signed : (int, int, Bigarray.int8_signed_elt) kind
+  | Int8_unsigned : (int, int, Bigarray.int8_unsigned_elt) kind
+  | Int16_signed : (int, int, Bigarray.int16_signed_elt) kind
+  | Int16_unsigned : (int, int, Bigarray.int16_unsigned_elt) kind
+  | Int32_signed : (int32, Int32.t, Bigarray.int32_elt) kind
+  | Int32_unsigned : (uint32, Int32.t, Bigarray.int32_elt) kind
+  | Float32 : (number_t, float, Bigarray.float32_elt) kind
+  | Float64 : (number_t, float, Bigarray.float64_elt) kind
 
 val kind : ('typed_array, 'bigarray, 'elt) typedArray t -> ('bigarray, 'elt) Bigarray.kind
 
 val from_genarray :
-     ('typed_array, 'bigarray, 'elt) type'
+     ('typed_array, 'bigarray, 'elt) kind
   -> ('bigarray, 'elt, Bigarray.c_layout) Bigarray.Genarray.t
   -> ('typed_array, 'bigarray, 'elt) typedArray t
 

--- a/lib/js_of_ocaml/typed_array.mli
+++ b/lib/js_of_ocaml/typed_array.mli
@@ -22,10 +22,6 @@
 
 open Js
 
-type int32 = number_t
-
-type uint32 = number_t
-
 class type arrayBuffer = object
   method byteLength : int readonly_prop
 
@@ -76,9 +72,9 @@ type int16Array = (int, int, Bigarray.int16_signed_elt) typedArray
 
 type uint16Array = (int, int, Bigarray.int16_unsigned_elt) typedArray
 
-type int32Array = (int32, Int32.t, Bigarray.int32_elt) typedArray
+type int32Array = (number_t, Int32.t, Bigarray.int32_elt) typedArray
 
-type uint32Array = (uint32, Int32.t, Bigarray.int32_elt) typedArray
+type uint32Array = (number_t, Int32.t, Bigarray.int32_elt) typedArray
 
 type float32Array = (number_t, float, Bigarray.float32_elt) typedArray
 
@@ -90,8 +86,8 @@ type ('bigarray, 'typed_array, 'elt) kind =
   | Int8_unsigned : (int, int, Bigarray.int8_unsigned_elt) kind
   | Int16_signed : (int, int, Bigarray.int16_signed_elt) kind
   | Int16_unsigned : (int, int, Bigarray.int16_unsigned_elt) kind
-  | Int32_signed : (int32, Int32.t, Bigarray.int32_elt) kind
-  | Int32_unsigned : (uint32, Int32.t, Bigarray.int32_elt) kind
+  | Int32_signed : (number_t, Int32.t, Bigarray.int32_elt) kind
+  | Int32_unsigned : (number_t, Int32.t, Bigarray.int32_elt) kind
   | Float32 : (number_t, float, Bigarray.float32_elt) kind
   | Float64 : (number_t, float, Bigarray.float64_elt) kind
 
@@ -158,7 +154,7 @@ val int32Array_inBuffer : (arrayBuffer t -> int -> int -> int32Array t) constr
 
 val uint32Array : (int -> uint32Array t) constr
 
-val uint32Array_fromArray : (uint32 js_array t -> uint32Array t) constr
+val uint32Array_fromArray : (number_t js_array t -> uint32Array t) constr
 
 val uint32Array_fromTypedArray : (uint32Array t -> uint32Array t) constr
 
@@ -211,9 +207,9 @@ class type dataView = object
 
   method getInt32_ : int -> bool t -> int32 meth
 
-  method getUint32 : int -> uint32 meth
+  method getUint32 : int -> number_t meth
 
-  method getUint32_ : int -> bool t -> uint32 meth
+  method getUint32_ : int -> bool t -> number_t meth
 
   method getFloat32 : int -> number_t meth
 
@@ -239,9 +235,9 @@ class type dataView = object
 
   method setInt32_ : int -> int32 -> bool t -> unit meth
 
-  method setUint32 : int -> uint32 -> unit meth
+  method setUint32 : int -> number_t -> unit meth
 
-  method setUint32_ : int -> uint32 -> bool t -> unit meth
+  method setUint32_ : int -> number_t -> bool t -> unit meth
 
   method setFloat32 : int -> number_t -> unit meth
 

--- a/lib/js_of_ocaml/typed_array.mli
+++ b/lib/js_of_ocaml/typed_array.mli
@@ -81,7 +81,7 @@ type float32Array = (number_t, float, Bigarray.float32_elt) typedArray
 type float64Array = (number_t, float, Bigarray.float64_elt) typedArray
 
 type ('bigarray, 'typed_array, 'elt) kind =
-  | Char : (char, char, Bigarray.int8_unsigned_elt) kind
+  | Char : (int, char, Bigarray.int8_unsigned_elt) kind
   | Int8_signed : (int, int, Bigarray.int8_signed_elt) kind
   | Int8_unsigned : (int, int, Bigarray.int8_unsigned_elt) kind
   | Int16_signed : (int, int, Bigarray.int16_signed_elt) kind

--- a/lib/js_of_ocaml/typed_array.mli
+++ b/lib/js_of_ocaml/typed_array.mli
@@ -80,7 +80,11 @@ type float32Array = (number_t, float, Bigarray.float32_elt) typedArray
 
 type float64Array = (number_t, float, Bigarray.float64_elt) typedArray
 
-type ('bigarray, 'typed_array, 'elt) kind =
+(** The first type parameter is the type of values that can be read and written
+    in the {!classtype:typedArray}. The last two type parameters define the
+    kind of bigarrays that can be converted to and from the
+    {!classtype:typedArray}. See {!type:Bigarray.kind}. *)
+type (_, _, _) kind =
   | Int8_signed : (int, int, Bigarray.int8_signed_elt) kind
   | Int8_unsigned : (int, int, Bigarray.int8_unsigned_elt) kind
   | Int16_signed : (int, int, Bigarray.int16_signed_elt) kind

--- a/lib/js_of_ocaml/typed_array.mli
+++ b/lib/js_of_ocaml/typed_array.mli
@@ -22,7 +22,9 @@
 
 open Js
 
-type uint32 = float
+type int32 = number_t
+
+type uint32 = number_t
 
 class type arrayBuffer = object
   method byteLength : int readonly_prop
@@ -42,7 +44,7 @@ class type arrayBufferView = object
   method byteLength : int readonly_prop
 end
 
-class type ['a, 'b] typedArray = object
+class type ['a, 'b, 'c] typedArray = object
   inherit arrayBufferView
 
   method _BYTES_PER_ELEMENT : int readonly_prop
@@ -51,41 +53,58 @@ class type ['a, 'b] typedArray = object
 
   method set_fromArray : 'a js_array t -> int -> unit meth
 
-  method set_fromTypedArray : ('a, 'b) typedArray t -> int -> unit meth
+  method set_fromTypedArray : ('a, 'b, 'c) typedArray t -> int -> unit meth
 
-  method subarray : int -> int -> ('a, 'b) typedArray t meth
+  method subarray : int -> int -> ('a, 'b, 'c) typedArray t meth
 
-  method subarray_toEnd : int -> ('a, 'b) typedArray t meth
+  method subarray_toEnd : int -> ('a, 'b, 'c) typedArray t meth
 
-  method slice : int -> int -> ('a, 'b) typedArray t meth
+  method slice : int -> int -> ('a, 'b, 'c) typedArray t meth
 
-  method slice_toEnd : int -> ('a, 'b) typedArray t meth
+  method slice_toEnd : int -> ('a, 'b, 'c) typedArray t meth
 
-  method _content_type_ : 'b optdef readonly_prop
+  (* This fake method is needed for typing purposes. Without it, ['b] would not
+     be constrained. *)
+  method _content_type_ : ('b * 'c) optdef readonly_prop
 end
 
-type int8Array = (int, Bigarray.int8_signed_elt) typedArray
+type int8Array = (int, int, Bigarray.int8_signed_elt) typedArray
 
-type uint8Array = (int, Bigarray.int8_unsigned_elt) typedArray
+type uint8Array = (int, int, Bigarray.int8_unsigned_elt) typedArray
 
-type int16Array = (int, Bigarray.int16_signed_elt) typedArray
+type int16Array = (int, int, Bigarray.int16_signed_elt) typedArray
 
-type uint16Array = (int, Bigarray.int16_unsigned_elt) typedArray
+type uint16Array = (int, int, Bigarray.int16_unsigned_elt) typedArray
 
-type int32Array = (int32, Bigarray.int32_elt) typedArray
+type int32Array = (int32, Int32.t, Bigarray.int32_elt) typedArray
 
-type uint32Array = (int32, Bigarray.int32_elt) typedArray
+type uint32Array = (uint32, Int32.t, Bigarray.int32_elt) typedArray
 
-type float32Array = (float, Bigarray.float32_elt) typedArray
+type float32Array = (number_t, float, Bigarray.float32_elt) typedArray
 
-type float64Array = (float, Bigarray.float64_elt) typedArray
+type float64Array = (number_t, float, Bigarray.float64_elt) typedArray
 
-val kind : ('a, 'b) typedArray t -> ('a, 'b) Bigarray.kind
+type ('bigarray, 'typed_array, 'elt) type' =
+  | Char : (int, char, Bigarray.int8_unsigned_elt) type'
+  | Int8_signed : (int, int, Bigarray.int8_signed_elt) type'
+  | Int8_unsigned : (int, int, Bigarray.int8_unsigned_elt) type'
+  | Int16_signed : (int, int, Bigarray.int16_signed_elt) type'
+  | Int16_unsigned : (int, int, Bigarray.int16_unsigned_elt) type'
+  | Int32_signed : (int32, Int32.t, Bigarray.int32_elt) type'
+  | Int32_unsigned : (uint32, Int32.t, Bigarray.int32_elt) type'
+  | Float32 : (number_t, float, Bigarray.float32_elt) type'
+  | Float64 : (number_t, float, Bigarray.float64_elt) type'
+
+val kind : ('typed_array, 'bigarray, 'elt) typedArray t -> ('bigarray, 'elt) Bigarray.kind
 
 val from_genarray :
-  ('a, 'b, Bigarray.c_layout) Bigarray.Genarray.t -> ('a, 'b) typedArray t
+     ('typed_array, 'bigarray, 'elt) type'
+  -> ('bigarray, 'elt, Bigarray.c_layout) Bigarray.Genarray.t
+  -> ('typed_array, 'bigarray, 'elt) typedArray t
 
-val to_genarray : ('a, 'b) typedArray t -> ('a, 'b, Bigarray.c_layout) Bigarray.Genarray.t
+val to_genarray :
+     ('typed_array, 'bigarray, 'elt) typedArray t
+  -> ('bigarray, 'elt, Bigarray.c_layout) Bigarray.Genarray.t
 
 val int8Array : (int -> int8Array t) constr
 
@@ -167,11 +186,11 @@ val float64Array_fromBuffer : (arrayBuffer t -> float64Array t) constr
 
 val float64Array_inBuffer : (arrayBuffer t -> int -> int -> float64Array t) constr
 
-val set : ('a, 'b) typedArray t -> int -> 'a -> unit
+val set : ('a, _, _) typedArray t -> int -> 'a -> unit
 
-val get : ('a, 'b) typedArray t -> int -> 'a optdef
+val get : ('a, _, _) typedArray t -> int -> 'a optdef
 
-val unsafe_get : ('a, 'b) typedArray t -> int -> 'a
+val unsafe_get : ('a, _, _) typedArray t -> int -> 'a
 
 class type dataView = object
   inherit arrayBufferView
@@ -188,9 +207,9 @@ class type dataView = object
 
   method getUint16_ : int -> bool t -> int meth
 
-  method getInt32 : int -> int meth
+  method getInt32 : int -> int32 meth
 
-  method getInt32_ : int -> bool t -> int meth
+  method getInt32_ : int -> bool t -> int32 meth
 
   method getUint32 : int -> uint32 meth
 
@@ -216,9 +235,9 @@ class type dataView = object
 
   method setUint16_ : int -> int -> bool t -> unit meth
 
-  method setInt32 : int -> int -> unit meth
+  method setInt32 : int -> int32 -> unit meth
 
-  method setInt32_ : int -> int -> bool t -> unit meth
+  method setInt32_ : int -> int32 -> bool t -> unit meth
 
   method setUint32 : int -> uint32 -> unit meth
 

--- a/lib/tests/test_typed_array.ml
+++ b/lib/tests/test_typed_array.ml
@@ -18,24 +18,24 @@
 
 open Js_of_ocaml
 open Typed_array
-open Bigarray
+open! Bigarray
 
 type ('a, 'b) ba = ('a, 'b, c_layout) Genarray.t
 
-type ('a, 'b) ta = ('a, 'b) typedArray
+type ('a, 'b, 'c) ta = ('a, 'b, 'c) typedArray
 
 module Setup = struct
-  type (_, _) t =
-    | Int8 : (int, Bigarray.int8_signed_elt) t
-    | Uint8 : (int, Bigarray.int8_unsigned_elt) t
-    | Int16 : (int, Bigarray.int16_signed_elt) t
-    | Uint16 : (int, Bigarray.int16_unsigned_elt) t
-    | Int32 : (int32, Bigarray.int32_elt) t
-    | Float32 : (float, Bigarray.float32_elt) t
-    | Float64 : (float, Bigarray.float64_elt) t
+  type (_, _, _) t =
+    | Int8 : (int, int, Bigarray.int8_signed_elt) t
+    | Uint8 : (int, int, Bigarray.int8_unsigned_elt) t
+    | Int16 : (int, int, Bigarray.int16_signed_elt) t
+    | Uint16 : (int, int, Bigarray.int16_unsigned_elt) t
+    | Int32 : (Js.number_t, Int32.t, Bigarray.int32_elt) t
+    | Float32 : (Js.number_t, float, Bigarray.float32_elt) t
+    | Float64 : (Js.number_t, float, Bigarray.float64_elt) t
 end
 
-let kind_of_setup : type a b. (a, b) Setup.t -> (a, b) kind = function
+let kind_of_setup : type a b c. (a, b, c) Setup.t -> (b, c) kind = function
   | Setup.Int8 -> Int8_signed
   | Setup.Uint8 -> Int8_unsigned
   | Setup.Int16 -> Int16_signed
@@ -44,7 +44,25 @@ let kind_of_setup : type a b. (a, b) Setup.t -> (a, b) kind = function
   | Setup.Float32 -> Float32
   | Setup.Float64 -> Float64
 
-let ta_type_is_correct : type a b. (a, b) Setup.t -> (a, b) ta Js.t -> bool =
+let convert : type a b c. (a, b, c) Setup.t -> a -> b = function
+  | Setup.Int8 -> Fun.id
+  | Setup.Uint8 -> Fun.id
+  | Setup.Int16 -> Fun.id
+  | Setup.Uint16 -> Fun.id
+  | Setup.Int32 -> fun f -> Int32.of_float (Js.to_float f)
+  | Setup.Float32 -> Js.to_float
+  | Setup.Float64 -> Js.to_float
+
+let type_of_setup : type a b c. (a, b, c) Setup.t -> (a, b, c) type' = function
+  | Setup.Int8 -> Int8_signed
+  | Setup.Uint8 -> Int8_unsigned
+  | Setup.Int16 -> Int16_signed
+  | Setup.Uint16 -> Int16_unsigned
+  | Setup.Int32 -> Int32_signed
+  | Setup.Float32 -> Float32
+  | Setup.Float64 -> Float64
+
+let ta_type_is_correct : type a b c. (a, b, c) Setup.t -> (a, b, c) ta Js.t -> bool =
  fun setup a ->
   let get_prop prop obj = Js.Unsafe.get obj (Js.string prop) in
   let name = a |> get_prop "constructor" |> get_prop "name" |> Js.to_string in
@@ -58,7 +76,7 @@ let ta_type_is_correct : type a b. (a, b) Setup.t -> (a, b) ta Js.t -> bool =
   | Setup.Int32, "Int32Array" -> true
   | _, _ -> false
 
-let kind_field_is_correct : type a b. (a, b) Setup.t -> (a, b) ba -> bool =
+let kind_field_is_correct : type a b c. (a, b, c) Setup.t -> (b, c) ba -> bool =
  fun setup a ->
   (* To trigger a `false`, modify the `kind` integer hard coded in the
    * `caml_ba_kind_of_typed_array` stub
@@ -73,7 +91,7 @@ let kind_field_is_correct : type a b. (a, b) Setup.t -> (a, b) ba -> bool =
   | Int32, Int32 -> true
   | _, _ -> false
 
-let ba_of_array : type a b. (a, b) Setup.t -> a array -> (a, b) ba =
+let ba_of_array : type a b c. (a, b, c) Setup.t -> b array -> (b, c) ba =
  fun setup a -> Array1.of_array (kind_of_setup setup) c_layout a |> genarray_of_array1
 
 let array_of_ba : type a b. (a, b) ba -> a array =
@@ -85,16 +103,19 @@ let array_of_ba : type a b. (a, b) ba -> a array =
   in
   aux 0 |> Array.of_list
 
-let array_of_ta : type a b. (a, b) Setup.t -> (a, b) ta Js.t -> a array =
- fun _ a ->
+let array_of_ta : type a b c. (a, b, c) Setup.t -> (a, b, c) ta Js.t -> b array =
+ fun setup a ->
   let len = a##.length in
-  let rec aux i = if i == len then [] else unsafe_get a i :: aux (i + 1) in
+  let rec aux i =
+    if i == len then [] else convert setup (unsafe_get a i) :: aux (i + 1)
+  in
   aux 0 |> Array.of_list
 
-let test setup a0 =
+let test : type a b c. (a, b, c) Setup.t -> b array -> unit =
+ fun setup a0 ->
   let a1 = ba_of_array setup a0 in
 
-  let a2 = from_genarray a1 in
+  let a2 = from_genarray (type_of_setup setup) a1 in
   if not (array_of_ta setup a2 = a0) then print_endline "`a2` doesnt match `a0`";
   if not (ta_type_is_correct setup a2) then print_endline "corrupted typedArray type";
 

--- a/lib/tests/test_typed_array.ml
+++ b/lib/tests/test_typed_array.ml
@@ -28,7 +28,6 @@ module Setup = struct
   type (_, _, _) t =
     | Int8 : (int, int, Bigarray.int8_signed_elt) t
     | Uint8 : (int, int, Bigarray.int8_unsigned_elt) t
-    | Char : (char, char, Bigarray.int8_unsigned_elt) t
     | Int16 : (int, int, Bigarray.int16_signed_elt) t
     | Uint16 : (int, int, Bigarray.int16_unsigned_elt) t
     | Int32 : (Js.number_t, Int32.t, Bigarray.int32_elt) t
@@ -39,7 +38,6 @@ end
 let kind_of_setup : type a b c. (a, b, c) Setup.t -> (b, c) kind = function
   | Setup.Int8 -> Int8_signed
   | Setup.Uint8 -> Int8_unsigned
-  | Setup.Char -> Char
   | Setup.Int16 -> Int16_signed
   | Setup.Uint16 -> Int16_unsigned
   | Setup.Int32 -> Int32
@@ -49,7 +47,6 @@ let kind_of_setup : type a b c. (a, b, c) Setup.t -> (b, c) kind = function
 let convert : type a b c. (a, b, c) Setup.t -> a -> b = function
   | Setup.Int8 -> Fun.id
   | Setup.Uint8 -> Fun.id
-  | Setup.Char -> Fun.id
   | Setup.Int16 -> Fun.id
   | Setup.Uint16 -> Fun.id
   | Setup.Int32 -> fun f -> Int32.of_float (Js.to_float f)
@@ -59,7 +56,6 @@ let convert : type a b c. (a, b, c) Setup.t -> a -> b = function
 let type_of_setup : type a b c. (a, b, c) Setup.t -> (a, b, c) Typed_array.kind = function
   | Setup.Int8 -> Int8_signed
   | Setup.Uint8 -> Int8_unsigned
-  | Setup.Char -> Char
   | Setup.Int16 -> Int16_signed
   | Setup.Uint16 -> Int16_unsigned
   | Setup.Int32 -> Int32_signed
@@ -78,7 +74,6 @@ let ta_type_is_correct : type a b c. (a, b, c) Setup.t -> (a, b, c) ta Js.t -> b
   | Setup.Int16, "Int16Array" -> true
   | Setup.Uint16, "Uint16Array" -> true
   | Setup.Int32, "Int32Array" -> true
-  | Setup.Char, "Uint8Array" -> true
   | _, _ -> false
 
 let kind_field_is_correct : type a b c. (a, b, c) Setup.t -> (b, c) ba -> bool =
@@ -94,12 +89,6 @@ let kind_field_is_correct : type a b c. (a, b, c) Setup.t -> (b, c) ba -> bool =
   | Int16_signed, Int16_signed -> true
   | Int16_unsigned, Int16_unsigned -> true
   | Int32, Int32 -> true
-  | Char, (ba_kind : (char, int8_unsigned_elt) Bigarray.kind) -> (
-      (* For chars the underlying typed array is an Uint8Array so the
-         only well-typed pattern [Char, Char] is not what will appear at
-         runtime, namely [Char, Int8_unsigned] *)
-      match (Obj.magic ba_kind : (int, int8_unsigned_elt) Bigarray.kind) with
-      | Int8_unsigned -> true)
   | _, _ -> false
 
 let ba_of_array : type a b c. (a, b, c) Setup.t -> b array -> (b, c) ba =
@@ -174,10 +163,6 @@ let%expect_test "uint8" =
   let bytes'' = Typed_array.Bytes.of_arrayBuffer buffer in
   if not (Stdlib.Bytes.equal bytes'' bytes)
   then print_endline "bytes from arrayBuffer not equal to bytes from of_uint8Array";
-  [%expect {||}]
-
-let%expect_test "char" =
-  test Setup.Char [| Char.chr 0; Char.chr 64; Char.chr 104; Char.chr 255 |];
   [%expect {||}]
 
 let%expect_test "int16" =

--- a/lib/tests/test_typed_array.ml
+++ b/lib/tests/test_typed_array.ml
@@ -53,7 +53,7 @@ let convert : type a b c. (a, b, c) Setup.t -> a -> b = function
   | Setup.Float32 -> Js.to_float
   | Setup.Float64 -> Js.to_float
 
-let type_of_setup : type a b c. (a, b, c) Setup.t -> (a, b, c) type' = function
+let type_of_setup : type a b c. (a, b, c) Setup.t -> (a, b, c) Typed_array.kind = function
   | Setup.Int8 -> Int8_signed
   | Setup.Uint8 -> Int8_unsigned
   | Setup.Int16 -> Int16_signed

--- a/lib/tests/test_typed_array.ml
+++ b/lib/tests/test_typed_array.ml
@@ -28,6 +28,7 @@ module Setup = struct
   type (_, _, _) t =
     | Int8 : (int, int, Bigarray.int8_signed_elt) t
     | Uint8 : (int, int, Bigarray.int8_unsigned_elt) t
+    | Char : (char, char, Bigarray.int8_unsigned_elt) t
     | Int16 : (int, int, Bigarray.int16_signed_elt) t
     | Uint16 : (int, int, Bigarray.int16_unsigned_elt) t
     | Int32 : (Js.number_t, Int32.t, Bigarray.int32_elt) t
@@ -38,6 +39,7 @@ end
 let kind_of_setup : type a b c. (a, b, c) Setup.t -> (b, c) kind = function
   | Setup.Int8 -> Int8_signed
   | Setup.Uint8 -> Int8_unsigned
+  | Setup.Char -> Char
   | Setup.Int16 -> Int16_signed
   | Setup.Uint16 -> Int16_unsigned
   | Setup.Int32 -> Int32
@@ -47,6 +49,7 @@ let kind_of_setup : type a b c. (a, b, c) Setup.t -> (b, c) kind = function
 let convert : type a b c. (a, b, c) Setup.t -> a -> b = function
   | Setup.Int8 -> Fun.id
   | Setup.Uint8 -> Fun.id
+  | Setup.Char -> Fun.id
   | Setup.Int16 -> Fun.id
   | Setup.Uint16 -> Fun.id
   | Setup.Int32 -> fun f -> Int32.of_float (Js.to_float f)
@@ -56,6 +59,7 @@ let convert : type a b c. (a, b, c) Setup.t -> a -> b = function
 let type_of_setup : type a b c. (a, b, c) Setup.t -> (a, b, c) Typed_array.kind = function
   | Setup.Int8 -> Int8_signed
   | Setup.Uint8 -> Int8_unsigned
+  | Setup.Char -> Char
   | Setup.Int16 -> Int16_signed
   | Setup.Uint16 -> Int16_unsigned
   | Setup.Int32 -> Int32_signed
@@ -74,6 +78,7 @@ let ta_type_is_correct : type a b c. (a, b, c) Setup.t -> (a, b, c) ta Js.t -> b
   | Setup.Int16, "Int16Array" -> true
   | Setup.Uint16, "Uint16Array" -> true
   | Setup.Int32, "Int32Array" -> true
+  | Setup.Char, "Uint8Array" -> true
   | _, _ -> false
 
 let kind_field_is_correct : type a b c. (a, b, c) Setup.t -> (b, c) ba -> bool =
@@ -89,6 +94,12 @@ let kind_field_is_correct : type a b c. (a, b, c) Setup.t -> (b, c) ba -> bool =
   | Int16_signed, Int16_signed -> true
   | Int16_unsigned, Int16_unsigned -> true
   | Int32, Int32 -> true
+  | Char, _ ->
+      (* For chars the underlying typed array is an Uint8Array so the
+         only well-typed pattern [Char, Char] is not what will appear at
+         runtime, namely [Char, Int8_unsigned] *)
+      (match (Obj.magic Genarray.kind a : (int, int8_unsigned_elt) Bigarray.kind) with
+      | Int8_unsigned -> true)
   | _, _ -> false
 
 let ba_of_array : type a b c. (a, b, c) Setup.t -> b array -> (b, c) ba =
@@ -163,6 +174,10 @@ let%expect_test "uint8" =
   let bytes'' = Typed_array.Bytes.of_arrayBuffer buffer in
   if not (Stdlib.Bytes.equal bytes'' bytes)
   then print_endline "bytes from arrayBuffer not equal to bytes from of_uint8Array";
+  [%expect {||}]
+
+let%expect_test "char" =
+  test Setup.Char [| Char.chr 0; Char.chr 64; Char.chr 104; Char.chr 255 |];
   [%expect {||}]
 
 let%expect_test "int16" =

--- a/lib/tests/test_typed_array.ml
+++ b/lib/tests/test_typed_array.ml
@@ -94,11 +94,11 @@ let kind_field_is_correct : type a b c. (a, b, c) Setup.t -> (b, c) ba -> bool =
   | Int16_signed, Int16_signed -> true
   | Int16_unsigned, Int16_unsigned -> true
   | Int32, Int32 -> true
-  | Char, _ ->
+  | Char, (ba_kind : (char, int8_unsigned_elt) Bigarray.kind) -> (
       (* For chars the underlying typed array is an Uint8Array so the
          only well-typed pattern [Char, Char] is not what will appear at
          runtime, namely [Char, Int8_unsigned] *)
-      (match (Obj.magic Genarray.kind a : (int, int8_unsigned_elt) Bigarray.kind) with
+      match (Obj.magic ba_kind : (int, int8_unsigned_elt) Bigarray.kind) with
       | Int8_unsigned -> true)
   | _, _ -> false
 


### PR DESCRIPTION
**Note:** This PR depends on #1649 and is based on top of it. ~~The feature change consists in the last two commits.~~ edit: #1649 has been merged.

This:

- Updates the typing of `Typed_array` so that they work with the Wasm backend as well
- Adds tests for the new `Typed_array.Bytes` module.

This is part of a series of PRs intending to reduce the diff between js_of_ocaml and wasm_of_ocaml (see https://github.com/ocaml-wasm/wasm_of_ocaml/issues/47).