### PR TITLE
Fix Dom_html.Keyboard_code.of_event

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@
 * Compiler: fix stack overflow issues with double translation (#1869)
 * Compiler: minifier fix (#1867)
 * Compiler: fix assert failure with double translation (#1870)
+* Lib: fix Dom_html.Keyboard_code.of_event (#1878)
 
 # 6.0.1 (2025-02-07) - Lille
 

--- a/lib/js_of_ocaml/dom_html.ml
+++ b/lib/js_of_ocaml/dom_html.ml
@@ -3383,7 +3383,7 @@ module Keyboard_code = struct
     | 1 -> run_next (get_key_code evt) try_key_code_left
     | 2 -> run_next (get_key_code evt) try_key_code_right
     | 3 -> run_next (get_key_code evt) try_key_code_numpad
-    | _ -> make_unidentified
+    | _ -> fun v -> v
 
   let ( |> ) x f = f x
 


### PR DESCRIPTION
For the standard location (0) we were ignoring the `code` property of the keyboard event and using the deprecated `keyCode` property instead.