### PR TITLE
Fix current-bench benchmark config for JSOO time

### DIFF
--- a/benchmarks/report-jsoo-cb.config
+++ b/benchmarks/report-jsoo-cb.config
@@ -1,2 +1,2 @@
-histogramref times node js_of_ocaml #fbaf4f node
+histogram times node js_of_ocaml #fbaf4f node
 histogram sizes "" js_of_ocaml/gzipped #ffffff Size (gzipped)


### PR DESCRIPTION
Using `histogramref` causes the first metric to be always 1.