### PR TITLE
Remove dependency of wasm_of_ocaml on binaryen-bin

### DIFF
--- a/manual/wasm_overview.wiki
+++ b/manual/wasm_overview.wiki
@@ -7,6 +7,10 @@ It provides an alternative way to run pure OCaml programs in JavaScript environm
 
 The compiler is provided by the wasm_of_ocaml-compiler package. The <<a_manual chapter="overview" |Js_of_ocaml libraries>> are compatible with this compiler.
 
+== Dependencies
+
+Wasm_of_ocaml depends on [[https://github.com/WebAssembly/binaryen|the Binaryen toolchain]] version 119 or later.
+
 == Installation
 
 The easiest way to install wasm_of_ocaml is to use opam.

--- a/wasm_of_ocaml-compiler.opam
+++ b/wasm_of_ocaml-compiler.opam
@@ -26,7 +26,6 @@ depends: [
   "menhirLib"
   "menhirSdk"
   "yojson" {>= "2.1"}
-  "binaryen-bin"
   "odoc" {with-doc}
 ]
 depopts: ["ocamlfind"]


### PR DESCRIPTION
Depending on an external tool as an opam package is non-standard and makes it harder to set up a CI (#1842), or when Binaryen is installed in some other way. I think we should just remove it.