### PR TITLE
[wasm] Optimize calls to a statically known function

### DIFF
--- a/compiler/lib/code.mli
+++ b/compiler/lib/code.mli
@@ -196,11 +196,16 @@ type field_type =
   | Non_float
   | Float
 
+type apply_kind =
+  | Generic
+  | Exact (* # of arguments = # of parameters *)
+  | Known of Var.t (* Exact and we know which function is called *)
+
 type expr =
   | Apply of
       { f : Var.t
       ; args : Var.t list
-      ; exact : bool (* if true, then # of arguments = # of parameters *)
+      ; kind : apply_kind
       }
   | Block of int * Var.t array * array_or_not * mutability
   | Field of Var.t * int * field_type

--- a/compiler/lib/generate.ml
+++ b/compiler/lib/generate.ml
@@ -157,9 +157,14 @@ module Share = struct
           List.fold_left block.body ~init:share ~f:(fun share i ->
               match i with
               | Let (_, Constant c) -> get_constant c share
-              | Let (x, Apply { args; exact; _ }) ->
+              | Let (x, Apply { args; kind; _ }) ->
                   let trampolined = Var.Set.mem x trampolined_calls in
                   let in_cps = Var.Set.mem x in_cps in
+                  let exact =
+                    match kind with
+                    | Generic -> false
+                    | Exact | Known _ -> true
+                  in
                   if (not exact) || trampolined
                   then
                     add_apply
@@ -1245,7 +1250,12 @@ let remove_unused_tail_args ctx exact trampolined args =
 let rec translate_expr ctx loc x e level : (_ * J.statement_list) Expr_builder.t =
   let open Expr_builder in
   match e with
-  | Apply { f; args; exact } ->
+  | Apply { f; args; kind } ->
+      let exact =
+        match kind with
+        | Generic -> false
+        | Exact | Known _ -> true
+      in
       let trampolined = Var.Set.mem x ctx.Ctx.trampolined_calls in
       let args = remove_unused_tail_args ctx exact trampolined args in
       let* () = info ~need_loc:true mutator_p in

--- a/compiler/lib/global_flow.mli
+++ b/compiler/lib/global_flow.mli
@@ -46,6 +46,6 @@ type info =
 
 val f : fast:bool -> Code.program -> info
 
-val exact_call : info -> Var.t -> int -> bool
+val apply_kind : info -> Var.t -> int -> Code.apply_kind
 
-val function_arity : info -> Var.t -> int option
+val function_arity : info -> Var.t -> (int * Code.apply_kind) option

--- a/compiler/lib/inline.ml
+++ b/compiler/lib/inline.ml
@@ -179,7 +179,8 @@ let inline ~first_class_primitives live_vars closures name pc (outer, p) =
       ~init:([], (outer, block.branch, p))
       ~f:(fun i (rem, state) ->
         match i with
-        | Let (x, Apply { f; args; exact = true; _ }) when Var.Map.mem f closures -> (
+        | Let (x, Apply { f; args; kind = Exact | Known _; _ })
+          when Var.Map.mem f closures -> (
             let outer, branch, p = state in
             let { cl_params = params
                 ; cl_cont = clos_cont
@@ -268,7 +269,7 @@ let inline ~first_class_primitives live_vars closures name pc (outer, p) =
                   if recursive
                   then
                     ( Let (f, Closure (params, clos_cont))
-                      :: Let (x, Apply { f; args; exact = true })
+                      :: Let (x, Apply { f; args; kind = Known f })
                       :: rem
                     , (outer, branch, p) )
                   else

--- a/compiler/lib/lambda_lifting.ml
+++ b/compiler/lib/lambda_lifting.ml
@@ -200,7 +200,7 @@ let rec traverse var_depth (program, functions) pc depth limit =
                   Let (f'', Closure (List.map s ~f:snd, (pc'', []))) :: functions
                 in
                 let rem', st = rewrite_body false (program, functions) rem in
-                ( Let (f, Apply { f = f''; args = List.map ~f:fst s; exact = true })
+                ( Let (f, Apply { f = f''; args = List.map ~f:fst s; kind = Known f'' })
                   :: rem'
                 , st ))
               else

--- a/compiler/lib/lambda_lifting_simple.ml
+++ b/compiler/lib/lambda_lifting_simple.ml
@@ -175,7 +175,7 @@ and rewrite_body
         ~var_depth
         ~acc_instr:
           (* Replace closure with application of the lifter function *)
-          (Let (f, Apply { f = f''; args = List.map ~f:fst s; exact = true }) :: acc_instr)
+          (Let (f, Apply { f = f''; args = List.map ~f:fst s; kind = Exact }) :: acc_instr)
         ~depth
         rem
   | Let (cname, Closure (params, (pc', args))) :: rem ->
@@ -291,7 +291,7 @@ and rewrite_body
             in
             ( (program, functions, lifters)
             , rev_decl
-              @ Let (tuple, Apply { f = f_tuple; args = List.map ~f:fst s; exact = true })
+              @ Let (tuple, Apply { f = f_tuple; args = List.map ~f:fst s; kind = Exact })
                 :: acc_instr )
         | _ :: _ ->
             (* No need to lift the accumulated closures: just keep their definitions

--- a/compiler/lib/parse_bytecode.ml
+++ b/compiler/lib/parse_bytecode.ml
@@ -1058,7 +1058,7 @@ and compile infos pc state (instrs : instr list) =
           infos
           (pc + 2)
           (State.pop 3 state)
-          (Let (x, Apply { f; args; exact = false }) :: instrs)
+          (Let (x, Apply { f; args; kind = Generic }) :: instrs)
     | APPLY1 ->
         let f = State.accu state in
         let x, state = State.fresh_var state in
@@ -1070,7 +1070,7 @@ and compile infos pc state (instrs : instr list) =
           infos
           (pc + 1)
           (State.pop 1 state)
-          (Let (x, Apply { f; args = [ y ]; exact = false }) :: instrs)
+          (Let (x, Apply { f; args = [ y ]; kind = Generic }) :: instrs)
     | APPLY2 ->
         let f = State.accu state in
         let x, state = State.fresh_var state in
@@ -1093,7 +1093,7 @@ and compile infos pc state (instrs : instr list) =
           infos
           (pc + 1)
           (State.pop 2 state)
-          (Let (x, Apply { f; args = [ y; z ]; exact = false }) :: instrs)
+          (Let (x, Apply { f; args = [ y; z ]; kind = Generic }) :: instrs)
     | APPLY3 ->
         let f = State.accu state in
         let x, state = State.fresh_var state in
@@ -1119,7 +1119,7 @@ and compile infos pc state (instrs : instr list) =
           infos
           (pc + 1)
           (State.pop 3 state)
-          (Let (x, Apply { f; args = [ y; z; t ]; exact = false }) :: instrs)
+          (Let (x, Apply { f; args = [ y; z; t ]; kind = Generic }) :: instrs)
     | APPTERM ->
         let n = getu code (pc + 1) in
         let f = State.accu state in
@@ -1134,13 +1134,13 @@ and compile infos pc state (instrs : instr list) =
           done;
           Format.printf ")@.");
         let x, state = State.fresh_var state in
-        Let (x, Apply { f; args = l; exact = false }) :: instrs, Return x, state
+        Let (x, Apply { f; args = l; kind = Generic }) :: instrs, Return x, state
     | APPTERM1 ->
         let f = State.accu state in
         let x = State.peek 0 state in
         if debug_parser () then Format.printf "return %a(%a)@." Var.print f Var.print x;
         let y, state = State.fresh_var state in
-        Let (y, Apply { f; args = [ x ]; exact = false }) :: instrs, Return y, state
+        Let (y, Apply { f; args = [ x ]; kind = Generic }) :: instrs, Return y, state
     | APPTERM2 ->
         let f = State.accu state in
         let x = State.peek 0 state in
@@ -1148,7 +1148,7 @@ and compile infos pc state (instrs : instr list) =
         if debug_parser ()
         then Format.printf "return %a(%a, %a)@." Var.print f Var.print x Var.print y;
         let z, state = State.fresh_var state in
-        Let (z, Apply { f; args = [ x; y ]; exact = false }) :: instrs, Return z, state
+        Let (z, Apply { f; args = [ x; y ]; kind = Generic }) :: instrs, Return z, state
     | APPTERM3 ->
         let f = State.accu state in
         let x = State.peek 0 state in
@@ -1167,7 +1167,9 @@ and compile infos pc state (instrs : instr list) =
             Var.print
             z;
         let t, state = State.fresh_var state in
-        Let (t, Apply { f; args = [ x; y; z ]; exact = false }) :: instrs, Return t, state
+        ( Let (t, Apply { f; args = [ x; y; z ]; kind = Generic }) :: instrs
+        , Return t
+        , state )
     | RETURN ->
         let x = State.accu state in
 

--- a/compiler/lib/pure_fun.ml
+++ b/compiler/lib/pure_fun.ml
@@ -26,7 +26,9 @@ let pure_expr pure_funs e =
   match e with
   | Block _ | Field _ | Closure _ | Constant _ -> true
   | Special (Alias_prim _) -> true
-  | Apply { f; exact; _ } -> exact && Var.Set.mem f pure_funs
+  | Apply { kind = Known g; _ } -> Var.Set.mem g pure_funs
+  | Apply { f; kind = Exact; _ } -> Var.Set.mem f pure_funs
+  | Apply { kind = Generic; _ } -> false
   | Prim (p, _l) -> (
       match p with
       | Extern f -> Primitive.is_pure f

--- a/compiler/lib/specialize.mli
+++ b/compiler/lib/specialize.mli
@@ -18,6 +18,9 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *)
 
-val function_arity : Flow.Info.t -> Code.Var.t -> int option
+val function_arity : Flow.Info.t -> Code.Var.t -> (int * Code.apply_kind) option
 
-val f : function_arity:(Code.Var.t -> int option) -> Code.program -> Code.program
+val f :
+     function_arity:(Code.Var.t -> (int * Code.apply_kind) option)
+  -> Code.program
+  -> Code.program

--- a/compiler/lib/subst.ml
+++ b/compiler/lib/subst.ml
@@ -27,8 +27,7 @@ module Excluding_Binders = struct
   let expr s e =
     match e with
     | Constant _ -> e
-    | Apply { f; args; exact } ->
-        Apply { f = s f; args = List.map args ~f:(fun x -> s x); exact }
+    | Apply { f; args; kind } -> Apply { f = s f; args = List.map args ~f:s; kind }
     | Block (n, a, k, mut) -> Block (n, Array.map a ~f:(fun x -> s x), k, mut)
     | Field (x, n, typ) -> Field (s x, n, typ)
     | Closure (l, pc) -> Closure (l, subst_cont s pc)
@@ -115,7 +114,10 @@ module Including_Binders = struct
   let expr s e =
     match e with
     | Constant _ -> e
-    | Apply { f; args; exact } -> Apply { f = s f; args = List.map args ~f:s; exact }
+    | Apply { f; args; kind = Known g } ->
+        Apply { f = s f; args = List.map args ~f:s; kind = Known (s g) }
+    | Apply { f; args; kind = (Generic | Exact) as kind } ->
+        Apply { f = s f; args = List.map args ~f:s; kind }
     | Block (n, a, k, mut) -> Block (n, Array.map a ~f:s, k, mut)
     | Field (x, n, typ) -> Field (s x, n, typ)
     | Closure (l, pc) -> Closure (List.map l ~f:s, subst_cont s pc)


### PR DESCRIPTION
When the function to be called is statically known, we can call it directly instead of loading the code pointer from the closure.