### PR TITLE
Fix bound check for empty float array

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,7 @@
 * Runtime: fix caml_string_concat when not using JS strings (#1874)
 * Compiler: fix path rewriting of Wasm source maps (#1882)
 * Tools: fix jsoo_mktop and jsoo_mkcmis (#1877)
+* Compiler/wasm: fix bound check for empty float array (#1904)
 
 # 6.0.1 (2025-02-07) - Lille
 

--- a/compiler/lib-wasm/gc_target.ml
+++ b/compiler/lib-wasm/gc_target.ml
@@ -687,6 +687,10 @@ module Memory = struct
 
   let tag e = wasm_array_get e (Arith.const 0l)
 
+  let check_is_float_array e =
+    let* float_array = Type.float_array_type in
+    Value.ref_test (Value.ref float_array) e
+
   let array_length e =
     let* block = Type.block_type in
     let* e = wasm_cast block e in

--- a/compiler/lib-wasm/target_sig.ml
+++ b/compiler/lib-wasm/target_sig.ml
@@ -61,6 +61,8 @@ module type S = sig
 
     val float_array_set : expression -> expression -> expression -> unit Code_generation.t
 
+    val check_is_float_array : expression -> expression
+
     val gen_array_get : expression -> expression -> expression
 
     val gen_array_set : expression -> expression -> expression -> unit Code_generation.t

--- a/compiler/tests-wasm_of_ocaml/dune
+++ b/compiler/tests-wasm_of_ocaml/dune
@@ -1,5 +1,5 @@
 (tests
- (names gh38 gh46 gh107 gh112)
+ (names gh38 gh46 gh107 gh112 gh1904)
  (modes js wasm)
  (js_of_ocaml
   (flags :standard --disable optcall --no-inline))

--- a/compiler/tests-wasm_of_ocaml/gh1904.ml
+++ b/compiler/tests-wasm_of_ocaml/gh1904.ml
@@ -1,0 +1,15 @@
+let empty = [||]
+
+let get (x : float array) = x.(0)
+
+let set (x : float array) e = x.(0) <- e
+
+let catch_bound_error f x =
+  try
+    ignore (f x);
+    assert false
+  with Invalid_argument _ -> ()
+
+let () =
+  catch_bound_error get empty;
+  catch_bound_error (fun () -> set empty 0.) ()


### PR DESCRIPTION
A value of type `float array` is an unboxed float array, unless it is empty. The bound checking code was wrongly assuming that it was always an unboxed float array.