### PR TITLE
[wasm] Option to implement OCaml strings with JavaScript strings

### DIFF
--- a/.github/workflows/wasm_of_ocaml.yml
+++ b/.github/workflows/wasm_of_ocaml.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Set-up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: latest
+          node-version: 'v24.0.0-v8-canary202412116884e26428'
 
       - name: Set-up OCaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@v3

--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -22,7 +22,7 @@ bench:
 	$(MAKE) -C benchmark-ocamlc bench
 	$(MAKE) -C benchmark-partial-render-table bench
 	$(MAKE) -C benchmark-camlboy bench
-	$(MAKE) -C benchmark-others bench # To try later!
+	$(MAKE) -C benchmark-others bench
 
 microbenchmarks:
 	@date -u +"%FT%TZ - Microbenchmarks: starting"

--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -20,8 +20,8 @@ bench:
 	$(MAKE) microbenchmarks
 	$(MAKE) -C benchmark-fiat-crypto bench
 	$(MAKE) -C benchmark-ocamlc bench
-	$(MAKE) -C benchmark-partial-render-table bench
-	#$(MAKE) -C benchmark-camlboy bench
+	#$(MAKE) -C benchmark-partial-render-table bench
+	$(MAKE) -C benchmark-camlboy bench
 	$(MAKE) -C benchmark-others bench # To try later!
 
 microbenchmarks:

--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -20,7 +20,7 @@ bench:
 	$(MAKE) microbenchmarks
 	$(MAKE) -C benchmark-fiat-crypto bench
 	$(MAKE) -C benchmark-ocamlc bench
-	#$(MAKE) -C benchmark-partial-render-table bench
+	$(MAKE) -C benchmark-partial-render-table bench
 	$(MAKE) -C benchmark-camlboy bench
 	$(MAKE) -C benchmark-others bench # To try later!
 

--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -17,12 +17,12 @@ bench:
 	@date -u +"%FT%TZ - Installing dependencies"
 	opam pin -yn --with-version=dev ..
 	opam install -y wasm_of_ocaml-compiler js_of_ocaml-ppx gen_js_api brr
-	$(MAKE) microbenchmarks
-	$(MAKE) -C benchmark-fiat-crypto bench
-	$(MAKE) -C benchmark-ocamlc bench
+	#$(MAKE) microbenchmarks
+	#$(MAKE) -C benchmark-fiat-crypto bench
+	#$(MAKE) -C benchmark-ocamlc bench
 	$(MAKE) -C benchmark-partial-render-table bench
-	$(MAKE) -C benchmark-camlboy bench
-	$(MAKE) -C benchmark-others bench
+	#$(MAKE) -C benchmark-camlboy bench
+	#$(MAKE) -C benchmark-others bench # To try later!
 
 microbenchmarks:
 	@date -u +"%FT%TZ - Microbenchmarks: starting"

--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -17,12 +17,12 @@ bench:
 	@date -u +"%FT%TZ - Installing dependencies"
 	opam pin -yn --with-version=dev ..
 	opam install -y wasm_of_ocaml-compiler js_of_ocaml-ppx gen_js_api brr
-	#$(MAKE) microbenchmarks
-	#$(MAKE) -C benchmark-fiat-crypto bench
-	#$(MAKE) -C benchmark-ocamlc bench
+	$(MAKE) microbenchmarks
+	$(MAKE) -C benchmark-fiat-crypto bench
+	$(MAKE) -C benchmark-ocamlc bench
 	$(MAKE) -C benchmark-partial-render-table bench
-	#$(MAKE) -C benchmark-camlboy bench
-	#$(MAKE) -C benchmark-others bench # To try later!
+	$(MAKE) -C benchmark-camlboy bench
+	$(MAKE) -C benchmark-others bench # To try later!
 
 microbenchmarks:
 	@date -u +"%FT%TZ - Microbenchmarks: starting"

--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -21,7 +21,7 @@ bench:
 	$(MAKE) -C benchmark-fiat-crypto bench
 	$(MAKE) -C benchmark-ocamlc bench
 	$(MAKE) -C benchmark-partial-render-table bench
-	$(MAKE) -C benchmark-camlboy bench
+	#$(MAKE) -C benchmark-camlboy bench
 	$(MAKE) -C benchmark-others bench # To try later!
 
 microbenchmarks:

--- a/benchmarks/benchmark-camlboy/Makefile
+++ b/benchmarks/benchmark-camlboy/Makefile
@@ -2,7 +2,7 @@
 
 export NAME=Camlboy
 
-SHELL=/bin/bash -o pipefail
+SHELL=/usr/bin/env bash -o pipefail
 
 DIR=CAMLBOY
 SCRIPT=$(DIR)/_build/default/bin/web/bench_node.bc

--- a/benchmarks/benchmark-fiat-crypto/Makefile
+++ b/benchmarks/benchmark-fiat-crypto/Makefile
@@ -2,7 +2,7 @@
 
 export NAME=Fiat-Crypto
 
-SHELL=/bin/bash -o pipefail
+SHELL=/usr/bin/env bash -o pipefail
 
 bench:
 	@date -u +"%FT%TZ - $(NAME): starting"
@@ -11,7 +11,7 @@ bench:
 	@date -u +"%FT%TZ - $(NAME): done"
 
 perform: bedrock2_fiat_crypto.byte
-	/usr/bin/time -f "%E %R" $(COMPILER) --debug times --source-map $(EXTRA_ARGS) $< -o out.js 2>&1 | \
+	env time -f "%E %R" $(COMPILER) --debug times --source-map $(EXTRA_ARGS) $< -o out.js 2>&1 | \
 	ocaml -I +str str.cma ../utils/compilation_metrics.ml $(COMPILER) $(NAME) out.js | \
 	sh ../utils/aggregate.sh $(KIND)
 

