### PR TITLE
Ppx_js: more tests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,8 @@
 * Runtime: less conversion during un-marshalling (#1889)
 * Compiler: improve performance of Javascript linking
 * Runtime/wasm: support unmarshaling compressed data (#1898)
+* Ppx: explicitly disallow polymorphic method (#1897)
+* Ppx: allow "function" in object literals (#1897)
 
 ## Bug fixes
 * Runtime: fix path normalization (#1848)

--- a/ppx/ppx_js/lib_internal/ppx_js_internal.ml
+++ b/ppx/ppx_js/lib_internal/ppx_js_internal.ml
@@ -587,6 +587,7 @@ let preprocess_literal_object mappper fields :
           match exp.pexp_desc with
           | Pexp_fun (label, _, _, body) -> Arg.make ~label () :: create_meth_ty body
           | Pexp_function _ -> [ Arg.make () ]
+          | Pexp_newtype (_, body) -> create_meth_ty body
           | _ -> []
         in
         let fun_ty = create_meth_ty body in

--- a/ppx/ppx_js/lib_internal/ppx_js_internal.ml
+++ b/ppx/ppx_js/lib_internal/ppx_js_internal.ml
@@ -586,6 +586,7 @@ let preprocess_literal_object mappper fields :
         let rec create_meth_ty exp =
           match exp.pexp_desc with
           | Pexp_fun (label, _, _, body) -> Arg.make ~label () :: create_meth_ty body
+          | Pexp_function _ -> [ Arg.make () ]
           | _ -> []
         in
         let fun_ty = create_meth_ty body in

--- a/ppx/ppx_js/tests/dune
+++ b/ppx/ppx_js/tests/dune
@@ -14,6 +14,15 @@
   (run %{exe:main.bc} %{dep:ppx.mlt})))
 
 (rule
+ (targets gen.mlt.corrected)
+ (enabled_if
+  (and
+   (>= %{ocaml_version} 5.3)
+   (< %{ocaml_version} 5.4)))
+ (action
+  (run %{exe:main.bc} %{dep:gen.mlt})))
+
+(rule
  (alias runtest)
  (package js_of_ocaml-ppx)
  (enabled_if
@@ -22,3 +31,13 @@
    (< %{ocaml_version} 5.4)))
  (action
   (diff ppx.mlt ppx.mlt.corrected)))
+
+(rule
+ (alias runtest)
+ (package js_of_ocaml-ppx)
+ (enabled_if
+  (and
+   (>= %{ocaml_version} 5.3)
+   (< %{ocaml_version} 5.4)))
+ (action
+  (diff gen.mlt gen.mlt.corrected)))

--- a/ppx/ppx_js/tests/gen.mlt
+++ b/ppx/ppx_js/tests/gen.mlt
@@ -224,22 +224,24 @@ let o () =
 {|
 let o () =
   (fun (type res) ->
-     fun (type t12) ->
-       fun (type t13) ->
-         fun (t13 : res Js_of_ocaml.Js.t -> t12 -> t13)
-           (_ :
-             res Js_of_ocaml.Js.t ->
-               (res Js_of_ocaml.Js.t -> t12 -> t13 Js_of_ocaml.Js.meth) ->
-                 res)
-           : res Js_of_ocaml.Js.t->
-           Js_of_ocaml.Js.Unsafe.obj
-             [|("m1",
-                 (Js_of_ocaml.Js.Unsafe.inject
-                    (Js_of_ocaml.Js.wrap_meth_callback t13)))|])
+     fun (type t13) ->
+       fun (type t12) ->
+         fun (type t14) ->
+           fun (t14 : res Js_of_ocaml.Js.t -> t13 -> t12 -> t14)
+             (_ :
+               res Js_of_ocaml.Js.t ->
+                 (res Js_of_ocaml.Js.t ->
+                    t13 -> t12 -> t14 Js_of_ocaml.Js.meth)
+                   -> res)
+             : res Js_of_ocaml.Js.t->
+             Js_of_ocaml.Js.Unsafe.obj
+               [|("m1",
+                   (Js_of_ocaml.Js.Unsafe.inject
+                      (Js_of_ocaml.Js.wrap_meth_callback t14)))|])
     (fun _ a -> function | b -> a + b)
     ((fun self m1 -> object method m1 = m1 self end)[@merlin.hide ]);;
 val o :
-  unit -> < m1 : int -> (int -> int) Js_of_ocaml.Js.meth > Js_of_ocaml.Js.t =
+  unit -> < m1 : int -> int -> int Js_of_ocaml.Js.meth > Js_of_ocaml.Js.t =
   <fun>
 |}]
 
