### PR TITLE
Fix function declaration scopes in Js_traverse.rename_variable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
 * Runtime: fix reading from the pseudo-filesystem (#1859)
 * Runtime: fix initialization of standard streams under Windows (#1849)
 * Compiler: fix stack overflow issues with double translation (#1869)
+* Compiler: minifier fix (#1867)
 
 # 6.0.1 (2025-02-07) - Lille
 

--- a/compiler/lib/js_traverse.ml
+++ b/compiler/lib/js_traverse.ml
@@ -1268,9 +1268,11 @@ class rename_variable ~esm =
          | ExportClass (_id, _f) -> ()
          | ExportNames l -> List.iter ~f:(fun (id, _) -> self#ident id) l
          | ExportDefaultFun (Some id, decl) ->
-             self#statement (Function_declaration (id, decl))
+             if depth = 0 then decl_var id;
+             self#fun_decl decl
          | ExportDefaultClass (Some id, decl) ->
-             self#statement (Class_declaration (id, decl))
+             if depth = 0 then decl_var id;
+             self#class_decl decl
          | ExportDefaultFun (None, decl) -> self#fun_decl decl
          | ExportDefaultClass (None, decl) -> self#class_decl decl
          | ExportDefaultExpression e -> self#expression e

--- a/compiler/lib/js_traverse.mli
+++ b/compiler/lib/js_traverse.mli
@@ -165,14 +165,14 @@ class free : freevar
 
 type scope =
   | Module
+  | Script
   | Lexical_block
   | Fun_block of ident option
 
 class rename_variable : esm:bool -> object ('a)
   inherit mapper
 
-  method update_state :
-    ?toplevel:bool -> scope -> Javascript.ident list -> Javascript.statement_list -> 'a
+  method update_state : scope -> Javascript.ident list -> Javascript.statement_list -> 'a
 end
 
 class share_constant : mapper

--- a/compiler/lib/js_traverse.mli
+++ b/compiler/lib/js_traverse.mli
@@ -171,7 +171,8 @@ type scope =
 class rename_variable : esm:bool -> object ('a)
   inherit mapper
 
-  method update_state : scope -> Javascript.ident list -> Javascript.statement_list -> 'a
+  method update_state :
+    ?toplevel:bool -> scope -> Javascript.ident list -> Javascript.statement_list -> 'a
 end
 
 class share_constant : mapper

--- a/compiler/tests-compiler/scopes.ml
+++ b/compiler/tests-compiler/scopes.ml
@@ -517,8 +517,7 @@ export default ({obj : 2});
   t {|
 export default function functionName() { /* … */ }
 |};
-  [%expect
-    {|
+  [%expect {|
     $ cat "test.min.js"
       1: export default function v1(){}
     |}];
@@ -529,8 +528,7 @@ export default class ClassName { /* … */ }|};
       1: export default class v1{} |}];
   t {|
 export default function* generatorFunctionName() { /* … */ }|};
-  [%expect
-    {|
+  [%expect {|
     $ cat "test.min.js"
       1: export default function* v1(){}
     |}];

--- a/compiler/tests-compiler/scopes.ml
+++ b/compiler/tests-compiler/scopes.ml
@@ -520,7 +520,8 @@ export default function functionName() { /* … */ }
   [%expect
     {|
     $ cat "test.min.js"
-      1: export default function functionName(){} |}];
+      1: export default function v1(){}
+    |}];
   t {|
 export default class ClassName { /* … */ }|};
   [%expect {|
@@ -531,7 +532,8 @@ export default function* generatorFunctionName() { /* … */ }|};
   [%expect
     {|
     $ cat "test.min.js"
-      1: export default function* generatorFunctionName(){} |}];
+      1: export default function* v1(){}
+    |}];
   t {|
 export default function () { /* … */ }|};
   [%expect {|

--- a/compiler/tests-compiler/scopes.ml
+++ b/compiler/tests-compiler/scopes.ml
@@ -277,6 +277,21 @@ let%expect_test "let inside block" =
       7:   ());
     4 2 |}]
 
+let%expect_test "functions have local scope" =
+  test {|
+function f (p) {
+  return e
+  if (p) {
+    function e () {}
+    e ();
+  }
+}
+|};
+  [%expect
+    {|
+        $ cat "test.min.js"
+          1: function f(v1){return e; if(v1){function v2(){} v2();}} |}]
+
 let%expect_test "import" =
   let test ?(module_ = false) js_prog =
     let name = if module_ then "test.mjs" else "test.js" in
@@ -510,7 +525,7 @@ export default function functionName() { /* … */ }
 export default class ClassName { /* … */ }|};
   [%expect {|
     $ cat "test.min.js"
-      1: export default class ClassName{} |}];
+      1: export default class v1{} |}];
   t {|
 export default function* generatorFunctionName() { /* … */ }|};
   [%expect


### PR DESCRIPTION
Function declarations are block-scoped, except at toplevel where they are treated like var declarations.

This fixes #1865.