### PR TITLE
ppx: upgrade to ppxlib 0.36

### DIFF
--- a/.github/workflows/build-wasm_of_ocaml.yml
+++ b/.github/workflows/build-wasm_of_ocaml.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Pin dune
         if: runner.os == 'Windows'
-        run: opam pin add -n dune https://github.com/hhugo/dune.git#shorter-path-jsoo
+        run: opam pin add --no-action dune https://github.com/OlivierNicole/dune.git#jsoo-effects
 
       - name: Pin for ppxlib 0.36
         run: |

--- a/.github/workflows/build-wasm_of_ocaml.yml
+++ b/.github/workflows/build-wasm_of_ocaml.yml
@@ -123,8 +123,6 @@ jobs:
         run: |
           opam pin add -n base.v0.16.1 https://github.com/ocaml-wasm/base.git#wasm
           opam pin add -n time_now.v0.16.1 https://github.com/ocaml-wasm/time_now.git#wasm
-          opam pin add -n ppx_inline_test.v0.16.1 https://github.com/ocaml-wasm/ppx_inline_test.git#wasm
-          opam pin add -n ppx_expect.v0.16.1 https://github.com/ocaml-wasm/ppx_expect.git#wasm
 
       - name: Install wasm_of_ocaml and its test dependencies
         working-directory: ./wasm_of_ocaml

--- a/.github/workflows/build-wasm_of_ocaml.yml
+++ b/.github/workflows/build-wasm_of_ocaml.yml
@@ -121,8 +121,7 @@ jobs:
       - name: Pin Jane Street packages
         if: ${{ ! matrix.jane_street_tests }}
         run: |
-          opam pin add -n base.v0.16.1 https://github.com/ocaml-wasm/base.git#wasm
-          opam pin add -n time_now.v0.16.1 https://github.com/ocaml-wasm/time_now.git#wasm
+          opam pin add -n base https://github.com/ocaml-wasm/base.git#wasm
 
       - name: Install wasm_of_ocaml and its test dependencies
         working-directory: ./wasm_of_ocaml

--- a/.github/workflows/build-wasm_of_ocaml.yml
+++ b/.github/workflows/build-wasm_of_ocaml.yml
@@ -102,7 +102,6 @@ jobs:
         run: opam pin add -n dune https://github.com/hhugo/dune.git#shorter-path-jsoo
 
       - name: Pin for ppxlib 0.36
-        if: ${{ matrix.ocaml-compiler >= 5.1 }}
         run: |
           opam pin add --no-action https://github.com/hhugo/ppx_inline_test.git#ppxlib36
           opam pin add --no-action https://github.com/hhugo/ppx_expect.git#ppxlib36

--- a/.github/workflows/build-wasm_of_ocaml.yml
+++ b/.github/workflows/build-wasm_of_ocaml.yml
@@ -101,6 +101,13 @@ jobs:
         if: runner.os == 'Windows'
         run: opam pin add -n dune https://github.com/hhugo/dune.git#shorter-path-jsoo
 
+      - name: Pin for ppxlib 0.36
+        if: ${{ matrix.ocaml-compiler >= 5.1 }}
+        run: |
+          opam pin add --no-action https://github.com/hhugo/ppx_inline_test.git#ppxlib36
+          opam pin add --no-action https://github.com/hhugo/ppx_expect.git#ppxlib36
+          opam pin add --no-action https://github.com/hhugo/sedlex.git#ppxlib36
+
       - name: Pin wasm_of_ocaml
         working-directory: ./wasm_of_ocaml
         run: opam pin . -n --with-version dev

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,7 +122,6 @@ jobs:
         run: opam pin add --no-action dune https://github.com/OlivierNicole/dune.git#jsoo-effects
 
       - name: Pin for ppxlib 0.36
-        if: ${{ matrix.ocaml-compiler >= 5.1 }}
         run: |
           opam pin add --no-action https://github.com/hhugo/ppx_inline_test.git#ppxlib36
           opam pin add --no-action https://github.com/hhugo/ppx_expect.git#ppxlib36

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,6 +121,12 @@ jobs:
       - name: Pin Dune
         run: opam pin add --no-action dune https://github.com/OlivierNicole/dune.git#jsoo-effects
 
