### PR TITLE
runtime(js): better caml_xmlhttprequest_create error handling and remove Map polyfill

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 * Compiler: use a Wasm text files preprocessor (#1822)
 * Compiler: support for OCaml 4.14.3+trunk (#1844)
 * Runtime: support more Unix functions (#1829)
+* Runtime: remove polyfill for Map to simplify MlObjectTable implementation (#1846)
+* Runtime: refactor caml_xmlhttprequest_create implementation (#1846)
 
 # 6.0.1 (2025-02-07) - Lille
 

--- a/ECMASCRIPT.md
+++ b/ECMASCRIPT.md
@@ -27,6 +27,10 @@ Features are grouped by ECMAScript version.
 - [Compatibility](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#browser_compatibility)
 - To implement bigarray
 
+### Map
+
+- [Compatibility](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#browser_compatibility)
+
 ## ECMAScript 2016
 
 ### async function
@@ -47,6 +51,7 @@ Features are grouped by ECMAScript version.
 - Polyfilled in the repository
 
 ### BigInt
+
 - [Compatibility](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt#browser_compatibility)
 - For Wasm_of_ocaml
 
@@ -57,6 +62,12 @@ Features are grouped by ECMAScript version.
 - [Compatibility](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakRef#browser_compatibility)
 - To implement weak and ephemeron
 - Optional
+
+## Web APIs
+
+### XMLHttpRequest
+
+- [Compatibility](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest#browser_compatibility)
 
 ## Node.js
 

--- a/runtime/js/jslib_js_of_ocaml.js
+++ b/runtime/js/jslib_js_of_ocaml.js
@@ -72,12 +72,14 @@ function caml_js_get_console() {
 //Requires: caml_failwith
 //Weakdef
 function caml_xmlhttprequest_create(unit) {
-  if (typeof globalThis.XMLHttpRequest !== "undefined") {
-    try {
-      return new globalThis.XMLHttpRequest();
-    } catch (e) {}
+  if (typeof XMLHttpRequest === "undefined") {
+    caml_failwith("XMLHttpRequest is not available");
   }
-  caml_failwith("Cannot create a XMLHttpRequest");
+  try {
+    return new XMLHttpRequest();
+  } catch {
+    caml_failwith("Failed to create XMLHttpRequest");
+  }
 }
 
 //Provides: caml_js_error_of_exception

--- a/runtime/js/marshal.js
+++ b/runtime/js/marshal.js
@@ -630,32 +630,9 @@ function caml_marshal_data_size(s, ofs) {
 }
 
 //Provides: MlObjectTable
-var MlObjectTable;
-if (typeof globalThis.Map === "undefined") {
-  MlObjectTable = (function () {
-    /* polyfill (using linear search) */
-    function NaiveLookup(objs) {
-      this.objs = objs;
-    }
-    NaiveLookup.prototype.get = function (v) {
-      for (var i = 0; i < this.objs.length; i++) {
-        if (this.objs[i] === v) return i;
-      }
-    };
-    NaiveLookup.prototype.set = function () {
-      // Do nothing here. [MlObjectTable.store] will push to [this.objs] directly.
-    };
-
-    return function MlObjectTable() {
-      this.objs = [];
-      this.lookup = new NaiveLookup(this.objs);
-    };
-  })();
-} else {
-  MlObjectTable = function MlObjectTable() {
-    this.objs = [];
-    this.lookup = new globalThis.Map();
-  };
+function MlObjectTable() {
+  this.objs = [];
+  this.lookup = new globalThis.Map();
 }
 
 MlObjectTable.prototype.store = function (v) {


### PR DESCRIPTION
This PR enhances error handling in the `caml_xmlhttprequest_create` implementation and removes the unnecessary Map polyfill to simplify the `MlObjectTable` implementation. It provides more detailed error messages when `caml_xmlhttprequest_create` fails and updates documentation to reflect the use of these APIs.