@@ -255,22 +257,24 @@ let o () =
 {|
 let o () =
   (fun (type res) ->
-     fun (type t14) ->
+     fun (type t16) ->
        fun (type t15) ->
-         fun (t15 : res Js_of_ocaml.Js.t -> t14 -> t15)
-           (_ :
-             res Js_of_ocaml.Js.t ->
-               (res Js_of_ocaml.Js.t -> t14 -> t15 Js_of_ocaml.Js.meth) ->
-                 res)
-           : res Js_of_ocaml.Js.t->
-           Js_of_ocaml.Js.Unsafe.obj
-             [|("m1",
-                 (Js_of_ocaml.Js.Unsafe.inject
-                    (Js_of_ocaml.Js.wrap_meth_callback t15)))|])
+         fun (type t17) ->
+           fun (t17 : res Js_of_ocaml.Js.t -> t16 -> t15 -> t17)
+             (_ :
+               res Js_of_ocaml.Js.t ->
+                 (res Js_of_ocaml.Js.t ->
+                    t16 -> t15 -> t17 Js_of_ocaml.Js.meth)
+                   -> res)
+             : res Js_of_ocaml.Js.t->
+             Js_of_ocaml.Js.Unsafe.obj
+               [|("m1",
+                   (Js_of_ocaml.Js.Unsafe.inject
+                      (Js_of_ocaml.Js.wrap_meth_callback t17)))|])
     (fun _ a -> function | 0 -> a | b -> a + b)
     ((fun self m1 -> object method m1 = m1 self end)[@merlin.hide ]);;
 val o :
-  unit -> < m1 : int -> (int -> int) Js_of_ocaml.Js.meth > Js_of_ocaml.Js.t =
+  unit -> < m1 : int -> int -> int Js_of_ocaml.Js.meth > Js_of_ocaml.Js.t =
   <fun>
 |}]
 
@@ -286,16 +290,16 @@ let o () =
 {|
 let o () =
   (fun (type res) ->
-     fun (type t16) ->
-       fun (t16 : res Js_of_ocaml.Js.t -> t16)
+     fun (type t18) ->
+       fun (t18 : res Js_of_ocaml.Js.t -> t18)
          (_ :
            res Js_of_ocaml.Js.t ->
-             (res Js_of_ocaml.Js.t -> t16 Js_of_ocaml.Js.meth) -> res)
+             (res Js_of_ocaml.Js.t -> t18 Js_of_ocaml.Js.meth) -> res)
          : res Js_of_ocaml.Js.t->
          Js_of_ocaml.Js.Unsafe.obj
            [|("m1",
                (Js_of_ocaml.Js.Unsafe.inject
-                  (Js_of_ocaml.Js.wrap_meth_callback t16)))|])
+                  (Js_of_ocaml.Js.wrap_meth_callback t18)))|])
     (fun _ (type b) a -> function | 0 -> a | b -> a + b)
     ((fun self m1 -> object method m1 = m1 self end)[@merlin.hide ]);;
 val o :
@@ -315,18 +319,18 @@ let o () =
 {|
 let o () =
   (fun (type res) ->
-     fun (type t17) ->
-       fun (type t18) ->
-         fun (t18 : res Js_of_ocaml.Js.t -> t17 -> t18)
+     fun (type t19) ->
+       fun (type t20) ->
+         fun (t20 : res Js_of_ocaml.Js.t -> t19 -> t20)
            (_ :
              res Js_of_ocaml.Js.t ->
-               (res Js_of_ocaml.Js.t -> t17 -> t18 Js_of_ocaml.Js.meth) ->
+               (res Js_of_ocaml.Js.t -> t19 -> t20 Js_of_ocaml.Js.meth) ->
                  res)
            : res Js_of_ocaml.Js.t->
            Js_of_ocaml.Js.Unsafe.obj
              [|("m1",
                  (Js_of_ocaml.Js.Unsafe.inject
-                    (Js_of_ocaml.Js.wrap_meth_callback t18)))|])
+                    (Js_of_ocaml.Js.wrap_meth_callback t20)))|])
     (fun _ a (type b) -> function | 0 -> a | b -> a + b)
     ((fun self m1 -> object method m1 = m1 self end)[@merlin.hide ]);;
 val o :
@@ -343,21 +347,21 @@ let o () =
 [%%expect {|
 let o () =
   (fun (type res) ->
-     fun (type t19) ->
-       fun (type t20) ->
-         fun (t20 : res Js_of_ocaml.Js.t -> t19 -> t20)
+     fun (type t21) ->
+       fun (type t22) ->
+         fun (t22 : res Js_of_ocaml.Js.t -> t21 -> t22)
            (_ :
              res Js_of_ocaml.Js.t ->
-               (res Js_of_ocaml.Js.t -> t19 -> t20 Js_of_ocaml.Js.meth) ->
+               (res Js_of_ocaml.Js.t -> t21 -> t22 Js_of_ocaml.Js.meth) ->
                  res)
            : res Js_of_ocaml.Js.t->
            Js_of_ocaml.Js.Unsafe.obj
              [|("m1",
                  (Js_of_ocaml.Js.Unsafe.inject
-                    (Js_of_ocaml.Js.wrap_meth_callback t20)))|])
+                    (Js_of_ocaml.Js.wrap_meth_callback t22)))|])
     (fun _ a -> ignore a) ((fun self m1 -> object method m1 = m1 self end)
     [@merlin.hide ]);;