+      - name: Pin for ppxlib 0.36
+        run: |
+          opam pin add --no-action https://github.com/hhugo/ppx_inline_test.git#ppxlib36
+          opam pin add --no-action https://github.com/hhugo/ppx_epxect.git#ppxlib36
+          opam pin add --no-action https://github.com/hhugo/sedlex.git#ppxlib36
+
       # Work-around a race between reinstalling mingw-w64-shims
       # (because of conf-pkg-config optional dep) and installing other
       # packages that implicitly depend on mingw-w64-shims.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Pin for ppxlib 0.36
         run: |
           opam pin add --no-action https://github.com/hhugo/ppx_inline_test.git#ppxlib36
-          opam pin add --no-action https://github.com/hhugo/ppx_epxect.git#ppxlib36
+          opam pin add --no-action https://github.com/hhugo/ppx_expect.git#ppxlib36
           opam pin add --no-action https://github.com/hhugo/sedlex.git#ppxlib36
 
       # Work-around a race between reinstalling mingw-w64-shims

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,6 +122,7 @@ jobs:
         run: opam pin add --no-action dune https://github.com/OlivierNicole/dune.git#jsoo-effects
 
       - name: Pin for ppxlib 0.36
+        if: ${{ matrix.ocaml-compiler >= 5.1 }}
         run: |
           opam pin add --no-action https://github.com/hhugo/ppx_inline_test.git#ppxlib36
           opam pin add --no-action https://github.com/hhugo/ppx_expect.git#ppxlib36

--- a/dune-project
+++ b/dune-project
@@ -21,7 +21,7 @@
   (ocaml (and (>= 4.08) (< 5.4)))
   (num :with-test)
   (ppx_expect (and (>= v0.16.1) :with-test))
-  (ppxlib (>= 0.15.0))
+  (ppxlib (>= 0.36))
   (re :with-test)
   (cmdliner (>= 1.1.0))
   (sedlex (>= 3.3))
@@ -49,7 +49,7 @@
   (lwt (>= 2.4.4))
   (num :with-test)
   (ppx_expect (and (>= v0.14.2) :with-test))
-  (ppxlib (and (>= 0.22.0) :with-test))
+  (ppxlib (and (>= 0.36) :with-test))
   (re (and (>= 1.9.0) :with-test)))
  (depopts
   graphics
@@ -64,7 +64,7 @@
  (depends
   (ocaml (>= 4.08))
   (js_of_ocaml (= :version))
-  (ppxlib (>= 0.15))
+  (ppxlib (>= 0.36))
   (num :with-test)
   (ppx_expect (and (>= v0.14.2) :with-test))
   (re (and (>= 1.9.0) :with-test))
@@ -78,7 +78,7 @@
  (depends
   (ocaml (>= 4.08))
   (js_of_ocaml (= :version))
-  (ppxlib (>= 0.15.0))
+  (ppxlib (>= 0.36))
   (num :with-test)
   (ppx_expect (and (>= v0.14.2) :with-test))
   (re (and (>= 1.9.0) :with-test))
@@ -97,7 +97,7 @@
   (graphics :with-test)
   (num :with-test)
   (ppx_expect (and (>= v0.14.2) :with-test))
-  (ppxlib (and (>= 0.15)))
+  (ppxlib (and (>= 0.36)))
   (re (and (>= 1.9.0) :with-test))
 ))
 
@@ -115,7 +115,7 @@
   (tyxml (>= 4.6))
   (num :with-test)
   (ppx_expect (and (>= v0.14.2) :with-test))
-  (ppxlib (and (>= 0.22.0) :with-test))
+  (ppxlib (and (>= 0.36) :with-test))
   (re (and (>= 1.9.0) :with-test))
 ))
 