--- a/benchmarks/benchmark-ocamlc/Makefile
+++ b/benchmarks/benchmark-ocamlc/Makefile
@@ -15,8 +15,10 @@ ARGS=ml/*.ml ml/*.ml ml/*.ml ml/*.ml ml/*.ml ml/*.ml ml/*.ml ml/*.ml
 
 perform:
 	env time -f "%E %R" $(COMPILER) --debug times --opt 2 --pretty `which ocamlc.byte` -o $(SCRIPT) 2>&1 | \
+  tee /dev/stderr | \
 	ocaml -I +str str.cma ../utils/compilation_metrics.ml $(COMPILER) $(NAME) $(SCRIPT) | \
 	sh ../utils/aggregate.sh $(KIND)
 	env time -f '{"compiler": "$(COMPILER)", "time":"%E"}' node $(SCRIPT) -c $(ARGS) 2>&1 | \
+  tee /dev/stderr | \
 	sh ../utils/format_metrics.sh exec | \
 	sh ../utils/aggregate.sh $(KIND)

--- a/benchmarks/benchmark-ocamlc/Makefile
+++ b/benchmarks/benchmark-ocamlc/Makefile
@@ -2,7 +2,7 @@
 
 export NAME=Ocamlc
 
-SHELL=/bin/bash -o pipefail
+SHELL=/usr/bin/env bash -o pipefail
 
 bench:
 	@date -u +"%FT%TZ - $(NAME): starting"
@@ -14,9 +14,9 @@ bench:
 ARGS=ml/*.ml ml/*.ml ml/*.ml ml/*.ml ml/*.ml ml/*.ml ml/*.ml ml/*.ml
 
 perform:
-	/usr/bin/time -f "%E %R" $(COMPILER) --debug times --opt 2 --pretty `which ocamlc.byte` -o $(SCRIPT) 2>&1 | \
+	env time -f "%E %R" $(COMPILER) --debug times --opt 2 --pretty `which ocamlc.byte` -o $(SCRIPT) 2>&1 | \
 	ocaml -I +str str.cma ../utils/compilation_metrics.ml $(COMPILER) $(NAME) $(SCRIPT) | \
 	sh ../utils/aggregate.sh $(KIND)
-	/usr/bin/time -f '{"compiler": "$(COMPILER)", "time":"%E"}' node $(SCRIPT) -c $(ARGS) 2>&1 | \
+	env time -f '{"compiler": "$(COMPILER)", "time":"%E"}' node $(SCRIPT) -c $(ARGS) 2>&1 | \
 	sh ../utils/format_metrics.sh exec | \
 	sh ../utils/aggregate.sh $(KIND)

--- a/benchmarks/benchmark-others/bigarrays/Makefile
+++ b/benchmarks/benchmark-others/bigarrays/Makefile
@@ -3,17 +3,17 @@
 export NAME=Others
 export SUBNAME=bigarrays
 
-SHELL=/bin/bash -o pipefail
+SHELL=/usr/bin/env bash -o pipefail
 
 bench:
 	@date -u +"%FT%TZ - $(NAME)/$(SUBNAME): starting"
 	ocamlc bench.ml -o bench
-	$(MAKE) perform COMPILER=js_of_ocaml SCRIPT=bench.js KIND=js
-	$(MAKE) perform COMPILER=wasm_of_ocaml SCRIPT=bench.wasm.js KIND=wasm
+	#$(MAKE) perform COMPILER=js_of_ocaml FLAGS= SCRIPT=bench.js KIND=js
+	$(MAKE) perform COMPILER=wasm_of_ocaml FLAGS="--enable use-js-string" SCRIPT=bench.wasm.js KIND=wasm
 	@date -u +"%FT%TZ - $(NAME)/$(SUBNAME): done"
 
 perform:
-	$(COMPILER) --opt 2 --pretty bench -o $(SCRIPT)
-	/usr/bin/time -f '{"compiler": "$(COMPILER)", "time":"%E"}' node $(SCRIPT) 2>&1 | \
+	$(COMPILER) $(FLAGS) --opt 2 --pretty bench -o $(SCRIPT)
+	env time -f '{"compiler": "$(COMPILER)", "time":"%E"}' node $(SCRIPT) 2>&1 | \
 	sh ../../utils/format_metrics.sh exec | \
 	sh ../../utils/aggregate.sh $(KIND)

--- a/benchmarks/benchmark-others/bin_prot/Makefile
+++ b/benchmarks/benchmark-others/bin_prot/Makefile
@@ -3,7 +3,7 @@
 export NAME=Others
 export SUBNAME=bin_prot
 
-SHELL=/bin/bash -o pipefail
+SHELL=/usr/bin/env bash -o pipefail
 
 bench:
 	@date -u +"%FT%TZ - $(NAME)/$(SUBNAME): starting"
@@ -14,7 +14,7 @@ bench:
 	@date -u +"%FT%TZ - $(NAME)/$(SUBNAME): done"
 
 perform:
-	/usr/bin/time -f '{"compiler": "$(COMPILER)", "time":"%E"}' node $(SCRIPT) 2>&1 1> /dev/null | \
+	env time -f '{"compiler": "$(COMPILER)", "time":"%E"}' node $(SCRIPT) 2>&1 1> /dev/null | \
 	tee /dev/stderr | \
 	sh ../../utils/format_metrics.sh exec | \
 	sh ../../utils/aggregate.sh $(KIND)

--- a/benchmarks/benchmark-others/bin_prot/Makefile
+++ b/benchmarks/benchmark-others/bin_prot/Makefile
@@ -7,10 +7,13 @@ SHELL=/usr/bin/env bash -o pipefail
 
 bench:
 	@date -u +"%FT%TZ - $(NAME)/$(SUBNAME): starting"
-	dune build --profile release --root .
-	node _build/default/bench.bc.js 400000
-	$(MAKE) perform COMPILER=js_of_ocaml SCRIPT=_build/default/bench.bc.js KIND=js
-	$(MAKE) perform COMPILER=wasm_of_ocaml SCRIPT=_build/default/bench.bc.wasm.js KIND=wasm
+	mkdir -p ../../../../janestreet/bench/bin_prot/
+	cp -f dune bench.ml ../../../../janestreet/bench/bin_prot/
+	cd ../../../../janestreet/bench/bin_prot && dune build --root ../.. --profile release bench/bin_prot/bench.bc.js bench/bin_prot/bench.bc.wasm.js
+	cp -rf ../../../../janestreet/_build/default/bench/bin_prot/bench.bc* .
+	node bench.bc.js 400000
+	$(MAKE) perform COMPILER=js_of_ocaml SCRIPT=bench.bc.js KIND=js
+	$(MAKE) perform COMPILER=wasm_of_ocaml SCRIPT=bench.bc.wasm.js KIND=wasm
 	@date -u +"%FT%TZ - $(NAME)/$(SUBNAME): done"
 
 perform:

--- a/benchmarks/benchmark-others/bin_prot/dune
+++ b/benchmarks/benchmark-others/bin_prot/dune
@@ -4,7 +4,7 @@
  (js_of_ocaml
   (flags --opt 2))
  (wasm_of_ocaml
-  (flags --opt 2))
+  (flags --opt 2 --enable use-js-string))
  (preprocess
   (pps ppx_bin_prot))
  (libraries unix))

--- a/benchmarks/benchmark-others/bin_prot/dune
+++ b/benchmarks/benchmark-others/bin_prot/dune
@@ -2,6 +2,7 @@
  (names bench)
  (modes js wasm)
  (js_of_ocaml
+  (enabled_if true)
   (flags --opt 2))
  (wasm_of_ocaml
   (flags --opt 2 --enable use-js-string))

--- a/benchmarks/benchmark-others/lexifi-g2pp/Makefile
+++ b/benchmarks/benchmark-others/lexifi-g2pp/Makefile
@@ -3,7 +3,7 @@
 export NAME=Others
 export SUBNAME=lexifi-g2pp
 
-SHELL=/bin/bash -o pipefail
+SHELL=/usr/bin/env bash -o pipefail
 
 bench:
 	@date -u +"%FT%TZ - $(NAME)/$(SUBNAME): starting"
@@ -13,6 +13,6 @@ bench:
 	@date -u +"%FT%TZ - $(NAME)/$(SUBNAME): done"
 
 perform:
-	/usr/bin/time -f '{"compiler": "$(COMPILER)", "time":"%E"}' node $(SCRIPT) 2>&1 1> /dev/null | \
+	env time -f '{"compiler": "$(COMPILER)", "time":"%E"}' node $(SCRIPT) 2>&1 1> /dev/null | \
 	sh ../../utils/format_metrics.sh exec | \
 	sh ../../utils/aggregate.sh $(KIND)

--- a/benchmarks/benchmark-partial-render-table/Makefile
+++ b/benchmarks/benchmark-partial-render-table/Makefile
@@ -3,7 +3,6 @@
 export NAME=Partial Render Table
 
 SHELL=/usr/bin/env bash -o pipefail
-TIME=$(shell whereis time | cut -d ' ' -f 2)
 
 bench:
 	@date -u +"%FT%TZ - $(NAME): starting"
@@ -15,7 +14,7 @@ bench:
 	@date -u +"%FT%TZ - $(NAME): done"
 
 perform:
-	$(TIME) -f "%E %R" $(COMPILER) --debug times --opt 2 --pretty --enable use-js-string main.bc-for-jsoo -o out.js 2>&1 | \
+	env time -f "%E %R" $(COMPILER) --debug times --opt 2 --pretty --enable use-js-string main.bc-for-jsoo -o out.js 2>&1 | \
 	tee /dev/stderr | \
 	ocaml -I +str str.cma ../utils/compilation_metrics.ml $(COMPILER) "$(NAME)" out.js | \
 	sh ../utils/aggregate.sh $(KIND)

--- a/benchmarks/benchmark-partial-render-table/Makefile
+++ b/benchmarks/benchmark-partial-render-table/Makefile
@@ -2,7 +2,8 @@
 
 export NAME=Partial Render Table
 
-SHELL=/bin/bash -o pipefail
+SHELL=/usr/bin/env bash -o pipefail
+TIME=$(shell whereis time | cut -d ' ' -f 2)
 
 bench:
 	@date -u +"%FT%TZ - $(NAME): starting"
@@ -14,7 +15,7 @@ bench:
 	@date -u +"%FT%TZ - $(NAME): done"
 
 perform:
-	/usr/bin/time -f "%E %R" $(COMPILER) --debug times --opt 2 --pretty --enable use-js-string main.bc-for-jsoo -o out.js 2>&1 | \
+	$(TIME) -f "%E %R" $(COMPILER) --debug times --opt 2 --pretty --enable use-js-string main.bc-for-jsoo -o out.js 2>&1 | \
 	tee /dev/stderr | \
 	ocaml -I +str str.cma ../utils/compilation_metrics.ml $(COMPILER) "$(NAME)" out.js | \
 	sh ../utils/aggregate.sh $(KIND)

--- a/benchmarks/benchmark-partial-render-table/Makefile
+++ b/benchmarks/benchmark-partial-render-table/Makefile
@@ -14,7 +14,7 @@ bench:
 	@date -u +"%FT%TZ - $(NAME): done"
 
 perform:
-	/usr/bin/time -f "%E %R" $(COMPILER) --debug times --opt 2 --pretty main.bc-for-jsoo -o out.js 2>&1 | \
+	/usr/bin/time -f "%E %R" $(COMPILER) --debug times --opt 2 --pretty --enable use-js-string main.bc-for-jsoo -o out.js 2>&1 | \
 	tee /dev/stderr | \
 	ocaml -I +str str.cma ../utils/compilation_metrics.ml $(COMPILER) "$(NAME)" out.js | \
 	sh ../utils/aggregate.sh $(KIND)

--- a/compiler/bin-wasm_of_ocaml/compile.ml
+++ b/compiler/bin-wasm_of_ocaml/compile.ml
@@ -127,6 +127,7 @@ let build_runtime ~runtime_file =
              [ "bindings"
              ; "Math"
              ; "js"
+             ; "str"
              ; "wasm:js-string"
              ; "wasm:text-encoder"
              ; "wasm:text-decoder"

--- a/compiler/bin-wasm_of_ocaml/compile.ml
+++ b/compiler/bin-wasm_of_ocaml/compile.ml
@@ -84,6 +84,7 @@ let preprocessor_variables () =
         | `Disabled | `Jspi -> "jspi"
         | `Cps -> "cps"
         | `Double_translation -> assert false) )
+  ; "use-js-string", Wat_preprocess.Bool (Config.Flag.use_js_string ())
   ]
 
 let with_runtime_files ~runtime_wasm_files f =

--- a/compiler/bin-wasm_of_ocaml/compile.ml
+++ b/compiler/bin-wasm_of_ocaml/compile.ml
@@ -484,7 +484,7 @@ let run
      let z = Zip.open_out tmp_output_file in
      Zip.add_file z ~name:"runtime.wasm" ~file:tmp_wasm_file;
      Zip.add_entry z ~name:"runtime.js" ~contents:js_runtime;
-     let predefined_exceptions, (strings, fragments) = build_prelude z in
+     let predefined_exceptions, fragments = build_prelude z in
      Link.add_info
        z
        ~predefined_exceptions
@@ -492,7 +492,6 @@ let run
        ~unit_data:
          [ { Link.unit_name = "wasmoo_prelude"
            ; unit_info = Unit_info.empty
-           ; strings
            ; fragments
            }
          ]

--- a/compiler/bin-wasm_of_ocaml/compile.ml
+++ b/compiler/bin-wasm_of_ocaml/compile.ml
@@ -257,10 +257,10 @@ let generate_prelude ~out_file =
     Driver.optimize_for_wasm ~profile ~shapes:false code
   in
   let context = Generate.start () in
-  let _ =
+  let _, generated_js =
     Generate.f
       ~context
-      ~unit_name:(Some "prelude")
+      ~unit_name:(Some "wasmoo_prelude")
       ~live_vars:variable_uses
       ~in_cps
       ~deadcode_sentinal
@@ -268,14 +268,14 @@ let generate_prelude ~out_file =
       program
   in
   Generate.wasm_output ch ~opt_source_map_file:None ~context;
-  uinfo.provides
+  uinfo.provides, generated_js
 
 let build_prelude z =
   Fs.with_intermediate_file (Filename.temp_file "prelude" ".wasm")
   @@ fun prelude_file ->
-  let predefined_exceptions = generate_prelude ~out_file:prelude_file in
+  let info = generate_prelude ~out_file:prelude_file in
   Zip.add_file z ~name:"prelude.wasm" ~file:prelude_file;
-  predefined_exceptions
+  info
 
 let build_js_runtime ~primitives ?runtime_arguments () =
   let always_required_js, primitives =
@@ -483,12 +483,18 @@ let run
      let z = Zip.open_out tmp_output_file in
      Zip.add_file z ~name:"runtime.wasm" ~file:tmp_wasm_file;
      Zip.add_entry z ~name:"runtime.js" ~contents:js_runtime;
-     let predefined_exceptions = build_prelude z in
+     let predefined_exceptions, (strings, fragments) = build_prelude z in
      Link.add_info
        z
        ~predefined_exceptions
        ~build_info:(Build_info.create `Runtime)
-       ~unit_data:[]
+       ~unit_data:
+         [ { Link.unit_name = "wasmoo_prelude"
+           ; unit_info = Unit_info.empty
+           ; strings
+           ; fragments
+           }
+         ]
        ();
      Zip.close_out z)
    else

--- a/compiler/bin-wasm_of_ocaml/gen/gen.ml
+++ b/compiler/bin-wasm_of_ocaml/gen/gen.ml
@@ -77,7 +77,12 @@ let check_js_file fname =
 
 let default_flags = []
 
-let interesting_runtimes = [ [ "effects", `S "jspi" ]; [ "effects", `S "cps" ] ]
+let interesting_runtimes =
+  [ [ "effects", `S "jspi"; "use-js-string", `B false ]
+  ; [ "effects", `S "cps"; "use-js-string", `B false ]
+  ; [ "effects", `S "jspi"; "use-js-string", `B true ]
+  ; [ "effects", `S "cps"; "use-js-string", `B true ]
+  ]
 
 let name_runtime standard l =
   let flags =

--- a/compiler/bin-wasm_of_ocaml/link_wasm.ml
+++ b/compiler/bin-wasm_of_ocaml/link_wasm.ml
@@ -69,7 +69,14 @@ let options =
   in
   let build_t input_modules output_file variables allowed_imports common opt merge =
     let allowed_imports =
-      if List.is_empty allowed_imports then None else Some (List.concat allowed_imports)
+      match allowed_imports with
+      | [] -> Some [ "str" ]
+      | _ :: _ as l ->
+          let l = List.concat l in
+          if List.mem ~eq:String.equal "str" l then
+            Some l
+          else
+            Some ("str" :: l)
     in
     `Ok
       { input_modules

--- a/compiler/lib-wasm/gc_target.ml
+++ b/compiler/lib-wasm/gc_target.ml
@@ -861,8 +861,8 @@ module Memory = struct
              })
       in
       let* e = string_value e in
-      let* e' = Value.int_val e' in
-      Value.val_int (return (W.Call (f, [ e; e' ])))
+      let* e' = e' in
+      return (W.Call (f, [ e; e' ]))
     else bytes_get e e'
 
   let field e idx = wasm_array_get e (Arith.const (Int32.of_int (idx + 1)))

--- a/compiler/lib-wasm/gc_target.ml
+++ b/compiler/lib-wasm/gc_target.ml
@@ -33,13 +33,30 @@ module Type = struct
           ; typ = W.Array { mut = true; typ = Value value }
           })
 
-  let string_type =
-    register_type "string" (fun () ->
+  let bytes_type =
+    register_type "bytes" (fun () ->
         return
           { supertype = None
           ; final = true
           ; typ = W.Array { mut = true; typ = Packed I8 }
           })
+
+  let string_type =
+    register_type "string" (fun () ->
+        return
+          (if Config.Flag.use_js_string ()
+           then
+             { supertype = None
+             ; final = true
+             ; typ =
+                 W.Struct
+                   [ { mut = false; typ = Value (Ref { nullable = true; typ = Any }) } ]
+             }
+           else
+             { supertype = None
+             ; final = true
+             ; typ = W.Array { mut = true; typ = Packed I8 }
+             }))
 
   let float_type =
     register_type "float" (fun () ->
@@ -805,13 +822,48 @@ module Memory = struct
        wasm_array_set ~ty:Type.float_array_type (load a) (load i) (unbox_float (load v)))
 
   let bytes_length e =
-    let* ty = Type.string_type in
+    let* ty = Type.bytes_type in
     let* e = wasm_cast ty e in
     return (W.ArrayLen e)
 
-  let bytes_get e e' = wasm_array_get ~ty:Type.string_type e e'
+  let bytes_get e e' = wasm_array_get ~ty:Type.bytes_type e e'
 
-  let bytes_set e e' e'' = wasm_array_set ~ty:Type.string_type e e' e''
+  let bytes_set e e' e'' = wasm_array_set ~ty:Type.bytes_type e e' e''
+
+  let string_value e =
+    let* string = Type.string_type in
+    let* e = wasm_struct_get string (wasm_cast string e) 0 in
+    return (W.ExternConvertAny e)
+
+  let string_length e =
+    if Config.Flag.use_js_string ()
+    then
+      let* f =
+        register_import
+          ~import_module:"wasm:js-string"
+          ~name:"length"
+          (Fun { W.params = [ Ref { nullable = true; typ = Extern } ]; result = [ I32 ] })
+      in
+      let* e = string_value e in
+      return (W.Call (f, [ e ]))
+    else bytes_length e
+
+  let string_get e e' =
+    if Config.Flag.use_js_string ()
+    then
+      let* f =
+        register_import
+          ~import_module:"wasm:js-string"
+          ~name:"charCodeAt"
+          (Fun
+             { W.params = [ Ref { nullable = true; typ = Extern }; I32 ]
+             ; result = [ I32 ]
+             })
+      in
+      let* e = string_value e in
+      let* e' = Value.int_val e' in
+      Value.val_int (return (W.Call (f, [ e; e' ])))
+    else bytes_get e e'
 
   let field e idx = wasm_array_get e (Arith.const (Int32.of_int (idx + 1)))
 
@@ -940,6 +992,17 @@ module Constant = struct
     | Const_named of string
     | Mutated
 
+  let translate_js_string s =
+    let* x =
+      register_import
+        ~import_module:"str"
+        ~name:s
+        (Global { mut = false; typ = Ref { nullable = false; typ = Extern } })
+    in
+    let* ty = Type.js_type in
+    return
+      (Const_named ("str_" ^ s), W.StructNew (ty, [ AnyConvertExtern (GlobalGet x) ]))
+
   let rec translate_rec c =
     match c with
     | Code.Int i -> return (Const, W.RefI31 (Const (I32 (Targetint.to_int32 i))))
@@ -998,34 +1061,29 @@ module Constant = struct
           | Utf (Utf8 s) -> s
           | Byte s -> byte_string s
         in
-        let* x =
-          register_import
-            ~import_module:"str"
-            ~name:s
-            (Global { mut = false; typ = Ref { nullable = false; typ = Extern } })
-        in
-        let* ty = Type.js_type in
-        return
-          (Const_named ("str_" ^ s), W.StructNew (ty, [ AnyConvertExtern (GlobalGet x) ]))
+        translate_js_string s
     | String s ->
-        let* ty = Type.string_type in
-        if String.length s >= string_length_threshold
-        then
-          let name = Code.Var.fresh_n "string" in
-          let* () = register_data_segment name s in
-          return
-            ( Mutated
-            , W.ArrayNewData
-                (ty, name, Const (I32 0l), Const (I32 (Int32.of_int (String.length s))))
-            )
+        if Config.Flag.use_js_string ()
+        then translate_js_string (str_js_byte s)
         else
-          let l =
-            String.fold_right
-              ~f:(fun c r -> W.Const (I32 (Int32.of_int (Char.code c))) :: r)
-              s
-              ~init:[]
-          in
-          return (Const_named ("str_" ^ s), W.ArrayNewFixed (ty, l))
+          let* ty = Type.string_type in
+          if String.length s >= string_length_threshold
+          then
+            let name = Code.Var.fresh_n "string" in
+            let* () = register_data_segment name s in
+            return
+              ( Mutated
+              , W.ArrayNewData
+                  (ty, name, Const (I32 0l), Const (I32 (Int32.of_int (String.length s))))
+              )
+          else
+            let l =
+              String.fold_right
+                ~f:(fun c r -> W.Const (I32 (Int32.of_int (Char.code c))) :: r)
+                s
+                ~init:[]
+            in
+            return (Const_named ("str_" ^ s), W.ArrayNewFixed (ty, l))
     | Float f ->
         let* ty = Type.float_type in
         return (Const, W.StructNew (ty, [ Const (F64 (Int64.float_of_bits f)) ]))

--- a/compiler/lib-wasm/gc_target.ml
+++ b/compiler/lib-wasm/gc_target.ml
@@ -1064,7 +1064,7 @@ module Constant = struct
         translate_js_string s
     | String s ->
         if Config.Flag.use_js_string ()
-        then translate_js_string (str_js_byte s)
+        then translate_js_string (byte_string s)
         else
           let* ty = Type.string_type in
           if String.length s >= string_length_threshold

--- a/compiler/lib-wasm/generate.ml
+++ b/compiler/lib-wasm/generate.ml
@@ -331,7 +331,7 @@ module Generate (Target : Target_sig.S) = struct
       (fun x y z -> seq (Memory.bytes_set x y z) Value.unit);
     let string_get context x y =
       seq
-        (let* cond = Arith.uge (Value.int_val y) (Memory.string_length x) in
+        (let* cond = Arith.uge y (Memory.string_length x) in
          instr (W.Br_if (label_index context bound_error_pc, cond)))
         (Memory.string_get x y)
     in

--- a/compiler/lib-wasm/generate.ml
+++ b/compiler/lib-wasm/generate.ml
@@ -318,29 +318,30 @@ module Generate (Target : Target_sig.S) = struct
         seq (Memory.array_set x y z) Value.unit);
     register_tern_prim "caml_floatarray_unsafe_set" ~ty:(Int Normalized) (fun x y z ->
         seq (Memory.float_array_set x y z) Value.unit);
-    register_bin_prim "caml_string_unsafe_get" `Pure ~ty:(Int Normalized) Memory.bytes_get;
+    register_bin_prim "caml_string_unsafe_get" `Pure ~ty:(Int Normalized) Memory.string_get;
     register_bin_prim
       "caml_bytes_unsafe_get"
       `Mutable
       ~ty:(Int Normalized)
       Memory.bytes_get;
     register_tern_prim
-      "caml_string_unsafe_set"
-      ~ty:(Int Normalized)
-      ~tz:(Int Unnormalized)
-      (fun x y z -> seq (Memory.bytes_set x y z) Value.unit);
-    register_tern_prim
       "caml_bytes_unsafe_set"
       ~ty:(Int Normalized)
       ~tz:(Int Unnormalized)
       (fun x y z -> seq (Memory.bytes_set x y z) Value.unit);
+    let string_get context x y =
+      seq
+        (let* cond = Arith.uge (Value.int_val y) (Memory.string_length x) in
+         instr (W.Br_if (label_index context bound_error_pc, cond)))
+        (Memory.string_get x y)
+    in
+    register_bin_prim_ctx "caml_string_get" ~ty:(Int Normalized) string_get;
     let bytes_get context x y =
       seq
         (let* cond = Arith.uge y (Memory.bytes_length x) in
          instr (W.Br_if (label_index context bound_error_pc, cond)))
         (Memory.bytes_get x y)
     in
-    register_bin_prim_ctx "caml_string_get" ~ty:(Int Normalized) bytes_get;
     register_bin_prim_ctx "caml_bytes_get" ~ty:(Int Normalized) bytes_get;
     let bytes_set context x y z =
       seq
@@ -350,16 +351,11 @@ module Generate (Target : Target_sig.S) = struct
         Value.unit
     in
     register_tern_prim_ctx
-      "caml_string_set"
-      ~ty:(Int Normalized)
-      ~tz:(Int Unnormalized)
-      bytes_set;
-    register_tern_prim_ctx
       "caml_bytes_set"
       ~ty:(Int Normalized)
       ~tz:(Int Unnormalized)
       bytes_set;
-    register_un_prim "caml_ml_string_length" `Pure (fun x -> Memory.bytes_length x);
+    register_un_prim "caml_ml_string_length" `Pure (fun x -> Memory.string_length x);
     register_un_prim "caml_ml_bytes_length" `Pure (fun x -> Memory.bytes_length x);
     register_bin_prim
       "%int_add"
@@ -1041,7 +1037,6 @@ module Generate (Target : Target_sig.S) = struct
                     ( Extern
                         ( "caml_string_get"
                         | "caml_bytes_get"
-                        | "caml_string_set"
                         | "caml_bytes_set"
                         | "caml_check_bound"
                         | "caml_check_bound_gen"

--- a/compiler/lib-wasm/link.ml
+++ b/compiler/lib-wasm/link.ml
@@ -393,7 +393,7 @@ let generate_start_function ~to_link ~out_file =
   Filename.gen_file out_file
   @@ fun ch ->
   let context = Generate.start () in
-  Generate.add_init_function ~context ~to_link:("prelude" :: to_link);
+  Generate.add_init_function ~context ~to_link:("wasmoo_prelude" :: to_link);
   Generate.wasm_output ch ~opt_source_map_file:None ~context;
   if times () then Format.eprintf "    generate start: %a@." Timer.print t1
 
@@ -647,11 +647,11 @@ let load_information files =
   match files with
   | [] -> assert false
   | runtime :: other_files ->
-      let build_info, predefined_exceptions, _unit_data =
+      let build_info, predefined_exceptions, unit_data =
         Zip.with_open_in runtime read_info
       in
       ( predefined_exceptions
-      , (runtime, (build_info, []))
+      , (runtime, (build_info, unit_data))
         :: List.map other_files ~f:(fun file ->
                let build_info, _predefined_exceptions, unit_data =
                  Zip.with_open_in file read_info
@@ -748,7 +748,8 @@ let link ~output_file ~linkall ~enable_source_maps ~files =
               || cmo_file
               || linkall
               || unit_info.force_link
-              || not (StringSet.is_empty (StringSet.inter requires unit_info.provides))
+              || (not (StringSet.is_empty (StringSet.inter requires unit_info.provides)))
+              || String.equal unit_name "wasmoo_prelude"
             then
               ( StringSet.diff
                   (StringSet.union unit_info.requires requires)

--- a/compiler/lib-wasm/runtime.ml
+++ b/compiler/lib-wasm/runtime.ml
@@ -24,7 +24,9 @@ let build ~allowed_imports ~link_options ~opt_options ~variables ~inputs ~output
       let missing_imports =
         List.filter
           ~f:(fun { Link.Wasm_binary.module_; _ } ->
-            not (List.mem ~eq:String.equal module_ allowed_imports))
+            not
+              (String.equal module_ ""
+              || List.mem ~eq:String.equal module_ allowed_imports))
           imports
       in
       if not (List.is_empty missing_imports)

--- a/compiler/lib-wasm/runtime.ml
+++ b/compiler/lib-wasm/runtime.ml
@@ -24,9 +24,7 @@ let build ~allowed_imports ~link_options ~opt_options ~variables ~inputs ~output
       let missing_imports =
         List.filter
           ~f:(fun { Link.Wasm_binary.module_; _ } ->
-            not
-            (String.equal module_ "str"
-             || List.mem ~eq:String.equal module_ allowed_imports))
+            not (List.mem ~eq:String.equal module_ allowed_imports))
           imports
       in
       if not (List.is_empty missing_imports)

--- a/compiler/lib-wasm/runtime.ml
+++ b/compiler/lib-wasm/runtime.ml
@@ -24,7 +24,9 @@ let build ~allowed_imports ~link_options ~opt_options ~variables ~inputs ~output
       let missing_imports =
         List.filter
           ~f:(fun { Link.Wasm_binary.module_; _ } ->
-            not (List.mem ~eq:String.equal module_ allowed_imports))
+            not
+            (String.equal module_ "str"
+             || List.mem ~eq:String.equal module_ allowed_imports))
           imports
       in
       if not (List.is_empty missing_imports)

--- a/compiler/lib-wasm/runtime.ml
+++ b/compiler/lib-wasm/runtime.ml
@@ -24,9 +24,7 @@ let build ~allowed_imports ~link_options ~opt_options ~variables ~inputs ~output
       let missing_imports =
         List.filter
           ~f:(fun { Link.Wasm_binary.module_; _ } ->
-            not
-              (String.equal module_ ""
-              || List.mem ~eq:String.equal module_ allowed_imports))
+            not (List.mem ~eq:String.equal module_ allowed_imports))
           imports
       in
       if not (List.is_empty missing_imports)

--- a/compiler/lib-wasm/target_sig.ml
+++ b/compiler/lib-wasm/target_sig.ml
@@ -80,6 +80,10 @@ module type S = sig
 
     val bytes_set : expression -> expression -> expression -> unit Code_generation.t
 
+    val string_length : expression -> expression
+
+    val string_get : expression -> expression -> expression
+
     val box_float : expression -> expression
 
     val unbox_float : expression -> expression

--- a/compiler/lib-wasm/wat_preprocess.ml
+++ b/compiler/lib-wasm/wat_preprocess.ml
@@ -586,7 +586,7 @@ and rewrite st elt =
       write st pos;
       Printf.bprintf
         st.head_buf
-        "(import \"\" %s (global %s$string externref)) "
+        "(import \"str\" %s (global %s$string externref)) "
         value
         name;
       insert
@@ -608,7 +608,7 @@ and rewrite st elt =
       write st pos;
       Printf.bprintf
         st.head_buf
-        "(import \"\" %s (global %s$string externref)) "
+        "(import \"str\" %s (global %s$string externref)) "
         value
         name;
       insert

--- a/compiler/lib-wasm/wat_preprocess.ml
+++ b/compiler/lib-wasm/wat_preprocess.ml
@@ -520,7 +520,7 @@ and rewrite st elt =
       then (
         Printf.bprintf
           st.head_buf
-          "(import \"\" %s (global %s$string externref)) "
+          "(import \"str\" %s (global %s$string externref)) "
           value
           name;
         insert
@@ -555,7 +555,7 @@ and rewrite st elt =
       then (
         Printf.bprintf
           st.head_buf
-          "(import \"\" %s (global %s$string externref)) "
+          "(import \"str\" %s (global %s$string externref)) "
           value
           name;
         insert

--- a/compiler/lib/config.ml
+++ b/compiler/lib/config.ml
@@ -222,9 +222,7 @@ let target () =
 let set_target (t : [ `JavaScript | `Wasm ]) =
   (match t with
   | `JavaScript -> Targetint.set_num_bits 32
-  | `Wasm ->
-      Targetint.set_num_bits 31;
-      Flag.disable "use-js-string");
+  | `Wasm -> Targetint.set_num_bits 31);
   target_ := (t :> [ `JavaScript | `Wasm | `None ])
 
 type effects_backend =

--- a/compiler/lib/config.ml
+++ b/compiler/lib/config.ml
@@ -222,7 +222,9 @@ let target () =
 let set_target (t : [ `JavaScript | `Wasm ]) =
   (match t with
   | `JavaScript -> Targetint.set_num_bits 32
-  | `Wasm -> Targetint.set_num_bits 31);
+  | `Wasm ->
+      Targetint.set_num_bits 31;
+      Flag.disable "use-js-string");
   target_ := (t :> [ `JavaScript | `Wasm | `None ])
 
 type effects_backend =

--- a/compiler/tests-wasm_of_ocaml/preprocess/dune
+++ b/compiler/tests-wasm_of_ocaml/preprocess/dune
@@ -17,5 +17,26 @@
  (action
   (diff tests.expected tests.output)))
 
+(rule
+ (with-stdout-to
+  tests-js-string.output
+  (run
+   %{bin:wasm_of_ocaml}
+   pp
+   --enable
+   use-js-string
+   --enable
+   a
+   --disable
+   b
+   --set
+   c=1
+   %{dep:tests.txt})))
+
+(rule
+ (alias runtest)
+ (action
+  (diff tests-js-string.expected tests-js-string.output)))
+
 (cram
  (deps %{bin:wasm_of_ocaml}))

--- a/compiler/tests-wasm_of_ocaml/preprocess/tests-js-string.expected
+++ b/compiler/tests-wasm_of_ocaml/preprocess/tests-js-string.expected
@@ -1,4 +1,4 @@
-(import "" "abcd" (global $s$string externref)) (import "" "abcd" (global $js$string$0$$string externref)) (import "" "\\\'\28\n" (global $js$string$1$$string externref)) (import "" "abcd" (global $js$string$2$$string externref)) (import "" "abcd" (global $js$string$3$$string externref)) (import "" "0" (global $js$string$4$$string externref)) (import "" "\n" (global $js$string$5$$string externref)) ;; conditional
+(import "str" "abcd" (global $s$string externref)) (import "str" "abcd" (global $js$string$0$$string externref)) (import "str" "\\\'\28\n" (global $js$string$1$$string externref)) (import "str" "abcd" (global $js$string$2$$string externref)) (import "str" "abcd" (global $js$string$3$$string externref)) (import "str" "0" (global $js$string$4$$string externref)) (import "str" "\n" (global $js$string$5$$string externref)) ;; conditional
               a is true                     
                                 b is false  
               a is true  

--- a/compiler/tests-wasm_of_ocaml/preprocess/tests-js-string.expected
+++ b/compiler/tests-wasm_of_ocaml/preprocess/tests-js-string.expected
@@ -1,0 +1,79 @@
+(import "" "abcd" (global $s$string externref)) (import "" "abcd" (global $js$string$0$$string externref)) (import "" "\\\'\28\n" (global $js$string$1$$string externref)) (import "" "abcd" (global $js$string$2$$string externref)) (import "" "abcd" (global $js$string$3$$string externref)) (import "" "0" (global $js$string$4$$string externref)) (import "" "\n" (global $js$string$5$$string externref)) ;; conditional
+              a is true                     
+                                b is false  
+              a is true  
+                         
+
+;; nested conditionals
+                                                     a is true and b is false  
+                                                                            
+
+;; not
+                                
+                    b is false  
+
+;; and
+                  true  
+                    a is true  
+                               
+                                        
+                            a is true and b is false  
+                                                      
+                                                     
+
+;; or
+                        
+                   a is true  
+                              
+                     a or b is true  
+                           a is true or b is false  
+                                                    
+                                 a or b is false  
+
+;; strings
+                           newline  
+                         quote  
+
+;; string comparisons
+                      c is 1  
+                              
+                                   
+                       c is not 2  
+
+;; version comparisons
+                                                   
+                                (4 1 1) = (4 1 1)  
+                                                   
+                                 (4 1 1) <> (4 1 0)  
+                                                     
+                                 (4 1 1) <> (4 1 2)  
+                                                     
+                                 (4 1 1) <= (4 1 1)  
+                                 (4 1 1) <= (4 1 2)  
+                                 (4 1 1) >= (4 1 0)  
+                                 (4 1 1) >= (4 1 1)  
+                                                     
+                                (4 1 1) > (4 1 0)  
+                                                   
+                                                   
+
+;; version comparisons: lexicographic order
+                                                   
+                                                   
+                                (4 1 1) < (4 1 2)  
+                                                   
+                                (4 1 1) < (4 2 0)  
+                                (4 1 1) < (5 0 1)  
+                                                   
+
+;; strings
+(global $s (ref eq) (struct.new $string (any.convert_extern (global.get $s$string))))
+(struct.new $string (any.convert_extern (global.get $js$string$0$$string)))
+(struct.new $string (any.convert_extern (global.get $js$string$1$$string)))
+                  (struct.new $string (any.convert_extern (global.get $js$string$2$$string)))  
+                         (struct.new $string (any.convert_extern (global.get $js$string$3$$string)))  
+
+;; chars
+(struct.new $string (any.convert_extern (global.get $js$string$4$$string)))
+(struct.new $string (any.convert_extern (global.get $js$string$5$$string)))
+

--- a/dune
+++ b/dune
@@ -8,7 +8,10 @@
     (:standard)))
   (binaries
    (tools/node_wrapper.exe as node)
-   (tools/node_wrapper.exe as node.exe)))
+   (tools/node_wrapper.exe as node.exe))
+  (wasm_of_ocaml
+   (flags
+    (:standard --enable use-js-string))))
  (with-effects
   (js_of_ocaml
    (compilation_mode separate)

--- a/runtime/wasm/array.wat
+++ b/runtime/wasm/array.wat
@@ -21,6 +21,7 @@
 
    (type $block (array (mut (ref eq))))
    (type $bytes (array (mut i8)))
+   (type $string (struct (field anyref)))
    (type $float (struct (field f64)))
    (type $float_array (array (mut f64)))
 

--- a/runtime/wasm/backtrace.wat
+++ b/runtime/wasm/backtrace.wat
@@ -25,6 +25,7 @@
 
    (type $block (array (mut (ref eq))))
    (type $bytes (array (mut i8)))
+   (type $string (struct (field anyref)))
 
    (func (export "caml_get_exception_raw_backtrace")
       (param (ref eq)) (result (ref eq))

--- a/runtime/wasm/blake2.wat
+++ b/runtime/wasm/blake2.wat
@@ -7,6 +7,8 @@
       (func $caml_string_of_jsbytes (param (ref eq)) (result (ref eq))))
    (import "jslib" "caml_jsbytes_of_string"
       (func $caml_jsbytes_of_string (param (ref eq)) (result (ref eq))))
+   (import "jsstring" "jsbytes_of_bytes"
+      (func $jsbytes_of_bytes (param (ref $bytes)) (result anyref)))
 
    (import "js" "blake2_js_for_wasm_create"
       (func $blake2_js_for_wasm_create (param (ref eq) anyref) (result anyref)))
@@ -30,7 +32,7 @@
             (local.get $hashlen)
             (call $unwrap (call $caml_jsbytes_of_string (local.get $key))))))
 
-   (func $jsbytes_of_substring
+   (func $jsbytes_of_subbytes
       (param $vbuf (ref eq)) (param $vofs (ref eq)) (param $vlen (ref eq))
       (result anyref i32 i32)
       (local $buf (ref $bytes)) (local $buf' (ref $bytes))
@@ -49,17 +51,27 @@
             (local.set $buf (local.get $buf'))
             (local.set $ofs (i32.const 0))))
       (tuple.make 3
-         (call $unwrap (call $caml_jsbytes_of_string (local.get $buf)))
+         (call $jsbytes_of_bytes (local.get $buf))
          (local.get $ofs)
          (local.get $len)))
 
    (func (export "caml_blake2_update")
       (param $ctx (ref eq)) (param $buf (ref eq)) (param $ofs (ref eq))
       (param $len (ref eq)) (result (ref eq))
+(@if (and use-js-string (< ocaml_version (5 3 0)))
+(@then
       (call $blake2_js_for_wasm_update
          (call $unwrap (local.get $ctx))
-         (call $jsbytes_of_substring
+         (call $unwrap (local.get $buf))
+         (i31.get_u (ref.cast (ref i31) (local.get $ofs)))
+         (i31.get_u (ref.cast (ref i31) (local.get $len))))
+)
+(@else
+      (call $blake2_js_for_wasm_update
+         (call $unwrap (local.get $ctx))
+         (call $jsbytes_of_subbytes
             (local.get $buf) (local.get $ofs) (local.get $len)))
+))
       (ref.i31 (i32.const 0)))
 
    (func (export "caml_blake2_final")
@@ -70,7 +82,29 @@
                (call $unwrap (local.get $ctx))
                (local.get $hashlen)))))
 
-   (func (export "caml_blake2_string") (export "caml_blake2_bytes")
+(@if use-js-string
+(@then
+   (func (export "caml_blake2_string")
+      (param $hashlen (ref eq)) (param $key (ref eq)) (param $buf (ref eq))
+      (param $ofs (ref eq)) (param $len (ref eq)) (result (ref eq))
+      (local $ctx anyref)
+      (local.set $ctx
+         (call $blake2_js_for_wasm_create
+            (local.get $hashlen)
+            (call $unwrap (local.get $key))))
+      (call $blake2_js_for_wasm_update
+         (local.get $ctx)
+         (call $unwrap (local.get $buf))
+         (i31.get_u (ref.cast (ref i31) (local.get $ofs)))
+         (i31.get_u (ref.cast (ref i31) (local.get $len))))
+      (return_call $wrap
+         (call $blake2_js_for_wasm_final
+            (local.get $ctx) (local.get $hashlen))))
+)
+(@else
+   (export "caml_blake2_string" (func $caml_blake2_bytes))
+))
+   (func $caml_blake2_bytes (export "caml_blake2_bytes")
       (param $hashlen (ref eq)) (param $key (ref eq)) (param $buf (ref eq))
       (param $ofs (ref eq)) (param $len (ref eq)) (result (ref eq))
       (local $ctx anyref)
@@ -80,7 +114,7 @@
             (call $unwrap (call $caml_jsbytes_of_string (local.get $key)))))
       (call $blake2_js_for_wasm_update
          (local.get $ctx)
-         (call $jsbytes_of_substring
+         (call $jsbytes_of_subbytes
             (local.get $buf) (local.get $ofs) (local.get $len)))
       (return_call $caml_string_of_jsbytes
          (call $wrap

--- a/runtime/wasm/compare.wat
+++ b/runtime/wasm/compare.wat
@@ -39,6 +39,7 @@
 
    (type $block (array (mut (ref eq))))
    (type $bytes (array (mut i8)))
+   (type $string (struct (field anyref)))
    (type $float (struct (field f64)))
    (type $float_array (array (mut f64)))
    (type $js (struct (field anyref)))
@@ -62,7 +63,13 @@
    (type $dup (func (param (ref eq)) (result (ref eq))))
    (type $custom_operations
       (struct
+(@if use-js-string
+(@then
+         (field $id (ref $string))
+)
+(@else
          (field $id (ref $bytes))
+))
          (field $compare (ref null $compare))
          (field $compare_ext (ref null $compare))
          (field $hash (ref null $hash))

--- a/runtime/wasm/dune
+++ b/runtime/wasm/dune
@@ -17,6 +17,7 @@
    --binaryen=-g
    --binaryen-opt=-O3
    --set=effects=jspi
+   --disable=use-js-string
    --allowed-imports=bindings,Math,js,wasm:js-string,wasm:text-encoder,wasm:text-decoder
    %{target}
    %{read-lines:args})))
@@ -32,6 +33,39 @@
    --binaryen=-g
    --binaryen-opt=-O3
    --set=effects=cps
+   --disable=use-js-string
+   --allowed-imports=bindings,Math,js,wasm:js-string,wasm:text-encoder,wasm:text-decoder
+   %{target}
+   %{read-lines:args})))
+
+(rule
+ (target runtime-jspi-use-js-string.wasm)
+ (deps
+  args
+  (glob_files *.wat))
+ (action
+  (run
+   ../../compiler/bin-wasm_of_ocaml/wasmoo_link_wasm.exe
+   --binaryen=-g
+   --binaryen-opt=-O3
+   --set=effects=jspi
+   --enable=use-js-string
+   --allowed-imports=bindings,Math,js,wasm:js-string,wasm:text-encoder,wasm:text-decoder
+   %{target}
+   %{read-lines:args})))
+
+(rule
+ (target runtime-cps-use-js-string.wasm)
+ (deps
+  args
+  (glob_files *.wat))
+ (action
+  (run
+   ../../compiler/bin-wasm_of_ocaml/wasmoo_link_wasm.exe
+   --binaryen=-g
+   --binaryen-opt=-O3
+   --set=effects=cps
+   --enable=use-js-string
    --allowed-imports=bindings,Math,js,wasm:js-string,wasm:text-encoder,wasm:text-decoder
    %{target}
    %{read-lines:args})))

--- a/runtime/wasm/effect.wat
+++ b/runtime/wasm/effect.wat
@@ -44,6 +44,7 @@
 
    (type $block (array (mut (ref eq))))
    (type $bytes (array (mut i8)))
+   (type $string (struct (field anyref)))
    (type $function_1 (func (param (ref eq) (ref eq)) (result (ref eq))))
    (type $closure (sub (struct (field (ref $function_1)))))
    (type $function_3

--- a/runtime/wasm/fail.wat
+++ b/runtime/wasm/fail.wat
@@ -22,6 +22,7 @@
 
    (type $block (array (mut (ref eq))))
    (type $bytes (array (mut i8)))
+   (type $string (struct (field anyref)))
 
    (tag $ocaml_exception (export "ocaml_exception") (param (ref eq)))
    (export "javascript_exception" (tag $javascript_exception))
@@ -60,7 +61,7 @@
        (return_call $caml_raise_with_arg
            (array.get $block (global.get $caml_global_data)
               (global.get $FAILURE_EXN))
-           (local.get 0)))
+           (local.get $arg)))
 
    (global $INVALID_EXN i32 (i32.const 3))
 

--- a/runtime/wasm/fs.wat
+++ b/runtime/wasm/fs.wat
@@ -50,6 +50,7 @@
       (func $caml_string_concat (param (ref eq) (ref eq)) (result (ref eq))))
 
    (type $bytes (array (mut i8)))
+   (type $string (struct (field anyref)))
 
    (func (export "caml_sys_getcwd")
       (param (ref eq)) (result (ref eq))

--- a/runtime/wasm/hash.wat
+++ b/runtime/wasm/hash.wat
@@ -180,6 +180,7 @@
       (return_call $jsstring_hash
          (local.get $h) (struct.get $js 0 (local.get $s))))
 
+   (export "caml_hash_mix_bytes" (func $caml_hash_mix_bytes))
 (@if use-js-string
 (@then
    (export "caml_hash_mix_string" (func $caml_hash_mix_string))

--- a/runtime/wasm/hash.wat
+++ b/runtime/wasm/hash.wat
@@ -25,6 +25,7 @@
 
    (type $block (array (mut (ref eq))))
    (type $bytes (array (mut i8)))
+   (type $string (struct (field anyref)))
    (type $float (struct (field f64)))
    (type $js (struct (field anyref)))
 
@@ -39,7 +40,13 @@
    (type $dup (func (param (ref eq)) (result (ref eq))))
    (type $custom_operations
       (struct
+(@if use-js-string
+(@then
+         (field $id (ref $string))
+)
+(@else
          (field $id (ref $bytes))
+))
          (field $compare (ref null $compare))
          (field $compare_ext (ref null $compare))
          (field $hash (ref null $hash))
@@ -120,7 +127,7 @@
          (then (local.set $i (i32.const 0))))
       (return_call $caml_hash_mix_int (local.get $h) (local.get $i)))
 
-   (func $caml_hash_mix_string (export "caml_hash_mix_string")
+   (func $caml_hash_mix_bytes
       (param $h i32) (param $s (ref $bytes)) (result i32)
       (local $i i32) (local $len i32) (local $w i32)
       (local.set $len (array.len (local.get $s)))
@@ -167,6 +174,22 @@
                (array.get_u $bytes (local.get $s) (local.get $i))))
          (local.set $h (call $caml_hash_mix_int (local.get $h) (local.get $w))))
       (i32.xor (local.get $h) (local.get $len)))
+
+   (func $caml_hash_mix_string
+      (param $h i32) (param $s (ref $string)) (result i32)
+      (return_call $jsstring_hash
+         (local.get $h) (struct.get $js 0 (local.get $s))))
+
+(;
+(@if use-js-string
+(@then
+   (export "caml_hash_mix_string" (func $caml_hash_mix_string))
+)
+(@else
+   (export "caml_hash_mix_string" (func $caml_hash_mix_bytes))
+))
+;)
+   (export "caml_hash_mix_string" (func $caml_hash_mix_bytes)) ;; ZZZ Fix base
 
    (global $HASH_QUEUE_SIZE i32 (i32.const 256))
    (global $MAX_FORWARD_DEREFERENCE i32 (i32.const 1000))
@@ -216,10 +239,10 @@
                               (i32.const 1))))
                      (local.set $num (i32.sub (local.get $num) (i32.const 1)))
                      (br $loop)))
-                  (drop (block $not_string (result (ref eq))
+                  (drop (block $not_bytes (result (ref eq))
                      (local.set $h
-                        (call $caml_hash_mix_string (local.get $h)
-                           (br_on_cast_fail $not_string (ref eq) (ref $bytes)
+                        (call $caml_hash_mix_bytes (local.get $h)
+                           (br_on_cast_fail $not_bytes (ref eq) (ref $bytes)
                               (local.get $v))))
                      (local.set $num (i32.sub (local.get $num) (i32.const 1)))
                      (br $loop)))
@@ -323,6 +346,8 @@
       (ref.i31 (i32.and (call $caml_hash_mix_final (local.get $h))
                         (i32.const 0x3FFFFFFF))))
 
+(@if use-js-string
+(@then
    (func (export "caml_string_hash")
       (param (ref eq)) (param (ref eq)) (result (ref eq))
       (local $h i32)
@@ -331,6 +356,19 @@
             (call $caml_hash_mix_final
                (call $caml_hash_mix_string
                   (i31.get_s (ref.cast (ref i31) (local.get 0)))
+                  (ref.cast (ref $string) (local.get 1))))
+            (i32.const 0x3FFFFFFF))))
+)
+(@else
+   (func (export "caml_string_hash")
+      (param (ref eq)) (param (ref eq)) (result (ref eq))
+      (local $h i32)
+      (ref.i31
+         (i32.and
+            (call $caml_hash_mix_final
+               (call $caml_hash_mix_bytes
+                  (i31.get_s (ref.cast (ref i31) (local.get 0)))
                   (ref.cast (ref $bytes) (local.get 1))))
             (i32.const 0x3FFFFFFF))))
+))
 )

--- a/runtime/wasm/hash.wat
+++ b/runtime/wasm/hash.wat
@@ -180,7 +180,6 @@
       (return_call $jsstring_hash
          (local.get $h) (struct.get $js 0 (local.get $s))))
 
-(;
 (@if use-js-string
 (@then
    (export "caml_hash_mix_string" (func $caml_hash_mix_string))
@@ -188,8 +187,6 @@
 (@else
    (export "caml_hash_mix_string" (func $caml_hash_mix_bytes))
 ))
-;)
-   (export "caml_hash_mix_string" (func $caml_hash_mix_bytes)) ;; ZZZ Fix base
 
    (global $HASH_QUEUE_SIZE i32 (i32.const 256))
    (global $MAX_FORWARD_DEREFERENCE i32 (i32.const 1000))

--- a/runtime/wasm/int32.wat
+++ b/runtime/wasm/int32.wat
@@ -33,6 +33,7 @@
       (func $caml_deserialize_int_4 (param (ref eq)) (result i32)))
 
    (type $bytes (array (mut i8)))
+   (type $string (struct (field anyref)))
    (type $compare
       (func (param (ref eq)) (param (ref eq)) (param i32) (result i32)))
    (type $hash
@@ -44,7 +45,13 @@
    (type $dup (func (param (ref eq)) (result (ref eq))))
    (type $custom_operations
       (struct
+(@if use-js-string
+(@then
+         (field $id (ref $string))
+)
+(@else
          (field $id (ref $bytes))
+))
          (field $compare (ref null $compare))
          (field $compare_ext (ref null $compare))
          (field $hash (ref null $hash))

--- a/runtime/wasm/jslib_js_of_ocaml.wat
+++ b/runtime/wasm/jslib_js_of_ocaml.wat
@@ -33,6 +33,7 @@
 
    (type $block (array (mut (ref eq))))
    (type $bytes (array (mut i8)))
+   (type $js (struct (field anyref)))
 
    (func (export "caml_js_html_escape") (param (ref eq)) (result (ref eq))
       (return_call $wrap
@@ -42,13 +43,13 @@
       (return_call $wrap
          (call $caml_js_html_entities_js (call $unwrap (local.get 0)))))
 
-   (@string $console "console")
+   (@jsstring $console "console")
 
    (func (export "caml_js_get_console") (param (ref eq)) (result (ref eq))
       (return_call $caml_js_get (call $caml_js_global (ref.i31 (i32.const 0)))
          (global.get $console)))
 
-   (@string $XMLHttpRequest "XMLHttpRequest")
+   (@jsstring $XMLHttpRequest "XMLHttpRequest")
 
    (func (export "caml_xmlhttprequest_create") (param (ref eq)) (result (ref eq))
       (return_call $caml_js_new

--- a/runtime/wasm/obj.wat
+++ b/runtime/wasm/obj.wat
@@ -29,8 +29,13 @@
       (func $caml_cps_trampoline (param (ref eq) (ref eq)) (result (ref eq))))
 ))
 
+   (import "jsstring" "jsstring_test"
+      (func $jsstring_test (param anyref) (result i32)))
+
    (type $block (array (mut (ref eq))))
    (type $bytes (array (mut i8)))
+   (type $string (struct (field anyref)))
+   (type $js (struct (field anyref)))
    (type $float (struct (field f64)))
    (type $float_array (array (mut f64)))
    (type $function_1 (func (param (ref eq) (ref eq)) (result (ref eq))))
@@ -237,6 +242,8 @@
                (struct.get $float 0
                   (br_on_cast_fail $not_float (ref eq) (ref $float)
                      (local.get 0)))))))
+      (if (ref.test (ref $js) (local.get 0))
+         (then (return (local.get 0))))
       (call $caml_dup_custom (local.get 0)))
 
    (func (export "caml_obj_with_tag")
@@ -280,6 +287,13 @@
          (then (return (ref.i31 (global.get $closure_tag)))))
       (if (call $caml_is_continuation (local.get $v))
          (then (return (ref.i31 (global.get $cont_tag)))))
+      (drop (block $not_string (result (ref eq))
+         (if (call $jsstring_test
+                (struct.get $js 0
+                   (br_on_cast_fail $not_string (ref eq) (ref $js)
+                      (local.get $v))))
+            (then (return (ref.i31 (global.get $string_tag)))))
+         (ref.i31 (i32.const 0))))
       (ref.i31 (global.get $abstract_tag)))
 
    (func (export "caml_obj_make_forward")

--- a/runtime/wasm/stdlib.wat
+++ b/runtime/wasm/stdlib.wat
@@ -35,6 +35,8 @@
    (import "string" "caml_string_concat"
       (func $caml_string_concat
          (param (ref eq)) (param (ref eq)) (result (ref eq))))
+   (import "string" "caml_string_of_bytes"
+      (func $caml_string_of_bytes (param (ref eq)) (result (ref eq))))
    (import "printexc" "caml_format_exception"
       (func $caml_format_exception (param (ref eq)) (result (ref eq))))
    (import "sys" "ocaml_exit" (tag $ocaml_exit))
@@ -45,10 +47,11 @@
 
    (type $block (array (mut (ref eq))))
    (type $bytes (array (mut i8)))
+   (type $string (struct (field anyref)))
 
    (type $assoc
       (struct
-         (field (ref $bytes))
+         (field (ref eq))
          (field (mut (ref eq)))
          (field (mut (ref null $assoc)))))
 
@@ -115,9 +118,7 @@
          (return (ref.i31 (i32.const 0))))
       (array.set $assoc_array
          (global.get $named_value_table) (local.get $h)
-         (struct.new $assoc
-            (ref.cast (ref $bytes) (local.get 0))
-            (local.get 1) (local.get $r)))
+         (struct.new $assoc (local.get 0) (local.get 1) (local.get $r)))
       (ref.i31 (i32.const 0)))
 
    ;; Used only for testing (tests-jsoo/bin), but inconvenient to pull out

--- a/runtime/wasm/sync.wat
+++ b/runtime/wasm/sync.wat
@@ -25,6 +25,7 @@
    (import "custom" "custom_next_id" (func $custom_next_id (result i64)))
 
    (type $bytes (array (mut i8)))
+   (type $string (struct (field anyref)))
    (type $compare
       (func (param (ref eq)) (param (ref eq)) (param i32) (result i32)))
    (type $hash
@@ -36,7 +37,13 @@
    (type $dup (func (param (ref eq)) (result (ref eq))))
    (type $custom_operations
       (struct
+(@if use-js-string
+(@then
+         (field $id (ref $string))
+)
+(@else
          (field $id (ref $bytes))
+))
          (field $compare (ref null $compare))
          (field $compare_ext (ref null $compare))
          (field $hash (ref null $hash))

--- a/runtime/wasm/sys.wat
+++ b/runtime/wasm/sys.wat
@@ -56,6 +56,7 @@
 
    (type $block (array (mut (ref eq))))
    (type $bytes (array (mut i8)))
+   (type $string (struct (field anyref)))
    (type $float (struct (field f64)))
 
    (tag $ocaml_exit (export "ocaml_exit"))

--- a/runtime/wasm/unix.wat
+++ b/runtime/wasm/unix.wat
@@ -118,6 +118,7 @@
       (func $Int64_val (param (ref eq)) (result i64)))
 
    (type $bytes (array (mut i8)))
+   (type $string (struct (field anyref)))
    (type $block (array (mut (ref eq))))
    (type $float (struct (field f64)))
    (type $float_array (array (mut f64)))

--- a/runtime/wasm/weak.wat
+++ b/runtime/wasm/weak.wat
@@ -34,6 +34,7 @@
    (import "jslib" "wrap" (func $wrap (param anyref) (result (ref eq))))
    (type $block (array (mut (ref eq))))
    (type $bytes (array (mut i8)))
+   (type $string (struct (field anyref)))
    (type $js (struct (field anyref)))
 
    ;; A weak array is a an abstract value composed of possibly some

--- a/tools/ci_setup.ml
+++ b/tools/ci_setup.ml
@@ -25,6 +25,7 @@ let forked_packages =
     [ "async_js"
     ; "base"
     ; "basement"
+    ; "bigstringaf"
     ; "core"
     ; "core_kernel"
     ; "core_unix"

--- a/tools/ci_setup.ml
+++ b/tools/ci_setup.ml
@@ -24,6 +24,7 @@ let forked_packages =
   StringSet.of_list
     [ "async_js"
     ; "base"
+    ; "basement"
     ; "core"
     ; "core_kernel"
     ; "core_unix"
@@ -32,6 +33,7 @@ let forked_packages =
     ; "bonsai_web" (* Compatibility with effect syntax *)
     ; "bonsai_web_components"
     ; "bonsai_web_test"
+    ; "ppx_hash"
     ; "time_now"
     ; "typerep" (* https://github.com/janestreet/typerep/pull/7 *)
     ; "virtual_dom" (* Compatibility with effect syntax *)
@@ -348,10 +350,12 @@ let branch nm =
     match nm with
     | "async_js"
     | "base"
+    | "basement"
     | "bigstringaf"
     | "core"
     | "core_kernel"
     | "core_unix"
+    | "ppx_hash"
     | "time_now"
     | "zarith_stubs_js" -> Some "js-strings"
     | _ -> Some "wasm-latest"

--- a/tools/ci_setup.ml
+++ b/tools/ci_setup.ml
@@ -358,7 +358,7 @@ let branch nm =
     None
 
 let pin nm =
-  let branch = Option.value ~default:"wasm-v0.18" (branch nm) in
+  let branch = Option.value ~default:"wasm-latest" (branch nm) in
   exec_async
     (Printf.sprintf
        "opam pin add -n %s https://github.com/ocaml-wasm/%s.git#%s"

--- a/tools/ci_setup.ml
+++ b/tools/ci_setup.ml
@@ -348,6 +348,7 @@ let branch nm =
     match nm with
     | "async_js"
     | "base"
+    | "bigstringaf"
     | "core"
     | "core_kernel"
     | "core_unix"

--- a/tools/ci_setup.ml
+++ b/tools/ci_setup.ml
@@ -39,6 +39,9 @@ let dune_workspace =
  (_
   (env-vars (TESTING_FRAMEWORK inline-test))
   (js_of_ocaml (enabled_if false))
+  (wasm_of_ocaml
+   (flags
+    (:standard --enable use-js-string)))
   (flags :standard -alert -all -warn-error -7-8-27-30-32-34-37-49-52-55 -w -7-27-30-32-34-37-49-52-55-56-58-67-69)))
 |}
 

--- a/tools/ci_setup.ml
+++ b/tools/ci_setup.ml
@@ -22,15 +22,19 @@ let do_pin =
 
 let forked_packages =
   StringSet.of_list
-    [ "base"
+    [ "async_js"
+    ; "base"
     ; "core"
+    ; "core_kernel"
+    ; "core_unix"
     ; "bonsai" (* Compatibility with effect syntax *)
     ; "bonsai_test"
     ; "bonsai_web" (* Compatibility with effect syntax *)
     ; "bonsai_web_components"
     ; "bonsai_web_test"
-    ; "virtual_dom" (* Compatibility with effect syntax *)
+    ; "time_now"
     ; "typerep" (* https://github.com/janestreet/typerep/pull/7 *)
+    ; "virtual_dom" (* Compatibility with effect syntax *)
     ; "zarith_stubs_js"
     ]
 
@@ -403,7 +407,14 @@ let () =
       let branch =
         if is_forked nm then
           match nm with
-          | "zarith_stubs_js" -> Some "js-strings"
+          | "async_js"
+          | "base"
+          | "core"
+          | "core_kernel"
+          | "core_unix"
+          | "time_now"
+          | "zarith_stubs_js" ->
+              Some "js-strings"
           | _ -> Some "wasm-latest"
         else None
       in

--- a/tools/ci_setup.ml
+++ b/tools/ci_setup.ml
@@ -31,6 +31,7 @@ let forked_packages =
     ; "bonsai_web_test"
     ; "virtual_dom" (* Compatibility with effect syntax *)
     ; "typerep" (* https://github.com/janestreet/typerep/pull/7 *)
+    ; "zarith_stubs_js"
     ]
 
 let dune_workspace =
@@ -95,7 +96,7 @@ index c6d09fb..61b1e5b 100644
 @@ -3,6 +3,11 @@ open! Expect_test_helpers_core
  open Bignum
  open Bignum.For_testing
- 
+
 +module Zarith = struct
 +  module Q = Q
 +  module Z = Z
@@ -211,7 +212,7 @@ index 5fd0ddc..4833923 100644
 +    [%expect {| ((hash d937e61f530ab9c27544e392922d286d) (uniqueness_rate 42.96875)) |}]
    ;;
  end
- 
+
 @@ -102,7 +102,7 @@ module Ml_z_hamdist = struct
        ();
      (* Compression rate is low because our quickcheck implementation generates
@@ -220,7 +221,7 @@ index 5fd0ddc..4833923 100644
 +    [%expect {| ((hash 0d36530b39292e2c31f13d10ec004a38) (uniqueness_rate 33.284457)) |}]
    ;;
  end
- 
+
 diff --git a/test/dune b/test/dune
 index 7996514..d0b463a 100644
 --- a/test/dune
@@ -235,14 +236,14 @@ index 7996514..d0b463a 100644
 + (modules (:standard \ zarith))
   (preprocess
    (pps ppx_jane)))
- 
+
 @@ -35,10 +37,16 @@
   (deps implemented_externals.txt tested_externals.txt)
   (action
    (bash "diff %{deps}"))
 - (alias runtest))
 + (alias runtest-))
- 
+
  (rule
   (deps implemented_externals.txt zarith_externals.txt)
   (action
@@ -399,7 +400,13 @@ let () =
   sync_exec (fun () -> exec_async "opam install uri --deps-only") [ () ];
   sync_exec
     (fun nm ->
-      let branch = if is_forked nm then Some "wasm-latest" else None in
+      let branch =
+        if is_forked nm then
+          match nm with
+          | "zarith_stubs_js" -> Some "js-strings"
+          | _ -> Some "wasm-latest"
+        else None
+      in
       let commit =
         if is_forked nm
         then None


### PR DESCRIPTION
- [x] Conditional compilation of Wasm runtime
- [x] Import string constants (define JS strings in Wasm runtime)
- [x] default should  be not to use js strings
- [x] Compatibilty for when JS string builtins proposal is not available
- [ ] Performance improvements
  - [x] skip conversions for ASCII strings
  - [x] lower level version of caml_blit_string
  - [ ] Use I16 array for conversions 
  - [x] Remove unnecessary conversion
- [x] clean-up / check for missing tests
- [ ] adapt Jane street libraries
- [ ] performance measurements
