### PR TITLE
Build_info/Unit_info: conversion to and from string maps

### DIFF
--- a/compiler/lib/build_info.ml
+++ b/compiler/lib/build_info.ml
@@ -90,6 +90,10 @@ let parse s =
       in
       Some t
 
+let to_map : t -> string StringMap.t = Fun.id
+
+let of_map : string StringMap.t -> t = Fun.id
+
 exception
   Incompatible_build_info of
     { key : string

--- a/compiler/lib/build_info.mli
+++ b/compiler/lib/build_info.mli
@@ -34,6 +34,10 @@ val to_string : t -> string
 
 val parse : string -> t option
 
+val to_map : t -> string StringMap.t
+
+val of_map : string StringMap.t -> t
+
 val with_kind : t -> kind -> t
 
 exception


### PR DESCRIPTION
This is part of a series of PRs intending to reduce the diff between js_of_ocaml and wasm_of_ocaml (see https://github.com/ocaml-wasm/wasm_of_ocaml/issues/47).