@@ -127,7 +127,7 @@
  (depends
   (ocaml (>= 4.08))
   (js_of_ocaml-compiler (= :version))
-  (ppxlib (>= 0.15))
+  (ppxlib (>= 0.36))
   (num :with-test)
   (ppx_expect (and (>= v0.14.2) :with-test))
   (re (and (>= 1.9.0) :with-test))
@@ -143,7 +143,7 @@
   (js_of_ocaml (= :version))
   (num :with-test)
   (ppx_expect (and (>= v0.14.2) :with-test))
-  (ppxlib (>= 0.15.0))
+  (ppxlib (>= 0.36))
   (re :with-test)
   (cmdliner (>= 1.1.0))
   (opam-format :with-test)

--- a/js_of_ocaml-compiler.opam
+++ b/js_of_ocaml-compiler.opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.08" & < "5.4"}
   "num" {with-test}
   "ppx_expect" {>= "v0.16.1" & with-test}
-  "ppxlib" {>= "0.15.0"}
+  "ppxlib" {>= "0.36"}
   "re" {with-test}
   "cmdliner" {>= "1.1.0"}
   "sedlex" {>= "3.3"}

--- a/js_of_ocaml-lwt.opam
+++ b/js_of_ocaml-lwt.opam
@@ -19,7 +19,7 @@ depends: [
   "lwt" {>= "2.4.4"}
   "num" {with-test}
   "ppx_expect" {>= "v0.14.2" & with-test}
-  "ppxlib" {>= "0.22.0" & with-test}
+  "ppxlib" {>= "0.36" & with-test}
   "re" {>= "1.9.0" & with-test}
   "odoc" {with-doc}
 ]

--- a/js_of_ocaml-ppx.opam
+++ b/js_of_ocaml-ppx.opam
@@ -15,7 +15,7 @@ depends: [
   "dune" {>= "3.17"}
   "ocaml" {>= "4.08"}
   "js_of_ocaml" {= version}
-  "ppxlib" {>= "0.15.0"}
+  "ppxlib" {>= "0.36"}
   "num" {with-test}
   "ppx_expect" {>= "v0.14.2" & with-test}
   "re" {>= "1.9.0" & with-test}

--- a/js_of_ocaml-ppx_deriving_json.opam
+++ b/js_of_ocaml-ppx_deriving_json.opam
@@ -15,7 +15,7 @@ depends: [
   "dune" {>= "3.17"}
   "ocaml" {>= "4.08"}
   "js_of_ocaml" {= version}
-  "ppxlib" {>= "0.15"}
+  "ppxlib" {>= "0.36"}
   "num" {with-test}
   "ppx_expect" {>= "v0.14.2" & with-test}
   "re" {>= "1.9.0" & with-test}

--- a/js_of_ocaml-toplevel.opam
+++ b/js_of_ocaml-toplevel.opam
@@ -19,7 +19,7 @@ depends: [
   "graphics" {with-test}
   "num" {with-test}
   "ppx_expect" {>= "v0.14.2" & with-test}
-  "ppxlib" {>= "0.15"}
+  "ppxlib" {>= "0.36"}
   "re" {>= "1.9.0" & with-test}
   "odoc" {with-doc}
 ]

--- a/js_of_ocaml-tyxml.opam
+++ b/js_of_ocaml-tyxml.opam
@@ -21,7 +21,7 @@ depends: [
   "tyxml" {>= "4.6"}
   "num" {with-test}
   "ppx_expect" {>= "v0.14.2" & with-test}
-  "ppxlib" {>= "0.22.0" & with-test}
+  "ppxlib" {>= "0.36" & with-test}
   "re" {>= "1.9.0" & with-test}
   "odoc" {with-doc}
 ]

--- a/js_of_ocaml.opam
+++ b/js_of_ocaml.opam
@@ -15,7 +15,7 @@ depends: [
   "dune" {>= "3.17"}
   "ocaml" {>= "4.08"}
   "js_of_ocaml-compiler" {= version}
-  "ppxlib" {>= "0.15"}
+  "ppxlib" {>= "0.36"}
   "num" {with-test}
   "ppx_expect" {>= "v0.14.2" & with-test}
   "re" {>= "1.9.0" & with-test}

--- a/ppx/ppx_js/lib_internal/ppx_js_internal.ml
+++ b/ppx/ppx_js/lib_internal/ppx_js_internal.ml
@@ -581,16 +581,13 @@ let preprocess_literal_object mappper fields :
     | Pcf_method (id, priv, Cfk_concrete (bang, body)) ->
         let names = check_name id names in
         let body, body_ty = drop_pexp_poly (mappper body) in
-        let rec create_meth_ty exp =
+        let create_meth_ty exp =
           match exp.pexp_desc with
-          | Pexp_function (params, _, Pfunction_body body) ->
-              let params =
-                List.filter_map params ~f:(function
-                  | { pparam_desc = Pparam_newtype _; _ } -> None
-                  | { pparam_desc = Pparam_val (label, _, _arg); _ } ->
-                      Some (Arg.make ~label ()))
-              in
-              params @ create_meth_ty body
+          | Pexp_function (params, _, _) ->
+              List.filter_map params ~f:(function
+                | { pparam_desc = Pparam_newtype _; _ } -> None
+                | { pparam_desc = Pparam_val (label, _, _arg); _ } ->
+                    Some (Arg.make ~label ()))
           | _ -> []
         in
         let fun_ty = create_meth_ty body in

--- a/ppx/ppx_js/lib_internal/ppx_js_internal.ml
+++ b/ppx/ppx_js/lib_internal/ppx_js_internal.ml
@@ -583,9 +583,14 @@ let preprocess_literal_object mappper fields :
         let body, body_ty = drop_pexp_poly (mappper body) in
         let rec create_meth_ty exp =
           match exp.pexp_desc with
-          | Pexp_fun (label, _, _, body) -> Arg.make ~label () :: create_meth_ty body
-          | Pexp_function _ -> [ Arg.make () ]
-          | Pexp_newtype (_, body) -> create_meth_ty body
+          | Pexp_function (params, _, Pfunction_body body) ->
+              let params =
+                List.filter_map params ~f:(function
+                  | { pparam_desc = Pparam_newtype _; _ } -> None
+                  | { pparam_desc = Pparam_val (label, _, _arg); _ } ->
+                      Some (Arg.make ~label ()))
+              in
+              params @ create_meth_ty body
           | _ -> []
         in
         let fun_ty = create_meth_ty body in

--- a/ppx/ppx_js/tests/gen.mlt
+++ b/ppx/ppx_js/tests/gen.mlt
@@ -104,20 +104,16 @@ let o () =
 [%%expect
 {|
 let o () =
-  (fun (type res) ->
-     fun (type t1) ->
-       fun (type t0) ->
-         fun (type t2) ->
-           fun (t2 : res Js_of_ocaml.Js.t -> t1 -> t0 -> t2)
-             (_ :
-               res Js_of_ocaml.Js.t ->
-                 (res Js_of_ocaml.Js.t -> t1 -> t0 -> t2 Js_of_ocaml.Js.meth)
-                   -> res)
-             : res Js_of_ocaml.Js.t->
-             Js_of_ocaml.Js.Unsafe.obj
-               [|("m1",
-                   (Js_of_ocaml.Js.Unsafe.inject
-                      (Js_of_ocaml.Js.wrap_meth_callback t2)))|])
+  (fun (type res) (type t0) (type t1) (type t2)
+     (t2 : res Js_of_ocaml.Js.t -> t0 -> t1 -> t2)
+     (_ :
+       res Js_of_ocaml.Js.t ->
+         (res Js_of_ocaml.Js.t -> t0 -> t1 -> t2 Js_of_ocaml.Js.meth) -> res)
+     : res Js_of_ocaml.Js.t->
+     Js_of_ocaml.Js.Unsafe.obj
+       [|("m1",
+           (Js_of_ocaml.Js.Unsafe.inject
+              (Js_of_ocaml.Js.wrap_meth_callback t2)))|])
     (fun _ a b -> a + b) ((fun self m1 -> object method m1 = m1 self end)
     [@merlin.hide ]);;
 val o :
@@ -133,20 +129,16 @@ let o () =
 [%%expect
 {|
 let o () =
-  (fun (type res) ->
-     fun (type t4) ->
-       fun (type t3) ->
-         fun (type t5) ->
-           fun (t5 : res Js_of_ocaml.Js.t -> t4 -> t3 -> t5)
-             (_ :
-               res Js_of_ocaml.Js.t ->
-                 (res Js_of_ocaml.Js.t -> t4 -> t3 -> t5 Js_of_ocaml.Js.meth)
-                   -> res)
-             : res Js_of_ocaml.Js.t->
-             Js_of_ocaml.Js.Unsafe.obj
-               [|("m1",
-                   (Js_of_ocaml.Js.Unsafe.inject
-                      (Js_of_ocaml.Js.wrap_meth_callback t5)))|])
+  (fun (type res) (type t4) (type t3) (type t5)
+     (t5 : res Js_of_ocaml.Js.t -> t4 -> t3 -> t5)
+     (_ :
+       res Js_of_ocaml.Js.t ->
+         (res Js_of_ocaml.Js.t -> t4 -> t3 -> t5 Js_of_ocaml.Js.meth) -> res)
+     : res Js_of_ocaml.Js.t->
+     Js_of_ocaml.Js.Unsafe.obj
+       [|("m1",
+           (Js_of_ocaml.Js.Unsafe.inject
+              (Js_of_ocaml.Js.wrap_meth_callback t5)))|])
     (fun _ a -> fun b -> a + b)
     ((fun self m1 -> object method m1 = m1 self end)[@merlin.hide ]);;
 val o :
@@ -162,20 +154,16 @@ let o () =
 [%%expect
 {|
 let o () =
-  (fun (type res) ->
-     fun (type t7) ->
-       fun (type t6) ->
-         fun (type t8) ->
-           fun (t8 : res Js_of_ocaml.Js.t -> t7 -> t6 -> t8)
-             (_ :
-               res Js_of_ocaml.Js.t ->
-                 (res Js_of_ocaml.Js.t -> t7 -> t6 -> t8 Js_of_ocaml.Js.meth)
-                   -> res)
-             : res Js_of_ocaml.Js.t->
-             Js_of_ocaml.Js.Unsafe.obj
-               [|("m1",
-                   (Js_of_ocaml.Js.Unsafe.inject
-                      (Js_of_ocaml.Js.wrap_meth_callback t8)))|])
+  (fun (type res) (type t6) (type t7) (type t8)
+     (t8 : res Js_of_ocaml.Js.t -> t6 -> t7 -> t8)
+     (_ :
+       res Js_of_ocaml.Js.t ->
+         (res Js_of_ocaml.Js.t -> t6 -> t7 -> t8 Js_of_ocaml.Js.meth) -> res)
+     : res Js_of_ocaml.Js.t->
+     Js_of_ocaml.Js.Unsafe.obj
+       [|("m1",
+           (Js_of_ocaml.Js.Unsafe.inject
+              (Js_of_ocaml.Js.wrap_meth_callback t8)))|])
     (fun _ a b -> a + b) ((fun self m1 -> object method m1 = m1 self end)
     [@merlin.hide ]);;
 val o :
@@ -191,21 +179,17 @@ let o () =
 [%%expect
 {|
 let o () =
-  (fun (type res) ->
-     fun (type t10) ->
-       fun (type t9) ->
-         fun (type t11) ->
-           fun (t11 : res Js_of_ocaml.Js.t -> t10 -> t9 -> t11)
-             (_ :
-               res Js_of_ocaml.Js.t ->
-                 (res Js_of_ocaml.Js.t ->
-                    t10 -> t9 -> t11 Js_of_ocaml.Js.meth)
-                   -> res)
-             : res Js_of_ocaml.Js.t->
-             Js_of_ocaml.Js.Unsafe.obj
-               [|("m1",
-                   (Js_of_ocaml.Js.Unsafe.inject
-                      (Js_of_ocaml.Js.wrap_meth_callback t11)))|])
+  (fun (type res) (type t10) (type t9) (type t11)
+     (t11 : res Js_of_ocaml.Js.t -> t10 -> t9 -> t11)
+     (_ :
+       res Js_of_ocaml.Js.t ->
+         (res Js_of_ocaml.Js.t -> t10 -> t9 -> t11 Js_of_ocaml.Js.meth) ->
+           res)
+     : res Js_of_ocaml.Js.t->
+     Js_of_ocaml.Js.Unsafe.obj
+       [|("m1",
+           (Js_of_ocaml.Js.Unsafe.inject
+              (Js_of_ocaml.Js.wrap_meth_callback t11)))|])
     (fun _ a -> fun b -> a + b)
     ((fun self m1 -> object method m1 = m1 self end)[@merlin.hide ]);;
 val o :
@@ -223,21 +207,17 @@ let o () =
 [%%expect
 {|
 let o () =
-  (fun (type res) ->
-     fun (type t13) ->
-       fun (type t12) ->
-         fun (type t14) ->
-           fun (t14 : res Js_of_ocaml.Js.t -> t13 -> t12 -> t14)
-             (_ :
-               res Js_of_ocaml.Js.t ->
-                 (res Js_of_ocaml.Js.t ->
-                    t13 -> t12 -> t14 Js_of_ocaml.Js.meth)
-                   -> res)
-             : res Js_of_ocaml.Js.t->
-             Js_of_ocaml.Js.Unsafe.obj
-               [|("m1",
-                   (Js_of_ocaml.Js.Unsafe.inject
-                      (Js_of_ocaml.Js.wrap_meth_callback t14)))|])
+  (fun (type res) (type t13) (type t12) (type t14)
+     (t14 : res Js_of_ocaml.Js.t -> t13 -> t12 -> t14)
+     (_ :
+       res Js_of_ocaml.Js.t ->
+         (res Js_of_ocaml.Js.t -> t13 -> t12 -> t14 Js_of_ocaml.Js.meth) ->
+           res)
+     : res Js_of_ocaml.Js.t->
+     Js_of_ocaml.Js.Unsafe.obj
+       [|("m1",
+           (Js_of_ocaml.Js.Unsafe.inject
+              (Js_of_ocaml.Js.wrap_meth_callback t14)))|])
     (fun _ a -> function | b -> a + b)
     ((fun self m1 -> object method m1 = m1 self end)[@merlin.hide ]);;
 val o :
@@ -256,21 +236,17 @@ let o () =
 [%%expect
 {|
 let o () =
-  (fun (type res) ->
-     fun (type t16) ->
-       fun (type t15) ->
-         fun (type t17) ->
-           fun (t17 : res Js_of_ocaml.Js.t -> t16 -> t15 -> t17)
-             (_ :
-               res Js_of_ocaml.Js.t ->
-                 (res Js_of_ocaml.Js.t ->
-                    t16 -> t15 -> t17 Js_of_ocaml.Js.meth)
-                   -> res)
-             : res Js_of_ocaml.Js.t->
-             Js_of_ocaml.Js.Unsafe.obj
-               [|("m1",
-                   (Js_of_ocaml.Js.Unsafe.inject
-                      (Js_of_ocaml.Js.wrap_meth_callback t17)))|])
+  (fun (type res) (type t16) (type t15) (type t17)
+     (t17 : res Js_of_ocaml.Js.t -> t16 -> t15 -> t17)
+     (_ :
+       res Js_of_ocaml.Js.t ->
+         (res Js_of_ocaml.Js.t -> t16 -> t15 -> t17 Js_of_ocaml.Js.meth) ->
+           res)
+     : res Js_of_ocaml.Js.t->
+     Js_of_ocaml.Js.Unsafe.obj
+       [|("m1",
+           (Js_of_ocaml.Js.Unsafe.inject
+              (Js_of_ocaml.Js.wrap_meth_callback t17)))|])
     (fun _ a -> function | 0 -> a | b -> a + b)
     ((fun self m1 -> object method m1 = m1 self end)[@merlin.hide ]);;
 val o :
@@ -289,21 +265,17 @@ let o () =
 [%%expect
 {|
 let o () =
-  (fun (type res) ->
-     fun (type t19) ->
-       fun (type t18) ->
-         fun (type t20) ->
-           fun (t20 : res Js_of_ocaml.Js.t -> t19 -> t18 -> t20)
-             (_ :
-               res Js_of_ocaml.Js.t ->
-                 (res Js_of_ocaml.Js.t ->
-                    t19 -> t18 -> t20 Js_of_ocaml.Js.meth)
-                   -> res)
-             : res Js_of_ocaml.Js.t->
-             Js_of_ocaml.Js.Unsafe.obj
-               [|("m1",
-                   (Js_of_ocaml.Js.Unsafe.inject
-                      (Js_of_ocaml.Js.wrap_meth_callback t20)))|])
+  (fun (type res) (type t19) (type t18) (type t20)
+     (t20 : res Js_of_ocaml.Js.t -> t19 -> t18 -> t20)
+     (_ :
+       res Js_of_ocaml.Js.t ->
+         (res Js_of_ocaml.Js.t -> t19 -> t18 -> t20 Js_of_ocaml.Js.meth) ->
+           res)
+     : res Js_of_ocaml.Js.t->
+     Js_of_ocaml.Js.Unsafe.obj
+       [|("m1",
+           (Js_of_ocaml.Js.Unsafe.inject
+              (Js_of_ocaml.Js.wrap_meth_callback t20)))|])
     (fun _ (type b) a -> function | 0 -> a | b -> a + b)
     ((fun self m1 -> object method m1 = m1 self end)[@merlin.hide ]);;
 val o :
@@ -322,21 +294,17 @@ let o () =
 [%%expect
 {|
 let o () =
-  (fun (type res) ->
-     fun (type t22) ->
-       fun (type t21) ->
-         fun (type t23) ->
-           fun (t23 : res Js_of_ocaml.Js.t -> t22 -> t21 -> t23)
-             (_ :
-               res Js_of_ocaml.Js.t ->
-                 (res Js_of_ocaml.Js.t ->
-                    t22 -> t21 -> t23 Js_of_ocaml.Js.meth)
-                   -> res)
-             : res Js_of_ocaml.Js.t->
-             Js_of_ocaml.Js.Unsafe.obj
-               [|("m1",
-                   (Js_of_ocaml.Js.Unsafe.inject
-                      (Js_of_ocaml.Js.wrap_meth_callback t23)))|])
+  (fun (type res) (type t22) (type t21) (type t23)
+     (t23 : res Js_of_ocaml.Js.t -> t22 -> t21 -> t23)
+     (_ :
+       res Js_of_ocaml.Js.t ->
+         (res Js_of_ocaml.Js.t -> t22 -> t21 -> t23 Js_of_ocaml.Js.meth) ->
+           res)
+     : res Js_of_ocaml.Js.t->
+     Js_of_ocaml.Js.Unsafe.obj
+       [|("m1",
+           (Js_of_ocaml.Js.Unsafe.inject
+              (Js_of_ocaml.Js.wrap_meth_callback t23)))|])
     (fun _ a (type b) -> function | 0 -> a | b -> a + b)
     ((fun self m1 -> object method m1 = m1 self end)[@merlin.hide ]);;
 val o :
@@ -377,41 +345,29 @@ let o () =
 
 [%%expect {|
 let o () =
-  (fun (type res) ->
-     fun (type t26) ->
-       fun (type t27) ->
-         fun (type t28) ->
-           fun (type t29) ->
-             fun (type t30) ->
-               fun (type t31) ->
-                 fun (t29 : res Js_of_ocaml.Js.t -> t26 -> t29)
-                   (t30 : res Js_of_ocaml.Js.t -> t27 -> t30)
-                   (t31 : res Js_of_ocaml.Js.t -> t28 -> t31)
-                   (_ :
-                     res Js_of_ocaml.Js.t ->
-                       (res Js_of_ocaml.Js.t ->
-                          t26 -> t29 Js_of_ocaml.Js.meth)
-                         ->
-                         (res Js_of_ocaml.Js.t ->
-                            t27 -> t30 Js_of_ocaml.Js.meth)
-                           ->
-                           (res Js_of_ocaml.Js.t ->
-                              t28 -> t31 Js_of_ocaml.Js.meth)
-                             -> res)
-                   : res Js_of_ocaml.Js.t->
-                   Js_of_ocaml.Js.Unsafe.obj
-                     [|("m1",
-                         (Js_of_ocaml.Js.Unsafe.inject
-                            (Js_of_ocaml.Js.wrap_meth_callback t29)));
-                       ("m2",
-                         (Js_of_ocaml.Js.Unsafe.inject
-                            (Js_of_ocaml.Js.wrap_meth_callback t30)));
-                       ("m3",
-                         (Js_of_ocaml.Js.Unsafe.inject
-                            (Js_of_ocaml.Js.wrap_meth_callback t31)))|])
-    (fun _ : 'a -> unit-> fun (type a) -> fun (a : a) -> ignore a)
-    (fun _ : int -> unit-> fun (type a) -> fun (a : a) -> ignore a)
-    (fun _ : 'b -> unit-> fun (a : 'b) -> ignore a)
+  (fun (type res) (type t26) (type t27) (type t28) (type t29) (type t30)
+     (type t31) (t29 : res Js_of_ocaml.Js.t -> t26 -> t29)
+     (t30 : res Js_of_ocaml.Js.t -> t27 -> t30)
+     (t31 : res Js_of_ocaml.Js.t -> t28 -> t31)
+     (_ :
+       res Js_of_ocaml.Js.t ->
+         (res Js_of_ocaml.Js.t -> t26 -> t29 Js_of_ocaml.Js.meth) ->
+           (res Js_of_ocaml.Js.t -> t27 -> t30 Js_of_ocaml.Js.meth) ->
+             (res Js_of_ocaml.Js.t -> t28 -> t31 Js_of_ocaml.Js.meth) -> res)
+     : res Js_of_ocaml.Js.t->
+     Js_of_ocaml.Js.Unsafe.obj
+       [|("m1",
+           (Js_of_ocaml.Js.Unsafe.inject
+              (Js_of_ocaml.Js.wrap_meth_callback t29)));("m2",
+                                                          (Js_of_ocaml.Js.Unsafe.inject
+                                                             (Js_of_ocaml.Js.wrap_meth_callback
+                                                                t30)));
+         ("m3",
+           (Js_of_ocaml.Js.Unsafe.inject
+              (Js_of_ocaml.Js.wrap_meth_callback t31)))|])
+    (fun _ -> (fun (type a) (a : a) -> ignore a : 'a -> unit))
+    (fun _ -> (fun (type a) (a : a) -> ignore a : int -> unit))
+    (fun _ -> (fun (a : 'b) -> ignore a : 'b -> unit))
     ((fun self m1 m2 m3 ->
         object method m1 = m1 self method m2 = m2 self method m3 = m3 self
         end)[@merlin.hide ]);;

--- a/toplevel/examples/server/dune
+++ b/toplevel/examples/server/dune
@@ -1,5 +1,4 @@
 (executables
- (enabled_if false)
  (names server)
  (enabled_if false)
  (libraries findlib cohttp-lwt-unix))

--- a/toplevel/examples/server/dune
+++ b/toplevel/examples/server/dune
@@ -1,4 +1,5 @@
 (executables
+ (enabled_if false)
  (names server)
  (enabled_if false)
  (libraries findlib cohttp-lwt-unix))

--- a/wasm_of_ocaml-compiler.opam
+++ b/wasm_of_ocaml-compiler.opam
@@ -17,7 +17,7 @@ depends: [
   "js_of_ocaml" {= version}
   "num" {with-test}
   "ppx_expect" {>= "v0.14.2" & with-test}
-  "ppxlib" {>= "0.15.0"}
+  "ppxlib" {>= "0.36"}
   "re" {with-test}
   "cmdliner" {>= "1.1.0"}
   "opam-format" {with-test}


### PR DESCRIPTION
- Upgrades the JSOO ppxes to ppxlib 0.36 with https://github.com/ocaml-ppx/ppxlib/pull/514
- I realize `ppx_expect` and its transitive deps need to be upgraded first before this change can be considered, but I'm opening this up to unblock some of my PRs in other repos (this builds fine if you don't run the tests)