### PR TITLE
Handle composite sourcemaps

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@
   that follows the semantic of the backend (js or wasm)
 * Compiler: warn on joo_global_object
 * Compiler: revisit static env handling (#1708)
+* Compiler: Emit index map when linking multiple js files together (#1714)
 * Runtime: change Sys.os_type on windows (Cygwin -> Win32)
 * Runtime: backtraces are really expensive, they need to be be explicitly
   requested at compile time (--enable with-js-error) or at startup (OCAMLRUNPARAM=b=1)

--- a/compiler/bin-js_of_ocaml/build_fs.ml
+++ b/compiler/bin-js_of_ocaml/build_fs.ml
@@ -74,7 +74,7 @@ function jsoo_create_file_extern(name,content){
   let code = Code.prepend Code.empty instr in
   Filename.gen_file output_file (fun chan ->
       let pfs_fmt = Pretty_print.to_out_channel chan in
-      let (_ : Source_map.t option) =
+      let (_ : Source_map.Standard.t option) =
         Driver.f
           ~standalone:true
           ~wrap_with_fun:`Iife

--- a/compiler/bin-js_of_ocaml/cmd_arg.ml
+++ b/compiler/bin-js_of_ocaml/cmd_arg.ml
@@ -302,9 +302,9 @@ let options =
       then
         let file, sm_output_file =
           match output_file with
-          | `Name file, _ when sourcemap_inline_in_js -> file, None
-          | `Name file, _ -> file, Some (chop_extension file ^ ".map")
-          | `Stdout, _ -> "STDIN", None
+          | `Name file, _ when sourcemap_inline_in_js -> Some file, None
+          | `Name file, _ -> Some file, Some (chop_extension file ^ ".map")
+          | `Stdout, _ -> None, None
         in
         Some
           ( sm_output_file
@@ -531,9 +531,9 @@ let options_runtime_only =
       then
         let file, sm_output_file =
           match output_file with
-          | `Name file, _ when sourcemap_inline_in_js -> file, None
-          | `Name file, _ -> file, Some (chop_extension file ^ ".map")
-          | `Stdout, _ -> "STDIN", None
+          | `Name file, _ when sourcemap_inline_in_js -> Some file, None
+          | `Name file, _ -> Some file, Some (chop_extension file ^ ".map")
+          | `Stdout, _ -> None, None
         in
         Some
           ( sm_output_file

--- a/compiler/bin-js_of_ocaml/cmd_arg.ml
+++ b/compiler/bin-js_of_ocaml/cmd_arg.ml
@@ -43,7 +43,7 @@ type t =
   { common : Jsoo_cmdline.Arg.t
   ; (* compile option *)
     profile : Driver.profile option
-  ; source_map : (string option * Source_map.t) option
+  ; source_map : (string option * Source_map.Standard.t) option
   ; runtime_files : string list
   ; no_runtime : bool
   ; include_runtime : bool
@@ -308,7 +308,7 @@ let options =
         in
         Some
           ( sm_output_file
-          , { Source_map.version = 3
+          , { Source_map.Standard.version = 3
             ; file
             ; sourceroot = sourcemap_root
             ; sources = []
@@ -537,7 +537,7 @@ let options_runtime_only =
         in
         Some
           ( sm_output_file
-          , { Source_map.version = 3
+          , { Source_map.Standard.version = 3
             ; file
             ; sourceroot = sourcemap_root
             ; sources = []

--- a/compiler/bin-js_of_ocaml/cmd_arg.mli
+++ b/compiler/bin-js_of_ocaml/cmd_arg.mli
@@ -23,7 +23,7 @@ type t =
   { common : Jsoo_cmdline.Arg.t
   ; (* compile option *)
     profile : Driver.profile option
-  ; source_map : (string option * Source_map.t) option
+  ; source_map : (string option * Source_map.Standard.t) option
   ; runtime_files : string list
   ; no_runtime : bool
   ; include_runtime : bool

--- a/compiler/bin-js_of_ocaml/compile.ml
+++ b/compiler/bin-js_of_ocaml/compile.ml
@@ -47,6 +47,7 @@ let output_gen ~standalone ~custom_header ~build_info ~source_map output_file f 
     match source_map, sm with
     | None, _ | _, None -> ()
     | Some (output_file, _), Some sm ->
+        let sm = `Standard sm in
         let urlData =
           match output_file with
           | None ->

--- a/compiler/bin-js_of_ocaml/link.ml
+++ b/compiler/bin-js_of_ocaml/link.ml
@@ -96,9 +96,9 @@ let options =
       then
         let file, sm_output_file =
           match output_file with
-          | Some file when sourcemap_inline_in_js -> file, None
-          | Some file -> file, Some (chop_extension file ^ ".map")
-          | None -> "STDIN", None
+          | Some file when sourcemap_inline_in_js -> Some file, None
+          | Some file -> Some file, Some (chop_extension file ^ ".map")
+          | None -> None, None
         in
         Some
           ( sm_output_file

--- a/compiler/bin-js_of_ocaml/link.ml
+++ b/compiler/bin-js_of_ocaml/link.ml
@@ -23,7 +23,7 @@ open Cmdliner
 
 type t =
   { common : Jsoo_cmdline.Arg.t
-  ; source_map : (string option * Source_map.t) option
+  ; source_map : (string option * Source_map.Standard.t) option
   ; js_files : string list
   ; output_file : string option
   ; resolve_sourcemap_url : bool
@@ -102,7 +102,7 @@ let options =
         in
         Some
           ( sm_output_file
-          , { Source_map.version = 3
+          , { Source_map.Standard.version = 3
             ; file
             ; sourceroot = sourcemap_root
             ; sources = []

--- a/compiler/bin-jsoo_minify/jsoo_minify.ml
+++ b/compiler/bin-jsoo_minify/jsoo_minify.ml
@@ -92,7 +92,7 @@ let f { Cmd_arg.common; output_file; use_stdin; files } =
           if t () then (m ())#program p else p)
     in
     let p = Js_assign.program p in
-    let (_ : Source_map.t option) = Js_output.program pp p in
+    let (_ : Source_map.Standard.t option) = Js_output.program pp p in
     ()
   in
   with_output (fun out_channel ->

--- a/compiler/lib/driver.ml
+++ b/compiler/lib/driver.ml
@@ -713,7 +713,7 @@ let full ~standalone ~wrap_with_fun ~profile ~link ~source_map ~formatter d p =
   emit formatter optimized_code
 
 let full_no_source_map ~formatter ~standalone ~wrap_with_fun ~profile ~link d p =
-  let (_ : Source_map.t option) =
+  let (_ : Source_map.Standard.t option) =
     full ~standalone ~wrap_with_fun ~profile ~link ~source_map:None ~formatter d p
   in
   ()

--- a/compiler/lib/driver.mli
+++ b/compiler/lib/driver.mli
@@ -35,11 +35,11 @@ val f :
   -> ?wrap_with_fun:[ `Iife | `Anonymous | `Named of string ]
   -> ?profile:profile
   -> link:[ `All | `All_from of string list | `Needed | `No ]
-  -> ?source_map:Source_map.t
+  -> ?source_map:Source_map.Standard.t
   -> formatter:Pretty_print.t
   -> Parse_bytecode.Debug.t
   -> Code.program
-  -> Source_map.t option
+  -> Source_map.Standard.t option
 
 val f' :
      ?standalone:bool

--- a/compiler/lib/js_assign.ml
+++ b/compiler/lib/js_assign.ml
@@ -425,7 +425,7 @@ let program' (module Strategy : Strategy) p =
            "Some variables escaped (#%d). Use [--debug js_assign] for more info.@."
            (IdentSet.cardinal free)
        else
-         let (_ : Source_map.t option) =
+         let (_ : Source_map.Standard.t option) =
            Js_output.program
              ~accept_unnamed_var:true
              (Pretty_print.to_out_channel stderr)

--- a/compiler/lib/js_output.ml
+++ b/compiler/lib/js_output.ml
@@ -1905,8 +1905,8 @@ let program ?(accept_unnamed_var = false) f ?source_map p =
   let names = Hashtbl.create 17 in
   let contents : Source_map.Source_content.t option list ref option =
     match source_map with
-    | None | Some { Source_map.sources_content = None; _ } -> None
-    | Some { Source_map.sources_content = Some _; _ } -> Some (ref [])
+    | None | Some { Source_map.Standard.sources_content = None; _ } -> None
+    | Some { Source_map.Standard.sources_content = Some _; _ } -> Some (ref [])
   in
   let push_mapping, get_file_index, get_name_index, source_map_enabled =
     let source_map_enabled =
@@ -1926,7 +1926,7 @@ let program ?(accept_unnamed_var = false) f ?source_map p =
                 loop xs ys
           in
           loop sm.sources (Option.value ~default:[] sm.sources_content);
-          List.iter sm.Source_map.names ~f:(fun f ->
+          List.iter sm.Source_map.Standard.names ~f:(fun f ->
               Hashtbl.add names f (Hashtbl.length names));
           true
     in
@@ -2014,7 +2014,7 @@ let program ?(accept_unnamed_var = false) f ?source_map p =
                     { gen_line; gen_col; ori_source; ori_line; ori_col; ori_name })
         in
         let mappings = Source_map.Mappings.encode mappings in
-        Some { sm with Source_map.sources; names; sources_content; mappings }
+        Some { sm with Source_map.Standard.sources; names; sources_content; mappings }
   in
   PP.check f;
   (if stats ()

--- a/compiler/lib/js_output.mli
+++ b/compiler/lib/js_output.mli
@@ -21,6 +21,6 @@
 val program :
      ?accept_unnamed_var:bool
   -> Pretty_print.t
-  -> ?source_map:Source_map.t
+  -> ?source_map:Source_map.Standard.t
   -> Javascript.program
-  -> Source_map.t option
+  -> Source_map.Standard.t option

--- a/compiler/lib/link_js.ml
+++ b/compiler/lib/link_js.ml
@@ -154,7 +154,7 @@ type action =
   | Drop
   | Unit
   | Build_info of Build_info.t
-  | Source_map of Source_map.t
+  | Source_map of Source_map.Standard.t
 
 let prefix_kind line =
   match String.is_prefix ~prefix:sourceMappingURL line with
@@ -170,6 +170,10 @@ let prefix_kind line =
       | true -> `Json_base64 (String.length sourceMappingURL_base64)
       | false -> `Url (String.length sourceMappingURL))
 
+let rule_out_index_map = function
+  | `Standard sm -> sm
+  | `Index _ -> failwith "unexpected index map at this stage"
+
 let action ~resolve_sourcemap_url ~drop_source_map file line =
   match prefix_kind line, drop_source_map with
   | `Other, (true | false) -> Keep
@@ -177,7 +181,8 @@ let action ~resolve_sourcemap_url ~drop_source_map file line =
   | `Build_info bi, _ -> Build_info bi
   | (`Json_base64 _ | `Url _), true -> Drop
   | `Json_base64 offset, false ->
-      Source_map (Source_map.of_string (Base64.decode_exn ~off:offset line))
+      Source_map
+        (rule_out_index_map (Source_map.of_string (Base64.decode_exn ~off:offset line)))
   | `Url _, false when not resolve_sourcemap_url -> Drop
   | `Url offset, false ->
       let url = String.sub line ~pos:offset ~len:(String.length line - offset) in
@@ -186,7 +191,7 @@ let action ~resolve_sourcemap_url ~drop_source_map file line =
       let l = in_channel_length ic in
       let content = really_input_string ic l in
       close_in ic;
-      Source_map (Source_map.of_string content)
+      Source_map (rule_out_index_map (Source_map.of_string content))
 
 module Units : sig
   val read : Line_reader.t -> Unit_info.t -> Unit_info.t
@@ -444,18 +449,19 @@ let link ~output ~linkall ~mklib ~toplevel ~files ~resolve_sourcemap_url ~source
         List.rev_map !sm ~f:(fun (sm, reloc) ->
             let tbl = Hashtbl.create 17 in
             List.iter reloc ~f:(fun (a, b) -> Hashtbl.add tbl a b);
-            Source_map.filter_map sm ~f:(Hashtbl.find_opt tbl))
+            Source_map.Standard.filter_map sm ~f:(Hashtbl.find_opt tbl))
       in
-      (match Source_map.merge (init_sm :: sm) with
+      (match Source_map.Standard.merge (init_sm :: sm) with
       | None -> ()
       | Some sm -> (
           (* preserve some info from [init_sm] *)
           let sm =
-            { sm with
-              version = init_sm.version
-            ; file = init_sm.file
-            ; sourceroot = init_sm.sourceroot
-            }
+            `Standard
+              { sm with
+                version = init_sm.version
+              ; file = init_sm.file
+              ; sourceroot = init_sm.sourceroot
+              }
           in
           match file with
           | None ->

--- a/compiler/lib/link_js.mli
+++ b/compiler/lib/link_js.mli
@@ -24,5 +24,5 @@ val link :
   -> toplevel:bool
   -> files:string list
   -> resolve_sourcemap_url:bool
-  -> source_map:(string option * Source_map.t) option
+  -> source_map:(string option * Source_map.Standard.t) option
   -> unit

--- a/compiler/lib/source_map.mli
+++ b/compiler/lib/source_map.mli
@@ -70,7 +70,7 @@ end
 module Standard : sig
   type t =
     { version : int
-    ; file : string
+    ; file : string option
     ; sourceroot : string option
     ; sources : string list
     ; sources_content : Source_content.t option list option
@@ -90,7 +90,7 @@ module Standard : sig
   (** Merge two lists of debug mappings. The time cost of the merge is more than
     linear in function of the size of the input mappings. *)
 
-  val empty : filename:string -> t
+  val empty : t
 end
 
 module Index : sig
@@ -101,7 +101,7 @@ module Index : sig
 
   type nonrec t =
     { version : int
-    ; file : string
+    ; file : string option
     ; sections : (offset * [ `Map of Standard.t ]) list
     }
 end

--- a/compiler/tests-compiler/build_path_prefix_map.ml
+++ b/compiler/tests-compiler/build_path_prefix_map.ml
@@ -41,8 +41,8 @@ let%expect_test _ =
       | None -> failwith "no sourcemap generated!");
   [%expect
     {|
-      file: test.js
-      sourceRoot:
-      sources:
-      - /dune-root/test.ml
+    file: test.js
+    sourceRoot: <none>
+    sources:
+    - /dune-root/test.ml
     |}]

--- a/compiler/tests-compiler/build_path_prefix_map.ml
+++ b/compiler/tests-compiler/build_path_prefix_map.ml
@@ -20,6 +20,12 @@ open Js_of_ocaml_compiler.Stdlib
 open Util
 
 let%expect_test _ =
+  let print_section (sm : Js_of_ocaml_compiler.Source_map.Standard.t) =
+    Printf.printf "file: %s\n" sm.file;
+    Printf.printf "sourceRoot: %s\n" (Option.value ~default:"<none>" sm.sourceroot);
+    Printf.printf "sources:\n";
+    List.iter sm.sources ~f:(fun source -> Printf.printf "- %s\n" (normalize_path source))
+  in
   with_temp_dir ~f:(fun () ->
       let name = "test.ml" in
       Filetype.write_file name "let id x = x";
@@ -29,12 +35,9 @@ let%expect_test _ =
       |> compile_cmo_to_javascript ~sourcemap:true ~pretty:false
       |> extract_sourcemap
       |> function
-      | Some (sm : Js_of_ocaml_compiler.Source_map.t) ->
-          Printf.printf "file: %s\n" sm.file;
-          Printf.printf "sourceRoot: %s\n" (Option.value ~default:"<none>" sm.sourceroot);
-          Printf.printf "sources:\n";
-          List.iter sm.sources ~f:(fun source ->
-              Printf.printf "- %s\n" (normalize_path source))
+      | Some (`Standard (sm : Js_of_ocaml_compiler.Source_map.Standard.t)) ->
+          print_section sm
+      | Some (`Index i) -> List.iter i.sections ~f:(fun (_, `Map sm) -> print_section sm)
       | None -> failwith "no sourcemap generated!");
   [%expect
     {|

--- a/compiler/tests-compiler/build_path_prefix_map.ml
+++ b/compiler/tests-compiler/build_path_prefix_map.ml
@@ -21,7 +21,7 @@ open Util
 
 let%expect_test _ =
   let print_section (sm : Js_of_ocaml_compiler.Source_map.Standard.t) =
-    Printf.printf "file: %s\n" sm.file;
+    Printf.printf "file: %s\n" (Option.value ~default:"<none>" sm.file);
     Printf.printf "sourceRoot: %s\n" (Option.value ~default:"<none>" sm.sourceroot);
     Printf.printf "sources:\n";
     List.iter sm.sources ~f:(fun source -> Printf.printf "- %s\n" (normalize_path source))

--- a/compiler/tests-compiler/macro.ml
+++ b/compiler/tests-compiler/macro.ml
@@ -31,7 +31,9 @@ let print_macro_transformed source =
       in
       let parsed = Util.parse_js source in
       let transformed, _ = Jsoo.Macro.f ~flags:false parsed in
-      let (_ : Jsoo.Source_map.t option) = Jsoo.Js_output.program pp transformed in
+      let (_ : Jsoo.Source_map.Standard.t option) =
+        Jsoo.Js_output.program pp transformed
+      in
       print_endline (Buffer.contents buffer))
 
 let print_macro_transformed source =

--- a/compiler/tests-compiler/sourcemap.ml
+++ b/compiler/tests-compiler/sourcemap.ml
@@ -134,7 +134,7 @@ let%expect_test _ =
       { gen_line; gen_col; ori_source = source; ori_line = line; ori_col = col }
   in
   let s1 : Source_map.Standard.t =
-    { (Source_map.Standard.empty ~filename:"1.map") with
+    { Source_map.Standard.empty with
       names = [ "na"; "nb"; "nc" ]
     ; sources = [ "sa"; "sb" ]
     ; mappings =
@@ -142,7 +142,7 @@ let%expect_test _ =
     }
   in
   let s2 : Source_map.Standard.t =
-    { (Source_map.Standard.empty ~filename:"2.map") with
+    { Source_map.Standard.empty with
       names = [ "na2"; "nb2" ]
     ; sources = [ "sa2" ]
     ; mappings = Source_map.Mappings.encode [ gen (3, 3) (5, 5) 0 ]

--- a/compiler/tests-compiler/util/util.ml
+++ b/compiler/tests-compiler/util/util.ml
@@ -421,7 +421,7 @@ let program_to_string ?(compact = false) p =
   let buffer = Buffer.create 17 in
   let pp = Jsoo.Pretty_print.to_buffer buffer in
   Jsoo.Pretty_print.set_compact pp compact;
-  let (_ : Jsoo.Source_map.t option) = Jsoo.Js_output.program pp p in
+  let (_ : Jsoo.Source_map.Standard.t option) = Jsoo.Js_output.program pp p in
   (* This final comment should help to keep merge-confict inside
      {| .. |}, allowing to resolve confict with [dune promote]. *)
   Buffer.add_string buffer "//end\n";

--- a/compiler/tests-sourcemap/dump.reference
+++ b/compiler/tests-sourcemap/dump.reference
@@ -1,7 +1,7 @@
 sourcemap for test.bc.js
-b.ml:1:4 -> 12:   function <>f(x){return x - 1 | 0;}
-b.ml:1:6 -> 14:   function f(<>x){return x - 1 | 0;}
-b.ml:1:10 -> 17:   function f(x){<>return x - 1 | 0;}
-b.ml:1:6 -> 24:   function f(x){return <>x - 1 | 0;}
-b.ml:1:15 -> 34:   function f(x){return x - 1 | 0;<>}
-b.ml:1:4 -> 23:   var Testlib_B = [0, <>f];
+/my/sourceRoot#b.ml:1:4 -> 12:   function <>f(x){return x - 1 | 0;}
+/my/sourceRoot#b.ml:1:6 -> 14:   function f(<>x){return x - 1 | 0;}
+/my/sourceRoot#b.ml:1:10 -> 17:   function f(x){<>return x - 1 | 0;}
+/my/sourceRoot#b.ml:1:6 -> 24:   function f(x){return <>x - 1 | 0;}
+/my/sourceRoot#b.ml:1:15 -> 34:   function f(x){return x - 1 | 0;<>}
+/my/sourceRoot#b.ml:1:4 -> 23:   var Testlib_B = [0, <>f];

--- a/compiler/tests-sourcemap/dump_sourcemap.ml
+++ b/compiler/tests-sourcemap/dump_sourcemap.ml
@@ -36,7 +36,7 @@ let extract_sourcemap lines =
       Some (Source_map.of_string content)
   | _ -> None
 
-let print_mapping lines (sm : Source_map.t) =
+let print_mapping lines ?(line_offset = 0) (sm : Source_map.Standard.t) =
   let lines = Array.of_list lines in
   let sources = Array.of_list sm.sources in
   let _names = Array.of_list sm.names in
@@ -68,8 +68,17 @@ let print_mapping lines (sm : Source_map.t) =
                 ori_line
                 ori_col
                 gen_col
-                (mark gen_col lines.(gen_line - 1))
+                (mark gen_col lines.(gen_line - 1 + line_offset))
           | _ -> ()))
+
+let print_sourcemap lines = function
+  | `Standard sm -> print_mapping lines sm
+  | `Index l ->
+      List.iter
+        l.Source_map.Index.sections
+        ~f:(fun (Source_map.Index.{ gen_line; gen_column }, `Map sm) ->
+          assert (gen_column = 0);
+          print_mapping lines ~line_offset:gen_line sm)
 
 let files = Sys.argv |> Array.to_list |> List.tl
 
@@ -80,4 +89,4 @@ let () =
       | None -> Printf.printf "not sourcemap for %s\n" f
       | Some sm ->
           Printf.printf "sourcemap for %s\n" f;
-          print_mapping lines sm)
+          print_sourcemap lines sm)

--- a/compiler/tests-sourcemap/dump_sourcemap.ml
+++ b/compiler/tests-sourcemap/dump_sourcemap.ml
@@ -62,8 +62,14 @@ let print_mapping lines ?(line_offset = 0) (sm : Source_map.Standard.t) =
         -> (
           match file ori_source with
           | "a.ml" | "b.ml" | "c.ml" | "d.ml" ->
+              let root =
+                match sm.sourceroot with
+                | None -> ""
+                | Some root -> root ^ "#"
+              in
               Printf.printf
-                "%s:%d:%d -> %d:%s\n"
+                "%s%s:%d:%d -> %d:%s\n"
+                root
                 (file ori_source)
                 ori_line
                 ori_col

--- a/compiler/tests-sourcemap/dune
+++ b/compiler/tests-sourcemap/dune
@@ -7,6 +7,9 @@
  (name test)
  (modules test)
  (modes js)
+ (js_of_ocaml
+  (link_flags
+   (:standard --source-map-root /my/sourceRoot)))
  (libraries testlib))
 
 (library


### PR DESCRIPTION
This has been extracted from #1617 upon @hhugo's suggestion. “Index” sourcemaps are useful to merge multiple sourcemaps at a low cost and is part of the optimization in #1617.