-val o : unit -> < m1 : 't19 -> unit Js_of_ocaml.Js.meth > Js_of_ocaml.Js.t =
+val o : unit -> < m1 : 't21 -> unit Js_of_ocaml.Js.meth > Js_of_ocaml.Js.t =
   <fun>
 |}]
 
@@ -369,16 +373,16 @@ let o () =
 [%%expect {|
 let o () =
   (fun (type res) ->
-     fun (type t21) ->
-       fun (t21 : res Js_of_ocaml.Js.t -> t21)
+     fun (type t23) ->
+       fun (t23 : res Js_of_ocaml.Js.t -> t23)
          (_ :
            res Js_of_ocaml.Js.t ->
-             (res Js_of_ocaml.Js.t -> t21 Js_of_ocaml.Js.meth) -> res)
+             (res Js_of_ocaml.Js.t -> t23 Js_of_ocaml.Js.meth) -> res)
          : res Js_of_ocaml.Js.t->
          Js_of_ocaml.Js.Unsafe.obj
            [|("m1",
                (Js_of_ocaml.Js.Unsafe.inject
-                  (Js_of_ocaml.Js.wrap_meth_callback t21)))|])
+                  (Js_of_ocaml.Js.wrap_meth_callback t23)))|])
     (fun _ (type a) (a : a) -> ignore a)
     ((fun self m1 -> object method m1 = m1 self end)[@merlin.hide ]);;
 val o : unit -> < m1 : ('a -> unit) Js_of_ocaml.Js.meth > Js_of_ocaml.Js.t =

--- a/ppx/ppx_js/tests/gen.mlt
+++ b/ppx/ppx_js/tests/gen.mlt
@@ -1,0 +1,386 @@
+module Js_of_ocaml = struct
+  module Js = struct
+    class type js_string = object end
+
+    type +'a t
+
+    type (-'a, +'b) meth_callback
+
+    type +'a opt
+
+    type +'a optdef
+
+    type +'a meth
+
+    type +'a gen_prop
+
+    type 'a readonly_prop = < get : 'a > gen_prop
+
+    type 'a writeonly_prop = < set : 'a -> unit > gen_prop
+
+    type 'a prop = < get : 'a ; set : 'a -> unit > gen_prop
+
+    type 'a optdef_prop = < get : 'a optdef ; set : 'a -> unit > gen_prop
+
+    type +'a constr
+
+    (****)
+
+    type 'a callback = (unit, 'a) meth_callback
+
+    module Unsafe = struct
+      type any
+
+      type any_js_array = any
+
+      let inject : 'a -> any = fun _ -> assert false
+
+      let get : 'a -> 'b -> 'c = fun _ _ -> assert false
+
+      let set : 'a -> 'b -> 'c -> unit = fun _ _ _ -> assert false
+
+      let meth_call : 'a -> string -> any array -> 'b = fun _ _ _ -> assert false
+
+      let obj : (string * any) array -> 'a = fun _ -> assert false
+    end
+
+    let wrap_meth_callback : ('a -> 'b) -> ('a, 'b) meth_callback = fun _ -> assert false
+
+    let string : string -> js_string t = fun _ -> assert false
+
+    let undefined : unit -> 'a optdef = fun () -> assert false
+
+    let def : 'a -> 'a optdef = fun _ -> assert false
+  end
+end
+;;
+
+#directory "+compiler-libs"
+
+let () = Clflags.dump_source := true
+
+[%%expect
+{|
+module Js_of_ocaml :
+  sig
+    module Js :
+      sig
+        class type js_string = object  end
+        type +'a t
+        type (-'a, +'b) meth_callback
+        type +'a opt
+        type +'a optdef
+        type +'a meth
+        type +'a gen_prop
+        type 'a readonly_prop = < get : 'a > gen_prop
+        type 'a writeonly_prop = < set : 'a -> unit > gen_prop
+        type 'a prop = < get : 'a; set : 'a -> unit > gen_prop
+        type 'a optdef_prop = < get : 'a optdef; set : 'a -> unit > gen_prop
+        type +'a constr
+        type 'a callback = (unit, 'a) meth_callback
+        module Unsafe :
+          sig
+            type any
+            type any_js_array = any
+            val inject : 'a -> any
+            val get : 'a -> 'b -> 'c
+            val set : 'a -> 'b -> 'c -> unit
+            val meth_call : 'a -> string -> any array -> 'b
+            val obj : (string * any) array -> 'a
+          end
+        val wrap_meth_callback : ('a -> 'b) -> ('a, 'b) meth_callback
+        val string : string -> js_string t
+        val undefined : unit -> 'a optdef
+        val def : 'a -> 'a optdef
+      end
+  end
+|}]
+
+let o () =
+  object%js
+    method m1 a b = a + b
+  end
+
+[%%expect
+{|
+let o () =
+  (fun (type res) ->
+     fun (type t1) ->
+       fun (type t0) ->
+         fun (type t2) ->
+           fun (t2 : res Js_of_ocaml.Js.t -> t1 -> t0 -> t2)
+             (_ :
+               res Js_of_ocaml.Js.t ->
+                 (res Js_of_ocaml.Js.t -> t1 -> t0 -> t2 Js_of_ocaml.Js.meth)
+                   -> res)
+             : res Js_of_ocaml.Js.t->
+             Js_of_ocaml.Js.Unsafe.obj
+               [|("m1",
+                   (Js_of_ocaml.Js.Unsafe.inject
+                      (Js_of_ocaml.Js.wrap_meth_callback t2)))|])
+    (fun _ a b -> a + b) ((fun self m1 -> object method m1 = m1 self end)
+    [@merlin.hide ]);;
+val o :
+  unit -> < m1 : int -> int -> int Js_of_ocaml.Js.meth > Js_of_ocaml.Js.t =
+  <fun>
+|}]
+
+let o () =
+  object%js
+    method m1 a = fun b -> a + b
+  end
+
+[%%expect
+{|
+let o () =
+  (fun (type res) ->
+     fun (type t4) ->
+       fun (type t3) ->
+         fun (type t5) ->
+           fun (t5 : res Js_of_ocaml.Js.t -> t4 -> t3 -> t5)
+             (_ :
+               res Js_of_ocaml.Js.t ->
+                 (res Js_of_ocaml.Js.t -> t4 -> t3 -> t5 Js_of_ocaml.Js.meth)
+                   -> res)
+             : res Js_of_ocaml.Js.t->
+             Js_of_ocaml.Js.Unsafe.obj
+               [|("m1",
+                   (Js_of_ocaml.Js.Unsafe.inject
+                      (Js_of_ocaml.Js.wrap_meth_callback t5)))|])
+    (fun _ a -> fun b -> a + b)
+    ((fun self m1 -> object method m1 = m1 self end)[@merlin.hide ]);;
+val o :
+  unit -> < m1 : int -> int -> int Js_of_ocaml.Js.meth > Js_of_ocaml.Js.t =
+  <fun>
+|}]
+
+let o () =
+  object%js
+    method m1 = fun a b -> a + b
+  end
+
+[%%expect
+{|
+let o () =
+  (fun (type res) ->
+     fun (type t7) ->
+       fun (type t6) ->
+         fun (type t8) ->
+           fun (t8 : res Js_of_ocaml.Js.t -> t7 -> t6 -> t8)
+             (_ :
+               res Js_of_ocaml.Js.t ->
+                 (res Js_of_ocaml.Js.t -> t7 -> t6 -> t8 Js_of_ocaml.Js.meth)
+                   -> res)
+             : res Js_of_ocaml.Js.t->
+             Js_of_ocaml.Js.Unsafe.obj
+               [|("m1",
+                   (Js_of_ocaml.Js.Unsafe.inject
+                      (Js_of_ocaml.Js.wrap_meth_callback t8)))|])
+    (fun _ a b -> a + b) ((fun self m1 -> object method m1 = m1 self end)
+    [@merlin.hide ]);;
+val o :
+  unit -> < m1 : int -> int -> int Js_of_ocaml.Js.meth > Js_of_ocaml.Js.t =
+  <fun>
+|}]
+
+let o () =
+  object%js
+    method m1 = fun a -> fun b -> a + b
+  end
+
+[%%expect
+{|
+let o () =
+  (fun (type res) ->
+     fun (type t10) ->
+       fun (type t9) ->
+         fun (type t11) ->
+           fun (t11 : res Js_of_ocaml.Js.t -> t10 -> t9 -> t11)
+             (_ :
+               res Js_of_ocaml.Js.t ->
+                 (res Js_of_ocaml.Js.t ->
+                    t10 -> t9 -> t11 Js_of_ocaml.Js.meth)
+                   -> res)
+             : res Js_of_ocaml.Js.t->
+             Js_of_ocaml.Js.Unsafe.obj
+               [|("m1",
+                   (Js_of_ocaml.Js.Unsafe.inject
+                      (Js_of_ocaml.Js.wrap_meth_callback t11)))|])
+    (fun _ a -> fun b -> a + b)
+    ((fun self m1 -> object method m1 = m1 self end)[@merlin.hide ]);;
+val o :
+  unit -> < m1 : int -> int -> int Js_of_ocaml.Js.meth > Js_of_ocaml.Js.t =
+  <fun>
+|}]
+
+let o () =
+  object%js
+    method m1 a =
+      function
+      | b -> a + b
+  end
+
+[%%expect
+{|
+let o () =
+  (fun (type res) ->
+     fun (type t12) ->
+       fun (type t13) ->
+         fun (t13 : res Js_of_ocaml.Js.t -> t12 -> t13)
+           (_ :
+             res Js_of_ocaml.Js.t ->
+               (res Js_of_ocaml.Js.t -> t12 -> t13 Js_of_ocaml.Js.meth) ->
+                 res)
+           : res Js_of_ocaml.Js.t->
+           Js_of_ocaml.Js.Unsafe.obj
+             [|("m1",
+                 (Js_of_ocaml.Js.Unsafe.inject
+                    (Js_of_ocaml.Js.wrap_meth_callback t13)))|])
+    (fun _ a -> function | b -> a + b)
+    ((fun self m1 -> object method m1 = m1 self end)[@merlin.hide ]);;
+val o :
+  unit -> < m1 : int -> (int -> int) Js_of_ocaml.Js.meth > Js_of_ocaml.Js.t =
+  <fun>
+|}]
+
+let o () =
+  object%js
+    method m1 a =
+      function
+      | 0 -> a
+      | b -> a + b
+  end
+
+[%%expect
+{|
+let o () =
+  (fun (type res) ->
+     fun (type t14) ->
+       fun (type t15) ->
+         fun (t15 : res Js_of_ocaml.Js.t -> t14 -> t15)
+           (_ :
+             res Js_of_ocaml.Js.t ->
+               (res Js_of_ocaml.Js.t -> t14 -> t15 Js_of_ocaml.Js.meth) ->
+                 res)
+           : res Js_of_ocaml.Js.t->
+           Js_of_ocaml.Js.Unsafe.obj
+             [|("m1",
+                 (Js_of_ocaml.Js.Unsafe.inject
+                    (Js_of_ocaml.Js.wrap_meth_callback t15)))|])
+    (fun _ a -> function | 0 -> a | b -> a + b)
+    ((fun self m1 -> object method m1 = m1 self end)[@merlin.hide ]);;
+val o :
+  unit -> < m1 : int -> (int -> int) Js_of_ocaml.Js.meth > Js_of_ocaml.Js.t =
+  <fun>
+|}]
+
+let o () =
+  object%js
+    method m1 (type b) a =
+      function
+      | 0 -> a
+      | b -> a + b
+  end
+
+[%%expect
+{|
+let o () =
+  (fun (type res) ->
+     fun (type t16) ->
+       fun (t16 : res Js_of_ocaml.Js.t -> t16)
+         (_ :
+           res Js_of_ocaml.Js.t ->
+             (res Js_of_ocaml.Js.t -> t16 Js_of_ocaml.Js.meth) -> res)
+         : res Js_of_ocaml.Js.t->
+         Js_of_ocaml.Js.Unsafe.obj
+           [|("m1",
+               (Js_of_ocaml.Js.Unsafe.inject
+                  (Js_of_ocaml.Js.wrap_meth_callback t16)))|])
+    (fun _ (type b) a -> function | 0 -> a | b -> a + b)
+    ((fun self m1 -> object method m1 = m1 self end)[@merlin.hide ]);;
+val o :
+  unit -> < m1 : (int -> int -> int) Js_of_ocaml.Js.meth > Js_of_ocaml.Js.t =
+  <fun>
+|}]
+
+let o () =
+  object%js
+    method m1 a (type b) =
+      function
+      | 0 -> a
+      | b -> a + b
+  end
+
+[%%expect
+{|
+let o () =
+  (fun (type res) ->
+     fun (type t17) ->
+       fun (type t18) ->
+         fun (t18 : res Js_of_ocaml.Js.t -> t17 -> t18)
+           (_ :
+             res Js_of_ocaml.Js.t ->
+               (res Js_of_ocaml.Js.t -> t17 -> t18 Js_of_ocaml.Js.meth) ->
+                 res)
+           : res Js_of_ocaml.Js.t->
+           Js_of_ocaml.Js.Unsafe.obj
+             [|("m1",
+                 (Js_of_ocaml.Js.Unsafe.inject
+                    (Js_of_ocaml.Js.wrap_meth_callback t18)))|])
+    (fun _ a (type b) -> function | 0 -> a | b -> a + b)
+    ((fun self m1 -> object method m1 = m1 self end)[@merlin.hide ]);;
+val o :
+  unit -> < m1 : int -> (int -> int) Js_of_ocaml.Js.meth > Js_of_ocaml.Js.t =
+  <fun>
+|}]
+
+
+let o () =
+  object%js
+    method m1 : 'a. 'a -> unit = fun a -> ignore a
+  end
+
+[%%expect {|
+let o () =
+  (fun (type res) ->
+     fun (type t19) ->
+       fun (type t20) ->
+         fun (t20 : res Js_of_ocaml.Js.t -> t19 -> t20)
+           (_ :
+             res Js_of_ocaml.Js.t ->
+               (res Js_of_ocaml.Js.t -> t19 -> t20 Js_of_ocaml.Js.meth) ->
+                 res)
+           : res Js_of_ocaml.Js.t->
+           Js_of_ocaml.Js.Unsafe.obj
+             [|("m1",
+                 (Js_of_ocaml.Js.Unsafe.inject
+                    (Js_of_ocaml.Js.wrap_meth_callback t20)))|])
+    (fun _ a -> ignore a) ((fun self m1 -> object method m1 = m1 self end)
+    [@merlin.hide ]);;
+val o : unit -> < m1 : 't19 -> unit Js_of_ocaml.Js.meth > Js_of_ocaml.Js.t =
+  <fun>
+|}]
+
+let o () =
+  object%js
+    method m1 : 'a. 'a -> unit = fun (type a) (a : a) -> ignore a
+  end
+
+[%%expect {|
+let o () =
+  (fun (type res) ->
+     fun (type t21) ->
+       fun (t21 : res Js_of_ocaml.Js.t -> t21)
+         (_ :
+           res Js_of_ocaml.Js.t ->
+             (res Js_of_ocaml.Js.t -> t21 Js_of_ocaml.Js.meth) -> res)
+         : res Js_of_ocaml.Js.t->
+         Js_of_ocaml.Js.Unsafe.obj
+           [|("m1",
+               (Js_of_ocaml.Js.Unsafe.inject
+                  (Js_of_ocaml.Js.wrap_meth_callback t21)))|])
+    (fun _ (type a) (a : a) -> ignore a)
+    ((fun self m1 -> object method m1 = m1 self end)[@merlin.hide ]);;
+val o : unit -> < m1 : ('a -> unit) Js_of_ocaml.Js.meth > Js_of_ocaml.Js.t =
+  <fun>
+|}]

--- a/ppx/ppx_js/tests/gen.mlt
+++ b/ppx/ppx_js/tests/gen.mlt
@@ -290,20 +290,24 @@ let o () =
 {|
 let o () =
   (fun (type res) ->
-     fun (type t18) ->
-       fun (t18 : res Js_of_ocaml.Js.t -> t18)
-         (_ :
-           res Js_of_ocaml.Js.t ->
-             (res Js_of_ocaml.Js.t -> t18 Js_of_ocaml.Js.meth) -> res)
-         : res Js_of_ocaml.Js.t->
-         Js_of_ocaml.Js.Unsafe.obj
-           [|("m1",
-               (Js_of_ocaml.Js.Unsafe.inject
-                  (Js_of_ocaml.Js.wrap_meth_callback t18)))|])
+     fun (type t19) ->
+       fun (type t18) ->
+         fun (type t20) ->
+           fun (t20 : res Js_of_ocaml.Js.t -> t19 -> t18 -> t20)
+             (_ :
+               res Js_of_ocaml.Js.t ->
+                 (res Js_of_ocaml.Js.t ->
+                    t19 -> t18 -> t20 Js_of_ocaml.Js.meth)
+                   -> res)
+             : res Js_of_ocaml.Js.t->
+             Js_of_ocaml.Js.Unsafe.obj
+               [|("m1",
+                   (Js_of_ocaml.Js.Unsafe.inject
+                      (Js_of_ocaml.Js.wrap_meth_callback t20)))|])
     (fun _ (type b) a -> function | 0 -> a | b -> a + b)
     ((fun self m1 -> object method m1 = m1 self end)[@merlin.hide ]);;
 val o :
-  unit -> < m1 : (int -> int -> int) Js_of_ocaml.Js.meth > Js_of_ocaml.Js.t =
+  unit -> < m1 : int -> int -> int Js_of_ocaml.Js.meth > Js_of_ocaml.Js.t =
   <fun>
 |}]
 
