### PR TITLE
Effects: introduce primitive caml_cps_trampoline

### DIFF
--- a/compiler/lib-wasm/generate.ml
+++ b/compiler/lib-wasm/generate.ml
@@ -1186,7 +1186,6 @@ let init () =
   let l =
     [ "caml_ensure_stack_capacity", "%identity"
     ; "caml_process_pending_actions_with_root", "%identity"
-    ; "caml_callback", "caml_trampoline"
     ; "caml_make_array", "caml_array_of_uniform_array"
     ]
   in

--- a/runtime/js/jslib.js
+++ b/runtime/js/jslib.js
@@ -86,6 +86,7 @@ var caml_callback = caml_call_gen;
 //If: !doubletranslate
 //Requires: caml_stack_depth, caml_call_gen, caml_wrap_exception
 //Requires: caml_current_stack
+//Alias: caml_cps_trampoline
 function caml_callback(f, args) {
   var saved_stack_depth = caml_stack_depth;
   var saved_current_stack = caml_current_stack;

--- a/runtime/wasm/effect.wat
+++ b/runtime/wasm/effect.wat
@@ -562,7 +562,7 @@
       (param (ref eq)) (param (ref eq)) (param (ref eq)) (result (ref eq))
       (unreachable))
 
-   (func $caml_trampoline (export "caml_trampoline")
+   (func $caml_trampoline (export "caml_cps_trampoline")
       (param $f (ref eq)) (param $vargs (ref eq)) (result (ref eq))
       (local $args (ref $block))
       (local $i i32) (local $res (ref eq))


### PR DESCRIPTION
This is a better name for the primitive that sets up a trampoline to switch to CPS.