### PR TITLE
!js-string implementation of caml_string_concat fix

### DIFF
--- a/runtime/mlBytes.js
+++ b/runtime/mlBytes.js
@@ -692,12 +692,12 @@ function caml_string_concat(a, b) {
 }
 
 //Provides: caml_string_concat
-//Requires: caml_convert_string_to_bytes, MlBytes
+//Requires: caml_string_of_jsbytes, caml_jsbytes_of_string
 //If: !js-string
 function caml_string_concat(s1, s2) {
-  s1.t & 6 && caml_convert_string_to_bytes(s1);
-  s2.t & 6 && caml_convert_string_to_bytes(s2);
-  return new MlBytes(s1.t, s1.c + s2.c, s1.l + s2.l);
+  return caml_string_of_jsbytes(
+    caml_jsbytes_of_string(s1) + caml_jsbytes_of_string(s2),
+  );
 }
 
 //Provides: caml_string_unsafe_get const


### PR DESCRIPTION
If you write some code like (note this is not an ascii x!):
```ocaml
str ^ " ×"
```
And have compiled your code with `--disable use-js-string`, then the concat will not work correctly. I've changed to an implementation that seems correct, but likely has quite a few extra conversions. I'm not sure exactly what the original function was doing, but it felt complicated and so I was a bit nervous about fixing in a lower-level way.

I'd like to have tests in place but I'm not sure what the infrastructure looks like for testing with these flags?