### PR TITLE
Improved global deadcode elimination

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
   requested at compile time (--enable with-js-error) or at startup (OCAMLRUNPARAM=b=1)
 * Runtime: allow dynlink of precompiled js with separate compilation (#1676)
 * Lib: Modify Typed_array API for compatibility with WebAssembly
+* Compiler: improved global dead code elimination (#2206)
 
 
 ## Bug fixes

--- a/compiler/lib/code.ml
+++ b/compiler/lib/code.ml
@@ -452,9 +452,7 @@ type prim_arg =
   | Pv of Var.t
   | Pc of constant
 
-type special =
-  | Undefined
-  | Alias_prim of string
+type special = Alias_prim of string
 
 type mutability =
   | Immutable
@@ -603,7 +601,6 @@ module Print = struct
 
   let special f s =
     match s with
-    | Undefined -> Format.fprintf f "undefined"
     | Alias_prim s -> Format.fprintf f "alias %s" s
 
   let expr f e =

--- a/compiler/lib/code.ml
+++ b/compiler/lib/code.ml
@@ -95,6 +95,8 @@ module Var : sig
 
   module Map : Map.S with type key = t
 
+  module Hashtbl : Hashtbl.S with type key = t
+
   module Tbl : sig
     type key = t
 
@@ -159,6 +161,8 @@ end = struct
     let compare : t -> t -> int = compare
 
     let equal (a : t) (b : t) = a = b
+
+    let hash x = x
   end
 
   include T
@@ -303,6 +307,8 @@ end = struct
         f i (Array.unsafe_get t i)
       done
   end
+
+  module Hashtbl = Hashtbl.Make (T)
 
   module ISet = struct
     type t = BitSet.t

--- a/compiler/lib/code.mli
+++ b/compiler/lib/code.mli
@@ -101,14 +101,6 @@ module Var : sig
       val fold : ('a -> 'acc -> 'acc) -> 'a t -> 'acc -> 'acc
     end
 
-    module DataMap : sig
-      type ('a, 'b) t
-
-      val iter : ('a -> 'b -> unit) -> ('a, 'b) t -> unit
-
-      val fold : ('a -> 'b -> 'acc -> 'acc) -> ('a, 'b) t -> 'acc -> 'acc
-    end
-
     type 'a t
 
     type size = unit
@@ -119,11 +111,7 @@ module Var : sig
 
     val make : size -> 'a -> 'a t
 
-    val make_map : size -> ('a, 'b) DataMap.t t
-
     val make_set : size -> 'a DataSet.t t
-
-    val add_map : ('a, 'b) DataMap.t t -> key -> 'a -> 'b -> unit
 
     val add_set : 'a DataSet.t t -> key -> 'a -> unit
 

--- a/compiler/lib/code.mli
+++ b/compiler/lib/code.mli
@@ -210,9 +210,7 @@ type prim_arg =
   | Pv of Var.t
   | Pc of constant
 
-type special =
-  | Undefined
-  | Alias_prim of string
+type special = Alias_prim of string
 
 type mutability =
   | Immutable

--- a/compiler/lib/code.mli
+++ b/compiler/lib/code.mli
@@ -88,6 +88,8 @@ module Var : sig
 
   module Map : Map.S with type key = t
 
+  module Hashtbl : Hashtbl.S with type key = t
+
   module Tbl : sig
     type key = t
 

--- a/compiler/lib/dgraph.mli
+++ b/compiler/lib/dgraph.mli
@@ -104,3 +104,39 @@ module Make_Imperative
       -> D.t NTbl.t
   end
 end
+
+module type ACTION = sig
+  type t
+end
+
+module type DOMAIN = sig
+  type t
+
+  val equal : t -> t -> bool
+
+  val bot : t
+
+  val top : t
+
+  val join : t -> t -> t
+end
+
+module Solver
+    (N : sig
+      type t
+    end)
+    (NSet : ISet with type elt = N.t)
+    (NTbl : Tbl with type key = N.t)
+    (A : ACTION)
+    (D : DOMAIN) : sig
+  type t =
+    { domain : NSet.t
+    ; iter_children : (N.t -> A.t -> unit) -> N.t -> unit
+    }
+
+  val f :
+       state:D.t NTbl.t
+    -> t
+    -> (state:D.t NTbl.t -> dep:N.t -> target:N.t -> action:A.t -> D.t)
+    -> unit
+end

--- a/compiler/lib/driver.ml
+++ b/compiler/lib/driver.ml
@@ -667,7 +667,7 @@ let full ~standalone ~wrap_with_fun ~profile ~link ~source_map formatter d p =
   in
   let deadcode_sentinal =
     (* If deadcode is disabled, this field is just fresh variable *)
-    Code.Var.fresh_n "undef"
+    Code.Var.fresh_n "dummy"
   in
   let opt =
     specialize_js_once

--- a/compiler/lib/generate.ml
+++ b/compiler/lib/generate.ml
@@ -1112,7 +1112,11 @@ let rec translate_expr ctx queue loc x e level : _ * J.statement_list =
             (st, loc) :: rem
         | _ -> clo
       in
-      let clo = J.EFun (None, J.fun_ (List.map args ~f:(fun v -> J.V v)) clo loc) in
+      let clo =
+        J.EFun
+          ( None
+          , J.fun_ (List.map args ~f:(fun v -> J.V v)) (Js_simpl.function_body clo) loc )
+      in
       (clo, (fst const_p, fv), queue), []
   | Constant c ->
       let js, instrs = constant ~ctx c level in

--- a/compiler/lib/generate.ml
+++ b/compiler/lib/generate.ml
@@ -1124,8 +1124,6 @@ let rec translate_expr ctx queue loc x e level : _ * J.statement_list =
   | Special (Alias_prim name) ->
       let prim = Share.get_prim (runtime_fun ctx) name ctx.Ctx.share in
       (prim, const_p, queue), []
-  | Special Undefined ->
-      (J.(EVar (ident (Utf8_string.of_string_exn "undefined"))), const_p, queue), []
   | Prim (Extern "debugger", _) ->
       let ins =
         if Config.Flag.debugger () then J.Debugger_statement else J.Empty_statement

--- a/compiler/lib/global_deadcode.ml
+++ b/compiler/lib/global_deadcode.ml
@@ -423,7 +423,7 @@ end
 
 (** Add a sentinal variable declaration to the IR. The fresh variable is assigned to `undefined`. *)
 let add_sentinal p sentinal =
-  let instr, loc = Let (sentinal, Special Undefined), noloc in
+  let instr, loc = Let (sentinal, Constant (Int 0l)), noloc in
   Code.prepend p [ instr, loc ]
 
 (** Run the liveness analysis and replace dead variables with the given sentinal. *)

--- a/compiler/lib/global_deadcode.ml
+++ b/compiler/lib/global_deadcode.ml
@@ -206,7 +206,8 @@ let liveness prog pure_funs (global_info : Global_flow.info) =
     let live_fields =
       match Var.Tbl.get live_vars v with
       | Live fields -> Live (IntSet.add i fields)
-      | Top | Dead -> Live (IntSet.singleton i)
+      | Top -> Top
+      | Dead -> Live (IntSet.singleton i)
     in
     Var.Tbl.set live_vars v live_fields
   in

--- a/compiler/lib/global_deadcode.ml
+++ b/compiler/lib/global_deadcode.ml
@@ -445,7 +445,7 @@ let f p ~deadcode_sentinal global_info =
   (* Print debug info *)
   if debug ()
   then (
-    Format.eprintf "Before Zeroing:\n";
+    Format.eprintf "Before Zeroing:@.";
     Code.Print.program (fun _ _ -> "") p;
     Print.print_liveness live_vars;
     Print.print_uses uses;
@@ -454,7 +454,7 @@ let f p ~deadcode_sentinal global_info =
   let p = zero p deadcode_sentinal live_table in
   if debug ()
   then (
-    Format.printf "After Zeroing:\n";
+    Format.eprintf "After Zeroing:@.";
     Code.Print.program (fun _ _ -> "") p);
-  if times () then Format.eprintf "  deadcode dgraph.: %a@." Timer.print t;
+  if times () then Format.eprintf "  global dead code elim.: %a@." Timer.print t;
   p

--- a/compiler/lib/global_deadcode.ml
+++ b/compiler/lib/global_deadcode.ml
@@ -93,6 +93,18 @@ end = struct
     | Dead, Dead -> Dead
 end
 
+let iter_with_scope prog f =
+  Code.fold_closures
+    prog
+    (fun scope _ (pc, _) () ->
+      Code.traverse
+        { fold = fold_children }
+        (fun pc () -> f scope (Addr.Map.find pc prog.blocks))
+        pc
+        prog.blocks
+        ())
+    ()
+
 let definitions prog =
   let defs = Var.Tbl.make () Param in
   let set_def x d = Var.Tbl.set defs x d in
@@ -117,7 +129,11 @@ let variable_may_escape x (global_info : Global_flow.info) =
 (** Type of variable usage. *)
 type usage_kind =
   | Compute  (** variable y is used to compute x *)
-  | Propagate  (** values of y propagate to x *)
+  | Propagate of
+      { scope : Var.t list
+      ; src : Var.t
+      }  (** values of y propagate to x when the scope is live *)
+  | Scope  (** variable x is defined in function y *)
 
 (** Compute the adjacency list for the dependency graph of given program. An edge between
     variables [x] and [y] is marked [Compute] if [x] is used in the definition of [y]. It is marked
@@ -125,21 +141,27 @@ type usage_kind =
 
     We use information from global flow to try to add edges between function calls and their return values
     at known call sites. *)
-let usages prog (global_info : Global_flow.info) : (usage_kind * Var.Set.t) list Var.Tbl.t
-    =
+let usages prog (global_info : Global_flow.info) scoped_live_vars :
+    (usage_kind * Var.Set.t) list Var.Tbl.t =
   let uses = Var.Tbl.make () [] in
-  let add_uses kind x vars = Var.Tbl.set uses x ((kind, vars) :: Var.Tbl.get uses x) in
+  let add_uses kind x vars =
+    let p = kind, vars in
+    Var.Tbl.set uses x (p :: Var.Tbl.get uses x);
+    match kind with
+    | Propagate { scope; _ } ->
+        List.iter ~f:(fun z -> Var.Tbl.set uses z (p :: Var.Tbl.get uses z)) scope
+    | _ -> ()
+  in
   let add_use kind x y = add_uses kind x (Var.Set.singleton y) in
-
   let add_arg_dep params args =
-    List.iter2 ~f:(fun x y -> add_use Propagate x y) params args
+    List.iter2 ~f:(fun x y -> add_use (Propagate { scope = []; src = x }) x y) params args
   in
   let add_cont_deps (pc, args) =
     match try Some (Addr.Map.find pc prog.blocks) with Not_found -> None with
     | Some block -> add_arg_dep block.params args
     | None -> () (* Dead continuation *)
   in
-  let add_expr_uses x e : unit =
+  let add_expr_uses scope x e : unit =
     match e with
     | Apply { f; args; _ } ->
         (match Var.Tbl.get global_info.info_approximation f with
@@ -155,8 +177,16 @@ let usages prog (global_info : Global_flow.info) : (usage_kind * Var.Set.t) list
                        So we only need to consider the case when there is an exact application. *)
                     if List.compare_lengths params args = 0
                     then (
-                      add_uses Propagate x (Var.Map.find k global_info.info_return_vals);
-                      List.iter2 ~f:(fun x y -> add_use Propagate x y) params args)
+                      (* Both the function and the call-site must be live *)
+                      let scope = k :: scope in
+                      add_uses
+                        (Propagate { scope; src = x })
+                        x
+                        (Var.Map.find k global_info.info_return_vals);
+                      List.iter2
+                        ~f:(fun x y -> add_use (Propagate { scope; src = x }) x y)
+                        params
+                        args)
                 | _ -> ())
               known);
         add_use Compute x f;
@@ -176,30 +206,41 @@ let usages prog (global_info : Global_flow.info) : (usage_kind * Var.Set.t) list
             | Pc _ -> ())
           args
   in
