### PR TITLE
Runtime: fresh obj_id when un-marshaling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@
 * Compiler: Fix small bug in global data flow analysis (#1768)
 * Runtime: no longer leak channels
 * Runtime: Fix Marshal.to_buffer (#1798)
+* Runtime: unmarshalling objects should refresh its id
 
 # 5.9.1 (02-12-2024) - Lille
 

--- a/compiler/tests-ocaml/lib-dynarray/test.ml
+++ b/compiler/tests-ocaml/lib-dynarray/test.ml
@@ -537,6 +537,6 @@ let () =
   let c = Marshal.from_string buf 0 in
   (* Note: currently the equality of dynarrays is *not* stable by
      marshalling-unmarshalling. *)
-  if false then assert (Stdlib.compare a c <> 0);
-  if false then assert (a <> c);
+  assert (Stdlib.compare a c <> 0);
+  assert (a <> c);
   ();;

--- a/runtime/js/marshal.js
+++ b/runtime/js/marshal.js
@@ -330,6 +330,7 @@ var caml_custom_ops = {
 //Requires: caml_float_of_bytes, caml_custom_ops
 //Requires: UInt8ArrayReader
 //Requires: caml_decompress_input
+//Requires: caml_set_oo_id
 function caml_input_value_from_reader(reader, ofs) {
   function readvlq(overflow) {
     var c = reader.read8u();

--- a/runtime/js/marshal.js
+++ b/runtime/js/marshal.js
@@ -378,6 +378,7 @@ function caml_input_value_from_reader(reader, ofs) {
       break;
   }
   var stack = [];
+  var objects = [];
   var intern_obj_table = num_objects > 0 ? [] : null;
   var obj_counter = 0;
   function intern_rec(reader) {
@@ -389,6 +390,7 @@ function caml_input_value_from_reader(reader, ofs) {
         var v = [tag];
         if (size === 0) return v;
         if (intern_obj_table) intern_obj_table[obj_counter++] = v;
+        if (tag === 248) objects.push(v);
         stack.push(v, size);
         return v;
       } else return code & 0x3f;
@@ -428,6 +430,7 @@ function caml_input_value_from_reader(reader, ofs) {
             var v = [tag];
             if (size === 0) return v;
             if (intern_obj_table) intern_obj_table[obj_counter++] = v;
+            if (tag === 248) objects.push(v);
             stack.push(v, size);
             return v;
           case 0x13: //cst.CODE_BLOCK64:
@@ -563,6 +566,10 @@ function caml_input_value_from_reader(reader, ofs) {
     var d = v.length;
     if (d < size) stack.push(v, size);
     v[d] = intern_rec(reader);
+  }
+  while (objects.length > 0) {
+    var x = objects.pop();
+    if (x[2] >= 0) caml_set_oo_id(x);
   }
   return res;
 }


### PR DESCRIPTION
This brings the behavior closer to the upstream runtime 