### PR TITLE
Fix assert failure in double translation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
 * Runtime: fix initialization of standard streams under Windows (#1849)
 * Compiler: fix stack overflow issues with double translation (#1869)
 * Compiler: minifier fix (#1867)
+* Compiler: fix assert failure with double translation (#1870)
 
 # 6.0.1 (2025-02-07) - Lille
 

--- a/compiler/lib/generate.ml
+++ b/compiler/lib/generate.ml
@@ -1947,7 +1947,6 @@ and compile_conditional st queue ~fall_through loc last scope_stack : _ * _ =
           compile_branch st J.U [] e1 scope_stack ~fall_through
         in
         let exn_var, handler =
-          assert (not (List.mem x ~set:(snd e1)));
           let wrap_exn x =
             J.call
               (Share.get_prim (runtime_fun st.ctx) "caml_wrap_exception" st.ctx.Ctx.share)

--- a/compiler/lib/generate.ml
+++ b/compiler/lib/generate.ml
@@ -1943,25 +1943,36 @@ and compile_conditional st queue ~fall_through loc last scope_stack : _ * _ =
     | Pushtrap (c1, x, e1) ->
         let never_body, body = compile_branch st J.N [] c1 scope_stack ~fall_through in
         if debug () then Format.eprintf "@,}@]@,@[<hv 2>catch {@;";
-        let never_handler, handler =
-          compile_branch st J.U [] e1 scope_stack ~fall_through
-        in
-        let exn_var, handler =
-          let wrap_exn x =
-            J.call
-              (Share.get_prim (runtime_fun st.ctx) "caml_wrap_exception" st.ctx.Ctx.share)
-              [ J.EVar (J.V x) ]
-              J.N
-          in
+        let exn_var, never_handler, handler =
           match st.ctx.Ctx.live.(Var.idx x) with
-          | 0 -> x, handler
-          | _ ->
+          | 0 ->
+              let never_handler, handler =
+                compile_branch st J.U [] e1 scope_stack ~fall_through
+              in
+              x, never_handler, handler
+          | n ->
               let handler_var = Code.Var.fork x in
-              ( handler_var
-              , (J.variable_declaration [ J.V x, (wrap_exn handler_var, J.U) ], J.N)
-                :: handler )
+              let wrapped_exn =
+                J.call
+                  (Share.get_prim
+                     (runtime_fun st.ctx)
+                     "caml_wrap_exception"
+                     st.ctx.Ctx.share)
+                  [ J.EVar (J.V handler_var) ]
+                  J.N
+              in
+              let instrs, queue =
+                if List.mem x ~set:(snd e1)
+                then (
+                  assert (n = 1);
+                  enqueue [] const_p x wrapped_exn J.U None [])
+                else [ J.variable_declaration [ J.V x, (wrapped_exn, J.U) ], J.N ], []
+              in
+              let never_handler, handler =
+                compile_branch st J.U queue e1 scope_stack ~fall_through
+              in
+              handler_var, never_handler, instrs @ handler
         in
-
         ( never_body && never_handler
         , flush_all
             queue

--- a/compiler/tests-compiler/dune.inc
+++ b/compiler/tests-compiler/dune.inc
@@ -450,6 +450,21 @@
   (pps ppx_expect)))
 
 (library
+ ;; compiler/tests-compiler/gh1868.ml
+ (name gh1868_15)
+ (enabled_if true)
+ (modules gh1868)
+ (libraries js_of_ocaml_compiler unix str jsoo_compiler_expect_tests_helper)
+ (inline_tests
+  (enabled_if true)
+  (deps
+   (file %{project_root}/compiler/bin-js_of_ocaml/js_of_ocaml.exe)
+   (file %{project_root}/compiler/bin-jsoo_minify/jsoo_minify.exe)))
+ (flags (:standard -open Jsoo_compiler_expect_tests_helper))
+ (preprocess
+  (pps ppx_expect)))
+
+(library
  ;; compiler/tests-compiler/gh747.ml
  (name gh747_15)
  (enabled_if true)

--- a/compiler/tests-compiler/gh1868.ml
+++ b/compiler/tests-compiler/gh1868.ml
@@ -36,15 +36,16 @@ let wrap f =
 |}
   in
   print_double_fun_decl program "wrap";
-  [%expect {|
+  [%expect
+    {|
     function wrap$0(f){
      try{var _d_ = caml_call1(f, 0); return _d_;}
-     catch(exn$2){
-      var exn = caml_wrap_exception(exn$2), exn$0 = exn;
+     catch(exn$1){
+      var exn = caml_wrap_exception(exn$1);
       for(;;){
-       if(exn$0[1] !== Nested) throw caml_maybe_attach_backtrace(exn$0, 1);
-       var exn$1 = exn$0[2];
-       exn$0 = exn$1;
+       if(exn[1] !== Nested) throw caml_maybe_attach_backtrace(exn, 1);
+       var exn$0 = exn[2];
+       exn = exn$0;
       }
      }
     }
@@ -64,4 +65,5 @@ let wrap f =
     }
     //end
     var wrap = runtime.caml_cps_closure(wrap$0, wrap$1);
-    //end |}]
+    //end
+    |}]

--- a/compiler/tests-compiler/gh1868.ml
+++ b/compiler/tests-compiler/gh1868.ml
@@ -1,0 +1,67 @@
+(* Js_of_ocaml compiler
+ * http://www.ocsigen.org/js_of_ocaml/
+ * Copyright (C) 2019 Hugo Heuzard
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+
+open Util
+
+let%expect_test "" =
+  let program =
+    compile_and_parse
+      ~effects:`Double_translation
+      {|
+exception Nested of exn
+let wrap f =
+  try f () with exn ->
+  let rec unwrap exn =
+    match exn with
+    | Nested e -> unwrap e
+    | _ -> raise exn
+  in
+  unwrap exn
+|}
+  in
+  print_double_fun_decl program "wrap";
+  [%expect {|
+    function wrap$0(f){
+     try{var _d_ = caml_call1(f, 0); return _d_;}
+     catch(exn$2){
+      var exn = caml_wrap_exception(exn$2), exn$0 = exn;
+      for(;;){
+       if(exn$0[1] !== Nested) throw caml_maybe_attach_backtrace(exn$0, 1);
+       var exn$1 = exn$0[2];
+       exn$0 = exn$1;
+      }
+     }
+    }
+    //end
+    function wrap$1(f, cont){
+     function _b_(exn$1){
+      if(exn$1[1] === Nested){
+       var exn$0 = exn$1[2];
+       return caml_exact_trampoline_call1(_b_, exn$0);
+      }
+      var raise = caml_pop_trap(), exn = caml_maybe_attach_backtrace(exn$1, 1);
+      return raise(exn);
+     }
+     runtime.caml_push_trap(_b_);
+     return caml_trampoline_cps_call2
+             (f, 0, function(_c_){caml_pop_trap(); return cont(_c_);});
+    }
+    //end
+    var wrap = runtime.caml_cps_closure(wrap$0, wrap$1);
+    //end |}]

--- a/compiler/tests-compiler/util/util.ml
+++ b/compiler/tests-compiler/util/util.ml
@@ -527,7 +527,11 @@ class find_double_function_declaration r n =
                 ( S { name = Utf8 name; _ }
                 , Some
                     ( ECall
-                        ( EVar (S { name = Utf8 "caml_cps_closure"; _ })
+                        ( ( EVar (S { name = Utf8 "caml_cps_closure"; _ })
+                          | EDot
+                              ( EVar (S { name = Utf8 "runtime"; _ })
+                              , _
+                              , Utf8 "caml_cps_closure" ) )
                         , _
                         , [ Arg e1; Arg e2 ]
                         , _ )


### PR DESCRIPTION
We have a pass that removes empty blocks. This can trigger an assertion failure in code generation. It is safe to remove this assertion.

This fixes #1868.