-  Addr.Map.iter
-    (fun _ block ->
-      (* Add uses from block body *)
-      List.iter
-        ~f:(fun (i, _) ->
-          match i with
-          | Let (x, e) -> add_expr_uses x e
-          (* For assignment, propagate liveness from new to old variable like a block parameter *)
-          | Assign (x, y) -> add_use Propagate x y
-          | Set_field (_, _, _, _) | Offset_ref (_, _) | Array_set (_, _, _) -> ())
-        block.body;
-      (* Add uses from block branch *)
-      match fst block.branch with
-      | Return _ | Raise _ | Stop -> ()
-      | Branch cont -> add_cont_deps cont
-      | Cond (_, cont1, cont2) ->
-          add_cont_deps cont1;
-          add_cont_deps cont2
-      | Switch (_, a) -> Array.iter ~f:add_cont_deps a
-      | Pushtrap (cont, _, cont_h) ->
-          add_cont_deps cont;
-          add_cont_deps cont_h
-      | Poptrap cont -> add_cont_deps cont)
-    prog.blocks;
+  let add_block_uses scope block =
+    (* Add uses from block body *)
+    List.iter
+      ~f:(fun (i, _) ->
+        match i with
+        | Let (x, e) -> add_expr_uses scope x e
+        (* For assignment, propagate liveness from new to old variable like a block parameter *)
+        | Assign (x, y) -> add_use (Propagate { scope = []; src = x }) x y
+        | Set_field (_, _, _, _) | Offset_ref (_, _) | Array_set (_, _, _) -> ())
+      block.body;
+    (* Add uses from block branch *)
+    match fst block.branch with
+    | Return _ | Raise _ | Stop -> ()
+    | Branch cont -> add_cont_deps cont
+    | Cond (_, cont1, cont2) ->
+        add_cont_deps cont1;
+        add_cont_deps cont2
+    | Switch (_, a) -> Array.iter ~f:add_cont_deps a
+    | Pushtrap (cont, _, cont_h) ->
+        add_cont_deps cont;
+        add_cont_deps cont_h
+    | Poptrap cont -> add_cont_deps cont
+  in
+  iter_with_scope prog (fun f block ->
+      add_block_uses
+        (match f with
+        | Some f -> [ f ]
+        | None -> [])
+        block);
+  Var.Tbl.iter
+    (fun scope h ->
+      match h with
+      | None -> ()
+      | Some h -> Var.Hashtbl.iter (fun x _ -> add_use Scope scope x) h)
+    scoped_live_vars;
   uses
 
 (** Return the set of variables used in a given expression *)
@@ -237,17 +278,34 @@ let expr_vars e =
     A variable [x[i]] is marked as [Live {i}] if it is used in an instruction where field [i] is referenced or set. *)
 let liveness prog pure_funs (global_info : Global_flow.info) =
   let live_vars = Var.Tbl.make () Domain.bot in
-  let add_top v = Var.Tbl.set live_vars v Domain.top in
-  let add_live_field v i =
-    let live_fields =
-      match Var.Tbl.get live_vars v with
-      | Live _ as l -> Domain.join l (Domain.live_field i Domain.top)
-      | Top -> Domain.top
-      | Dead -> Domain.live_field i Domain.top
-    in
-    Var.Tbl.set live_vars v live_fields
+  let scoped_live_vars = Var.Tbl.make () None in
+  let get_hashtbl scope =
+    match Var.Tbl.get scoped_live_vars scope with
+    | Some h -> h
+    | None ->
+        let h = Var.Hashtbl.create 8 in
+        Var.Tbl.set scoped_live_vars scope (Some h);
+        h
   in
-  let live_instruction i =
+  let add_top scope v =
+    match scope with
+    | None -> Var.Tbl.set live_vars v Domain.top
+    | Some scope ->
+        let h = get_hashtbl scope in
+        Var.Hashtbl.replace h v Domain.top
+  in
+  let add_live_field scope v i =
+    let update_field l i = Domain.join l (Domain.live_field i Domain.top) in
+    match scope with
+    | None -> Var.Tbl.set live_vars v (update_field (Var.Tbl.get live_vars v) i)
+    | Some scope ->
+        let h = get_hashtbl scope in
+        Var.Hashtbl.replace
+          h
+          v
+          (update_field (try Var.Hashtbl.find h v with Not_found -> Domain.bot) i)
+  in
+  let live_instruction scope i =
     match i with
     (* If e is impure, set all variables in e as Top. The only exception is for function applications,
        where we may be able to do better. Global flow gives us information about which arguments in
@@ -257,9 +315,9 @@ let liveness prog pure_funs (global_info : Global_flow.info) =
         then
           match e with
           | Apply { f; args; _ } ->
-              add_top f;
+              add_top scope f;
               List.iter
-                ~f:(fun x -> if variable_may_escape x global_info then add_top x)
+                ~f:(fun x -> if variable_may_escape x global_info then add_top scope x)
                 args
           | Block (_, _, _, _)
           | Field (_, _, _)
@@ -268,29 +326,29 @@ let liveness prog pure_funs (global_info : Global_flow.info) =
           | Prim (_, _)
           | Special _ ->
               let vars = expr_vars e in
-              Var.Set.iter add_top vars)
+              Var.Set.iter (fun x -> add_top scope x) vars)
     | Set_field (x, i, _, y) ->
-        add_live_field x i;
-        add_top y
+        add_live_field scope x i;
+        add_top scope y
     | Array_set (x, y, z) ->
-        add_top x;
-        add_top y;
-        add_top z
-    | Offset_ref (x, _) -> add_live_field x 0
+        add_top scope x;
+        add_top scope y;
+        add_top scope z
+    | Offset_ref (x, _) -> add_live_field scope x 0
     (* Assignment can be ignored. Liveness of old variable is just propagated to new variable. See [usages]. *)
     | Assign (_, _) -> ()
   in
-  let live_block block =
-    List.iter ~f:(fun (i, _) -> live_instruction i) block.body;
+  let live_block scope block =
+    List.iter ~f:(fun (i, _) -> live_instruction scope i) block.body;
     match fst block.branch with
