### PR TITLE
[ci] Add 32bit 5.2.0 job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
         # getting much better, but no luck yet, c.f:
         # https://github.com/ocaml/opam-repository/pull/26626
       - name: Install apt 32-bit dependencies
-        if: matrix.ocaml-compiler == 'ocaml-variants.4.14.2+options,ocaml-option-32bit' || matrix.ocaml-compiler == 'ocaml-variants.5.2.0+options,ocaml-option-32bit'
+        if: contains( matrix.ocaml-compiler, "ocaml-option-32bit")
         run: |
           sudo apt-get install aptitude
           sudo dpkg --add-architecture i386

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,12 @@ jobs:
             skip-effects: false
             skip-test: false
             skip-doc: false
+            # Note this OCaml compiler is bytecode only
+          - os: ubuntu-latest
+            ocaml-compiler: "ocaml-variants.5.2.0+options,ocaml-option-32bit"
+            skip-effects: true # disabled for the same reason than `skip-test`
+            skip-test: true # the `time_now.0.17` package is pulled and doesn't work in 32 bits :(
+            skip-doc: true
           - os: macos-latest
             ocaml-compiler: "5.2"
             skip-effects: true
@@ -82,7 +88,7 @@ jobs:
         # getting much better, but no luck yet, c.f:
         # https://github.com/ocaml/opam-repository/pull/26626
       - name: Install apt 32-bit dependencies
-        if: matrix.ocaml-compiler == 'ocaml-variants.4.14.2+options,ocaml-option-32bit'
+        if: matrix.ocaml-compiler == 'ocaml-variants.4.14.2+options,ocaml-option-32bit' || matrix.ocaml-compiler == 'ocaml-variants.5.2.0+options,ocaml-option-32bit'
         run: |
           sudo apt-get install aptitude
           sudo dpkg --add-architecture i386

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
         # getting much better, but no luck yet, c.f:
         # https://github.com/ocaml/opam-repository/pull/26626
       - name: Install apt 32-bit dependencies
-        if: contains( matrix.ocaml-compiler, "ocaml-option-32bit")
+        if: contains( matrix.ocaml-compiler, 'ocaml-option-32bit')
         run: |
           sudo apt-get install aptitude
           sudo dpkg --add-architecture i386


### PR DESCRIPTION
Caveats:

- The OCaml switch in this case byte-only, so things are slow, as jsoo itself won't have a native mode

- JS ppx libs 0.17 don't really support 32bit builds, this will likely become a problem in the future (if not now actually, for example `ppx_inline_test.0.17.0` fails to build)

- jsCoq/coq-lsp works in this setup, which is IMO a great "data point" as to whether this setup is OK

p.s: Coq stops working in 5.2.0 if I pass `--enable=effects` tho, the error is `Reason: Uncaught RangeError: Maximum call stack size exceeded`, is that worth reporting?