### PR TITLE
precompute prng lxm constants

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,8 @@
 * Lib: Modify Typed_array API for compatibility with WebAssembly
 * Lib: add details element and toggle event (#1728)
 * Toplevel: no longer set globals for toplevel initialization
+* Runtime: precompute constants used in `caml_lxm_next` (#1730)
+
 
 ## Bug fixes
 * Runtime: fix parsing of unsigned integers (0u2147483648) (#1633, #1666)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,7 +28,6 @@
 * Toplevel: no longer set globals for toplevel initialization
 * Runtime: precompute constants used in `caml_lxm_next` (#1730)
 
-
 ## Bug fixes
 * Runtime: fix parsing of unsigned integers (0u2147483648) (#1633, #1666)
 * Runtime: fix incorrect pos_in after unmarshalling

--- a/compiler/tests-check-prim/main.output
+++ b/compiler/tests-check-prim/main.output
@@ -177,9 +177,6 @@ caml_obj_is_block
 caml_obj_is_shared
 caml_obj_update_tag
 
-From +prng.js:
-caml_lxm_next
-
 From +runtime_events.js:
 caml_custom_event_index
 caml_ml_runtime_events_pause

--- a/compiler/tests-check-prim/unix-unix.output
+++ b/compiler/tests-check-prim/unix-unix.output
@@ -286,9 +286,6 @@ caml_obj_is_block
 caml_obj_is_shared
 caml_obj_update_tag
 
-From +prng.js:
-caml_lxm_next
-
 From +runtime_events.js:
 caml_custom_event_index
 caml_ml_runtime_events_pause

--- a/compiler/tests-check-prim/unix-win32.output
+++ b/compiler/tests-check-prim/unix-win32.output
@@ -251,9 +251,6 @@ caml_obj_is_block
 caml_obj_is_shared
 caml_obj_update_tag
 
-From +prng.js:
-caml_lxm_next
-
 From +runtime_events.js:
 caml_custom_event_index
 caml_ml_runtime_events_pause

--- a/runtime/js/prng.js
+++ b/runtime/js/prng.js
@@ -1,11 +1,13 @@
 //Provides: caml_lxm_M
 //Requires: caml_int64_of_string
 //Requires: caml_new_string
+//Version: >= 5
 var caml_lxm_M = caml_int64_of_string(caml_new_string("0xd1342543de82ef95"));
 
 //Provides: caml_lxm_daba
 //Requires: caml_int64_of_string
 //Requires: caml_new_string
+//Version: >= 5
 var caml_lxm_daba = caml_int64_of_string(caml_new_string("0xdaba0b6eb09322e3"));
 
 //Provides: caml_lxm_next
@@ -19,6 +21,7 @@ var caml_lxm_daba = caml_int64_of_string(caml_new_string("0xdaba0b6eb09322e3"));
 //Requires: caml_ba_set_1
 //Requires: caml_lxm_M
 //Requires: caml_lxm_daba
+//Version: >= 5
 function caml_lxm_next(v) {
   function shift_l(x, k) {
     return caml_int64_shift_left(x, k);

--- a/runtime/js/prng.js
+++ b/runtime/js/prng.js
@@ -1,3 +1,13 @@
+//Provides: caml_lxm_M
+//Requires: caml_int64_of_string
+//Requires: caml_new_string
+var caml_lxm_M = caml_int64_of_string(caml_new_string("0xd1342543de82ef95"));
+
+//Provides: caml_lxm_daba
+//Requires: caml_int64_of_string
+//Requires: caml_new_string
+var caml_lxm_daba = caml_int64_of_string(caml_new_string("0xdaba0b6eb09322e3"));
+
 //Provides: caml_lxm_next
 //Requires: caml_int64_shift_left
 //Requires: caml_int64_shift_right_unsigned
@@ -7,8 +17,8 @@
 //Requires: caml_int64_mul
 //Requires: caml_ba_get_1
 //Requires: caml_ba_set_1
-//Requires: caml_int64_of_string
-//Requires: caml_new_string
+//Requires: caml_lxm_M
+//Requires: caml_lxm_daba
 function caml_lxm_next(v) {
   function shift_l(x, k) {
     return caml_int64_shift_left(x, k);
@@ -37,8 +47,8 @@ function caml_lxm_next(v) {
   function set(a, i, x) {
     return caml_ba_set_1(a, i, x);
   }
-  var M = caml_int64_of_string(caml_new_string("0xd1342543de82ef95"));
-  var daba = caml_int64_of_string(caml_new_string("0xdaba0b6eb09322e3"));
+  var M = caml_lxm_M;
+  var daba = caml_lxm_daba;
   var z, q0, q1;
   var st = v;
   var a = get(st, 0);


### PR DESCRIPTION
`caml_int64_of_string` is quite slow.  Move the call from the body of `caml_lxm_next` to a constant.

Making this change resulted in a 2x speedup of some code that calls `caml_lxm_next` in a tight loop.