-    | Return x -> if variable_may_escape x global_info then add_top x
-    | Raise (x, _) -> add_top x
-    | Cond (x, _, _) -> add_top x
-    | Switch (x, _) -> add_top x
+    | Return x -> if variable_may_escape x global_info then add_top scope x
+    | Raise (x, _) -> add_top scope x
+    | Cond (x, _, _) -> add_top scope x
+    | Switch (x, _) -> add_top scope x
     | Stop | Branch _ | Poptrap _ | Pushtrap _ -> ()
   in
-  Addr.Map.iter (fun _ block -> live_block block) prog.blocks;
-  live_vars
+  iter_with_scope prog live_block;
+  live_vars, scoped_live_vars
 
 (* Returns the set of variables given a table of variables. *)
 let variables deps =
@@ -301,7 +359,7 @@ let variables deps =
 (** Propagate liveness of the usages of a variable [x] to [x]. The liveness of [x] is
     defined by joining its current liveness and the contribution of each vairable [y]
     that uses [x]. *)
-let propagate defs ~state ~dep:y ~target:x ~action:usage_kind =
+let propagate defs scoped_live_vars ~state ~dep:y ~target:x ~action:usage_kind =
   (* Variable [y] uses [x] either in its definition ([Compute]) or as a closure/block parameter
       ([Propagate]). In the latter case, the contribution is simply the liveness of [y]. In the former,
        the contribution depends on the liveness of [y] and its definition. *)
@@ -333,7 +391,20 @@ let propagate defs ~state ~dep:y ~target:x ~action:usage_kind =
           | Expr (Field (_, i, _)) -> Domain.live_field i Domain.top
           | _ -> Domain.top))
   (* If x is used as an argument for parameter y, then contribution is liveness of y *)
-  | Propagate -> Var.Tbl.get state y
+  | Propagate { scope; src } ->
+      if List.for_all scope ~f:(fun z ->
+             match Var.Tbl.get state z with
+             | Dead -> false
+             | _ -> true)
+      then Var.Tbl.get state src
+      else Domain.bot
+  | Scope -> (
+      match Var.Tbl.get state y with
+      | Dead -> Domain.bot
+      | _ -> (
+          match Var.Tbl.get scoped_live_vars y with
+          | Some h -> Var.Hashtbl.find h x
+          | None -> assert false))
 
 module Solver =
   Dgraph.Solver (Var) (Var.ISet) (Var.Tbl)
@@ -342,7 +413,7 @@ module Solver =
     end)
     (Domain)
 
-let solver vars uses defs live_vars =
+let solver vars uses defs live_vars scoped_live_vars =
   let g =
     { Solver.domain = vars
     ; iter_children =
@@ -352,7 +423,7 @@ let solver vars uses defs live_vars =
             (Var.Tbl.get uses x))
     }
   in
-  Solver.f ~state:live_vars g (propagate defs)
+  Solver.f ~state:live_vars g (propagate defs scoped_live_vars)
 
 (** Replace each instance of a dead variable with a sentinal value.
   Blocks that end in dead variables are compacted to the first live entry.
@@ -454,7 +525,13 @@ module Print = struct
                   d
                   (match k with
                   | Compute -> "C"
-                  | Propagate -> "P"))
+                  | Propagate { scope; src } ->
+                      "P("
+                      ^ String.concat
+                          ~sep:" "
+                          (List.map ~f:(fun x -> Format.asprintf "%a" Var.print x) scope)
+                      ^ Format.asprintf "/%a)" Var.print src
+                  | Scope -> "S"))
               s)
           ds;
         Format.eprintf "}\n")
@@ -480,14 +557,14 @@ let f p ~deadcode_sentinal global_info =
   let p = add_sentinal p deadcode_sentinal in
   (* Compute definitions *)
   let defs = definitions p in
-  (* Compute usages *)
-  let uses = usages p global_info in
   (* Compute initial liveness *)
   let pure_funs = Pure_fun.f p in
-  let live_table = liveness p pure_funs global_info in
+  let live_table, scoped_live_vars = liveness p pure_funs global_info in
+  (* Compute usages *)
+  let uses = usages p global_info scoped_live_vars in
   (* Propagate liveness to dependencies *)
   let vars = variables uses in
-  solver vars uses defs live_table;
+  solver vars uses defs live_table scoped_live_vars;
   (* Print debug info *)
   if debug ()
   then (

--- a/compiler/lib/js_simpl.ml
+++ b/compiler/lib/js_simpl.ml
@@ -274,3 +274,26 @@ let if_statement e loc iftrue truestop iffalse falsestop =
         iftrue'
         falsestop
   | _ -> if_statement_2 e loc iftrue truestop iffalse falsestop
+
+let function_body b =
+  (* We only check for a return at the end since it is by far the most
+     common case in practice. *)
+  let has_useless_return =
+    let rec check l =
+      match l with
+      | [] -> false
+      | [ (J.Return_statement None, _) ] -> true
+      | _ :: r -> check r
+    in
+    check b
+  in
+  if has_useless_return
+  then
+    let rec remove acc l =
+      match l with
+      | [] -> acc
+      | [ (J.Return_statement None, _) ] -> acc
+      | i :: r -> remove (i :: acc) r
+    in
+    List.rev (remove [] b)
+  else b

--- a/compiler/lib/js_simpl.mli
+++ b/compiler/lib/js_simpl.mli
@@ -32,3 +32,5 @@ val if_statement :
 val block : (Javascript.statement * location) list -> Javascript.statement * location
 
 val unblock : Javascript.statement * location -> (Javascript.statement * location) list
+
+val function_body : (statement * location) list -> (statement * location) list

--- a/compiler/lib/pure_fun.ml
+++ b/compiler/lib/pure_fun.ml
@@ -25,7 +25,7 @@ open Code
 let pure_expr pure_funs e =
   match e with
   | Block _ | Field _ | Closure _ | Constant _ -> true
-  | Special (Alias_prim _ | Undefined) -> true
+  | Special (Alias_prim _) -> true
   | Apply { f; exact; _ } -> exact && Var.Set.mem f pure_funs
   | Prim (p, _l) -> (
       match p with

--- a/compiler/tests-compiler/direct_calls.ml
+++ b/compiler/tests-compiler/direct_calls.ml
@@ -141,14 +141,14 @@ let%expect_test "direct calls with --enable effects" =
     {|
     function test1(param, cont){
      function f(g, x){
-      try{g(undef); return;}
+      try{g(); return;}
       catch(e$0){
        var e = caml_wrap_exception(e$0);
        throw caml_maybe_attach_backtrace(e, 0);
       }
      }
-     f(function(x){return;}, undef);
-     f(function(x){return;}, undef);
+     f(function(x){return;});
+     f(function(x){return;});
      return cont(0);
     }
     //end
@@ -160,11 +160,11 @@ let%expect_test "direct calls with --enable effects" =
          return raise(e$0);
         });
       return caml_cps_exact_call2
-              (g, x, function(_f_){caml_pop_trap(); return cont(undef);});
+              (g, x, function(_f_){caml_pop_trap(); return cont();});
      }
      return caml_cps_exact_call3
              (f,
-              function(x, cont){return cont(undef);},
+              function(x, cont){return cont();},
               7,
               function(_d_){
                return caml_cps_exact_call3
@@ -179,7 +179,7 @@ let%expect_test "direct calls with --enable effects" =
     //end
     function test3(x, cont){
      function F(symbol){function f(x){return x + 1 | 0;} return [0, f];}
-     var M1 = F(undef), M2 = F(undef), _c_ = (0, M2[1])(2);
+     var M1 = F(), M2 = F(), _c_ = (0, M2[1])(2);
      return cont([0, (0, M1[1])(1), _c_]);
     }
     //end
@@ -188,7 +188,7 @@ let%expect_test "direct calls with --enable effects" =
       function f(x, cont){return caml_cps_call3(Stdlib_Printf[2], _a_, x, cont);}
       return [0, f];
      }
-     var M1 = F(undef), M2 = F(undef);
+     var M1 = F(), M2 = F();
      return caml_cps_exact_call2
              (M1[1],
               1,

--- a/compiler/tests-compiler/direct_calls.ml
+++ b/compiler/tests-compiler/direct_calls.ml
@@ -147,8 +147,8 @@ let%expect_test "direct calls with --enable effects" =
        throw caml_maybe_attach_backtrace(e, 0);
       }
      }
-     f(function(x){return;});
-     f(function(x){return;});
+     f(function(x){});
+     f(function(x){});
      return cont(0);
     }
     //end