@@ -319,22 +323,24 @@ let o () =
 {|
 let o () =
   (fun (type res) ->
-     fun (type t19) ->
-       fun (type t20) ->
-         fun (t20 : res Js_of_ocaml.Js.t -> t19 -> t20)
-           (_ :
-             res Js_of_ocaml.Js.t ->
-               (res Js_of_ocaml.Js.t -> t19 -> t20 Js_of_ocaml.Js.meth) ->
-                 res)
-           : res Js_of_ocaml.Js.t->
-           Js_of_ocaml.Js.Unsafe.obj
-             [|("m1",
-                 (Js_of_ocaml.Js.Unsafe.inject
-                    (Js_of_ocaml.Js.wrap_meth_callback t20)))|])
+     fun (type t22) ->
+       fun (type t21) ->
+         fun (type t23) ->
+           fun (t23 : res Js_of_ocaml.Js.t -> t22 -> t21 -> t23)
+             (_ :
+               res Js_of_ocaml.Js.t ->
+                 (res Js_of_ocaml.Js.t ->
+                    t22 -> t21 -> t23 Js_of_ocaml.Js.meth)
+                   -> res)
+             : res Js_of_ocaml.Js.t->
+             Js_of_ocaml.Js.Unsafe.obj
+               [|("m1",
+                   (Js_of_ocaml.Js.Unsafe.inject
+                      (Js_of_ocaml.Js.wrap_meth_callback t23)))|])
     (fun _ a (type b) -> function | 0 -> a | b -> a + b)
     ((fun self m1 -> object method m1 = m1 self end)[@merlin.hide ]);;
 val o :
