### PR TITLE
Fix initialization of standard streams under Windows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 
 ## Bug fixes
 * Runtime: fix path normalization (#1848)
+* Runtime: fix initialization of standard streams under Windows (#1849)
 
 # 6.0.1 (2025-02-07) - Lille
 

--- a/compiler/tests-jsoo/gh1845.t
+++ b/compiler/tests-jsoo/gh1845.t
@@ -1,0 +1,9 @@
+
+  $ echo 'prerr_endline "test"' > test.ml
+
+  $ ocamlc test.ml -o test.bc
+
+  $ dune exec -- js_of_ocaml test.bc -o test.js
+
+  $ node test.js
+  test

--- a/runtime/js/fs_node.js
+++ b/runtime/js/fs_node.js
@@ -392,9 +392,15 @@ class MlNodeFd extends MlFile {
     this.fs = require("node:fs");
     this.fd = fd;
     this.flags = flags;
-    var stats = this.fs.fstatSync(fd);
-    flags.noSeek =
-      stats.isCharacterDevice() || stats.isFIFO() || stats.isSocket();
+    try {
+      var stats = this.fs.fstatSync(fd);
+      flags.noSeek =
+        stats.isCharacterDevice() || stats.isFIFO() || stats.isSocket();
+    } catch (err) {
+      // The fstat will fail on standard streams under Windows with node
+      // 18 (and lower). See https://github.com/libuv/libuv/pull/3811.
+      flags.noSeek = true;
+    }
     this.offset = this.flags.append ? stats.size : 0;
     this.seeked = false;
   }


### PR DESCRIPTION
We are using fstat to test whether the file is seekable. This function  fails on standard streams under Windows with node 18 (and lower). See  https://github.com/libuv/libuv/pull/3811. So, we just assume that the   file is not seekable in case an exception is risen.

Fixes #1845 