--- a/compiler/tests-compiler/effects_toplevel.ml
+++ b/compiler/tests-compiler/effects_toplevel.ml
@@ -65,7 +65,7 @@ let%expect_test "test-compiler/lib-effects/test1.ml" =
        return caml_callback
                (function(cont){
                  var
-                  undef = undefined,
+                  dummy = 0,
                   global_data = runtime.caml_get_global_data(),
                   Stdlib_Printf = global_data.Stdlib__Printf,
                   _a_ =
@@ -75,15 +75,15 @@ let%expect_test "test-compiler/lib-effects/test1.ml" =
                  function g(param, cont){
                   return caml_cps_call2(Stdlib_Printf[2], _a_, cont);
                  }
-                 caml_callback(g, [undef]);
+                 caml_callback(g, [dummy]);
                  function _b_(i){
                   return caml_cps_exact_call2
                           (g,
-                           undef,
+                           dummy,
                            function(_c_){
                             var _d_ = i + 1 | 0;
                             if(5 !== i) return caml_cps_exact_call1(_b_, _d_);
-                            caml_callback(g, [undef]);
+                            caml_callback(g, [dummy]);
                             var Test = [0];
                             runtime.caml_register_global(2, Test, "Test");
                            });

--- a/compiler/tests-compiler/effects_toplevel.ml
+++ b/compiler/tests-compiler/effects_toplevel.ml
@@ -86,7 +86,6 @@ let%expect_test "test-compiler/lib-effects/test1.ml" =
                             caml_callback(g, [undef]);
                             var Test = [0];
                             runtime.caml_register_global(2, Test, "Test");
-                            return;
                            });
                  }
                  return _b_(1);

--- a/compiler/tests-compiler/global_deadcode.ml
+++ b/compiler/tests-compiler/global_deadcode.ml
@@ -125,8 +125,7 @@ let%expect_test "Omit unused return expressions" =
   in
   (* Expect return value of f to be omitted. *)
   print_fun_decl program (Some "f");
-  [%expect
-    {|
-       function f(x){caml_call1(Stdlib[44], x); return;}
+  [%expect {|
+       function f(x){caml_call1(Stdlib[44], x);}
        //end
      |}]

--- a/compiler/tests-full/stdlib.cma.expected.js
+++ b/compiler/tests-full/stdlib.cma.expected.js
@@ -5713,7 +5713,6 @@
       /*<<bytes.ml:517:7>>*/ return;
     }
      /*<<bytes.ml:518:7>>*/  /*<<bytes.ml:518:7>>*/ caml_bytes_set16(b, i, x);
-     /*<<bytes.ml:518:7>>*/ return;
     /*<<bytes.ml:518:33>>*/ }
    function unsafe_set_uint16_be(b, i, x){
      /*<<bytes.ml:521:2>>*/ if(Stdlib_Sys[11]){
@@ -5722,7 +5721,6 @@
     }
      /*<<bytes.ml:523:2>>*/  /*<<bytes.ml:523:2>>*/ caml_bytes_set16
      (b, i, caml_bswap16(x));
-     /*<<bytes.ml:523:2>>*/ return;
     /*<<bytes.ml:523:37>>*/ }
    function set_int16_le(b, i, x){
      /*<<bytes.ml:526:2>>*/ return Stdlib_Sys[11]
@@ -5974,7 +5972,6 @@
    function set_utf_8_uchar(b, i, u){
      /*<<bytes.ml:651:2>>*/ function set(_i_, _h_, _g_){
       /*<<?>>*/ caml_bytes_unsafe_set(_i_, _h_, _g_);
-     return;
     }
      /*<<bytes.ml:652:2>>*/ var
       /*<<bytes.ml:652:2>>*/ max =
@@ -10076,7 +10073,6 @@
      (Stdlib_Array[9], env[4], 0, new_end, 0, oldsize);
     env[4] = new_end;
     env[5] = newsize;
-    return;
     /*<<parsing.ml:122:28>>*/ }
    function clear_parser(param){
      /*<<parsing.ml:125:2>>*/  /*<<parsing.ml:125:2>>*/ caml_call4
@@ -12760,7 +12756,6 @@
      /*<<buffer.ml:99:2>>*/  /*<<buffer.ml:99:2>>*/ caml_call5
      (Stdlib_Bytes[11], b[1][1], 0, new_buffer, 0, b[2]);
     b[1] = [0, new_buffer, new_len[1]];
-    return;
     /*<<buffer.ml:100:55>>*/ }
    function add_char(b, c){
      /*<<buffer.ml:113:2>>*/ var
@@ -13487,7 +13482,6 @@
      st =  /*<<domain.ml:89:13>>*/ caml_make_vect(8, none);
      /*<<domain.ml:90:4>>*/  /*<<domain.ml:90:4>>*/ runtime.caml_domain_dls_set
      (st);
-     /*<<domain.ml:90:4>>*/ return;
     /*<<domain.ml:90:20>>*/ }
     /*<<domain.ml:92:10>>*/ create_dls(0);
     /*<<domain.ml:96:20>>*/ var
@@ -13589,10 +13583,7 @@
      /*<<domain.ml:210:27>>*/ first_domain_spawned =
        /*<<domain.ml:210:27>>*/ caml_call1(Stdlib_Atomic[1], 0),
      /*<<domain.ml:212:27>>*/ first_spawn_function =
-      [0,
-       function(param){
-         /*<<domain.ml:212:42>>*/ return;
-        /*<<domain.ml:212:44>>*/ }],
+      [0, function(param){ /*<<domain.ml:212:44>>*/ }],
     cst_first_domain_already_spawn = "first domain already spawned";
    function before_first_spawn(f){
      /*<<domain.ml:215:2>>*/ if
@@ -14030,14 +14021,12 @@
       (Stdlib_Bytes[11], buf[2], 0, new_str, 0, len);
      buf[2] = new_str;
     }
-    return;
     /*<<camlinternalFormat.ml:267:3>>*/ }
    function buffer_add_char(buf, c){
      /*<<camlinternalFormat.ml:271:2>>*/ buffer_check_size(buf, 1);
      /*<<camlinternalFormat.ml:272:2>>*/  /*<<camlinternalFormat.ml:272:2>>*/ caml_bytes_set
      (buf[2], buf[1], c);
     buf[1] = buf[1] + 1 | 0;
-    return;
     /*<<camlinternalFormat.ml:273:24>>*/ }
    function buffer_add_string(buf, s){
      /*<<camlinternalFormat.ml:277:2>>*/ var
@@ -14046,7 +14035,6 @@
      /*<<camlinternalFormat.ml:279:2>>*/  /*<<camlinternalFormat.ml:279:2>>*/ caml_call5
      (Stdlib_String[6], s, 0, buf[2], buf[1], str_len);
     buf[1] = buf[1] + str_len | 0;
-    return;
     /*<<camlinternalFormat.ml:280:30>>*/ }
    function buffer_contents(buf){
      /*<<camlinternalFormat.ml:284:2>>*/ return caml_call3
@@ -14146,7 +14134,6 @@
     }
     if(prec)
       /*<<camlinternalFormat.ml:410:4>>*/ return buffer_add_string(buf, cst);
-     /*<<camlinternalFormat.ml:405:20>>*/ return;
     /*<<camlinternalFormat.ml:410:30>>*/ }
    function bprint_iconv_flag(buf, iconv){
      /*<<camlinternalFormat.ml:415:34>>*/ switch(iconv){
@@ -14185,7 +14172,6 @@
     }
     if(8 <= fconv[2])
       /*<<camlinternalFormat.ml:450:16>>*/ return buffer_add_char(buf, 35);
-     /*<<camlinternalFormat.ml:452:35>>*/ return;
     /*<<camlinternalFormat.ml:452:37>>*/ }
    function string_of_formatting_lit(formatting_lit){
      /*<<camlinternalFormat.ml:465:46>>*/ if
@@ -14242,7 +14228,6 @@
       i = _cP_;
      }
     }
