### PR TITLE
Runtime: implement Json output for Wasm

### DIFF
--- a/lib/js_of_ocaml/js_of_ocaml_stubs.c
+++ b/lib/js_of_ocaml/js_of_ocaml_stubs.c
@@ -4,6 +4,10 @@ void caml_bytes_of_array () {
   caml_fatal_error("Unimplemented Javascript primitive caml_bytes_of_array!");
 }
 
+void caml_custom_identifier () {
+  caml_fatal_error("Unimplemented Javascript primitive caml_custom_identifier!");
+}
+
 void caml_js_error_of_exception () {
   caml_fatal_error("Unimplemented Javascript primitive caml_js_error_of_exception!");
 }

--- a/lib/js_of_ocaml/json.ml
+++ b/lib/js_of_ocaml/json.ml
@@ -173,8 +173,10 @@ let use_native_stringify () = !use_native_stringify_
 
 let set_use_native_stringify b = use_native_stringify_ := b
 
+let output_ x = to_json (Obj.repr x)
+
 let output obj =
   match Sys.backend_type with
   | Other "js_of_ocaml" when use_native_stringify () ->
       json##stringify_ obj (Js.wrap_callback output_reviver)
-  | _ -> Js.string (to_json (Obj.repr obj))
+  | _ -> Js.string (output_ obj)

--- a/lib/js_of_ocaml/json.ml
+++ b/lib/js_of_ocaml/json.ml
@@ -141,9 +141,10 @@ let input_reviver =
 let unsafe_input s =
   match Sys.backend_type with
   | Other "wasm_of_ocaml" ->
-      failwith
-        "Json.unsafe_input: not implemented (and not planned) in the Wasm backend as the \
-         inverse of `output` is not implementable"
+      (* https://github.com/ocsigen/js_of_ocaml/pull/1660#discussion_r1731099372
+         The encoding of OCaml values is ambiguous since both integers and floats
+         are mapped to numbers *)
+      failwith "Json.unsafe_input: not implemented in the Wasm backend"
   | _ -> json##parse_ s input_reviver
 
 class type obj = object

--- a/lib/js_of_ocaml/json.ml
+++ b/lib/js_of_ocaml/json.ml
@@ -140,7 +140,10 @@ let input_reviver =
 
 let unsafe_input s =
   match Sys.backend_type with
-  | Other "wasm_of_ocaml" -> failwith "Json.unsafe_input: not implemented"
+  | Other "wasm_of_ocaml" ->
+      failwith
+        "Json.unsafe_input: not implemented (and not planned) in the Wasm backend as the \
+         inverse of `output` is not implementable"
   | _ -> json##parse_ s input_reviver
 
 class type obj = object

--- a/lib/js_of_ocaml/json.ml
+++ b/lib/js_of_ocaml/json.ml
@@ -164,10 +164,10 @@ let output_reviver _key (value : Unsafe.any) : Obj.t =
   else Obj.repr value
 
 let use_native_stringify_ =
-  ref (
-    match Sys.backend_type with
-      | Other "js_of_ocaml" -> true
-      | Native | Bytecode | Other _ -> false)
+  ref
+    (match Sys.backend_type with
+    | Other "js_of_ocaml" -> true
+    | Native | Bytecode | Other _ -> false)
 
 let use_native_stringify () = !use_native_stringify_
 

--- a/lib/js_of_ocaml/json.mli
+++ b/lib/js_of_ocaml/json.mli
@@ -26,6 +26,10 @@ val unsafe_input : Js.js_string Js.t -> 'a
 (** Unmarshal a string in JSON format as an OCaml value (unsafe but
     fast !). *)
 
+(**/**)
+
+val output_ : 'a -> string
+
 val set_use_native_stringify : bool -> unit
 (** Only affects js_of_ocaml. Whether to use native Javascript [stringify] to
     turn a value into JSON in {!val:output}. Otherwise, fall back to the slower

--- a/lib/js_of_ocaml/json.mli
+++ b/lib/js_of_ocaml/json.mli
@@ -25,3 +25,12 @@ val output : 'a -> Js.js_string Js.t
 val unsafe_input : Js.js_string Js.t -> 'a
 (** Unmarshal a string in JSON format as an OCaml value (unsafe but
     fast !). *)
+
+val set_use_native_stringify : bool -> unit
+(** Only affects js_of_ocaml. Whether to use native Javascript [stringify] to
+    turn a value into JSON in {!val:output}. Otherwise, fall back to the slower
+    method used by other backends, such as wasm_of_ocaml. *)
+
+val use_native_stringify : unit -> bool
+(** Whether js_of_ocaml is using [stringify] in {!val:output}. See
+    {!val:set_use_native_stringify}. *)

--- a/lib/tests/test_json.ml
+++ b/lib/tests/test_json.ml
@@ -23,29 +23,35 @@ open Js_of_ocaml
 let round_trip x =
   let s = Json.output x in
   Printf.printf "%s\n" (Js.to_bytestring s);
-  let y = Json.unsafe_input s in
-  Printf.printf "%b\n" (x = y)
+  (* Other direction of the round-trip (unmarshalling from JSON) is only
+     available with js_of_ocaml *)
+  match Sys.backend_type with
+  | Other "js_of_ocaml" when Json.use_native_stringify () ->
+      let y = Json.unsafe_input s in
+      if not (x = y) then Printf.printf "not invariant by round-trip\n"
+  | _ -> ()
 
 let%expect_test _ =
-  round_trip 123L;
-  [%expect {|
-    [255,123,0,0]
-    true |}];
-  round_trip "asd";
-  [%expect {|
-    "asd"
-    true |}];
-  round_trip "\000\255\254";
-  [%expect {|
-    "\u0000ÿþ"
-    true |}];
-  round_trip (2, 3);
-  round_trip (2., 3.);
-  round_trip (2.2, 3.3);
-  [%expect {|
-    [0,2,3]
-    true
-    [0,2,3]
-    true
-    [0,2.2,3.3]
-    true |}]
+  let tests ~use_native_stringify =
+    let () = Json.set_use_native_stringify use_native_stringify in
+    round_trip 123L;
+    [%expect {|
+      [255,123,0,0] |}];
+    round_trip "asd";
+    [%expect {|
+      "asd" |}];
+    round_trip "\000\255\254";
+    [%expect {|
+      "\u0000ÿþ" |}];
+    round_trip (2, 3);
+    round_trip (2., 3.);
+    round_trip (2.2, 3.3);
+    [%expect {|
+      [0,2,3]
+      [0,2,3]
+      [0,2.2,3.3] |}]
+  in
+  tests ~use_native_stringify:false;
+  match Sys.backend_type with
+  | Other "js_of_ocaml" -> tests ~use_native_stringify:true
+  | _ -> ()

--- a/runtime/obj.js
+++ b/runtime/obj.js
@@ -214,3 +214,9 @@ function caml_is_continuation_tag(t) {
 function caml_is_continuation_tag(t) {
   return (t == 245) ? 1 : 0;
 }
+
+//Provides: caml_custom_identifier
+//Requires: caml_string_of_jsstring
+function caml_custom_identifier (o) {
+  return caml_string_of_jsstring(o.caml_custom);
+}


### PR DESCRIPTION
This is part of a series of PRs intending to reduce the diff between js_of_ocaml and wasm_of_ocaml (see https://github.com/ocaml-wasm/wasm_of_ocaml/issues/47).

In Wasm, some additional functions are required to output Json.