### PR TITLE
Generate: explicit initialization

### DIFF
--- a/compiler/bin-js_of_ocaml/check_runtime.ml
+++ b/compiler/bin-js_of_ocaml/check_runtime.ml
@@ -43,6 +43,7 @@ let print_groups output l =
               output_string output (Printf.sprintf "%s\n" name)))
 
 let f (runtime_files, bytecode, target_env) =
+  Linker.reset ();
   let runtime_files, builtin =
     List.partition_map runtime_files ~f:(fun name ->
         match Builtins.find name with

--- a/compiler/bin-js_of_ocaml/compile.ml
+++ b/compiler/bin-js_of_ocaml/compile.ml
@@ -91,6 +91,7 @@ let run
   let include_cmis = toplevel && not no_cmis in
   let custom_header = common.Jsoo_cmdline.Arg.custom_header in
   Jsoo_cmdline.Arg.eval common;
+  Linker.reset ();
   (match output_file with
   | `Stdout, _ -> ()
   | `Name name, _ when debug_mem () -> Debug.start_profiling name

--- a/compiler/bin-js_of_ocaml/link.ml
+++ b/compiler/bin-js_of_ocaml/link.ml
@@ -151,6 +151,7 @@ let f
     ; toplevel
     } =
   Jsoo_cmdline.Arg.eval common;
+  Linker.reset ();
   let with_output f =
     match output_file with
     | None -> f stdout

--- a/compiler/lib-dynlink/js_of_ocaml_compiler_dynlink.ml
+++ b/compiler/lib-dynlink/js_of_ocaml_compiler_dynlink.ml
@@ -29,6 +29,7 @@ let () =
   let global = J.pure_js_expr "globalThis" in
   Config.Flag.set "use-js-string" (Jsoo_runtime.Sys.Config.use_js_string ());
   Config.Flag.set "effects" (Jsoo_runtime.Sys.Config.effects ());
+  Linker.reset ();
   (* this needs to stay synchronized with toplevel.js *)
   let toplevel_compile (s : string) (debug : Instruct.debug_event list array) :
       unit -> J.t =

--- a/compiler/lib/generate.ml
+++ b/compiler/lib/generate.ml
@@ -2054,5 +2054,3 @@ let init () =
   Hashtbl.iter
     (fun name (k, _) -> Primitive.register name k None None)
     internal_primitives
-
-let () = init ()

--- a/compiler/lib/primitive.ml
+++ b/compiler/lib/primitive.ml
@@ -98,17 +98,17 @@ let register p k kargs arity =
         (string_of_kind k));
   add_external p;
   (match arity with
-  | Some a -> Hashtbl.add arities p a
+  | Some a -> Hashtbl.replace arities p a
   | _ -> ());
   (match kargs with
-  | Some k -> Hashtbl.add kind_args_tbl p k
+  | Some k -> Hashtbl.replace kind_args_tbl p k
   | _ -> ());
-  Hashtbl.add kinds p k
+  Hashtbl.replace kinds p k
 
 let alias nm nm' =
   add_external nm';
   add_external nm;
-  Hashtbl.add aliases nm nm'
+  Hashtbl.replace aliases nm nm'
 
 let named_values = ref StringSet.empty
 


### PR DESCRIPTION
This is part of a series of PRs intending to reduce the diff between js_of_ocaml and wasm_of_ocaml (see https://github.com/ocaml-wasm/wasm_of_ocaml/issues/47).