### PR TITLE
CI: wasm tests are flaky on windows because of libuv

### DIFF
--- a/.github/workflows/build-wasm_of_ocaml.yml
+++ b/.github/workflows/build-wasm_of_ocaml.yml
@@ -132,6 +132,7 @@ jobs:
 
       - name: Run tests with CPS effects
         if: ${{ matrix.ocaml-compiler >= '5.' && matrix.separate_compilation }}
+        continue-on-error: ${{ matrix.os == 'windows-latest' }}
         working-directory: ./wasm_of_ocaml
         run: opam exec -- dune build @runtest-wasm --profile with-effects
 


### PR DESCRIPTION
See https://github.com/libuv/libuv/issues/3622