### PR TITLE
Double translation: callback fixes

### DIFF
--- a/lib/tests/test_fun_call.ml
+++ b/lib/tests/test_fun_call.ml
@@ -184,6 +184,19 @@ let%expect_test "wrap_callback_strict" =
     got 1, 2, undefined, done
     Result: 0 |}]
 
+(* Wrap callback unsafe *)
+let%expect_test "over application, extra arguments are dropped" =
+  call_and_log (Js.Unsafe.callback cb3) {| (function(f){ return f(1,2,3,4) }) |};
+  [%expect {|
+    got 1, 2, 3, done
+    Result: 0 |}]
+
+let%expect_test "partial application, extra arguments set to undefined" =
+  call_and_log (Js.Unsafe.callback cb3) {| (function(f){ return f(1,2) }) |};
+  [%expect {|
+    got 1, 2, undefined, done
+    Result: 0 |}]
+
 (* Wrap meth callback *)
 
 let%expect_test "over application, extra arguments are dropped" =

--- a/lib/tests/test_fun_call_2.ml
+++ b/lib/tests/test_fun_call_2.ml
@@ -181,6 +181,19 @@ let%expect_test "wrap_callback_strict" =
     got 1, 2, undefined, done
     Result: 0 |}]
 
+(* Wrap callback unsafe *)
+let%expect_test "over application, extra arguments are dropped" =
+  call_and_log (Js.Unsafe.callback cb3) {| (function(f){ return f(1,2,3,4) }) |};
+  [%expect {|
+    got 1, 2, 3, done
+    Result: 0 |}]
+
+let%expect_test "partial application, extra arguments set to undefined" =
+  call_and_log (Js.Unsafe.callback cb3) {| (function(f){ return f(1,2) }) |};
+  [%expect {|
+    got 1, 2, undefined, done
+    Result: 0 |}]
+
 (* Wrap meth callback *)
 
 let%expect_test "over application, extra arguments are dropped" =

--- a/runtime/js/jslib.js
+++ b/runtime/js/jslib.js
@@ -443,6 +443,14 @@ function caml_js_function_arity(f) {
 
 //Provides: caml_js_function_arity
 //If: effects
+//If: doubletranslate
+function caml_js_function_arity(f) {
+  return f.l >= 0 ? f.l : (f.l = f.length);
+}
+
+//Provides: caml_js_function_arity
+//If: effects
+//If: !doubletranslate
 function caml_js_function_arity(f) {
   // Functions have an additional continuation parameter. This should
   // not be visible when calling them from JavaScript

--- a/runtime/js/stdlib.js
+++ b/runtime/js/stdlib.js
@@ -141,10 +141,9 @@ var caml_call_gen_tuple = (function () {
     if (d === 0) {
       return f.apply(null, args);
     } else if (d < 0) {
-      return caml_call_gen_direct(
-        f.apply(null, args.slice(0, n)),
-        args.slice(n),
-      );
+      var g = f(...args.slice(0, n));
+      if (typeof g !== "function") return g;
+      return caml_call_gen_direct(g, args.slice(n));
     } else {
       // FIXME: Restore the optimization of handling specially d = 1 or 2
       var args_ = args.slice();


### PR DESCRIPTION
There is a hack in caml_call_gen functions to make Js.wrap_callback work even when the OCaml function is called with more arguments that it expects. This hack was missing in the double translation case.

Also, fix function arity computation for `Js.Unsafe.meth_callback` and `Js.Unsafe.callback`.

We should probably run the whole test suite with `--enable double-translation`, not just the effect tests. (I have run it manually.)