### PR TITLE
Fix: marshal.js BigStringReader use offset method on bigstring

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 * Runtime: make Obj.dup work with floats and boxed numbers (#1871)
 * Lib: make the Wasm version of Json.output work with native ints and JavaScript objects (#1872)
 * Runtime: implement BLAKE2b primitives for Wasm (#1873)
+* Runtime: fix marshal.js BigStringReader (#1887)
 
 ## Bug fixes
 * Runtime: fix path normalization (#1848)

--- a/runtime/js/marshal.js
+++ b/runtime/js/marshal.js
@@ -233,7 +233,7 @@ class BigStringReader {
 
   readstr(len) {
     var i = this.i;
-    var offset = this.offset(i);
+    var offset = this.s.offset(i);
     this.i = i + len;
     return caml_string_of_uint8_array(
       this.s.data.subarray(offset, offset + len),
@@ -242,7 +242,7 @@ class BigStringReader {
 
   readuint8array(len) {
     var i = this.i;
-    var offset = this.offset(i);
+    var offset = this.s.offset(i);
     this.i = i + len;
     return this.s.data.subarray(offset, offset + len);
   }


### PR DESCRIPTION
`BigStringReader.readstr` and `BigStringReader.readuint8array` were calling an `offset` method on `self`, when it should have been going through `self.s`.

The tests that caught this bug are proprietary and not trivial to public-release, so I'd appreciate some advice on how best to add a regression test for this code.