### PR TITLE
Add flag `--empty-sourcemap`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@
 * Ppx: explicitly disallow polymorphic method (#1897)
 * Ppx: allow "function" in object literals (#1897)
 * Lib: make the Wasm version of Json.output work with native ints and JavaScript objects (#1872)
+* Compiler: add the `--empty-sourcemap` flag
 * Compiler: static evaluation of more primitives (#1912)
 * Compiler: faster compilation by stopping sooner when optimizations become unproductive (#1939)
 * Runtime: use Dataview to convert between floats and bit representation

--- a/compiler/bin-js_of_ocaml/cmd_arg.ml
+++ b/compiler/bin-js_of_ocaml/cmd_arg.ml
@@ -54,7 +54,7 @@ type t =
   { common : Jsoo_cmdline.Arg.t
   ; (* compile option *)
     profile : Driver.profile option
-  ; source_map : (string option * Source_map.Standard.t) option
+  ; source_map : Source_map.Encoding_spec.t option
   ; runtime_files : string list
   ; no_runtime : bool
   ; include_runtime : bool
@@ -157,6 +157,10 @@ let options =
   let sourcemap_don't_inline_content =
     let doc = "Do not inline sources in source map." in
     Arg.(value & flag & info [ "source-map-no-source" ] ~doc)
+  in
+  let sourcemap_empty =
+    let doc = "Always generate empty source maps." in
+    Arg.(value & flag & info [ "empty-sourcemap"; "empty-source-map" ] ~doc)
   in
   let sourcemap_root =
     let doc = "root dir for source map." in
@@ -296,6 +300,7 @@ let options =
       sourcemap
       sourcemap_inline_in_js
       sourcemap_don't_inline_content
+      sourcemap_empty
       sourcemap_root
       target_env
       output_file
@@ -330,12 +335,19 @@ let options =
           | `Name file, _ -> Some file, Some (chop_extension file ^ ".map")
           | `Stdout, _ -> None, None
         in
-        Some
-          ( sm_output_file
-          , { (Source_map.Standard.empty ~inline_source_content) with
-              file
-            ; sourceroot = sourcemap_root
-            } )
+        let source_map =
+          { (Source_map.Standard.empty ~inline_source_content) with
+            file
+          ; sourceroot = sourcemap_root
+          }
+        in
+        let spec =
+          { Source_map.Encoding_spec.output_file = sm_output_file
+          ; source_map
+          ; keep_empty = sourcemap_empty
+          }
+        in
+        Some spec
       else None
     in
     let params : (string * string) list = List.flatten set_param in
@@ -391,6 +403,7 @@ let options =
       $ sourcemap
       $ sourcemap_inline_in_js
       $ sourcemap_don't_inline_content
+      $ sourcemap_empty
       $ sourcemap_root
       $ target_env
       $ output_file
@@ -436,6 +449,10 @@ let options_runtime_only =
   let sourcemap_don't_inline_content =
     let doc = "Do not inline sources in source map." in
     Arg.(value & flag & info [ "source-map-no-source" ] ~doc)
+  in
+  let sourcemap_empty =
+    let doc = "Always generate empty source maps." in
+    Arg.(value & flag & info [ "empty-sourcemap"; "empty-source-map" ] ~doc)
   in
   let sourcemap_root =
     let doc = "root dir for source map." in
@@ -548,6 +565,7 @@ let options_runtime_only =
       sourcemap
       sourcemap_inline_in_js
       sourcemap_don't_inline_content
+      sourcemap_empty
       sourcemap_root
       target_env
       output_file
@@ -570,12 +588,19 @@ let options_runtime_only =
           | `Name file, _ -> Some file, Some (chop_extension file ^ ".map")
           | `Stdout, _ -> None, None
         in
-        Some
-          ( sm_output_file
-          , { (Source_map.Standard.empty ~inline_source_content) with
-              file
-            ; sourceroot = sourcemap_root
-            } )
+        let source_map =
+          { (Source_map.Standard.empty ~inline_source_content) with
+            file
+          ; sourceroot = sourcemap_root
+          }
+        in
+        let spec =
+          { Source_map.Encoding_spec.output_file = sm_output_file
+          ; source_map
+          ; keep_empty = sourcemap_empty
+          }
+        in
+        Some spec
       else None
     in
     let params : (string * string) list = List.flatten set_param in
@@ -626,6 +651,7 @@ let options_runtime_only =
       $ sourcemap
       $ sourcemap_inline_in_js
       $ sourcemap_don't_inline_content
+      $ sourcemap_empty
       $ sourcemap_root
       $ target_env
       $ output_file

--- a/compiler/bin-js_of_ocaml/cmd_arg.mli
+++ b/compiler/bin-js_of_ocaml/cmd_arg.mli
@@ -23,7 +23,7 @@ type t =
   { common : Jsoo_cmdline.Arg.t
   ; (* compile option *)
     profile : Driver.profile option
-  ; source_map : (string option * Source_map.Standard.t) option
+  ; source_map : Source_map.Encoding_spec.t option
   ; runtime_files : string list
   ; no_runtime : bool
   ; include_runtime : bool

--- a/compiler/bin-js_of_ocaml/compile.ml
+++ b/compiler/bin-js_of_ocaml/compile.ml
@@ -56,7 +56,8 @@ let output_gen
     let sm = f ~standalone ~source_map (k, fmt) in
     match source_map, sm with
     | None, _ | _, None -> ()
-    | Some { output_file = output; source_map = _; keep_empty = _ }, Some sm ->
+    | Some { output_file = output; source_map; keep_empty }, Some sm ->
+        let sm = if keep_empty then Source_map.Standard source_map else sm in
         if Debug.find "invariant" () then Source_map.invariant sm;
         let urlData =
           match output with

--- a/compiler/lib/link_js.mli
+++ b/compiler/lib/link_js.mli
@@ -24,5 +24,5 @@ val link :
   -> toplevel:bool
   -> files:string list
   -> resolve_sourcemap_url:bool
-  -> source_map:(string option * Source_map.Standard.t) option
+  -> source_map:Source_map.Encoding_spec.t option
   -> unit

--- a/compiler/lib/source_map.ml
+++ b/compiler/lib/source_map.ml
@@ -792,3 +792,12 @@ let find_in_js_file file =
       in
       Some (of_string content)
   | _ -> None
+
+module Encoding_spec = struct
+  type t =
+    { output_file : string option  (** Source map file ([None] means generate inline. *)
+    ; source_map : Standard.t  (** Source map to extend. *)
+    ; keep_empty : bool
+          (** Don't add anything to the source map (for js_of_ocaml's "empty sourcemap" option. *)
+    }
+end

--- a/compiler/lib/source_map.mli
+++ b/compiler/lib/source_map.mli
@@ -156,3 +156,12 @@ type info =
   ; sources : string list
   ; names : string list
   }
+
+module Encoding_spec : sig
+  type t =
+    { output_file : string option  (** Source map file ([None] means generate inline. *)
+    ; source_map : Standard.t  (** Source map to extend. *)
+    ; keep_empty : bool
+          (** Don't add anything to the source map (for js_of_ocaml's "empty sourcemap" option. *)
+    }
+end

--- a/compiler/tests-jsoo/empty_sourcemap.t
+++ b/compiler/tests-jsoo/empty_sourcemap.t
@@ -1,0 +1,25 @@
+  $ echo 'prerr_endline "a"' > a.ml
+  $ echo 'prerr_endline "b"' > b.ml
+  $ ocamlc -g a.ml -c
+  $ ocamlc -g b.ml -c
+  $ ocamlc -g a.cmo b.cmo -o test.bc
+
+Build object files and executable with --empty-sourcemap:
+
+  $ dune exec -- js_of_ocaml --sourcemap --empty-sourcemap a.cmo -o a.js
+  $ cat a.map
+  {"version":3,"file":"a.js","names":[],"sources":[],"mappings":"","sourcesContent":[]}
+  $ dune exec -- js_of_ocaml --sourcemap --empty-sourcemap b.cmo -o b.js
+  $ cat b.map
+  {"version":3,"file":"b.js","names":[],"sources":[],"mappings":"","sourcesContent":[]}
+  $ dune exec -- js_of_ocaml --sourcemap --empty-sourcemap test.bc -o test.js
+  $ cat test.map
+  {"version":3,"file":"test.js","names":[],"sources":[],"mappings":"","sourcesContent":[]}
+
+Build object files with sourcemap and link with --empty-sourcemap:
+
+  $ dune exec -- js_of_ocaml --sourcemap a.cmo -o a.js
+  $ dune exec -- js_of_ocaml --sourcemap b.cmo -o b.js
+  $ dune exec -- js_of_ocaml link --sourcemap --resolve-sourcemap-url=true --empty-sourcemap a.js b.js -o test.js -a
+  $ cat test.map
+  {"version":3,"file":"test.js","sections":[]}


### PR DESCRIPTION
This patch implements the `--empty-sourcemap` flag. It is used to generate an empty sourcemap, which is cheap. Sometimes application authors would like the cheapness of not building sourcemap files to speed up development iterations, but their build pipelines do not handle the case where `.map` files are not produced at all (think, e.g., custom Dune rules depending on `.map` files and passing them to a bundler). In such cases, they would like to still generate the empty `.map` files.

cc @rickyvetter 