### PR TITLE
Generate new exception handling instructions

### DIFF
--- a/compiler/lib-wasm/binaryen.ml
+++ b/compiler/lib-wasm/binaryen.ml
@@ -136,6 +136,7 @@ let optimize
     () =
   command
     ("wasm-opt"
+     :: "--emit-exnref"
      :: (common_options ()
         @ (match options with
           | Some o -> o

--- a/compiler/lib-wasm/wasm_output.ml
+++ b/compiler/lib-wasm/wasm_output.ml
@@ -690,15 +690,16 @@ end = struct
         output_byte ch 0x0B
     | Try (typ, l, catches) ->
         Feature.require exception_handling;
-        output_byte ch 0x06;
+        output_byte ch 0x1f;
         output_blocktype st.type_names ch typ;
-        List.iter ~f:(fun i' -> output_instruction st ch i') l;
+        output_uint ch (List.length catches);
         List.iter
-          ~f:(fun (tag, l, ty) ->
-            output_byte ch 0x07;
+          ~f:(fun (tag, l, _) ->
+            output_byte ch 0x00;
             output_uint ch (Code.Var.Hashtbl.find st.tag_names tag);
-            output_instruction st ch (Br (l + 1, Some (Pop ty))))
+            output_uint ch l)
           catches;
+        List.iter ~f:(fun i' -> output_instruction st ch i') l;
         output_byte ch 0X0B
     | ExternConvertAny e' ->
         Feature.require gc;

--- a/compiler/lib-wasm/wat_output.ml
+++ b/compiler/lib-wasm/wat_output.ml
@@ -484,17 +484,13 @@ let expression_or_instructions ctx st in_function =
         ]
     | Try (ty, body, catches) ->
         [ List
-            (Atom "try"
+            (Atom "try_table"
             :: (block_type st ty
-               @ List (Atom "do" :: instructions body)
-                 :: List.map
-                      ~f:(fun (tag, i, ty) ->
-                        List
-                          (Atom "catch"
-                          :: index st.tag_names tag
-                          :: (instruction (Wasm_ast.Event Code_generation.hidden_location)
-                             @ instruction (Wasm_ast.Br (i + 1, Some (Pop ty))))))
-                      catches))
+               @ List.map
+                   ~f:(fun (tag, i, _ty) ->
+                     List [ Atom "catch"; index st.tag_names tag; Atom (string_of_int i) ])
+                   catches
+               @ instructions body))
         ]
     | ExternConvertAny e' -> [ List (Atom "extern.convert_any" :: expression e') ]
     | AnyConvertExtern e' -> [ List (Atom "any.convert_extern" :: expression e') ]

--- a/tools/node_wrapper.ml
+++ b/tools/node_wrapper.ml
@@ -1,6 +1,7 @@
 let extra_args_for_wasoo =
   [ "--experimental-wasm-imported-strings"
   ; "--experimental-wasm-stack-switching"
+  ; "--experimental-wasm-exnref"
   ; "--stack-size=10000"
   ]
 


### PR DESCRIPTION
Experiment with new exception handling instructions. There is no much point in using them for now since they are still under a flag in Chrome and Node.js.