### PR TITLE
runtime(js): use es6 class

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # dev
 
 ## Features/Changes
+* Runtime: use es6 class (#1840)
 * Compiler: use a Wasm text files preprocessor (#1822)
 * Compiler: support for OCaml 4.14.3+trunk (#1844)
 * Runtime: support more Unix functions (#1829)

--- a/ECMASCRIPT.md
+++ b/ECMASCRIPT.md
@@ -5,6 +5,10 @@ Features are grouped by ECMAScript version.
 
 ## ECMAScript 2015
 
+### Classes
+
+- [Compatibility](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes#browser_compatibility)
+
 ### Rest parameters
 
 - [Compatibility](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters#browser_compatibility)

--- a/runtime/js/fs_fake.js
+++ b/runtime/js/fs_fake.js
@@ -24,442 +24,497 @@
 //Requires: caml_bytes_of_array, caml_bytes_of_string, caml_bytes_of_jsbytes
 //Requires: caml_is_ml_bytes, caml_is_ml_string
 //Requires: caml_raise_system_error
-function MlFakeDevice(root, f) {
-  this.content = {};
-  this.root = root;
-  this.lookupFun = f;
-}
-MlFakeDevice.prototype.nm = function (name) {
-  return this.root + name;
-};
-MlFakeDevice.prototype.create_dir_if_needed = function (name) {
-  var comp = name.split("/");
-  var res = "";
-  for (var i = 0; i < comp.length - 1; i++) {
-    res += comp[i] + "/";
-    if (this.content[res]) continue;
-    this.content[res] = Symbol("directory");
+class MlFakeDevice {
+  constructor(root, f) {
+    this.content = {};
+    this.root = root;
+    this.lookupFun = f;
   }
-};
-MlFakeDevice.prototype.slash = function (name) {
-  return /\/$/.test(name) ? name : name + "/";
-};
-MlFakeDevice.prototype.lookup = function (name) {
-  if (!this.content[name] && this.lookupFun) {
-    var res = this.lookupFun(
-      caml_string_of_jsstring(this.root),
-      caml_string_of_jsstring(name),
-    );
-    if (res !== 0) {
-      this.create_dir_if_needed(name);
-      this.content[name] = new MlFakeFile(caml_bytes_of_string(res[1]));
+
+  nm(name) {
+    return this.root + name;
+  }
+
+  create_dir_if_needed(name) {
+    var comp = name.split("/");
+    var res = "";
+    for (var i = 0; i < comp.length - 1; i++) {
+      res += comp[i] + "/";
+      if (this.content[res]) continue;
+      this.content[res] = Symbol("directory");
     }
   }
-};
-MlFakeDevice.prototype.exists = function (name, do_not_lookup) {
-  // The root of the device exists
-  if (name === "") return 1;
-  // Check if a directory exists
-  var name_slash = this.slash(name);
-  if (this.content[name_slash]) return 1;
-  // Check if a file exists
-  if (!do_not_lookup) this.lookup(name);
-  return this.content[name] ? 1 : 0;
-};
-MlFakeDevice.prototype.isFile = function (name) {
-  if (this.exists(name) && !this.is_dir(name)) {
-    return 1;
-  } else {
-    return 0;
+
+  slash(name) {
+    return /\/$/.test(name) ? name : name + "/";
   }
-};
-MlFakeDevice.prototype.mkdir = function (name, mode, raise_unix) {
-  if (this.exists(name))
-    caml_raise_system_error(
-      raise_unix,
-      "EEXIST",
-      "mkdir",
-      "file already exists",
-      this.nm(name),
-    );
-  var parent = /^(.*)\/[^/]+/.exec(name);
-  parent = (parent && parent[1]) || "";
-  if (!this.exists(parent))
-    caml_raise_system_error(
-      raise_unix,
-      "ENOENT",
-      "mkdir",
-      "no such file or directory",
-      this.nm(name),
-    );
-  if (!this.is_dir(parent))
-    caml_raise_system_error(
-      raise_unix,
-      "ENOTDIR",
-      "mkdir",
-      "not a directory",
-      this.nm(name),
-    );
-  this.create_dir_if_needed(this.slash(name));
-};
-MlFakeDevice.prototype.rmdir = function (name, raise_unix) {
-  var name_slash = name === "" ? "" : this.slash(name);
-  var r = new RegExp("^" + name_slash + "([^/]+)");
-  if (!this.exists(name))
-    caml_raise_system_error(
-      raise_unix,
-      "ENOENT",
-      "rmdir",
-      "no such file or directory",
-      this.nm(name),
-    );
-  if (!this.is_dir(name))
-    caml_raise_system_error(
-      raise_unix,
-      "ENOTDIR",
-      "rmdir",
-      "not a directory",
-      this.nm(name),
-    );
-  for (var n in this.content) {
-    if (n.match(r))
-      caml_raise_system_error(
-        raise_unix,
-        "ENOTEMPTY",
-        "rmdir",
-        "directory not empty",
-        this.nm(name),
+
+  lookup(name) {
+    if (!this.content[name] && this.lookupFun) {
+      var res = this.lookupFun(
+        caml_string_of_jsstring(this.root),
+        caml_string_of_jsstring(name),
       );
-  }
-  delete this.content[name_slash];
-};
-MlFakeDevice.prototype.readdir = function (name) {
-  var name_slash = name === "" ? "" : this.slash(name);
-  if (!this.exists(name)) {
-    caml_raise_sys_error(name + ": No such file or directory");
-  }
-  if (!this.is_dir(name)) {
-    caml_raise_sys_error(name + ": Not a directory");
-  }
-  var r = new RegExp("^" + name_slash + "([^/]+)");
-  var seen = {};
-  var a = [];
-  for (var n in this.content) {
-    var m = n.match(r);
-    if (m && !seen[m[1]]) {
-      seen[m[1]] = true;
-      a.push(m[1]);
+      if (res !== 0) {
+        this.create_dir_if_needed(name);
+        this.content[name] = new MlFakeFile(caml_bytes_of_string(res[1]));
+      }
     }
   }
-  return a;
-};
-MlFakeDevice.prototype.opendir = function (name, raise_unix) {
-  var a = this.readdir(name);
-  var c = false;
-  var i = 0;
-  return {
-    readSync: function () {
-      if (c)
-        caml_raise_system_error(
-          raise_unix,
-          "EBADF",
-          "readdir",
-          "bad file descriptor",
-        );
-      if (i === a.length) return null;
-      var entry = a[i];
-      i++;
-      return { name: entry };
-    },
-    closeSync: function () {
-      if (c)
-        caml_raise_system_error(
-          raise_unix,
-          "EBADF",
-          "readdir",
-          "bad file descriptor",
-        );
-      c = true;
-      a = [];
-    },
-  };
-};
-MlFakeDevice.prototype.is_dir = function (name) {
-  if (name === "") return true;
-  var name_slash = this.slash(name);
-  return this.content[name_slash] ? 1 : 0;
-};
-MlFakeDevice.prototype.unlink = function (name, raise_unix) {
-  if (!this.exists(name, true)) {
-    // [true] means no "lookup" if not found.
-    caml_raise_system_error(
-      raise_unix,
-      "ENOENT",
-      "unlink",
-      "no such file or directory",
-      name,
-    );
+
+  exists(name, do_not_lookup) {
+    // The root of the device exists
+    if (name === "") return 1;
+    // Check if a directory exists
+    var name_slash = this.slash(name);
+    if (this.content[name_slash]) return 1;
+    // Check if a file exists
+    if (!do_not_lookup) this.lookup(name);
+    return this.content[name] ? 1 : 0;
   }
-  delete this.content[name];
-  return 0;
-};
-MlFakeDevice.prototype.access = function (name, f, raise_unix) {
-  var file;
-  this.lookup(name);
-  if (this.content[name]) {
-    if (this.is_dir(name))
-      caml_raise_system_error(
-        raise_unix,
-        "EACCESS",
-        "access",
-        "permission denied,",
-        this.nm(name),
-      );
-  } else {
-    caml_raise_no_such_file(this.nm(name), raise_unix);
+
+  isFile(name) {
+    if (this.exists(name) && !this.is_dir(name)) {
+      return 1;
+    } else {
+      return 0;
+    }
   }
-  return 0;
-};
-MlFakeDevice.prototype.open = function (name, f, _perms, raise_unix) {
-  var file;
-  this.lookup(name);
-  if (this.content[name]) {
-    if (this.is_dir(name))
-      caml_raise_system_error(
-        raise_unix,
-        "EISDIR",
-        "open",
-        "illegal operation on a directory",
-        this.nm(name),
-      );
-    if (f.create && f.excl)
+
+  mkdir(name, mode, raise_unix) {
+    if (this.exists(name))
       caml_raise_system_error(
         raise_unix,
         "EEXIST",
-        "open",
+        "mkdir",
         "file already exists",
         this.nm(name),
       );
-    file = this.content[name];
-    if (f.truncate) file.truncate();
-  } else if (f.create) {
-    this.create_dir_if_needed(name);
-    this.content[name] = new MlFakeFile(caml_create_bytes(0));
-    file = this.content[name];
-  } else {
-    caml_raise_no_such_file(this.nm(name), raise_unix);
-  }
-  return new MlFakeFd(this.nm(name), file, f);
-};
-MlFakeDevice.prototype.truncate = function (name, len, raise_unix) {
-  var file;
-  this.lookup(name);
-  if (this.content[name]) {
-    if (this.is_dir(name))
+    var parent = /^(.*)\/[^/]+/.exec(name);
+    parent = (parent && parent[1]) || "";
+    if (!this.exists(parent))
       caml_raise_system_error(
         raise_unix,
-        "EISDIR",
-        "open",
-        "illegal operation on a directory",
+        "ENOENT",
+        "mkdir",
+        "no such file or directory",
         this.nm(name),
       );
-    file = this.content[name];
-    file.truncate(len);
-  } else {
-    caml_raise_no_such_file(this.nm(name), raise_unix);
+    if (!this.is_dir(parent))
+      caml_raise_system_error(
+        raise_unix,
+        "ENOTDIR",
+        "mkdir",
+        "not a directory",
+        this.nm(name),
+      );
+    this.create_dir_if_needed(this.slash(name));
   }
-};
-MlFakeDevice.prototype.register = function (name, content) {
-  var file;
-  if (this.content[name])
-    caml_raise_sys_error(this.nm(name) + " : file already exists");
-  if (caml_is_ml_bytes(content)) file = new MlFakeFile(content);
-  if (caml_is_ml_string(content))
-    file = new MlFakeFile(caml_bytes_of_string(content));
-  else if (Array.isArray(content))
-    file = new MlFakeFile(caml_bytes_of_array(content));
-  else if (typeof content === "string")
-    file = new MlFakeFile(caml_bytes_of_jsbytes(content));
-  else if (content.toString) {
-    var bytes = caml_bytes_of_string(
-      caml_string_of_jsstring(content.toString()),
-    );
-    file = new MlFakeFile(bytes);
-  }
-  if (file) {
-    this.create_dir_if_needed(name);
-    this.content[name] = file;
-  } else
-    caml_raise_sys_error(
-      this.nm(name) + " : registering file with invalid content type",
-    );
-};
 
-MlFakeDevice.prototype.constructor = MlFakeDevice;
+  rmdir(name, raise_unix) {
+    var name_slash = name === "" ? "" : this.slash(name);
+    var r = new RegExp("^" + name_slash + "([^/]+)");
+    if (!this.exists(name))
+      caml_raise_system_error(
+        raise_unix,
+        "ENOENT",
+        "rmdir",
+        "no such file or directory",
+        this.nm(name),
+      );
+    if (!this.is_dir(name))
+      caml_raise_system_error(
+        raise_unix,
+        "ENOTDIR",
+        "rmdir",
+        "not a directory",
+        this.nm(name),
+      );
+    for (var n in this.content) {
+      if (n.match(r))
+        caml_raise_system_error(
+          raise_unix,
+          "ENOTEMPTY",
+          "rmdir",
+          "directory not empty",
+          this.nm(name),
+        );
+    }
+    delete this.content[name_slash];
+  }
+
+  readdir(name) {
+    var name_slash = name === "" ? "" : this.slash(name);
+    if (!this.exists(name)) {
+      caml_raise_sys_error(name + ": No such file or directory");
+    }
+    if (!this.is_dir(name)) {
+      caml_raise_sys_error(name + ": Not a directory");
+    }
+    var r = new RegExp("^" + name_slash + "([^/]+)");
+    var seen = {};
+    var a = [];
+    for (var n in this.content) {
+      var m = n.match(r);
+      if (m && !seen[m[1]]) {
+        seen[m[1]] = true;
+        a.push(m[1]);
+      }
+    }
+    return a;
+  }
+
+  opendir(name, raise_unix) {
+    var a = this.readdir(name);
+    var c = false;
+    var i = 0;
+    return {
+      readSync: function () {
+        if (c)
+          caml_raise_system_error(
+            raise_unix,
+            "EBADF",
+            "readdir",
+            "bad file descriptor",
+          );
+        if (i === a.length) return null;
+        var entry = a[i];
+        i++;
+        return { name: entry };
+      },
+      closeSync: function () {
+        if (c)
+          caml_raise_system_error(
+            raise_unix,
+            "EBADF",
+            "readdir",
+            "bad file descriptor",
+          );
+        c = true;
+        a = [];
+      },
+    };
+  }
+
+  is_dir(name) {
+    if (name === "") return true;
+    var name_slash = this.slash(name);
+    return this.content[name_slash] ? 1 : 0;
+  }
+
+  unlink(name, raise_unix) {
+    if (!this.exists(name, true)) {
+      // [true] means no "lookup" if not found.
+      caml_raise_system_error(
+        raise_unix,
+        "ENOENT",
+        "unlink",
+        "no such file or directory",
+        name,
+      );
+    }
+    delete this.content[name];
+    return 0;
+  }
+
+  access(name, f, raise_unix) {
+    var file;
+    this.lookup(name);
+    if (this.content[name]) {
+      if (this.is_dir(name))
+        caml_raise_system_error(
+          raise_unix,
+          "EACCESS",
+          "access",
+          "permission denied,",
+          this.nm(name),
+        );
+    } else {
+      caml_raise_no_such_file(this.nm(name), raise_unix);
+    }
+    return 0;
+  }
+
+  open(name, f, _perms, raise_unix) {
+    var file;
+    this.lookup(name);
+    if (this.content[name]) {
+      if (this.is_dir(name))
+        caml_raise_system_error(
+          raise_unix,
+          "EISDIR",
+          "open",
+          "illegal operation on a directory",
+          this.nm(name),
+        );
+      if (f.create && f.excl)
+        caml_raise_system_error(
+          raise_unix,
+          "EEXIST",
+          "open",
+          "file already exists",
+          this.nm(name),
+        );
+      file = this.content[name];
+      if (f.truncate) file.truncate();
+    } else if (f.create) {
+      this.create_dir_if_needed(name);
+      this.content[name] = new MlFakeFile(caml_create_bytes(0));
+      file = this.content[name];
+    } else {
+      caml_raise_no_such_file(this.nm(name), raise_unix);
+    }
+    return new MlFakeFd(this.nm(name), file, f);
+  }
+
+  truncate(name, len, raise_unix) {
+    var file;
+    this.lookup(name);
+    if (this.content[name]) {
+      if (this.is_dir(name))
+        caml_raise_system_error(
+          raise_unix,
+          "EISDIR",
+          "open",
+          "illegal operation on a directory",
+          this.nm(name),
+        );
+      file = this.content[name];
+      file.truncate(len);
+    } else {
+      caml_raise_no_such_file(this.nm(name), raise_unix);
+    }
+  }
+
+  register(name, content) {
+    var file;
+    if (this.content[name])
+      caml_raise_sys_error(this.nm(name) + " : file already exists");
+    if (caml_is_ml_bytes(content)) file = new MlFakeFile(content);
+    if (caml_is_ml_string(content))
+      file = new MlFakeFile(caml_bytes_of_string(content));
+    else if (Array.isArray(content))
+      file = new MlFakeFile(caml_bytes_of_array(content));
+    else if (typeof content === "string")
+      file = new MlFakeFile(caml_bytes_of_jsbytes(content));
+    else if (content.toString) {
+      var bytes = caml_bytes_of_string(
+        caml_string_of_jsstring(content.toString()),
+      );
+      file = new MlFakeFile(bytes);
+    }
+    if (file) {
+      this.create_dir_if_needed(name);
+      this.content[name] = file;
+    } else
+      caml_raise_sys_error(
+        this.nm(name) + " : registering file with invalid content type",
+      );
+  }
+}
 
 //Provides: MlFakeFile
 //Requires: MlFile
 //Requires: caml_create_bytes, caml_ml_bytes_length, caml_blit_bytes
 //Requires: caml_uint8_array_of_bytes, caml_bytes_of_uint8_array
-function MlFakeFile(content) {
-  this.data = content;
+class MlFakeFile extends MlFile {
+  constructor(content) {
+    super();
+    this.data = content;
+  }
+
+  truncate(len) {
+    var old = this.data;
+    this.data = caml_create_bytes(len | 0);
+    caml_blit_bytes(old, 0, this.data, 0, len);
+  }
+
+  length() {
+    return caml_ml_bytes_length(this.data);
+  }
+
+  write(offset, buf, pos, len) {
+    var clen = this.length();
+    if (offset + len >= clen) {
+      var new_str = caml_create_bytes(offset + len);
+      var old_data = this.data;
+      this.data = new_str;
+      caml_blit_bytes(old_data, 0, this.data, 0, clen);
+    }
+    caml_blit_bytes(
+      caml_bytes_of_uint8_array(buf),
+      pos,
+      this.data,
+      offset,
+      len,
+    );
+    return len;
+  }
+
+  read(offset, buf, pos, len) {
+    var clen = this.length();
+    if (offset + len >= clen) {
+      len = clen - offset;
+    }
+    if (len) {
+      var data = caml_create_bytes(len | 0);
+      caml_blit_bytes(this.data, offset, data, 0, len);
+      buf.set(caml_uint8_array_of_bytes(data), pos);
+    }
+    return len;
+  }
 }
-MlFakeFile.prototype = new MlFile();
-MlFakeFile.prototype.constructor = MlFakeFile;
-MlFakeFile.prototype.truncate = function (len) {
-  var old = this.data;
-  this.data = caml_create_bytes(len | 0);
-  caml_blit_bytes(old, 0, this.data, 0, len);
-};
-MlFakeFile.prototype.length = function () {
-  return caml_ml_bytes_length(this.data);
-};
-MlFakeFile.prototype.write = function (offset, buf, pos, len) {
-  var clen = this.length();
-  if (offset + len >= clen) {
-    var new_str = caml_create_bytes(offset + len);
-    var old_data = this.data;
-    this.data = new_str;
-    caml_blit_bytes(old_data, 0, this.data, 0, clen);
-  }
-  caml_blit_bytes(caml_bytes_of_uint8_array(buf), pos, this.data, offset, len);
-  return len;
-};
-MlFakeFile.prototype.read = function (offset, buf, pos, len) {
-  var clen = this.length();
-  if (offset + len >= clen) {
-    len = clen - offset;
-  }
-  if (len) {
-    var data = caml_create_bytes(len | 0);
-    caml_blit_bytes(this.data, offset, data, 0, len);
-    buf.set(caml_uint8_array_of_bytes(data), pos);
-  }
-  return len;
-};
 
 //Provides: MlFakeFd_out
 //Requires: MlFakeFile, caml_create_bytes, caml_blit_bytes, caml_bytes_of_uint8_array
 //Requires: caml_raise_system_error
-function MlFakeFd_out(fd, flags) {
-  MlFakeFile.call(this, caml_create_bytes(0));
-  this.log = function (s) {
-    return 0;
-  };
-  if (fd === 1 && typeof console.log === "function") this.log = console.log;
-  else if (fd === 2 && typeof console.error === "function")
-    this.log = console.error;
-  else if (typeof console.log === "function") this.log = console.log;
-  this.flags = flags;
-}
-MlFakeFd_out.prototype.length = function () {
-  return 0;
-};
-MlFakeFd_out.prototype.truncate = function (len, raise_unix) {
-  caml_raise_system_error(
-    raise_unix,
-    "EINVAL",
-    "ftruncate",
-    "invalid argument",
-  );
-};
-MlFakeFd_out.prototype.write = function (buf, pos, len, raise_unix) {
-  var written = len;
-  if (this.log) {
-    if (
-      len > 0 &&
-      pos >= 0 &&
-      pos + len <= buf.length &&
-      buf[pos + len - 1] === 10
-    )
-      len--;
-    // Do not output the last \n if present
-    // as console logging display a newline at the end
-    var src = caml_create_bytes(len);
-    caml_blit_bytes(caml_bytes_of_uint8_array(buf), pos, src, 0, len);
-    this.log(src.toUtf16());
-    return written;
+class MlFakeFd_out extends MlFakeFile {
+  constructor(fd, flags) {
+    super(caml_create_bytes(0));
+    this.log = function (s) {
+      return 0;
+    };
+    if (fd === 1 && typeof console.log === "function") this.log = console.log;
+    else if (fd === 2 && typeof console.error === "function")
+      this.log = console.error;
+    else if (typeof console.log === "function") this.log = console.log;
+    this.flags = flags;
   }
-  caml_raise_system_error(raise_unix, "EBADF", "write", "bad file descriptor");
-};
-MlFakeFd_out.prototype.read = function (buf, pos, len, raise_unix) {
-  caml_raise_system_error(raise_unix, "EBADF", "read", "bad file descriptor");
-};
-MlFakeFd_out.prototype.seek = function (len, whence, raise_unix) {
-  caml_raise_system_error(raise_unix, "ESPIPE", "lseek", "illegal seek");
-};
-MlFakeFd_out.prototype.close = function () {
-  this.log = undefined;
-};
-MlFakeFd_out.prototype.check_stream_semantics = function (cmd) {};
+
+  length() {
+    return 0;
+  }
+
+  truncate(len, raise_unix) {
+    caml_raise_system_error(
+      raise_unix,
+      "EINVAL",
+      "ftruncate",
+      "invalid argument",
+    );
+  }
+
+  write(buf, pos, len, raise_unix) {
+    var written = len;
+    if (this.log) {
+      if (
+        len > 0 &&
+        pos >= 0 &&
+        pos + len <= buf.length &&
+        buf[pos + len - 1] === 10
+      )
+        len--;
+      // Do not output the last \n if present
+      // as console logging display a newline at the end
+      var src = caml_create_bytes(len);
+      caml_blit_bytes(caml_bytes_of_uint8_array(buf), pos, src, 0, len);
+      this.log(src.toUtf16());
+      return written;
+    }
+    caml_raise_system_error(
+      raise_unix,
+      "EBADF",
+      "write",
+      "bad file descriptor",
+    );
+  }
+
+  read(buf, pos, len, raise_unix) {
+    caml_raise_system_error(raise_unix, "EBADF", "read", "bad file descriptor");
+  }
+
+  seek(len, whence, raise_unix) {
+    caml_raise_system_error(raise_unix, "ESPIPE", "lseek", "illegal seek");
+  }
+
+  close() {
+    this.log = undefined;
+  }
+
+  check_stream_semantics(cmd) {}
+}
 
 //Provides: MlFakeFd
 //Requires: MlFakeFile
 //Requires: caml_raise_system_error
-function MlFakeFd(name, file, flags) {
-  this.file = file;
-  this.name = name;
-  this.flags = flags;
-  this.offset = 0;
-  this.seeked = false;
-}
+class MlFakeFd {
+  constructor(name, file, flags) {
+    this.file = file;
+    this.name = name;
+    this.flags = flags;
+    this.offset = 0;
+    this.seeked = false;
+  }
 
-MlFakeFd.prototype.err_closed = function (cmd, raise_unix) {
-  caml_raise_system_error(raise_unix, "EBADF", cmd, "bad file descriptor");
-};
-MlFakeFd.prototype.length = function () {
-  if (this.file) return this.file.length();
-  this.err_closed("length");
-};
-MlFakeFd.prototype.truncate = function (len, raise_unix) {
-  if (this.file) {
-    if (!(this.flags.wronly || this.flags.rdwr))
+  err_closed(cmd, raise_unix) {
+    caml_raise_system_error(raise_unix, "EBADF", cmd, "bad file descriptor");
+  }
+
+  length() {
+    if (this.file) return this.file.length();
+    this.err_closed("length");
+  }
+
+  truncate(len, raise_unix) {
+    if (this.file) {
+      if (!(this.flags.wronly || this.flags.rdwr))
+        caml_raise_system_error(
+          raise_unix,
+          "EINVAL",
+          "truncate",
+          "invalid argument",
+        );
+      return this.file.truncate(len);
+    }
+    this.err_closed("truncate", raise_unix);
+  }
+
+  write(buf, pos, len, raise_unix) {
+    if (this.file && (this.flags.wronly || this.flags.rdwr)) {
+      var offset = this.offset;
+      this.offset += len;
+      return this.file.write(offset, buf, pos, len);
+    }
+    this.err_closed("write", raise_unix);
+  }
+
+  read(buf, pos, len, raise_unix) {
+    if (this.file && !this.flags.wronly) {
+      var offset = this.offset;
+      this.offset += len;
+      return this.file.read(offset, buf, pos, len);
+    }
+    this.err_closed("read", raise_unix);
+  }
+
+  seek(offset, whence, raise_unix) {
+    switch (whence) {
+      case 0:
+        break;
+      case 1:
+        offset += this.offset;
+        break;
+      case 2:
+        offset += this.length();
+        break;
+    }
+    if (offset < 0)
       caml_raise_system_error(
         raise_unix,
         "EINVAL",
-        "truncate",
+        "lseek",
         "invalid argument",
       );
-    return this.file.truncate(len);
+    this.offset = offset;
+    this.seeked = true;
   }
-  this.err_closed("truncate", raise_unix);
-};
-MlFakeFd.prototype.write = function (buf, pos, len, raise_unix) {
-  if (this.file && (this.flags.wronly || this.flags.rdwr)) {
-    var offset = this.offset;
-    this.offset += len;
-    return this.file.write(offset, buf, pos, len);
+
+  close() {
+    if (!this.file) this.err_closed("close");
+    this.file = undefined;
   }
-  this.err_closed("write", raise_unix);
-};
-MlFakeFd.prototype.read = function (buf, pos, len, raise_unix) {
-  if (this.file && !this.flags.wronly) {
-    var offset = this.offset;
-    this.offset += len;
-    return this.file.read(offset, buf, pos, len);
+
+  check_stream_semantics(cmd) {
+    if (!this.file) return this.err_closed(cmd, /* raise Unix_error */ 1);
   }
-  this.err_closed("read", raise_unix);
-};
-MlFakeFd.prototype.seek = function (offset, whence, raise_unix) {
-  switch (whence) {
-    case 0:
-      break;
-    case 1:
-      offset += this.offset;
-      break;
-    case 2:
-      offset += this.length();
-      break;
-  }
-  if (offset < 0)
-    caml_raise_system_error(raise_unix, "EINVAL", "lseek", "invalid argument");
-  this.offset = offset;
-  this.seeked = true;
-};
-MlFakeFd.prototype.close = function () {
-  if (!this.file) this.err_closed("close");
-  this.file = undefined;
-};
-MlFakeFd.prototype.check_stream_semantics = function (cmd) {
-  if (!this.file) return this.err_closed(cmd, /* raise Unix_error */ 1);
-};
+}

--- a/runtime/js/fs_node.js
+++ b/runtime/js/fs_node.js
@@ -444,10 +444,10 @@ class MlNodeFd extends MlFile {
         var read = this.fs.readSync(this.fd, a, buf_offset, len, this.offset);
       }
       this.offset += read;
+      return read;
     } catch (err) {
       caml_raise_nodejs_error(err, raise_unix);
     }
-    return read;
   }
 
   seek(offset, whence, raise_unix) {

--- a/runtime/js/io.js
+++ b/runtime/js/io.js
@@ -129,23 +129,29 @@ function caml_ml_set_channel_name(chanid, name) {
 
 //Provides: caml_ml_channels
 //Requires: MlChanid
-function caml_ml_channels_state() {
-  this.map = new globalThis.WeakMap();
-  this.opened = new globalThis.Set();
+class caml_ml_channels_state {
+  constructor() {
+    this.map = new globalThis.WeakMap();
+    this.opened = new globalThis.Set();
+  }
+
+  close(chanid) {
+    this.opened.delete(chanid);
+  }
+
+  get(chanid) {
+    return this.map.get(chanid);
+  }
+
+  set(chanid, val) {
+    if (val.opened) this.opened.add(chanid);
+    return this.map.set(chanid, val);
+  }
+
+  all() {
+    return this.opened.values();
+  }
 }
-caml_ml_channels_state.prototype.close = function (chanid) {
-  this.opened.delete(chanid);
-};
-caml_ml_channels_state.prototype.get = function (chanid) {
-  return this.map.get(chanid);
-};
-caml_ml_channels_state.prototype.set = function (chanid, val) {
-  if (val.opened) this.opened.add(chanid);
-  return this.map.set(chanid, val);
-};
-caml_ml_channels_state.prototype.all = function () {
-  return this.opened.values();
-};
 
 var caml_ml_channels = new caml_ml_channels_state();
 

--- a/runtime/js/marshal.js
+++ b/runtime/js/marshal.js
@@ -48,79 +48,92 @@ var caml_marshal_constants = {
 
 //Provides: UInt8ArrayReader
 //Requires: caml_string_of_uint8_array, caml_jsbytes_of_string
-function UInt8ArrayReader(s, i) {
-  this.s = s;
-  this.i = i;
-}
-UInt8ArrayReader.prototype = {
-  read8u: function () {
+class UInt8ArrayReader {
+  constructor(s, i) {
+    this.s = s;
+    this.i = i;
+  }
+
+  read8u() {
     return this.s[this.i++];
-  },
-  read8s: function () {
+  }
+
+  read8s() {
     return (this.s[this.i++] << 24) >> 24;
-  },
-  read16u: function () {
+  }
+
+  read16u() {
     var s = this.s,
       i = this.i;
     this.i = i + 2;
     return (s[i] << 8) | s[i + 1];
-  },
-  read16s: function () {
+  }
+
+  read16s() {
     var s = this.s,
       i = this.i;
     this.i = i + 2;
     return ((s[i] << 24) >> 16) | s[i + 1];
-  },
-  read32u: function () {
+  }
+
+  read32u() {
     var s = this.s,
       i = this.i;
     this.i = i + 4;
     return ((s[i] << 24) | (s[i + 1] << 16) | (s[i + 2] << 8) | s[i + 3]) >>> 0;
-  },
-  read32s: function () {
+  }
+
+  read32s() {
     var s = this.s,
       i = this.i;
     this.i = i + 4;
     return (s[i] << 24) | (s[i + 1] << 16) | (s[i + 2] << 8) | s[i + 3];
-  },
-  readstr: function (len) {
+  }
+
+  readstr(len) {
     var i = this.i;
     this.i = i + len;
     return caml_string_of_uint8_array(this.s.subarray(i, i + len));
-  },
-  readuint8array: function (len) {
+  }
+
+  readuint8array(len) {
     var i = this.i;
     this.i = i + len;
     return this.s.subarray(i, i + len);
-  },
-};
+  }
+}
 
 //Provides: MlStringReader
 //Requires: caml_string_of_jsbytes, caml_jsbytes_of_string
-function MlStringReader(s, i) {
-  this.s = caml_jsbytes_of_string(s);
-  this.i = i;
-}
-MlStringReader.prototype = {
-  read8u: function () {
+class MlStringReader {
+  constructor(s, i) {
+    this.s = caml_jsbytes_of_string(s);
+    this.i = i;
+  }
+
+  read8u() {
     return this.s.charCodeAt(this.i++);
-  },
-  read8s: function () {
+  }
+
+  read8s() {
     return (this.s.charCodeAt(this.i++) << 24) >> 24;
-  },
-  read16u: function () {
+  }
+
+  read16u() {
     var s = this.s,
       i = this.i;
     this.i = i + 2;
     return (s.charCodeAt(i) << 8) | s.charCodeAt(i + 1);
-  },
-  read16s: function () {
+  }
+
+  read16s() {
     var s = this.s,
       i = this.i;
     this.i = i + 2;
     return ((s.charCodeAt(i) << 24) >> 16) | s.charCodeAt(i + 1);
-  },
-  read32u: function () {
+  }
+
+  read32u() {
     var s = this.s,
       i = this.i;
     this.i = i + 4;
@@ -131,8 +144,9 @@ MlStringReader.prototype = {
         s.charCodeAt(i + 3)) >>>
       0
     );
-  },
-  read32s: function () {
+  }
+
+  read32s() {
     var s = this.s,
       i = this.i;
     this.i = i + 4;
@@ -142,13 +156,15 @@ MlStringReader.prototype = {
       (s.charCodeAt(i + 2) << 8) |
       s.charCodeAt(i + 3)
     );
-  },
-  readstr: function (len) {
+  }
+
+  readstr(len) {
     var i = this.i;
     this.i = i + len;
     return caml_string_of_jsbytes(this.s.slice(i, i + len));
-  },
-  readuint8array: function (len) {
+  }
+
+  readuint8array(len) {
     var b = new Uint8Array(len);
     var s = this.s;
     var i = this.i;
@@ -157,35 +173,40 @@ MlStringReader.prototype = {
     }
     this.i = i + len;
     return b;
-  },
-};
+  }
+}
 
 //Provides: BigStringReader
 //Requires: caml_string_of_uint8_array, caml_ba_get_1
-function BigStringReader(bs, i) {
-  this.s = bs;
-  this.i = i;
-}
-BigStringReader.prototype = {
-  read8u: function () {
+class BigStringReader {
+  constructor(bs, i) {
+    this.s = bs;
+    this.i = i;
+  }
+
+  read8u() {
     return caml_ba_get_1(this.s, this.i++);
-  },
-  read8s: function () {
+  }
+
+  read8s() {
     return (caml_ba_get_1(this.s, this.i++) << 24) >> 24;
-  },
-  read16u: function () {
+  }
+
+  read16u() {
     var s = this.s,
       i = this.i;
     this.i = i + 2;
     return (caml_ba_get_1(s, i) << 8) | caml_ba_get_1(s, i + 1);
-  },
-  read16s: function () {
+  }
+
+  read16s() {
     var s = this.s,
       i = this.i;
     this.i = i + 2;
     return ((caml_ba_get_1(s, i) << 24) >> 16) | caml_ba_get_1(s, i + 1);
-  },
-  read32u: function () {
+  }
+
+  read32u() {
     var s = this.s,
       i = this.i;
     this.i = i + 4;
@@ -196,8 +217,9 @@ BigStringReader.prototype = {
         caml_ba_get_1(s, i + 3)) >>>
       0
     );
-  },
-  read32s: function () {
+  }
+
+  read32s() {
     var s = this.s,
       i = this.i;
     this.i = i + 4;
@@ -207,22 +229,24 @@ BigStringReader.prototype = {
       (caml_ba_get_1(s, i + 2) << 8) |
       caml_ba_get_1(s, i + 3)
     );
-  },
-  readstr: function (len) {
+  }
+
+  readstr(len) {
     var i = this.i;
     var offset = this.offset(i);
     this.i = i + len;
     return caml_string_of_uint8_array(
       this.s.data.subarray(offset, offset + len),
     );
-  },
-  readuint8array: function (len) {
+  }
+
+  readuint8array(len) {
     var i = this.i;
     var offset = this.offset(i);
     this.i = i + len;
     return this.s.data.subarray(offset, offset + len);
-  },
-};
+  }
+}
 
 //Provides: caml_float_of_bytes
 //Requires: caml_int64_float_of_bits, caml_int64_of_bytes
@@ -630,22 +654,24 @@ function caml_marshal_data_size(s, ofs) {
 }
 
 //Provides: MlObjectTable
-function MlObjectTable() {
-  this.objs = [];
-  this.lookup = new globalThis.Map();
+class MlObjectTable {
+  constructor() {
+    this.objs = [];
+    this.lookup = new globalThis.Map();
+  }
+
+  store(v) {
+    this.lookup.set(v, this.objs.length);
+    this.objs.push(v);
+  }
+
+  recall(v) {
+    var i = this.lookup.get(v);
+    return i === undefined
+      ? undefined
+      : this.objs.length - i; /* index is relative */
+  }
 }
-
-MlObjectTable.prototype.store = function (v) {
-  this.lookup.set(v, this.objs.length);
-  this.objs.push(v);
-};
-
-MlObjectTable.prototype.recall = function (v) {
-  var i = this.lookup.get(v);
-  return i === undefined
-    ? undefined
-    : this.objs.length - i; /* index is relative */
-};
 
 //Provides: caml_output_val
 //Requires: caml_int64_to_bytes, caml_failwith
@@ -655,40 +681,46 @@ MlObjectTable.prototype.recall = function (v) {
 //Requires: MlObjectTable, caml_list_to_js_array, caml_custom_ops
 //Requires: caml_invalid_argument,caml_string_of_jsbytes, caml_is_continuation_tag
 var caml_output_val = (function () {
-  function Writer() {
-    this.chunk = [];
-  }
-  Writer.prototype = {
-    chunk_idx: 20,
-    block_len: 0,
-    obj_counter: 0,
-    size_32: 0,
-    size_64: 0,
-    write: function (size, value) {
+  class Writer {
+    constructor() {
+      this.chunk = [];
+      this.chunk_idx = 20;
+      this.block_len = 0;
+      this.obj_counter = 0;
+      this.size_32 = 0;
+      this.size_64 = 0;
+    }
+
+    write(size, value) {
       for (var i = size - 8; i >= 0; i -= 8)
         this.chunk[this.chunk_idx++] = (value >> i) & 0xff;
-    },
-    write_at: function (pos, size, value) {
+    }
+
+    write_at(pos, size, value) {
       var pos = pos;
       for (var i = size - 8; i >= 0; i -= 8)
         this.chunk[pos++] = (value >> i) & 0xff;
-    },
-    write_code: function (size, code, value) {
+    }
+
+    write_code(size, code, value) {
       this.chunk[this.chunk_idx++] = code;
       for (var i = size - 8; i >= 0; i -= 8)
         this.chunk[this.chunk_idx++] = (value >> i) & 0xff;
-    },
-    write_shared: function (offset) {
+    }
+
+    write_shared(offset) {
       if (offset < 1 << 8)
         this.write_code(8, 0x04 /*cst.CODE_SHARED8*/, offset);
       else if (offset < 1 << 16)
         this.write_code(16, 0x05 /*cst.CODE_SHARED16*/, offset);
       else this.write_code(32, 0x06 /*cst.CODE_SHARED32*/, offset);
-    },
-    pos: function () {
+    }
+
+    pos() {
       return this.chunk_idx;
-    },
-    finalize: function () {
+    }
+
+    finalize() {
       this.block_len = this.chunk_idx - 20;
       this.chunk_idx = 0;
       this.write(32, 0x8495a6be);
@@ -697,8 +729,8 @@ var caml_output_val = (function () {
       this.write(32, this.size_32);
       this.write(32, this.size_64);
       return this.chunk;
-    },
-  };
+    }
+  }
   return function (v, flags) {
     flags = caml_list_to_js_array(flags);
 

--- a/runtime/js/mlBytes.js
+++ b/runtime/js/mlBytes.js
@@ -412,36 +412,41 @@ function caml_bytes_of_utf16_jsstring(s) {
 
 //Provides: MlBytes
 //Requires: caml_convert_string_to_bytes, jsoo_is_ascii, caml_utf16_of_utf8
-function MlBytes(tag, contents, length) {
-  this.t = tag;
-  this.c = contents;
-  this.l = length;
-}
-MlBytes.prototype.toString = function () {
-  switch (this.t) {
-    case 9: /*BYTES | ASCII*/
-    case 8 /*BYTES | NOT_ASCII*/:
-      return this.c;
-    case 4: /* ARRAY */
-    case 2 /* PARTIAL */:
-      // biome-ignore lint/suspicious/noFallthroughSwitchClause:
-      caml_convert_string_to_bytes(this);
-    // fallthrough
-    case 0 /*BYTES | UNKOWN*/:
-      if (jsoo_is_ascii(this.c)) this.t = 9; /*BYTES | ASCII*/
-      else this.t = 8; /*BYTES | NOT_ASCII*/
-      return this.c;
+class MlBytes {
+  constructor(tag, contents, length) {
+    this.t = tag;
+    this.c = contents;
+    this.l = length;
   }
-};
-MlBytes.prototype.toUtf16 = function () {
-  var r = this.toString();
-  if (this.t === 9) return r;
-  return caml_utf16_of_utf8(r);
-};
-MlBytes.prototype.slice = function () {
-  var content = this.t === 4 ? this.c.slice() : this.c;
-  return new MlBytes(this.t, content, this.l);
-};
+
+  toString() {
+    switch (this.t) {
+      case 9: /*BYTES | ASCII*/
+      case 8 /*BYTES | NOT_ASCII*/:
+        return this.c;
+      case 4: /* ARRAY */
+      case 2 /* PARTIAL */:
+        // biome-ignore lint/suspicious/noFallthroughSwitchClause:
+        caml_convert_string_to_bytes(this);
+      // fallthrough
+      case 0 /*BYTES | UNKOWN*/:
+        if (jsoo_is_ascii(this.c)) this.t = 9; /*BYTES | ASCII*/
+        else this.t = 8; /*BYTES | NOT_ASCII*/
+        return this.c;
+    }
+  }
+
+  toUtf16() {
+    var r = this.toString();
+    if (this.t === 9) return r;
+    return caml_utf16_of_utf8(r);
+  }
+
+  slice() {
+    var content = this.t === 4 ? this.c.slice() : this.c;
+    return new MlBytes(this.t, content, this.l);
+  }
+}
 
 //Provides: caml_convert_string_to_bytes
 //Requires: caml_str_repeat, caml_sub_uint8_array_to_jsbytes

--- a/runtime/js/nat.js
+++ b/runtime/js/nat.js
@@ -10,18 +10,19 @@ function initialize_nat() {
 }
 
 //Provides: MlNat
-function MlNat(x) {
-  this.data = new Int32Array(x);
-  // For num < 1.5
-  // length_nat isn't external, so we have to make the Obj.size
-  // work out right.
-  // We add +2 to the array length:
-  // - +1 for the tag
-  // - +1 for the custom_ops slot
-  this.length = this.data.length + 2;
+class MlNat {
+  constructor(x) {
+    this.data = new Int32Array(x);
+    // For num < 1.5
+    // length_nat isn't external, so we have to make the Obj.size
+    // work out right.
+    // We add +2 to the array length:
+    // - +1 for the tag
+    // - +1 for the custom_ops slot
+    this.length = this.data.length + 2;
+    this.caml_custom = "_nat";
+  }
 }
-
-MlNat.prototype.caml_custom = "_nat";
 
 //Provides: caml_hash_nat
 //Requires: caml_hash_mix_int, num_digits_nat

--- a/runtime/js/sync.js
+++ b/runtime/js/sync.js
@@ -1,6 +1,8 @@
 //Provides: MlMutex
-function MlMutex() {
-  this.locked = false;
+class MlMutex {
+  constructor() {
+    this.locked = false;
+  }
 }
 
 //Provides: caml_ml_mutex_new


### PR DESCRIPTION
This PR updates several JavaScript runtime components to use ES6 class syntax instead of the traditional prototype-based object model. This modernization improves code readability and maintainability while aligning with current JavaScript best practices.

## Changes
- Converted the classes to ES6 syntax
- Updated class inheritance patterns to use the `extends` keyword
- Replaced prototype method definitions with class methods
- Maintained all existing functionality while improving code structure

## Benefits
- More readable and maintainable code structure
- Better alignment with modern JavaScript development practices
- Clearer class hierarchies through explicit `extends` relationships
- Improved code organization with methods contained within class definitions

## Documentation
- Updated `ECMASCRIPT.md` to document ES6 class support

## Testing
All existing tests continue to pass with the updated class implementations.

---

I recommend clicking this checkbox when reviewing on GitHub to improve readability:
<img width="404" alt="image" src="https://github.com/user-attachments/assets/3c4da799-1df8-484f-b192-bd32e6d0d704" />
