### PR TITLE
runtime(js): update constant imports to use `node:fs` module

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 * Runtime: support more Unix functions (#1829)
 * Runtime: remove polyfill for Map to simplify MlObjectTable implementation (#1846)
 * Runtime: refactor caml_xmlhttprequest_create implementation (#1846)
+* Runtime: update constant imports to use `node:fs` module (#1850)
 
 ## Bug fixes
 * Runtime: fix path normalization (#1848)

--- a/runtime/js/fs_node.js
+++ b/runtime/js/fs_node.js
@@ -122,7 +122,7 @@ class MlNodeDevice {
   }
 
   access(name, f, raise_unix) {
-    var consts = require("node:constants");
+    var consts = require("node:fs").constants;
     var res = 0;
     for (var key in f) {
       switch (key) {
@@ -152,7 +152,7 @@ class MlNodeDevice {
   }
 
   open(name, f, perms, raise_unix) {
-    var consts = require("node:constants");
+    var consts = require("node:fs").constants;
     var res = 0;
     for (var key in f) {
       switch (key) {


### PR DESCRIPTION
## Summary

This PR addresses the deprecation warning [DEP0008](https://nodejs.org/api/deprecations.html#DEP0008) by replacing direct usage of the deprecated `node:constants` module with the recommended approach of accessing constants through their respective modules.

## Changes

- Replaced `require("node:constants")` with `require("node:fs").constants` in `runtime/js/fs_node.js`
- Updated code to follow Node.js best practices for accessing module-specific constants

## Related Documentation

- [Node.js Deprecation Guide (DEP0008)](https://nodejs.org/api/deprecations.html#DEP0008)
- [Node.js File System Constants](https://nodejs.org/api/fs.html#fs_file_system_flags)