-  unit -> < m1 : int -> (int -> int) Js_of_ocaml.Js.meth > Js_of_ocaml.Js.t =
+  unit -> < m1 : int -> int -> int Js_of_ocaml.Js.meth > Js_of_ocaml.Js.t =
   <fun>
 |}]
 
@@ -347,21 +353,21 @@ let o () =
 [%%expect {|
 let o () =
   (fun (type res) ->
-     fun (type t21) ->
-       fun (type t22) ->
-         fun (t22 : res Js_of_ocaml.Js.t -> t21 -> t22)
+     fun (type t24) ->
+       fun (type t25) ->
+         fun (t25 : res Js_of_ocaml.Js.t -> t24 -> t25)
            (_ :
              res Js_of_ocaml.Js.t ->
-               (res Js_of_ocaml.Js.t -> t21 -> t22 Js_of_ocaml.Js.meth) ->
+               (res Js_of_ocaml.Js.t -> t24 -> t25 Js_of_ocaml.Js.meth) ->
                  res)
            : res Js_of_ocaml.Js.t->
            Js_of_ocaml.Js.Unsafe.obj
              [|("m1",
                  (Js_of_ocaml.Js.Unsafe.inject
-                    (Js_of_ocaml.Js.wrap_meth_callback t22)))|])
+                    (Js_of_ocaml.Js.wrap_meth_callback t25)))|])
     (fun _ a -> ignore a) ((fun self m1 -> object method m1 = m1 self end)
     [@merlin.hide ]);;
