### PR TITLE
CI: workaround opam pkg bug

### DIFF
--- a/.github/workflows/build-wasm_of_ocaml.yml
+++ b/.github/workflows/build-wasm_of_ocaml.yml
@@ -94,7 +94,7 @@ jobs:
       # Work-around a race between reinstalling mingw-w64-shims
       # (because of conf-pkg-config optional dep) and installing other
       # packages that implicitly depend on mingw-w64-shims.
-      - run: opam install conf-pkg-config conf-mingw-w64-gcc-i686
+      - run: opam install conf-pkg-config conf-mingw-w64-gcc-i686 conf-mingw-w64-g++-x86_64
         if: runner.os == 'Windows'
 
       - name: Pin dune

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,7 +119,7 @@ jobs:
       # Work-around a race between reinstalling mingw-w64-shims
       # (because of conf-pkg-config optional dep) and installing other
       # packages that implicitly depend on mingw-w64-shims.
-      - run: opam install conf-pkg-config
+      - run: opam install conf-pkg-config conf-mingw-w64-g++-i686 conf-mingw-w64-g++-x86_64
         if: runner.os == 'Windows'
 
       - name: Set-up Binaryen


### PR DESCRIPTION
Work-around a race between reinstalling mingw-w64-shims
(e.g. because of conf-pkg-config optional dep) and installing other
packages that implicitly depend on mingw-w64-shims.