### PR TITLE
Compiler: joo_global_object is deprecated

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
   prevision for the merge of wasm_of_ocaml
 * Compiler: introduce a Targetint module
   that follows the semantic of the backend (js or wasm)
+* Compiler: warn on joo_global_object
 * Runtime: change Sys.os_type on windows (Cygwin -> Win32)
 * Runtime: backtraces are really expensive, they need to be be explicitly
   requested at compile time (--enable with-js-error) or at startup (OCAMLRUNPARAM=b=1)

--- a/compiler/lib/linker.ml
+++ b/compiler/lib/linker.ml
@@ -136,10 +136,7 @@ module Check = struct
     let freename = StringSet.diff freename Reserved.provided in
     let freename = StringSet.remove Global_constant.global_object freename in
     let freename = if has_flags then StringSet.remove "FLAG" freename else freename in
-    if StringSet.mem Global_constant.old_global_object freename && false
-       (* Don't warn yet, we want to give a transition period where both
-          "globalThis" and "joo_global_object" are allowed without extra
-          noise *)
+    if StringSet.mem Global_constant.old_global_object freename
     then
       warn
         "warning: %s: 'joo_global_object' is being deprecated, please use `globalThis` \


### PR DESCRIPTION
follows #1193.
related to #1622  