-    return;
     /*<<camlinternalFormat.ml:488:6>>*/ }
    function bprint_fmtty(buf, fmtty){
      /*<<camlinternalFormat.ml:496:17>>*/ var fmtty$0 = fmtty;
@@ -14848,18 +14833,10 @@
    function fmtty_rel_det(param){
      /*<<?>>*/ if(typeof param === "number")
       /*<<camlinternalFormat.ml:691:4>>*/ return [0,
-             function(param){
-               /*<<camlinternalFormat.ml:691:17>>*/ return;
-              /*<<camlinternalFormat.ml:691:21>>*/ },
-             function(param){
-               /*<<camlinternalFormat.ml:692:17>>*/ return;
-              /*<<camlinternalFormat.ml:692:21>>*/ },
-             function(param){
-               /*<<camlinternalFormat.ml:693:17>>*/ return;
-              /*<<camlinternalFormat.ml:693:21>>*/ },
-             function(param){
-               /*<<camlinternalFormat.ml:694:17>>*/ return;
-              /*<<camlinternalFormat.ml:694:21>>*/ }];
+             function(param){ /*<<camlinternalFormat.ml:691:21>>*/ },
+             function(param){ /*<<camlinternalFormat.ml:692:21>>*/ },
+             function(param){ /*<<camlinternalFormat.ml:693:21>>*/ },
+             function(param){ /*<<camlinternalFormat.ml:694:21>>*/ }];
     switch(param[0]){
       case 0:
         /*<<camlinternalFormat.ml:696:25>>*/ var
@@ -14872,11 +14849,9 @@
         /*<<camlinternalFormat.ml:697:4>>*/ return [0,
                function(param){
                  /*<<camlinternalFormat.ml:697:17>>*/ fa(0);
-                 /*<<camlinternalFormat.ml:697:39>>*/ return;
                 /*<<camlinternalFormat.ml:697:43>>*/ },
                function(param){
                  /*<<camlinternalFormat.ml:698:17>>*/ af(0);
-                 /*<<camlinternalFormat.ml:698:39>>*/ return;
                 /*<<camlinternalFormat.ml:698:43>>*/ },
                ed,
                de];
@@ -14891,11 +14866,9 @@
         /*<<camlinternalFormat.ml:702:4>>*/ return [0,
                function(param){
                  /*<<camlinternalFormat.ml:702:17>>*/ fa$0(0);
-                 /*<<camlinternalFormat.ml:702:39>>*/ return;
                 /*<<camlinternalFormat.ml:702:43>>*/ },
                function(param){
                  /*<<camlinternalFormat.ml:703:17>>*/ af$0(0);
-                 /*<<camlinternalFormat.ml:703:39>>*/ return;
                 /*<<camlinternalFormat.ml:703:43>>*/ },
                ed$0,
                de$0];
@@ -14910,11 +14883,9 @@
         /*<<camlinternalFormat.ml:707:4>>*/ return [0,
                function(param){
                  /*<<camlinternalFormat.ml:707:17>>*/ fa$1(0);
-                 /*<<camlinternalFormat.ml:707:39>>*/ return;
                 /*<<camlinternalFormat.ml:707:43>>*/ },
                function(param){
                  /*<<camlinternalFormat.ml:708:17>>*/ af$1(0);
-                 /*<<camlinternalFormat.ml:708:39>>*/ return;
                 /*<<camlinternalFormat.ml:708:43>>*/ },
                ed$1,
                de$1];
@@ -14929,11 +14900,9 @@
         /*<<camlinternalFormat.ml:712:4>>*/ return [0,
                function(param){
                  /*<<camlinternalFormat.ml:712:17>>*/ fa$2(0);
-                 /*<<camlinternalFormat.ml:712:39>>*/ return;
                 /*<<camlinternalFormat.ml:712:43>>*/ },
                function(param){
                  /*<<camlinternalFormat.ml:713:17>>*/ af$2(0);
-                 /*<<camlinternalFormat.ml:713:39>>*/ return;
                 /*<<camlinternalFormat.ml:713:43>>*/ },
                ed$2,
                de$2];
@@ -14948,11 +14917,9 @@
         /*<<camlinternalFormat.ml:722:4>>*/ return [0,
                function(param){
                  /*<<camlinternalFormat.ml:722:17>>*/ fa$3(0);
-                 /*<<camlinternalFormat.ml:722:39>>*/ return;
                 /*<<camlinternalFormat.ml:722:43>>*/ },
                function(param){
                  /*<<camlinternalFormat.ml:723:17>>*/ af$3(0);
-                 /*<<camlinternalFormat.ml:723:39>>*/ return;
                 /*<<camlinternalFormat.ml:723:43>>*/ },
                ed$3,
                de$3];
@@ -14967,11 +14934,9 @@
         /*<<camlinternalFormat.ml:717:4>>*/ return [0,
                function(param){
                  /*<<camlinternalFormat.ml:717:17>>*/ fa$4(0);
-                 /*<<camlinternalFormat.ml:717:39>>*/ return;
                 /*<<camlinternalFormat.ml:717:43>>*/ },
                function(param){
                  /*<<camlinternalFormat.ml:718:17>>*/ af$4(0);
-                 /*<<camlinternalFormat.ml:718:39>>*/ return;
                 /*<<camlinternalFormat.ml:718:43>>*/ },
                ed$4,
                de$4];
@@ -14986,11 +14951,9 @@
         /*<<camlinternalFormat.ml:727:4>>*/ return [0,
                function(param){
                  /*<<camlinternalFormat.ml:727:17>>*/ fa$5(0);
-                 /*<<camlinternalFormat.ml:727:39>>*/ return;
                 /*<<camlinternalFormat.ml:727:43>>*/ },
                function(param){
                  /*<<camlinternalFormat.ml:728:17>>*/ af$5(0);
-                 /*<<camlinternalFormat.ml:728:39>>*/ return;
                 /*<<camlinternalFormat.ml:728:43>>*/ },
                ed$5,
                de$5];
@@ -15005,11 +14968,9 @@
         /*<<camlinternalFormat.ml:732:4>>*/ return [0,
                function(param){
                  /*<<camlinternalFormat.ml:732:17>>*/ fa$6(0);
-                 /*<<camlinternalFormat.ml:732:39>>*/ return;
                 /*<<camlinternalFormat.ml:732:43>>*/ },
                function(param){
                  /*<<camlinternalFormat.ml:733:17>>*/ af$6(0);
-                 /*<<camlinternalFormat.ml:733:39>>*/ return;
                 /*<<camlinternalFormat.ml:733:43>>*/ },
                ed$6,
                de$6];
@@ -15024,11 +14985,9 @@
         /*<<camlinternalFormat.ml:765:4>>*/ return [0,
                function(param){
                  /*<<camlinternalFormat.ml:765:17>>*/ fa$7(0);
-                 /*<<camlinternalFormat.ml:765:39>>*/ return;
                 /*<<camlinternalFormat.ml:765:43>>*/ },
                function(param){
                  /*<<camlinternalFormat.ml:766:17>>*/ af$7(0);
-                 /*<<camlinternalFormat.ml:766:39>>*/ return;
                 /*<<camlinternalFormat.ml:766:43>>*/ },
                ed$7,
                de$7];
@@ -15052,22 +15011,18 @@
                function(param){
                  /*<<camlinternalFormat.ml:772:17>>*/ fa$8(0);
                  /*<<camlinternalFormat.ml:772:50>>*/ ag(0);
-                 /*<<camlinternalFormat.ml:772:61>>*/ return;
                 /*<<camlinternalFormat.ml:772:65>>*/ },
                function(param){
                  /*<<camlinternalFormat.ml:773:17>>*/ ga(0);
                  /*<<camlinternalFormat.ml:773:50>>*/ af$8(0);
-                 /*<<camlinternalFormat.ml:773:61>>*/ return;
                 /*<<camlinternalFormat.ml:773:65>>*/ },
                function(param){
                  /*<<camlinternalFormat.ml:774:17>>*/ ed$8(0);
                  /*<<camlinternalFormat.ml:774:50>>*/ dj(0);
-                 /*<<camlinternalFormat.ml:774:61>>*/ return;
                 /*<<camlinternalFormat.ml:774:65>>*/ },
                function(param){
                  /*<<camlinternalFormat.ml:775:17>>*/ jd(0);
                  /*<<camlinternalFormat.ml:775:50>>*/ de$8(0);
-                 /*<<camlinternalFormat.ml:775:61>>*/ return;
                 /*<<camlinternalFormat.ml:775:65>>*/ }];
       case 10:
         /*<<camlinternalFormat.ml:742:25>>*/ var
@@ -15080,11 +15035,9 @@
         /*<<camlinternalFormat.ml:743:4>>*/ return [0,
                function(param){
                  /*<<camlinternalFormat.ml:743:17>>*/ fa$9(0);
-                 /*<<camlinternalFormat.ml:743:39>>*/ return;
                 /*<<camlinternalFormat.ml:743:43>>*/ },
                function(param){
                  /*<<camlinternalFormat.ml:744:17>>*/ af$9(0);
-                 /*<<camlinternalFormat.ml:744:39>>*/ return;
                 /*<<camlinternalFormat.ml:744:43>>*/ },
                ed$9,
                de$9];
@@ -15100,11 +15053,9 @@
         /*<<camlinternalFormat.ml:738:4>>*/ return [0,
                function(param){
                  /*<<camlinternalFormat.ml:738:17>>*/ fa$10(0);
-                 /*<<camlinternalFormat.ml:738:39>>*/ return;
                 /*<<camlinternalFormat.ml:738:43>>*/ },
                function(param){
                  /*<<camlinternalFormat.ml:739:17>>*/ af$10(0);
-                 /*<<camlinternalFormat.ml:739:39>>*/ return;
                 /*<<camlinternalFormat.ml:739:43>>*/ },
                ed$10,
                de$10];
@@ -15120,11 +15071,9 @@
         /*<<camlinternalFormat.ml:748:4>>*/ return [0,
                function(param){
                  /*<<camlinternalFormat.ml:748:17>>*/ fa$11(0);
-                 /*<<camlinternalFormat.ml:748:39>>*/ return;
                 /*<<camlinternalFormat.ml:748:43>>*/ },
                function(param){
                  /*<<camlinternalFormat.ml:749:17>>*/ af$11(0);
-                 /*<<camlinternalFormat.ml:749:39>>*/ return;
                 /*<<camlinternalFormat.ml:749:43>>*/ },
                ed$11,
                de$11];
@@ -15140,19 +15089,15 @@
         /*<<camlinternalFormat.ml:753:4>>*/ return [0,
                function(param){
                  /*<<camlinternalFormat.ml:753:17>>*/ fa$12(0);
-                 /*<<camlinternalFormat.ml:753:39>>*/ return;
                 /*<<camlinternalFormat.ml:753:43>>*/ },
                function(param){
                  /*<<camlinternalFormat.ml:754:17>>*/ af$12(0);
-                 /*<<camlinternalFormat.ml:754:39>>*/ return;
                 /*<<camlinternalFormat.ml:754:43>>*/ },
                function(param){
                  /*<<camlinternalFormat.ml:755:17>>*/ ed$12(0);
-                 /*<<camlinternalFormat.ml:755:39>>*/ return;
                 /*<<camlinternalFormat.ml:755:43>>*/ },
                function(param){
                  /*<<camlinternalFormat.ml:756:17>>*/ de$12(0);
-                 /*<<camlinternalFormat.ml:756:39>>*/ return;
                 /*<<camlinternalFormat.ml:756:43>>*/ }];
       default:
         /*<<camlinternalFormat.ml:758:25>>*/ var
@@ -15166,19 +15111,15 @@
         /*<<camlinternalFormat.ml:759:4>>*/ return [0,
                function(param){
                  /*<<camlinternalFormat.ml:759:17>>*/ fa$13(0);
-                 /*<<camlinternalFormat.ml:759:39>>*/ return;
                 /*<<camlinternalFormat.ml:759:43>>*/ },
                function(param){
                  /*<<camlinternalFormat.ml:760:17>>*/ af$13(0);
-                 /*<<camlinternalFormat.ml:760:39>>*/ return;
                 /*<<camlinternalFormat.ml:760:43>>*/ },
                function(param){
                  /*<<camlinternalFormat.ml:761:17>>*/ ed$13(0);
-                 /*<<camlinternalFormat.ml:761:39>>*/ return;
                 /*<<camlinternalFormat.ml:761:43>>*/ },
                function(param){
                  /*<<camlinternalFormat.ml:762:17>>*/ de$13(0);
-                 /*<<camlinternalFormat.ml:762:39>>*/ return;
                 /*<<camlinternalFormat.ml:762:43>>*/ }];
     }
    }
