### PR TITLE
Add `detailsElement` and `toggleEvent` objects.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@
 * Runtime: allow dynlink of precompiled js with separate compilation (#1676)
 * Runtime: reimplement the runtime of weak and ephemeron (#1707)
 * Lib: Modify Typed_array API for compatibility with WebAssembly
+* Lib: add details element and toggle event (#1728)
 * Toplevel: no longer set globals for toplevel initialization
 
 ## Bug fixes

--- a/lib/js_of_ocaml/dom_html.ml
+++ b/lib/js_of_ocaml/dom_html.ml
@@ -452,6 +452,14 @@ and clipboardEvent = object
   method clipboardData : dataTransfer t readonly_prop
 end
 
+and toggleEvent = object
+  inherit event
+
+  method newState : js_string t readonly_prop
+
+  method oldState : js_string t readonly_prop
+end
+
 and dataTransfer = object
   method dropEffect : js_string t prop
 
@@ -959,6 +967,8 @@ module Event = struct
 
   let waiting = Dom.Event.make "waiting"
 
+  let toggle = Dom.Event.make "toggle"
+
   let make = Dom.Event.make
 end
 
@@ -1370,6 +1380,16 @@ class type anchorElement = object
   method target : js_string t prop
 
   method _type : js_string t prop
+end
+
+class type detailsElement = object ('self)
+  inherit element
+
+  method open_ : bool t prop
+
+  method name : js_string t prop
+
+  method ontoggle : ('self t, toggleEvent t) event_listener prop
 end
 
 class type imageElement = object ('self)
@@ -2735,6 +2755,8 @@ module CoerceTo = struct
   let colgroup e = unsafeCoerce "colgroup" e
 
   let del e = unsafeCoerce "del" e
+
+  let details e = unsafeCoerce "details" e
 
   let div e = unsafeCoerce "div" e
 

--- a/lib/js_of_ocaml/dom_html.mli
+++ b/lib/js_of_ocaml/dom_html.mli
@@ -458,6 +458,14 @@ and clipboardEvent = object
   method clipboardData : dataTransfer t readonly_prop
 end
 
+and toggleEvent = object
+  inherit event
+
+  method newState : js_string t readonly_prop
+
+  method oldState : js_string t readonly_prop
+end
+
 and dataTransfer = object
   method dropEffect : js_string t prop
 
@@ -1188,6 +1196,16 @@ class type anchorElement = object
   method target : js_string t prop
 
   method _type : js_string t prop
+end
+
+class type detailsElement = object ('self)
+  inherit element
+
+  method open_ : bool t prop
+
+  method name : js_string t prop
+
+  method ontoggle : ('self t, toggleEvent t) event_listener prop
 end
 
 class type imageElement = object ('self)
@@ -2503,6 +2521,8 @@ module Event : sig
 
   val waiting : mediaEvent t typ
 
+  val toggle : toggleEvent t typ
+
   val make : string -> 'a typ
 end
 
@@ -3047,6 +3067,8 @@ module CoerceTo : sig
   val colgroup : #element t -> tableColElement t opt
 
   val del : #element t -> modElement t opt
+
+  val details : #element t -> detailsElement t opt
 
   val div : #element t -> divElement t opt
 

--- a/lib/tyxml/tyxml_cast.ml
+++ b/lib/tyxml/tyxml_cast.ml
@@ -79,6 +79,8 @@ end) : Tyxml_cast_sigs.TO with type 'a elt = 'a C.elt = struct
 
   let of_li elt = rebuild_node "of_li" elt
 
+  let of_details elt = rebuild_node "of_details" elt
+
   let of_dialog elt = rebuild_node "of_dialog" elt
 
   let of_div elt = rebuild_node "of_div" elt
@@ -176,8 +178,6 @@ end) : Tyxml_cast_sigs.TO with type 'a elt = 'a C.elt = struct
   let of_datalist elt = rebuild_node "of_datalist" elt
 
   let of_dd elt = rebuild_node "of_dd" elt
-
-  let of_details elt = rebuild_node "of_details" elt
 
   let of_dfn elt = rebuild_node "of_dfn" elt
 
@@ -310,6 +310,8 @@ end) : Tyxml_cast_sigs.OF with type 'a elt = 'a C.elt = struct
   let of_dList elt = rebuild_node "of_dList" elt
 
   let of_li elt = rebuild_node "of_li" elt
+
+  let of_details elt = rebuild_node "of_details" elt
 
   let of_dialog elt = rebuild_node "of_dialog" elt
 

--- a/lib/tyxml/tyxml_cast_sigs.ml
+++ b/lib/tyxml/tyxml_cast_sigs.ml
@@ -71,6 +71,8 @@ module type OF = sig
 
   val of_li : Dom_html.liElement Js.t -> [> Html_types.li ] elt
 
+  val of_details : Dom_html.detailsElement Js.t -> [> Html_types.details ] elt
+
   val of_dialog : Dom_html.dialogElement Js.t -> [> Html_types.dialog ] elt
 
   val of_div : Dom_html.divElement Js.t -> [> Html_types.div ] elt
@@ -182,6 +184,8 @@ module type TO = sig
 
   val of_li : [< Html_types.li ] elt -> Dom_html.liElement Js.t
 
+  val of_details : [< Html_types.details ] elt -> Dom_html.detailsElement Js.t
+
   val of_dialog : [< Html_types.dialog ] elt -> Dom_html.dialogElement Js.t
 
   val of_div : [< Html_types.div ] elt -> Dom_html.divElement Js.t
@@ -279,8 +283,6 @@ module type TO = sig
   val of_datalist : [> Html_types.datalist ] elt -> Dom_html.element Js.t
 
   val of_dd : [> Html_types.dd ] elt -> Dom_html.element Js.t
-
-  val of_details : [> Html_types.details ] elt -> Dom_html.element Js.t
 
   val of_dfn : [> Html_types.dfn ] elt -> Dom_html.element Js.t
 

--- a/lib/tyxml/tyxml_cast_sigs.mli
+++ b/lib/tyxml/tyxml_cast_sigs.mli
@@ -70,6 +70,8 @@ module type OF = sig
 
   val of_li : Dom_html.liElement Js.t -> [> Html_types.li ] elt
 
+  val of_details : Dom_html.detailsElement Js.t -> [> Html_types.details ] elt
+
   val of_dialog : Dom_html.dialogElement Js.t -> [> Html_types.dialog ] elt
 
   val of_div : Dom_html.divElement Js.t -> [> Html_types.div ] elt
@@ -181,6 +183,8 @@ module type TO = sig
 
   val of_li : [< Html_types.li ] elt -> Dom_html.liElement Js.t
 
+  val of_details : [< Html_types.details ] elt -> Dom_html.detailsElement Js.t
+
   val of_dialog : [< Html_types.dialog ] elt -> Dom_html.dialogElement Js.t
 
   val of_div : [< Html_types.div ] elt -> Dom_html.divElement Js.t
@@ -278,8 +282,6 @@ module type TO = sig
   val of_datalist : [> Html_types.datalist ] elt -> Dom_html.element Js.t
 
   val of_dd : [> Html_types.dd ] elt -> Dom_html.element Js.t
-
-  val of_details : [> Html_types.details ] elt -> Dom_html.element Js.t
 
   val of_dfn : [> Html_types.dfn ] elt -> Dom_html.element Js.t
 


### PR DESCRIPTION
Hello,

This PR adds the `detailsElement` and related `toggleEvent` objects.

See:
- https://html.spec.whatwg.org/multipage/interactive-elements.html#the-details-element ;
- https://html.spec.whatwg.org/multipage/indices.html#event-toggle ;
- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details#attributes ;
- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details#events .

See also these related PRs:
- [#341 in tyxml](https://github.com/ocsigen/tyxml/pull/341)
- [#806 in eliom](https://github.com/ocsigen/eliom/pull/806)

Please let me know of any issue.

Cheers,
