### PR TITLE
Wasm runtime changes

### DIFF
--- a/runtime/wasm/effect.wat
+++ b/runtime/wasm/effect.wat
@@ -24,7 +24,7 @@
      (func $caml_fresh_oo_id (param (ref eq)) (result (ref eq))))
    (import "obj" "cont_tag" (global $cont_tag i32))
    (import "stdlib" "caml_named_value"
-      (func $caml_named_value (param (ref $string)) (result (ref null eq))))
+      (func $caml_named_value (param (ref eq)) (result (ref null eq))))
    (import "fail" "ocaml_exception" (tag $ocaml_exception (param (ref eq))))
    (import "fail" "javascript_exception"
       (tag $javascript_exception (param externref)))

--- a/runtime/wasm/jslib.wat
+++ b/runtime/wasm/jslib.wat
@@ -77,7 +77,7 @@
    (import "fail" "caml_failwith_tag"
       (func $caml_failwith_tag (result (ref eq))))
    (import "stdlib" "caml_named_value"
-      (func $caml_named_value (param (ref $string)) (result (ref null eq))))
+      (func $caml_named_value (param (ref eq)) (result (ref null eq))))
    (import "obj" "caml_callback_1"
       (func $caml_callback_1
          (param (ref eq)) (param (ref eq)) (result (ref eq))))
@@ -89,6 +89,9 @@
       (func $jsstring_of_string (param (ref $string)) (result anyref)))
    (import "jsstring" "string_of_jsstring"
       (func $string_of_jsstring (param anyref) (result (ref $string))))
+   (import "jsstring" "jsstring_of_substring"
+      (func $jsstring_of_substring
+         (param (ref $string) i32 i32) (result anyref)))
    (import "int32" "caml_copy_int32"
       (func $caml_copy_int32 (param i32) (result (ref eq))))
    (import "int32" "Int32_val"
@@ -458,6 +461,16 @@
       (local $s (ref $string))
       (local.set $s (ref.cast (ref $string) (local.get 0)))
       (return (struct.new $js (call $jsstring_of_string (local.get $s)))))
+
+   (func (export "caml_jsstring_of_substring")
+      (param $s (ref eq)) (param $i (ref eq)) (param $l (ref eq))
+      (result (ref eq))
+      (return
+         (struct.new $js
+            (call $jsstring_of_substring
+               (ref.cast (ref $string) (local.get $s))
+               (i31.get_u (ref.cast (ref i31) (local.get $i)))
+               (i31.get_u (ref.cast (ref i31) (local.get $l)))))))
 
    (func $caml_jsbytes_of_string (export "caml_jsbytes_of_string")
       (param (ref eq)) (result (ref eq))

--- a/runtime/wasm/stdlib.wat
+++ b/runtime/wasm/stdlib.wat
@@ -79,7 +79,7 @@
             (br $loop))))
 
    (func $caml_named_value (export "caml_named_value")
-      (param $s (ref $string)) (result (ref null eq))
+      (param $s (ref eq)) (result (ref null eq))
       (block $not_found
          (return
             (struct.get $assoc 1

--- a/tools/ci_setup.ml
+++ b/tools/ci_setup.ml
@@ -266,7 +266,7 @@ let () =
       let branch =
         if is_forked nm
         then
-          if List.mem nm [ "bonsai"; "virtual_dom"; "async_js" ]
+          if List.mem nm [ "bonsai"; "virtual_dom"; "async_js"; "zarith_stubs_js" ]
           then Some "jsoo-6"
           else Some "wasm"
         else None


### PR DESCRIPTION
So that we can later implement `-enable use-js-string` without breaking compatibility with the Wasm runtime file of package  `zarith_stubs_js`:
- `caml_named_value` no longer assumes that strings are of type `ref $string`;
- add a function `caml_jsstring_of_substring` to be used instead of the low-level function `jsstring_of_substring`.