@@ -17057,7 +16998,6 @@
       /*<<camlinternalFormat.ml:1438:16>>*/  /*<<camlinternalFormat.ml:1438:16>>*/ caml_bytes_set
       (buf, pos[1], c);
      pos[1]++;
-     return;
      /*<<camlinternalFormat.ml:1438:46>>*/ }
      /*<<camlinternalFormat.ml:1439:15>>*/ var
       /*<<camlinternalFormat.ml:1439:15>>*/ left =
@@ -19010,7 +18950,6 @@
         (failwith_message(_C_), str, str_ind, _bd_);
       }
       flag[1] = 1;
-      return;
       /*<<camlinternalFormat.ml:2158:19>>*/ }
      a:
      b:
@@ -19476,7 +19415,6 @@
                 i = _a$_;
                }
               }
-              return;
               /*<<camlinternalFormat.ml:2726:10>>*/ },
            fail_single_percent =
              function(str_ind){
@@ -24270,7 +24208,6 @@
       j = _an_;
      }
     }
-    return;
     /*<<bigarray.ml:112:13>>*/ }
    function floop(arr, idx, f, col, max){
      /*<<bigarray.ml:114:4>>*/ if(0 > col){
@@ -24292,7 +24229,6 @@
       j = _ak_;
      }
     }
-    return;
     /*<<bigarray.ml:118:13>>*/ }
    function init(kind, layout, dims, f){
      /*<<bigarray.ml:120:4>>*/ var
@@ -27173,7 +27109,6 @@
      /*<<format.ml:258:2>>*/ state[9] = state[9] - size | 0;
      /*<<format.ml:259:2>>*/ pp_output_string(state, text);
     state[11] = 0;
-    return;
     /*<<format.ml:260:31>>*/ }
    function format_string(state, s){
      /*<<format.ml:264:2>>*/  /*<<format.ml:264:5>>*/ var
@@ -27452,7 +27387,6 @@
         }
          /*<<format.ml:488:10>>*/ return;
      }
-     /*<<format.ml:497:8>>*/ return;
     /*<<format.ml:497:10>>*/ }
    function scan_push(state, b, token){
      /*<<format.ml:503:2>>*/ pp_enqueue(state, token);
@@ -32911,7 +32845,6 @@
            nidx = key_index(h, hkey);
            /*<<ephemeron.ml:181:14>>*/ ndata[1 + nidx] =
            [0, hkey, data, caml_check_bound(ndata, nidx)[1 + nidx]];
-           /*<<ephemeron.ml:181:14>>*/ return;
           /*<<ephemeron.ml:181:60>>*/ },
         /*<<ephemeron.ml:170:6>>*/ _af_ = osize - 1 | 0,
         /*<<ephemeron.ml:182:8>>*/ _ae_ = 0;
@@ -34593,7 +34526,6 @@
        j = _L_;
       }
      }
-     return;
      /*<<filename.ml:186:66>>*/ }
      /*<<filename.ml:188:4>>*/ loop(0);
      /*<<filename.ml:188:4>>*/ return  /*<<filename.ml:188:4>>*/ caml_call1

