### PR TITLE
Dom_html: fix the type of some properties and methods

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# dev
+
+## Features/Changes
+* Lib: fix the type of some DOM properties and methods (#1747)
+
 # 5.9.0 (2024-11-22) - Lille
 
 ## Features/Changes

--- a/examples/hyperbolic/hypertree.ml
+++ b/examples/hyperbolic/hypertree.ml
@@ -296,10 +296,10 @@ let _debug_msg _s = ()
                     *)
 
 let handle_drag element move stop click =
-  let fuzz = 4 in
+  let fuzz = 4. in
   element##.onmousedown :=
     Html.handler (fun ev ->
-        let x0 = ev##.clientX and y0 = ev##.clientY in
+        let x0 = Js.to_float ev##.clientX and y0 = Js.to_float ev##.clientY in
         (*
 debug_msg (Format.sprintf "Mouse down %d %d" x0 y0);
 *)
@@ -309,11 +309,12 @@ debug_msg (Format.sprintf "Mouse down %d %d" x0 y0);
             Html.document
             Html.Event.mousemove
             (Html.handler (fun ev ->
-                 let x = ev##.clientX and y = ev##.clientY in
+                 let x = Js.to_float ev##.clientX and y = Js.to_float ev##.clientY in
                  (*
 debug_msg (Format.sprintf "Mouse move %d %d %d %d" x0 y0 x y);
 *)
-                 if (not !started) && (abs (x - x0) > fuzz || abs (y - y0) > fuzz)
+                 if (not !started)
+                    && (abs_float (x -. x0) > fuzz || abs_float (y -. y0) > fuzz)
                  then (
                    started := true;
                    element##.style##.cursor := Js.string "move");
@@ -337,14 +338,14 @@ debug_msg (Format.sprintf "Mouse up %d %d %d %d" x0 y0 ev##clientX ev##clientY);
                     if !started
                     then (
                       element##.style##.cursor := Js.string "";
-                      stop ev##.clientX ev##.clientY)
-                    else click ev##.clientX ev##.clientY;
+                      stop (Js.to_float ev##.clientX) (Js.to_float ev##.clientY))
+                    else click (Js.to_float ev##.clientX) (Js.to_float ev##.clientY);
                     Js._true))
                Js._true);
         Js._true)
 
 let handle_touch_events element move stop cancel click =
-  let fuzz = 4 in
+  let fuzz = 4. in
   ignore
     (Html.addEventListener
        element
@@ -354,7 +355,8 @@ let handle_touch_events element move stop cancel click =
               (ev##.changedTouches##item 0)
               (fun touch ->
                 let id = touch##.identifier in
-                let x0 = touch##.clientX and y0 = touch##.clientY in
+                let x0 = Js.to_float touch##.clientX
+                and y0 = Js.to_float touch##.clientY in
                 (*
 debug_msg (Format.sprintf "Touch start %d %d" x0 y0);
 *)
@@ -370,12 +372,14 @@ debug_msg (Format.sprintf "Touch start %d %d" x0 y0);
                              (fun touch ->
                                if touch##.identifier = id
                                then (
-                                 let x = touch##.clientX and y = touch##.clientY in
+                                 let x = Js.to_float touch##.clientX
+                                 and y = Js.to_float touch##.clientY in
                                  (*
   debug_msg (Format.sprintf "Touch move %d %d %d %d" x0 y0 x y);
 *)
                                  if (not !started)
-                                    && (abs (x - x0) > fuzz || abs (y - y0) > fuzz)
+                                    && (abs_float (x -. x0) > fuzz
+                                       || abs_float (y -. y0) > fuzz)
                                  then (
                                    started := true;
                                    element##.style##.cursor := Js.string "move");
@@ -399,7 +403,8 @@ debug_msg (Format.sprintf "Touch start %d %d" x0 y0);
                                 (fun touch ->
                                   if touch##.identifier = id
                                   then (
-                                    let x = touch##.clientX and y = touch##.clientY in
+                                    let x = Js.to_float touch##.clientX
+                                    and y = Js.to_float touch##.clientY in
                                     (*
 debug_msg (Format.sprintf "Touch end %d %d %d %d" x0 y0 x y);
 *)
@@ -577,7 +582,7 @@ let to_screen z = ((z.x +. 1.) *. r, (z.y +. 1.) *. r)
 *)
 let from_screen canvas x y =
   let rx, ry, dx, dy = screen_transform canvas in
-  let z = { x = (float x -. dx) /. rx; y = (float y -. dy) /. ry } in
+  let z = { x = (x -. dx) /. rx; y = (y -. dy) /. ry } in
   let n = norm z in
   if n <= 1. -. eps then z else sdiv z (n /. (1. -. eps))
 
@@ -1620,10 +1625,8 @@ debug_msg (Format.sprintf "Resize %d %d" w h);
       let p = ref (-1) in
       for i = 0 to Array.length boxes.bw - 1 do
         if Array.unsafe_get boxes.bw i > 0.
-           && abs_float (float x -. Array.unsafe_get boxes.bx i)
-              < Array.unsafe_get boxes.bw i
-           && abs_float (float y -. Array.unsafe_get boxes.by i)
-              < Array.unsafe_get boxes.bh i
+           && abs_float (x -. Array.unsafe_get boxes.bx i) < Array.unsafe_get boxes.bw i
+           && abs_float (y -. Array.unsafe_get boxes.by i) < Array.unsafe_get boxes.bh i
         then p := i
       done;
       !p
@@ -1644,7 +1647,7 @@ debug_msg (Format.sprintf "Resize %d %d" w h);
     in
     canvas##.onmousemove :=
       Html.handler (fun ev ->
-          update_cursor ev##.clientX ev##.clientY;
+          update_cursor (Js.to_float ev##.clientX) (Js.to_float ev##.clientY);
           Js._false);
     handle_drag
       canvas

--- a/examples/planet/planet.ml
+++ b/examples/planet/planet.ml
@@ -683,23 +683,23 @@ let start _ =
     p##.innerHTML :=
       Js.string "Credit: <a href='http://visibleearth.nasa.gov/'>Visual Earth</a>, Nasa";
     add doc##.body p;
-    let mx = ref 0 in
-    let my = ref 0 in
+    let mx = ref 0. in
+    let my = ref 0. in
     canvas##.onmousedown :=
       Dom_html.handler (fun ev ->
-          mx := ev##.clientX;
-          my := ev##.clientY;
+          mx := Js.to_float ev##.clientX;
+          my := Js.to_float ev##.clientY;
           let c1 =
             Html.addEventListener
               Html.document
               Html.Event.mousemove
               (Dom_html.handler (fun ev ->
-                   let x = ev##.clientX and y = ev##.clientY in
-                   let dx = x - !mx and dy = y - !my in
-                   if dy != 0
-                   then m := matrix_mul (yz_rotation (2. *. float dy /. float width)) !m;
-                   if dx != 0
-                   then m := matrix_mul (xz_rotation (2. *. float dx /. float width)) !m;
+                   let x = Js.to_float ev##.clientX and y = Js.to_float ev##.clientY in
+                   let dx = x -. !mx and dy = y -. !my in
+                   if dy != 0.
+                   then m := matrix_mul (yz_rotation (2. *. dy /. float width)) !m;
+                   if dx != 0.
+                   then m := matrix_mul (xz_rotation (2. *. dx /. float width)) !m;
                    mx := x;
                    my := y;
                    Js._true))

--- a/lib/js_of_ocaml/dom_html.ml
+++ b/lib/js_of_ocaml/dom_html.ml
@@ -297,17 +297,17 @@ and mouseEvent = object
 
   method relatedTarget : element t opt optdef readonly_prop
 
-  method clientX : int readonly_prop
+  method clientX : number_t readonly_prop
 
-  method clientY : int readonly_prop
+  method clientY : number_t readonly_prop
 
-  method screenX : int readonly_prop
+  method screenX : number_t readonly_prop
 
-  method screenY : int readonly_prop
+  method screenY : number_t readonly_prop
 
-  method offsetX : int readonly_prop
+  method offsetX : number_t readonly_prop
 
-  method offsetY : int readonly_prop
+  method offsetY : number_t readonly_prop
 
   method ctrlKey : bool t readonly_prop
 
@@ -325,9 +325,9 @@ and mouseEvent = object
 
   method toElement : element t opt optdef readonly_prop
 
-  method pageX : int optdef readonly_prop
+  method pageX : number_t optdef readonly_prop
 
-  method pageY : int optdef readonly_prop
+  method pageY : number_t optdef readonly_prop
 end
 
 and keyboardEvent = object
@@ -421,17 +421,17 @@ and touch = object
 
   method target : element t optdef readonly_prop
 
-  method screenX : int readonly_prop
+  method screenX : number_t readonly_prop
 
-  method screenY : int readonly_prop
+  method screenY : number_t readonly_prop
 
-  method clientX : int readonly_prop
+  method clientX : number_t readonly_prop
 
-  method clientY : int readonly_prop
+  method clientY : number_t readonly_prop
 
-  method pageX : int readonly_prop
+  method pageX : number_t readonly_prop
 
-  method pageY : int readonly_prop
+  method pageY : number_t readonly_prop
 end
 
 and submitEvent = object
@@ -2888,14 +2888,18 @@ let eventRelatedTarget (e : #mouseEvent t) =
 let eventAbsolutePosition' (e : #mouseEvent t) =
   let body = document##.body in
   let html = document##.documentElement in
-  ( e##.clientX + body##.scrollLeft + html##.scrollLeft
-  , e##.clientY + body##.scrollTop + html##.scrollTop )
+  ( Js.to_float e##.clientX +. Float.of_int (body##.scrollLeft + html##.scrollLeft)
+  , Js.to_float e##.clientY +. Float.of_int (body##.scrollTop + html##.scrollTop) )
 
 let eventAbsolutePosition (e : #mouseEvent t) =
   Optdef.case
     e##.pageX
     (fun () -> eventAbsolutePosition' e)
-    (fun x -> Optdef.case e##.pageY (fun () -> eventAbsolutePosition' e) (fun y -> x, y))
+    (fun x ->
+      Optdef.case
+        e##.pageY
+        (fun () -> eventAbsolutePosition' e)
+        (fun y -> Js.to_float x, Js.to_float y))
 
 let elementClientPosition (e : #element t) =
   let r = e##getBoundingClientRect in

--- a/lib/js_of_ocaml/dom_html.ml
+++ b/lib/js_of_ocaml/dom_html.ml
@@ -727,9 +727,9 @@ and element = object
 
   method offsetHeight : int readonly_prop
 
-  method scrollLeft : int prop
+  method scrollLeft : number_t prop
 
-  method scrollTop : int prop
+  method scrollTop : number_t prop
 
   method scrollWidth : int prop
 
@@ -2321,9 +2321,9 @@ class type window = object
 
   method blur : unit meth
 
-  method scroll : int -> int -> unit meth
+  method scroll : number_t -> number_t -> unit meth
 
-  method scrollBy : int -> int -> unit meth
+  method scrollBy : number_t -> number_t -> unit meth
 
   method sessionStorage : storage t optdef readonly_prop
 
@@ -2888,8 +2888,12 @@ let eventRelatedTarget (e : #mouseEvent t) =
 let eventAbsolutePosition' (e : #mouseEvent t) =
   let body = document##.body in
   let html = document##.documentElement in
-  ( Js.to_float e##.clientX +. Float.of_int (body##.scrollLeft + html##.scrollLeft)
-  , Js.to_float e##.clientY +. Float.of_int (body##.scrollTop + html##.scrollTop) )
+  ( Js.to_float e##.clientX
+    +. Js.to_float body##.scrollLeft
+    +. Js.to_float html##.scrollLeft
+  , Js.to_float e##.clientY
+    +. Js.to_float body##.scrollTop
+    +. Js.to_float html##.scrollTop )
 
 let eventAbsolutePosition (e : #mouseEvent t) =
   Optdef.case
@@ -2911,7 +2915,8 @@ let elementClientPosition (e : #element t) =
 let getDocumentScroll () =
   let body = document##.body in
   let html = document##.documentElement in
-  body##.scrollLeft + html##.scrollLeft, body##.scrollTop + html##.scrollTop
+  ( Js.to_float body##.scrollLeft +. Js.to_float html##.scrollLeft
+  , Js.to_float body##.scrollTop +. Js.to_float html##.scrollTop )
 
 let buttonPressed (ev : #mouseEvent Js.t) =
   Js.Optdef.case

--- a/lib/js_of_ocaml/dom_html.ml
+++ b/lib/js_of_ocaml/dom_html.ml
@@ -2321,7 +2321,13 @@ class type window = object
 
   method blur : unit meth
 
+  method scrollX : number_t readonly_prop
+
+  method scrollY : number_t readonly_prop
+
   method scroll : number_t -> number_t -> unit meth
+
+  method scrollTo : number_t -> number_t -> unit meth
 
   method scrollBy : number_t -> number_t -> unit meth
 

--- a/lib/js_of_ocaml/dom_html.mli
+++ b/lib/js_of_ocaml/dom_html.mli
@@ -299,18 +299,18 @@ and mouseEvent = object
   method relatedTarget : element t opt optdef readonly_prop
 
   (* Relative to viewport *)
-  method clientX : int readonly_prop
+  method clientX : number_t readonly_prop
 
-  method clientY : int readonly_prop
+  method clientY : number_t readonly_prop
 
   (* Relative to the edge of the screen *)
-  method screenX : int readonly_prop
+  method screenX : number_t readonly_prop
 
-  method screenY : int readonly_prop
+  method screenY : number_t readonly_prop
 
-  method offsetX : int readonly_prop
+  method offsetX : number_t readonly_prop
 
-  method offsetY : int readonly_prop
+  method offsetY : number_t readonly_prop
 
   method ctrlKey : bool t readonly_prop
 
@@ -329,9 +329,9 @@ and mouseEvent = object
 
   method toElement : element t opt optdef readonly_prop
 
-  method pageX : int optdef readonly_prop
+  method pageX : number_t optdef readonly_prop
 
-  method pageY : int optdef readonly_prop
+  method pageY : number_t optdef readonly_prop
 end
 
 and keyboardEvent = object
@@ -427,17 +427,17 @@ and touch = object
 
   method target : element t optdef readonly_prop
 
-  method screenX : int readonly_prop
+  method screenX : number_t readonly_prop
 
-  method screenY : int readonly_prop
+  method screenY : number_t readonly_prop
 
-  method clientX : int readonly_prop
+  method clientX : number_t readonly_prop
 
-  method clientY : int readonly_prop
+  method clientY : number_t readonly_prop
 
-  method pageX : int readonly_prop
+  method pageX : number_t readonly_prop
 
-  method pageY : int readonly_prop
+  method pageY : number_t readonly_prop
 end
 
 and submitEvent = object
@@ -2591,7 +2591,7 @@ val buttonPressed : #mouseEvent Js.t -> mouse_button
 
 (** {2 Position helper functions} *)
 
-val eventAbsolutePosition : #mouseEvent t -> int * int
+val eventAbsolutePosition : #mouseEvent t -> float * float
 (** Returns the absolute position of the mouse pointer. *)
 
 val elementClientPosition : #element t -> int * int

--- a/lib/js_of_ocaml/dom_html.mli
+++ b/lib/js_of_ocaml/dom_html.mli
@@ -2165,7 +2165,13 @@ class type window = object
 
   method blur : unit meth
 
+  method scrollX : number_t readonly_prop
+
+  method scrollY : number_t readonly_prop
+
   method scroll : number_t -> number_t -> unit meth
+
+  method scrollTo : number_t -> number_t -> unit meth
 
   method scrollBy : number_t -> number_t -> unit meth
 

--- a/lib/js_of_ocaml/dom_html.mli
+++ b/lib/js_of_ocaml/dom_html.mli
@@ -740,9 +740,9 @@ and element = object
 
   method offsetHeight : int readonly_prop
 
-  method scrollLeft : int prop
+  method scrollLeft : number_t prop
 
-  method scrollTop : int prop
+  method scrollTop : number_t prop
 
   method scrollWidth : int prop
 
@@ -2165,9 +2165,9 @@ class type window = object
 
   method blur : unit meth
 
-  method scroll : int -> int -> unit meth
+  method scroll : number_t -> number_t -> unit meth
 
-  method scrollBy : int -> int -> unit meth
+  method scrollBy : number_t -> number_t -> unit meth
 
   method sessionStorage : storage t optdef readonly_prop
 
@@ -2597,7 +2597,7 @@ val eventAbsolutePosition : #mouseEvent t -> float * float
 val elementClientPosition : #element t -> int * int
 (** Position of an element relative to the viewport *)
 
-val getDocumentScroll : unit -> int * int
+val getDocumentScroll : unit -> float * float
 (** Viewport top/left position *)
 
 (** {2 Key event helper functions} *)

--- a/lib/lwt/graphics/graphics_js.ml
+++ b/lib/lwt/graphics/graphics_js.ml
@@ -48,12 +48,12 @@ let open_canvas x =
 let compute_real_pos (elt : #Dom_html.element Js.t) ev =
   let r = elt##getBoundingClientRect in
   let x =
-    (float_of_int ev##.clientX -. Js.to_float r##.left)
+    (Js.to_float ev##.clientX -. Js.to_float r##.left)
     /. (Js.to_float r##.right -. Js.to_float r##.left)
     *. float_of_int elt##.width
   in
   let y =
-    (float_of_int ev##.clientY -. Js.to_float r##.top)
+    (Js.to_float ev##.clientY -. Js.to_float r##.top)
     /. (Js.to_float r##.bottom -. Js.to_float r##.top)
     *. float_of_int elt##.height
   in

--- a/toplevel/examples/lwt_toplevel/toplevel.ml
+++ b/toplevel/examples/lwt_toplevel/toplevel.ml
@@ -145,7 +145,7 @@ let resize ~container ~textbox () =
   textbox##.style##.height := Js.string "auto";
   textbox##.style##.height
   := Js.string (Printf.sprintf "%dpx" (max 18 textbox##.scrollHeight));
-  container##.scrollTop := container##.scrollHeight;
+  container##.scrollTop := Js.float (float container##.scrollHeight);
   Lwt.return ()
 
 let setup_printers () =
@@ -376,7 +376,7 @@ let run _ =
     JsooTop.execute true ~pp_code:sharp_ppf ~highlight_location caml_ppf content';
     resize ~container ~textbox ()
     >>= fun () ->
-    container##.scrollTop := container##.scrollHeight;
+    container##.scrollTop := Js.float (float container##.scrollHeight);
     textbox##focus;
     Lwt.return_unit
   in


### PR DESCRIPTION
Some properties and methods have been redefined to be numbers rather than just numbers.
This partially addresses  #1719.