### PR TITLE
runtime: do not force array shape for bytes in lexing.js

### DIFF
--- a/runtime/lexing.js
+++ b/runtime/lexing.js
@@ -27,7 +27,7 @@ function caml_lex_array(s) {
 }
 
 //Provides: caml_lex_engine
-//Requires: caml_failwith, caml_lex_array, caml_uint8_array_of_bytes
+//Requires: caml_failwith, caml_lex_array
 //Requires: caml_bytes_unsafe_get
 function caml_lex_engine(tbl, start_state, lexbuf) {
   var lex_buffer = 2;
@@ -106,7 +106,7 @@ function caml_lex_engine(tbl, start_state, lexbuf) {
 
 //Provides: caml_new_lex_engine
 //Requires: caml_failwith, caml_lex_array
-//Requires: caml_jsbytes_of_string, caml_uint8_array_of_bytes
+//Requires: caml_jsbytes_of_string
 //Requires: caml_bytes_unsafe_get
 function caml_lex_run_mem(s, i, mem, curr_pos) {
   for (;;) {

--- a/runtime/lexing.js
+++ b/runtime/lexing.js
@@ -28,6 +28,7 @@ function caml_lex_array(s) {
 
 //Provides: caml_lex_engine
 //Requires: caml_failwith, caml_lex_array, caml_uint8_array_of_bytes
+//Requires: caml_bytes_unsafe_get
 function caml_lex_engine(tbl, start_state, lexbuf) {
   var lex_buffer = 2;
   var lex_buffer_len = 3;
@@ -53,7 +54,7 @@ function caml_lex_engine(tbl, start_state, lexbuf) {
   var c,
     state = start_state;
 
-  var buffer = caml_uint8_array_of_bytes(lexbuf[lex_buffer]);
+  var buffer = lexbuf[lex_buffer];
 
   if (state >= 0) {
     /* First entry */
@@ -79,7 +80,7 @@ function caml_lex_engine(tbl, start_state, lexbuf) {
       else c = 256;
     } else {
       /* Read next input char */
-      c = buffer[lexbuf[lex_curr_pos]];
+      c = caml_bytes_unsafe_get(buffer, lexbuf[lex_curr_pos]);
       lexbuf[lex_curr_pos]++;
     }
     /* Determine next state */
@@ -106,6 +107,7 @@ function caml_lex_engine(tbl, start_state, lexbuf) {
 //Provides: caml_new_lex_engine
 //Requires: caml_failwith, caml_lex_array
 //Requires: caml_jsbytes_of_string, caml_uint8_array_of_bytes
+//Requires: caml_bytes_unsafe_get
 function caml_lex_run_mem(s, i, mem, curr_pos) {
   for (;;) {
     var dst = s.charCodeAt(i);
@@ -171,7 +173,7 @@ function caml_new_lex_engine(tbl, start_state, lexbuf) {
   var c,
     state = start_state;
 
-  var buffer = caml_uint8_array_of_bytes(lexbuf[lex_buffer]);
+  var buffer = lexbuf[lex_buffer];
 
   if (state >= 0) {
     /* First entry */
@@ -203,7 +205,7 @@ function caml_new_lex_engine(tbl, start_state, lexbuf) {
       else c = 256;
     } else {
       /* Read next input char */
-      c = buffer[lexbuf[lex_curr_pos]];
+      c = caml_bytes_unsafe_get(buffer, lexbuf[lex_curr_pos]);
       lexbuf[lex_curr_pos]++;
     }
     /* Determine next state */

--- a/runtime/mlBytes.js
+++ b/runtime/mlBytes.js
@@ -502,7 +502,6 @@ function caml_uint8_array_of_bytes(s) {
 }
 
 //Provides: caml_uint8_array_of_string mutable
-//Requires: caml_convert_bytes_to_array
 //Requires: caml_ml_string_length, caml_string_unsafe_get
 function caml_uint8_array_of_string(s) {
   var l = caml_ml_string_length(s);


### PR DESCRIPTION
fix #1703 