--- a/compiler/tests-full/stdlib.cma.expected.js
+++ b/compiler/tests-full/stdlib.cma.expected.js
@@ -14833,9 +14833,9 @@
    function fmtty_rel_det(param){
      /*<<?>>*/ if(typeof param === "number")
       /*<<camlinternalFormat.ml:691:4>>*/ return [0,
-             function(param){ /*<<camlinternalFormat.ml:691:21>>*/ },
+             ,
              function(param){ /*<<camlinternalFormat.ml:692:21>>*/ },
-             function(param){ /*<<camlinternalFormat.ml:693:21>>*/ },
+             ,
              function(param){ /*<<camlinternalFormat.ml:694:21>>*/ }];
     switch(param[0]){
       case 0:
@@ -14843,153 +14843,117 @@
         rest = param[1],
          /*<<camlinternalFormat.ml:696:25>>*/ match = fmtty_rel_det(rest),
         de = match[4],
-        ed = match[3],
-        af = match[2],
-        fa = match[1];
+        af = match[2];
         /*<<camlinternalFormat.ml:697:4>>*/ return [0,
-               function(param){
-                 /*<<camlinternalFormat.ml:697:17>>*/ fa(0);
-                /*<<camlinternalFormat.ml:697:43>>*/ },
+               ,
                function(param){
                  /*<<camlinternalFormat.ml:698:17>>*/ af(0);
                 /*<<camlinternalFormat.ml:698:43>>*/ },
-               ed,
+               ,
                de];
       case 1:
         /*<<camlinternalFormat.ml:701:25>>*/ var
         rest$0 = param[1],
          /*<<camlinternalFormat.ml:701:25>>*/ match$0 = fmtty_rel_det(rest$0),
         de$0 = match$0[4],
-        ed$0 = match$0[3],
-        af$0 = match$0[2],
-        fa$0 = match$0[1];
+        af$0 = match$0[2];
         /*<<camlinternalFormat.ml:702:4>>*/ return [0,
-               function(param){
-                 /*<<camlinternalFormat.ml:702:17>>*/ fa$0(0);
-                /*<<camlinternalFormat.ml:702:43>>*/ },
+               ,
                function(param){
                  /*<<camlinternalFormat.ml:703:17>>*/ af$0(0);
                 /*<<camlinternalFormat.ml:703:43>>*/ },
-               ed$0,
+               ,
                de$0];
       case 2:
         /*<<camlinternalFormat.ml:706:25>>*/ var
         rest$1 = param[1],
          /*<<camlinternalFormat.ml:706:25>>*/ match$1 = fmtty_rel_det(rest$1),
         de$1 = match$1[4],
-        ed$1 = match$1[3],
-        af$1 = match$1[2],
-        fa$1 = match$1[1];
+        af$1 = match$1[2];
         /*<<camlinternalFormat.ml:707:4>>*/ return [0,
-               function(param){
-                 /*<<camlinternalFormat.ml:707:17>>*/ fa$1(0);
-                /*<<camlinternalFormat.ml:707:43>>*/ },
+               ,
                function(param){
                  /*<<camlinternalFormat.ml:708:17>>*/ af$1(0);
                 /*<<camlinternalFormat.ml:708:43>>*/ },
-               ed$1,
+               ,
                de$1];
       case 3:
         /*<<camlinternalFormat.ml:711:25>>*/ var
         rest$2 = param[1],
          /*<<camlinternalFormat.ml:711:25>>*/ match$2 = fmtty_rel_det(rest$2),
         de$2 = match$2[4],
-        ed$2 = match$2[3],
-        af$2 = match$2[2],
-        fa$2 = match$2[1];
+        af$2 = match$2[2];
         /*<<camlinternalFormat.ml:712:4>>*/ return [0,
-               function(param){
-                 /*<<camlinternalFormat.ml:712:17>>*/ fa$2(0);
-                /*<<camlinternalFormat.ml:712:43>>*/ },
+               ,
                function(param){
                  /*<<camlinternalFormat.ml:713:17>>*/ af$2(0);
                 /*<<camlinternalFormat.ml:713:43>>*/ },
-               ed$2,
+               ,
                de$2];
       case 4:
         /*<<camlinternalFormat.ml:721:25>>*/ var
         rest$3 = param[1],
          /*<<camlinternalFormat.ml:721:25>>*/ match$3 = fmtty_rel_det(rest$3),
         de$3 = match$3[4],
-        ed$3 = match$3[3],
-        af$3 = match$3[2],
-        fa$3 = match$3[1];
+        af$3 = match$3[2];
         /*<<camlinternalFormat.ml:722:4>>*/ return [0,
-               function(param){
-                 /*<<camlinternalFormat.ml:722:17>>*/ fa$3(0);
-                /*<<camlinternalFormat.ml:722:43>>*/ },
+               ,
                function(param){
                  /*<<camlinternalFormat.ml:723:17>>*/ af$3(0);
                 /*<<camlinternalFormat.ml:723:43>>*/ },
-               ed$3,
+               ,
                de$3];
       case 5:
         /*<<camlinternalFormat.ml:716:25>>*/ var
         rest$4 = param[1],
          /*<<camlinternalFormat.ml:716:25>>*/ match$4 = fmtty_rel_det(rest$4),
         de$4 = match$4[4],
-        ed$4 = match$4[3],
-        af$4 = match$4[2],
-        fa$4 = match$4[1];
+        af$4 = match$4[2];
         /*<<camlinternalFormat.ml:717:4>>*/ return [0,
-               function(param){
-                 /*<<camlinternalFormat.ml:717:17>>*/ fa$4(0);
-                /*<<camlinternalFormat.ml:717:43>>*/ },
+               ,
                function(param){
                  /*<<camlinternalFormat.ml:718:17>>*/ af$4(0);
                 /*<<camlinternalFormat.ml:718:43>>*/ },
-               ed$4,
+               ,
                de$4];
       case 6:
         /*<<camlinternalFormat.ml:726:25>>*/ var
         rest$5 = param[1],
          /*<<camlinternalFormat.ml:726:25>>*/ match$5 = fmtty_rel_det(rest$5),
         de$5 = match$5[4],
-        ed$5 = match$5[3],
-        af$5 = match$5[2],
-        fa$5 = match$5[1];
+        af$5 = match$5[2];
         /*<<camlinternalFormat.ml:727:4>>*/ return [0,
-               function(param){
-                 /*<<camlinternalFormat.ml:727:17>>*/ fa$5(0);
-                /*<<camlinternalFormat.ml:727:43>>*/ },
+               ,
                function(param){
                  /*<<camlinternalFormat.ml:728:17>>*/ af$5(0);
                 /*<<camlinternalFormat.ml:728:43>>*/ },
-               ed$5,
+               ,
                de$5];
       case 7:
         /*<<camlinternalFormat.ml:731:25>>*/ var
         rest$6 = param[1],
          /*<<camlinternalFormat.ml:731:25>>*/ match$6 = fmtty_rel_det(rest$6),
         de$6 = match$6[4],
-        ed$6 = match$6[3],
-        af$6 = match$6[2],
-        fa$6 = match$6[1];
+        af$6 = match$6[2];
         /*<<camlinternalFormat.ml:732:4>>*/ return [0,
-               function(param){
-                 /*<<camlinternalFormat.ml:732:17>>*/ fa$6(0);
-                /*<<camlinternalFormat.ml:732:43>>*/ },
+               ,
                function(param){
                  /*<<camlinternalFormat.ml:733:17>>*/ af$6(0);
                 /*<<camlinternalFormat.ml:733:43>>*/ },
-               ed$6,
+               ,
                de$6];
       case 8:
         /*<<camlinternalFormat.ml:764:25>>*/ var
         rest$7 = param[2],
          /*<<camlinternalFormat.ml:764:25>>*/ match$7 = fmtty_rel_det(rest$7),
         de$7 = match$7[4],
-        ed$7 = match$7[3],
-        af$7 = match$7[2],
-        fa$7 = match$7[1];
+        af$7 = match$7[2];
         /*<<camlinternalFormat.ml:765:4>>*/ return [0,
-               function(param){
-                 /*<<camlinternalFormat.ml:765:17>>*/ fa$7(0);
-                /*<<camlinternalFormat.ml:765:43>>*/ },
+               ,
                function(param){
                  /*<<camlinternalFormat.ml:766:17>>*/ af$7(0);
                 /*<<camlinternalFormat.ml:766:43>>*/ },
-               ed$7,
+               ,
                de$7];
       case 9:
         /*<<camlinternalFormat.ml:769:25>>*/ var
@@ -14998,28 +14962,18 @@
         ty1 = param[1],
          /*<<camlinternalFormat.ml:769:25>>*/ match$8 = fmtty_rel_det(rest$8),
         de$8 = match$8[4],
-        ed$8 = match$8[3],
         af$8 = match$8[2],
-        fa$8 = match$8[1],
          /*<<camlinternalFormat.ml:770:13>>*/ ty = trans(symm(ty1), ty2),
          /*<<camlinternalFormat.ml:771:25>>*/ match$9 = fmtty_rel_det(ty),
         jd = match$9[4],
-        dj = match$9[3],
-        ga = match$9[2],
-        ag = match$9[1];
+        ga = match$9[2];
         /*<<camlinternalFormat.ml:772:4>>*/ return [0,
-               function(param){
-                 /*<<camlinternalFormat.ml:772:17>>*/ fa$8(0);
-                 /*<<camlinternalFormat.ml:772:50>>*/ ag(0);
-                /*<<camlinternalFormat.ml:772:65>>*/ },
+               ,
                function(param){
                  /*<<camlinternalFormat.ml:773:17>>*/ ga(0);
                  /*<<camlinternalFormat.ml:773:50>>*/ af$8(0);
                 /*<<camlinternalFormat.ml:773:65>>*/ },
-               function(param){
-                 /*<<camlinternalFormat.ml:774:17>>*/ ed$8(0);
-                 /*<<camlinternalFormat.ml:774:50>>*/ dj(0);
-                /*<<camlinternalFormat.ml:774:65>>*/ },
+               ,
                function(param){
                  /*<<camlinternalFormat.ml:775:17>>*/ jd(0);
                  /*<<camlinternalFormat.ml:775:50>>*/ de$8(0);
@@ -15029,17 +14983,13 @@
         rest$9 = param[1],
          /*<<camlinternalFormat.ml:742:25>>*/ match$10 = fmtty_rel_det(rest$9),
         de$9 = match$10[4],
-        ed$9 = match$10[3],
-        af$9 = match$10[2],
-        fa$9 = match$10[1];
+        af$9 = match$10[2];
         /*<<camlinternalFormat.ml:743:4>>*/ return [0,
-               function(param){
-                 /*<<camlinternalFormat.ml:743:17>>*/ fa$9(0);
-                /*<<camlinternalFormat.ml:743:43>>*/ },
+               ,
                function(param){
                  /*<<camlinternalFormat.ml:744:17>>*/ af$9(0);
                 /*<<camlinternalFormat.ml:744:43>>*/ },
-               ed$9,
+               ,
                de$9];
       case 11:
         /*<<camlinternalFormat.ml:737:25>>*/ var
@@ -15047,17 +14997,13 @@
          /*<<camlinternalFormat.ml:737:25>>*/ match$11 =
           fmtty_rel_det(rest$10),
         de$10 = match$11[4],
-        ed$10 = match$11[3],
-        af$10 = match$11[2],
-        fa$10 = match$11[1];
+        af$10 = match$11[2];
         /*<<camlinternalFormat.ml:738:4>>*/ return [0,
-               function(param){
-                 /*<<camlinternalFormat.ml:738:17>>*/ fa$10(0);
-                /*<<camlinternalFormat.ml:738:43>>*/ },
+               ,
                function(param){
                  /*<<camlinternalFormat.ml:739:17>>*/ af$10(0);
                 /*<<camlinternalFormat.ml:739:43>>*/ },
-               ed$10,
+               ,
                de$10];
       case 12:
         /*<<camlinternalFormat.ml:747:25>>*/ var
@@ -15065,17 +15011,13 @@
          /*<<camlinternalFormat.ml:747:25>>*/ match$12 =
           fmtty_rel_det(rest$11),
         de$11 = match$12[4],
-        ed$11 = match$12[3],
-        af$11 = match$12[2],
-        fa$11 = match$12[1];
+        af$11 = match$12[2];
         /*<<camlinternalFormat.ml:748:4>>*/ return [0,
-               function(param){
-                 /*<<camlinternalFormat.ml:748:17>>*/ fa$11(0);
-                /*<<camlinternalFormat.ml:748:43>>*/ },
+               ,
                function(param){
                  /*<<camlinternalFormat.ml:749:17>>*/ af$11(0);
                 /*<<camlinternalFormat.ml:749:43>>*/ },
-               ed$11,
+               ,
                de$11];
       case 13:
         /*<<camlinternalFormat.ml:752:25>>*/ var
@@ -15083,19 +15025,13 @@
          /*<<camlinternalFormat.ml:752:25>>*/ match$13 =
           fmtty_rel_det(rest$12),
         de$12 = match$13[4],
-        ed$12 = match$13[3],
-        af$12 = match$13[2],
-        fa$12 = match$13[1];
+        af$12 = match$13[2];
         /*<<camlinternalFormat.ml:753:4>>*/ return [0,
-               function(param){
-                 /*<<camlinternalFormat.ml:753:17>>*/ fa$12(0);
-                /*<<camlinternalFormat.ml:753:43>>*/ },
+               ,
                function(param){
                  /*<<camlinternalFormat.ml:754:17>>*/ af$12(0);
                 /*<<camlinternalFormat.ml:754:43>>*/ },
-               function(param){
-                 /*<<camlinternalFormat.ml:755:17>>*/ ed$12(0);
-                /*<<camlinternalFormat.ml:755:43>>*/ },
+               ,
                function(param){
                  /*<<camlinternalFormat.ml:756:17>>*/ de$12(0);
                 /*<<camlinternalFormat.ml:756:43>>*/ }];
@@ -15105,19 +15041,13 @@
          /*<<camlinternalFormat.ml:758:25>>*/ match$14 =
           fmtty_rel_det(rest$13),
         de$13 = match$14[4],
-        ed$13 = match$14[3],
-        af$13 = match$14[2],
-        fa$13 = match$14[1];
+        af$13 = match$14[2];
         /*<<camlinternalFormat.ml:759:4>>*/ return [0,
-               function(param){
-                 /*<<camlinternalFormat.ml:759:17>>*/ fa$13(0);
-                /*<<camlinternalFormat.ml:759:43>>*/ },
+               ,
                function(param){
                  /*<<camlinternalFormat.ml:760:17>>*/ af$13(0);
                 /*<<camlinternalFormat.ml:760:43>>*/ },
-               function(param){
-                 /*<<camlinternalFormat.ml:761:17>>*/ ed$13(0);
-                /*<<camlinternalFormat.ml:761:43>>*/ },
+               ,
                function(param){
                  /*<<camlinternalFormat.ml:762:17>>*/ de$13(0);
                 /*<<camlinternalFormat.ml:762:43>>*/ }];

--- a/compiler/tests-full/stdlib.cma.expected.js
+++ b/compiler/tests-full/stdlib.cma.expected.js
@@ -4880,7 +4880,7 @@
             : runtime.caml_call_gen(f, [a0, a1]);
    }
    var
-    undef = undefined,
+    dummy = 0,
     global_data = runtime.caml_get_global_data(),
     Stdlib = global_data.Stdlib,
     Stdlib_Uchar = global_data.Stdlib__Uchar,
@@ -10021,7 +10021,6 @@
             : runtime.caml_call_gen(f, [a0, a1, a2, a3, a4]);
    }
     /*<<parsing.ml:59:0>>*/ var
-    undef = undefined,
     global_data = runtime.caml_get_global_data(),
     Stdlib_Obj = global_data.Stdlib__Obj,
     Stdlib_Array = global_data.Stdlib__Array,
@@ -10047,7 +10046,8 @@
        0,
        0,
        0,
-       0];
+       0],
+    dummy = 0;
    function grow_stacks(param){
      /*<<parsing.ml:108:2>>*/ var
      oldsize = env[5],
@@ -12662,7 +12662,6 @@
             : runtime.caml_call_gen(f, [a0, a1, a2, a3, a4]);
    }
    var