-val o : unit -> < m1 : 't21 -> unit Js_of_ocaml.Js.meth > Js_of_ocaml.Js.t =
+val o : unit -> < m1 : 't24 -> unit Js_of_ocaml.Js.meth > Js_of_ocaml.Js.t =
   <fun>
 |}]
 
@@ -373,18 +379,20 @@ let o () =
 [%%expect {|
 let o () =
   (fun (type res) ->
-     fun (type t23) ->
-       fun (t23 : res Js_of_ocaml.Js.t -> t23)
-         (_ :
-           res Js_of_ocaml.Js.t ->
-             (res Js_of_ocaml.Js.t -> t23 Js_of_ocaml.Js.meth) -> res)
-         : res Js_of_ocaml.Js.t->
-         Js_of_ocaml.Js.Unsafe.obj
-           [|("m1",
-               (Js_of_ocaml.Js.Unsafe.inject
-                  (Js_of_ocaml.Js.wrap_meth_callback t23)))|])
+     fun (type t26) ->
+       fun (type t27) ->
+         fun (t27 : res Js_of_ocaml.Js.t -> t26 -> t27)
+           (_ :
+             res Js_of_ocaml.Js.t ->
+               (res Js_of_ocaml.Js.t -> t26 -> t27 Js_of_ocaml.Js.meth) ->
+                 res)
+           : res Js_of_ocaml.Js.t->
+           Js_of_ocaml.Js.Unsafe.obj
+             [|("m1",
+                 (Js_of_ocaml.Js.Unsafe.inject
+                    (Js_of_ocaml.Js.wrap_meth_callback t27)))|])
     (fun _ (type a) (a : a) -> ignore a)
     ((fun self m1 -> object method m1 = m1 self end)[@merlin.hide ]);;
-val o : unit -> < m1 : ('a -> unit) Js_of_ocaml.Js.meth > Js_of_ocaml.Js.t =
+val o : unit -> < m1 : 't26 -> unit Js_of_ocaml.Js.meth > Js_of_ocaml.Js.t =
   <fun>
 |}]

