### PR TITLE
Update and clarify wasm_of_ocaml documentation

### DIFF
--- a/README_wasm_of_ocaml.md
+++ b/README_wasm_of_ocaml.md
@@ -17,21 +17,9 @@ one can enable the CPS transformation from `js_of_ocaml` by passing the
 `--effects=jspi` and emit code utilizing
 - [the JavaScript-Promise Integration extension](https://github.com/WebAssembly/js-promise-integration/blob/main/proposals/js-promise-integration/Overview.md).
 
+## Installation and usage
 
-## Installation
-
-The following commands will perform a minimal installation:
-```
-git clone https://github.com/ocsigen/js_of_ocaml
-cd js_of_ocaml
-opam pin add -n --with-version 6.0.0 .
-opam install dune.3.17.0 wasm_of_ocaml-compiler
-```
-You may want to install additional packages. For instance:
-
-```
-opam install js_of_ocaml js_of_ocaml-ppx js_of_ocaml-lwt
-```
+Installation and usage documentation can be found in [the js_of_ocaml manual](https://ocsigen.org/js_of_ocaml/dev/manual/wasm_overview).
 
 ## Running the test suite
 
@@ -47,34 +35,6 @@ opam pin add -y -n --with-version 6.0.0 .
 opam install . --deps-only --with-test
 WASM_OF_OCAML=true dune build @runtest-wasm
 ```
-
-## Usage
-
-You can try compiling the program in `examples/cubes`. Your program must first be compiled using the OCaml bytecode compiler `ocamlc`. JavaScript bindings are provided by the `js_of_ocaml` package. The syntax extension is provided by `js_of_ocaml-ppx` package. Package `js_of_ocaml-lwt` provides Javascript specific Lwt functions.
-
-```
-ocamlfind ocamlc -package js_of_ocaml,js_of_ocaml-ppx,js_of_ocaml-lwt -linkpkg -o cubes.byte cubes.mli cubes.ml
-```
-
-Then, run the `wasm_of_ocaml` compiler to produce WebAssembly code:
-
-```
-wasm_of_ocaml cubes.byte -o cubes.bc.js
-```
-
-This outputs a file `cubes.bc.js` which loads the WebAssembly code from file `cube.bc.wasm`. For debugging, we currently also output the generated WebAssembly code in text file to `cube.wat`. Since Chrome does not allow loading from the filesystem, you need to serve the files using some Web server. For instance:
-```
-python3 -m http.server 8000 --directory .
-```
-
-As a larger example, you can try [CAMLBOY](https://github.com/linoscope/CAMLBOY). You need to install a forked version of [Brr](https://github.com/ocaml-wasm/brr/tree/wasm). Once the Js_of_ocaml UI is compiled (with `dune build --profile release`), you can generate WebAssembly code instead with the following command:
-```
-wasm_of_ocaml _build/default/bin/web/index.bc-for-jsoo
-```
-
-## Implementation status
-
-A large part of the runtime is [implemented](https://github.com/ocaml-wasm/wasm_of_ocaml/issues/5). File-related functions and dynamic linking are not supported yet.
 
 ## Compatibility with Js_of_ocaml
 

--- a/manual/menu.wiki
+++ b/manual/menu.wiki
@@ -9,8 +9,7 @@
 
 =Wasm_of_ocaml - Reference Manual
 ==[[wasm_overview|Overview]]
-==[[wasm_runtime|Binding a JS library]]
-==<<a_api subproject="js_of_ocaml" text="API"|index>>
+==[[wasm_runtime|Writing Wasm primitives]]
 
 =Js_of_ocaml_lwt - Reference Manual
 ==[[lwt|Lwt support]]

--- a/manual/wasm_overview.wiki
+++ b/manual/wasm_overview.wiki
@@ -48,7 +48,7 @@ Compared to Js_of_ocaml, dynlink is not supported, and it is not possible to bui
 
 OCaml 5.x code using effect handlers can be compiled in two different ways:
 one can enable the CPS transformation from {{{js_of_ocaml}}} by passing the
-{{{--effects=cps}}}{ flag. Without the flag {{{wasm_of_ocaml}}} will instead default to
+{{{--effects=cps}}} flag. Without the flag {{{wasm_of_ocaml}}} will instead default to
 {{{--effects=jspi}}} and emit code utilizing
  [[https://github.com/WebAssembly/js-promise-integration/blob/main/proposals/js-promise-integration/Overview.md|the JavaScript-Promise Integration extension]].
 The CPS transformation is not the default since the generated code is slower, larger and less readable. On the other hand, the JSPI extension is not yet enabled by default in Web browsers, and performing effects is slower when using this extension.

--- a/manual/wasm_overview.wiki
+++ b/manual/wasm_overview.wiki
@@ -14,19 +14,17 @@ The easiest way to install wasm_of_ocaml is to use opam.
 
 == Usage ==
 
-  Your program must first be compiled using the OCaml bytecode
-  compiler {{{ocamlc}}}.  JavaScript bindings are provided by the
-  {{{js_of_ocaml}}} package and the syntax extension by the
-  {{{js_of_ocaml-ppx}}} package
+Your program must first be compiled using the OCaml bytecode compiler
+{{{ocamlc}}}.  JavaScript bindings are provided by the {{{js_of_ocaml}}}
+package and the syntax extension by the {{{js_of_ocaml-ppx}}} package.
 {{{
       ocamlfind ocamlc -package js_of_ocaml -package js_of_ocaml-ppx \
           -linkpkg -o cubes.byte cubes.ml
 }}}
-  Then, run the {{{wasm_of_ocaml}}} compiler to produce Wasm code:
+Then, run the {{{wasm_of_ocaml}}} compiler to produce Wasm code:
 {{{
       wasm_of_ocaml cubes.byte
 }}}
-
 This produces a Javascript loading script {{{cube.js}} and a directory
 {{{cube.assets}} containing the Wasm code.
 
@@ -54,3 +52,7 @@ one can enable the CPS transformation from {{{js_of_ocaml}}} by passing the
 {{{--effects=jspi}}} and emit code utilizing
  [[https://github.com/WebAssembly/js-promise-integration/blob/main/proposals/js-promise-integration/Overview.md|the JavaScript-Promise Integration extension]].
 The CPS transformation is not the default since the generated code is slower, larger and less readable. On the other hand, the JSPI extension is not yet enabled by default in Web browsers, and performing effects is slower when using this extension.
+
+== Binding with Javascript libraries ==
+
+Js_of_ocaml lets the user bind their code with Javascript libraries by linking in {{{.js}}} files. Similarly, wasm_of_ocaml allows to link in Wasm modules ({{{.wasm}}} or {{{.wat}}} files): see [[wasm_runtime|Writing Wasm primitives]]. If a js_of_ocaml projects uses some {{{external}}} primitives defined in companion {{{.js}}} files, it will need the same primitives to be implemented in Wasm module in order to be build with wasm_of_ocaml.


### PR DESCRIPTION
This proposes to update wasm_of_ocaml documentation in several ways:

- Usage and installation instructions are removed from `README_wasm_of_ocaml.md` and a pointer to the relevant manual page is added instead. Several of these instructions were out of date. Similarly, the “Implementation status” section is removed in favor of the clearer “Supported features” section in the linked manual page.
- In the menu, the link “Binding JS libraries” is renamed to “Writing Wasm primitives”, which is the actual title of the page, and seems clearer to me. Also, a duplicate link is removed.
- In the manual, some superfluous indentations are removed (unless I’m missing something about the wikidoc format) and a subsection is added with a few explanations about primitives, and a link to the relevant page.