-    undef = undefined,
     global_data = runtime.caml_get_global_data(),
     Stdlib_Bytes = global_data.Stdlib__Bytes,
     Stdlib_Sys = global_data.Stdlib__Sys,
@@ -12673,7 +12672,8 @@
     cst_Buffer_sub = "Buffer.sub",
     cst_Buffer_blit = "Buffer.blit",
     cst_Buffer_nth = "Buffer.nth",
-    cst_Buffer_add_cannot_grow_buf = "Buffer.add: cannot grow buffer";
+    cst_Buffer_add_cannot_grow_buf = "Buffer.add: cannot grow buffer",
+    dummy = 0;
    function create(n){
      /*<<buffer.ml:41:1>>*/ var
      n$0 = 1 <= n ? n : 1,
@@ -13463,7 +13463,7 @@
             : runtime.caml_call_gen(f, [a0, a1, a2, a3, a4]);
    }
    var
-    undef = undefined,
+    dummy = 0,
     global_data = runtime.caml_get_global_data(),
     Stdlib_Condition = global_data.Stdlib__Condition,
     Stdlib_Mutex = global_data.Stdlib__Mutex,
@@ -13791,7 +13791,7 @@
             : runtime.caml_call_gen(f, [a0, a1, a2, a3, a4]);
    }
    var
-    undef = undefined,
+    dummy = 0,
     global_data = runtime.caml_get_global_data(),
     cst$9 = "%{",
     cst$10 = "%}",
@@ -21502,7 +21502,6 @@
             : runtime.caml_call_gen(f, [a0, a1, a2, a3, a4, a5]);
    }
     /*<<arg.ml:50:0>>*/ var
-    undef = undefined,
     global_data = runtime.caml_get_global_data(),
     cst$7 = "\n",
     cst$4 = cst$8,
@@ -21687,7 +21686,8 @@
     _n_ = [0, [2, 0, 0], cst_s],
     _o_ = [0, [2, 0, 0], cst_s],
     _p_ = [0, [2, 0, 0], cst_s],
-    _q_ = [0, [2, 0, 0], cst_s];
+    _q_ = [0, [2, 0, 0], cst_s],
+    dummy = 0;
    function int_of_string_opt(x){
      /*<<arg.ml:128:2>>*/ try{
       /*<<arg.ml:128:6>>*/  /*<<arg.ml:128:6>>*/ var
@@ -22987,7 +22987,6 @@
             : runtime.caml_call_gen(f, [a0, a1]);
    }
    var
-    undef = undefined,
     global_data = runtime.caml_get_global_data(),
     Stdlib_Printexc = global_data.Stdlib__Printexc,
     Stdlib = global_data.Stdlib;
@@ -23021,6 +23020,7 @@
                /*<<fun.ml:25:29>>*/ caml_call2
                (Stdlib[28], cst_Fun_Finally_raised, _a_)];
       /*<<fun.ml:26:11>>*/ });
+   var dummy = 0;
    function protect(finally$0, work){
     function finally_no_exn(param){
       /*<<fun.ml:30:4>>*/ try{
@@ -24142,7 +24142,7 @@
             : runtime.caml_call_gen(f, [a0, a1, a2]);
    }
    var
-    undef = undefined,
+    dummy = 0,
     global_data = runtime.caml_get_global_data(),
     Stdlib = global_data.Stdlib,
     Stdlib_Array = global_data.Stdlib__Array,
@@ -27048,7 +27048,7 @@
             : runtime.caml_call_gen(f, [a0, a1, a2, a3]);
    }
    var
-    undef = undefined,
+    dummy = 0,
     global_data = runtime.caml_get_global_data(),
     cst$14 = ".",
     cst$11 = cst$15,
@@ -32694,7 +32694,7 @@
             : runtime.caml_call_gen(f, [a0, a1, a2]);
    }
    var
-    undef = undefined,
+    dummy = 0,
     global_data = runtime.caml_get_global_data(),
     _c_ = [0, 0],
     _b_ = [0, 0],
@@ -33995,7 +33995,6 @@
             : runtime.caml_call_gen(f, [a0, a1, a2, a3]);
    }
    var
-    undef = undefined,
     global_data = runtime.caml_get_global_data(),
     cst$18 = cst$19,
     cst$17 = cst$19,
@@ -34171,6 +34170,7 @@
             : 0;
     /*<<filename.ml:114:10>>*/ }
    var
+    dummy = 0,
     _h_ = [0, 7, 0],
     _g_ = [0, 1, [0, 3, [0, 5, 0]]],
     _f_ = [0, [2, 0, [4, 6, [0, 2, 6], 0, [2, 0, 0]]], "%s%06x%s"],


### PR DESCRIPTION
We now take into account of whether an instruction is in a live function or not when generating constraints, so that dead code can no longer result in making a variable live.

We also keep track of nested module.

The performance of the algorithm has been greatly improved as well.

On the `basic_website` example of Tyxml, compiled with `--opt 3`, I get the following reduction in code size:
|     | before | after | |
| ---  | ---: | ---: |  --- |
| uncompressed | 139304 | 125168 | -10% |
| gzip | 47980 | 41367 | -14% |
| bzip2 | 45298 | 38885 | -14% |

Here are the numbers regarding #1612, when compiling `with_bedrock2_fiat_crypto.byte`. For comparison, I have included an intermediate step which just optimizes the current algorithm.
| |before | optimized | after |
| -- | --: | --: | --: |
| duration (s) | 48 | 4.9 | 9.8 |
| peak memory (GiB) | 4 | 2.8 | 2.8 |