--- a/ppx/ppx_js/tests/gen.mlt
+++ b/ppx/ppx_js/tests/gen.mlt
@@ -351,24 +351,9 @@ let o () =
   end
 
 [%%expect {|
-let o () =
-  (fun (type res) ->
-     fun (type t24) ->
-       fun (type t25) ->
-         fun (t25 : res Js_of_ocaml.Js.t -> t24 -> t25)
-           (_ :
-             res Js_of_ocaml.Js.t ->
-               (res Js_of_ocaml.Js.t -> t24 -> t25 Js_of_ocaml.Js.meth) ->
-                 res)
-           : res Js_of_ocaml.Js.t->
-           Js_of_ocaml.Js.Unsafe.obj
-             [|("m1",
-                 (Js_of_ocaml.Js.Unsafe.inject
-                    (Js_of_ocaml.Js.wrap_meth_callback t25)))|])
-    (fun _ a -> ignore a) ((fun self m1 -> object method m1 = m1 self end)
-    [@merlin.hide ]);;
-val o : unit -> < m1 : 't24 -> unit Js_of_ocaml.Js.meth > Js_of_ocaml.Js.t =
-  <fun>
+let o () = [%ocaml.error "Polymorphic method not supported."];;
+Line _, characters 4-50:
+Error: Polymorphic method not supported.
 |}]
 
 let o () =
