### PR TITLE
Runtime: don't use substr

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -22,7 +22,8 @@
         "noSwitchDeclarations": "off"
       },
       "nursery": {
-        "noUselessEscapeInRegex": "error"
+        "noUselessEscapeInRegex": "error",
+        "noSubstr": "error"
       },
       "style": {
         "noArguments": "off",

--- a/runtime/fs.js
+++ b/runtime/fs.js
@@ -52,7 +52,7 @@ function MlFile() {}
 //Requires: fs_node_supported
 function make_path_is_absolute() {
   function posix(path) {
-    if (path.charAt(0) === "/") return ["", path.substring(1)];
+    if (path.charAt(0) === "/") return ["", path.slice(1)];
     return;
   }
 
@@ -68,7 +68,7 @@ function make_path_is_absolute() {
     if (result[2] || isUnc) {
       var root = result[1] || "";
       var sep = result[2] || "";
-      return [root, path.substring(root.length + sep.length)];
+      return [root, path.slice(root.length + sep.length)];
     }
     return;
   }
@@ -156,7 +156,7 @@ function resolve_fs_device(name) {
       res = {
         path: m.path,
         device: m.device,
-        rest: name.substring(m.path.length, name.length),
+        rest: name.slice(m.path.length, name.length),
       };
   }
   if (!res && fs_node_supported()) {
@@ -167,7 +167,7 @@ function resolve_fs_device(name) {
       res = {
         path: m.path,
         device: m.device,
-        rest: name.substring(m.path.length, name.length),
+        rest: name.slice(m.path.length, name.length),
       };
     }
   }

--- a/runtime/ieee_754.js
+++ b/runtime/ieee_754.js
@@ -141,7 +141,7 @@ function caml_hexstring_of_float(x, prec, style) {
       var size = idx + 1 + prec;
       if (x_str.length < size)
         x_str += caml_str_repeat(size - x_str.length, "0");
-      else x_str = x_str.substr(0, size);
+      else x_str = x_str.slice(0, size);
     }
   }
   return caml_string_of_jsstring(

--- a/runtime/marshal.js
+++ b/runtime/marshal.js
@@ -146,7 +146,7 @@ MlStringReader.prototype = {
   readstr: function (len) {
     var i = this.i;
     this.i = i + len;
-    return caml_string_of_jsbytes(this.s.substring(i, i + len));
+    return caml_string_of_jsbytes(this.s.slice(i, i + len));
   },
   readuint8array: function (len) {
     var b = new Uint8Array(len);

--- a/runtime/mlBytes.js
+++ b/runtime/mlBytes.js
@@ -89,7 +89,7 @@ function caml_utf8_of_utf16(s) {
     if (c < 0x80) {
       for (var j = i + 1; j < l && (c = s.charCodeAt(j)) < 0x80; j++);
       if (j - i > 512) {
-        t.substr(0, 1);
+        t.slice(0, 1);
         b += t;
         t = "";
         b += s.slice(i, j);
@@ -125,7 +125,7 @@ function caml_utf8_of_utf16(s) {
       );
     }
     if (t.length > 1024) {
-      t.substr(0, 1);
+      t.slice(0, 1);
       b += t;
       t = "";
     }
@@ -140,7 +140,7 @@ function caml_utf16_of_utf8(s) {
     if (c1 < 0x80) {
       for (var j = i + 1; j < l && (c1 = s.charCodeAt(j)) < 0x80; j++);
       if (j - i > 512) {
-        t.substr(0, 1);
+        t.slice(0, 1);
         b += t;
         t = "";
         b += s.slice(i, j);
@@ -183,7 +183,7 @@ function caml_utf16_of_utf8(s) {
       t += String.fromCharCode(0xd7c0 + (v >> 10), 0xdc00 + (v & 0x3ff));
     else t += String.fromCharCode(v);
     if (t.length > 1024) {
-      t.substr(0, 1);
+      t.slice(0, 1);
       b += t;
       t = "";
     }
@@ -651,7 +651,7 @@ function caml_blit_bytes(s1, i1, s2, i2, len) {
         ? caml_subarray_to_jsbytes(s1.c, i1, len)
         : i1 === 0 && s1.c.length === len
           ? s1.c
-          : s1.c.substr(i1, len);
+          : s1.c.slice(i1, i1 + len);
     s2.t = s2.c.length === s2.l ? 0 /* BYTES | UNKOWN */ : 2; /* PARTIAL */
   } else if (s2.t === 2 /* PARTIAL */ && i2 === s2.c.length) {
     s2.c +=
@@ -659,7 +659,7 @@ function caml_blit_bytes(s1, i1, s2, i2, len) {
         ? caml_subarray_to_jsbytes(s1.c, i1, len)
         : i1 === 0 && s1.c.length === len
           ? s1.c
-          : s1.c.substr(i1, len);
+          : s1.c.slice(i1, i1 + len);
     s2.t = s2.c.length === s2.l ? 0 /* BYTES | UNKOWN */ : 2; /* PARTIAL */
   } else {
     if (s2.t !== 4 /* ARRAY */) caml_convert_bytes_to_array(s2);


### PR DESCRIPTION
> Note: substr() is not part of the main ECMAScript specification — it's defined in [Annex B: Additional ECMAScript Features for Web Browsers](https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html), which is normative optional for non-browser runtimes. Therefore, people are advised to use the standard [String.prototype.substring()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) and [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) methods instead to make their code maximally cross-platform friendly. The [String.prototype.substring() page](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring#the_difference_between_substring_and_substr) has some comparisons between the three methods.

Also,  `slice` and `substring` seem  to be equivalent when `0 <= start <= stop`. let's use `slice` everywhere.    