### PR TITLE
Stop parsing CRCs

### DIFF
--- a/compiler/lib-wasm/link.ml
+++ b/compiler/lib-wasm/link.ml
@@ -92,7 +92,6 @@ end = struct
     ; force_link = t |> member "force_link" |> bool empty.force_link
     ; effects_without_cps =
         t |> member "effects_without_cps" |> bool empty.effects_without_cps
-    ; crcs = StringMap.empty
     }
 end
 

--- a/compiler/lib/parse_bytecode.ml
+++ b/compiler/lib/parse_bytecode.ml
@@ -3090,7 +3090,6 @@ let predefined_exceptions () =
   let unit_info =
     { Unit_info.provides = StringSet.of_list (List.map ~f:snd predefined_exceptions)
     ; requires = StringSet.empty
-    ; crcs = StringMap.empty
     ; force_link = true
     ; effects_without_cps = false
     ; primitives = []

--- a/compiler/lib/unit_info.mli
+++ b/compiler/lib/unit_info.mli
@@ -23,7 +23,6 @@ type t =
   { provides : StringSet.t
   ; requires : StringSet.t
   ; primitives : string list
-  ; crcs : Digest.t option StringMap.t
   ; force_link : bool
   ; effects_without_cps : bool
   }


### PR DESCRIPTION
By @Enoumy:

> This field is semi-expensive to compute/parse and is also unused. This patch removes the computation of this field.

When linking js_of_ocaml.bc.js, the difference seems to be in the noise, however.