@@ -377,22 +362,63 @@ let o () =
   end
 
 [%%expect {|
+let o () = [%ocaml.error "Polymorphic method not supported."];;
+Line _, characters 4-65:
+Error: Polymorphic method not supported.
+|}]
+
+
+let o () =
+  object%js
+    method m1 : 'a  -> unit = fun (type a) (a : a) -> ignore a
+    method m2 : int -> unit = fun (type a) (a : a) -> ignore a
+    method m3 : 'b -> unit = fun (a : 'b) -> ignore a
+  end
+
+[%%expect {|
 let o () =
   (fun (type res) ->
      fun (type t26) ->
        fun (type t27) ->
-         fun (t27 : res Js_of_ocaml.Js.t -> t26 -> t27)
-           (_ :
-             res Js_of_ocaml.Js.t ->
-               (res Js_of_ocaml.Js.t -> t26 -> t27 Js_of_ocaml.Js.meth) ->
-                 res)
-           : res Js_of_ocaml.Js.t->
-           Js_of_ocaml.Js.Unsafe.obj
-             [|("m1",
-                 (Js_of_ocaml.Js.Unsafe.inject
-                    (Js_of_ocaml.Js.wrap_meth_callback t27)))|])
-    (fun _ (type a) (a : a) -> ignore a)
-    ((fun self m1 -> object method m1 = m1 self end)[@merlin.hide ]);;
-val o : unit -> < m1 : 't26 -> unit Js_of_ocaml.Js.meth > Js_of_ocaml.Js.t =
-  <fun>
+         fun (type t28) ->
+           fun (type t29) ->
+             fun (type t30) ->
+               fun (type t31) ->
+                 fun (t29 : res Js_of_ocaml.Js.t -> t26 -> t29)
+                   (t30 : res Js_of_ocaml.Js.t -> t27 -> t30)
+                   (t31 : res Js_of_ocaml.Js.t -> t28 -> t31)
+                   (_ :
+                     res Js_of_ocaml.Js.t ->
+                       (res Js_of_ocaml.Js.t ->
+                          t26 -> t29 Js_of_ocaml.Js.meth)
+                         ->
+                         (res Js_of_ocaml.Js.t ->
+                            t27 -> t30 Js_of_ocaml.Js.meth)
+                           ->
+                           (res Js_of_ocaml.Js.t ->
+                              t28 -> t31 Js_of_ocaml.Js.meth)
+                             -> res)
+                   : res Js_of_ocaml.Js.t->
+                   Js_of_ocaml.Js.Unsafe.obj
+                     [|("m1",
+                         (Js_of_ocaml.Js.Unsafe.inject
+                            (Js_of_ocaml.Js.wrap_meth_callback t29)));
+                       ("m2",
+                         (Js_of_ocaml.Js.Unsafe.inject
+                            (Js_of_ocaml.Js.wrap_meth_callback t30)));
+                       ("m3",
+                         (Js_of_ocaml.Js.Unsafe.inject
+                            (Js_of_ocaml.Js.wrap_meth_callback t31)))|])
+    (fun _ : 'a -> unit-> fun (type a) -> fun (a : a) -> ignore a)
+    (fun _ : int -> unit-> fun (type a) -> fun (a : a) -> ignore a)
+    (fun _ : 'b -> unit-> fun (a : 'b) -> ignore a)
+    ((fun self m1 m2 m3 ->
+        object method m1 = m1 self method m2 = m2 self method m3 = m3 self
+        end)[@merlin.hide ]);;
+val o :
+  unit ->
+  < m1 : 't26 -> unit Js_of_ocaml.Js.meth;
+    m2 : int -> unit Js_of_ocaml.Js.meth;
+    m3 : 't28 -> unit Js_of_ocaml.Js.meth >
+  Js_of_ocaml.Js.t = <fun>
 |}]


### PR DESCRIPTION
We now support `function <CASES>` and `(type <TYPE>`) in object literals
and explicitly forbid polymorphic method instead of dropping part of the parsetree. 