### PR TITLE
Compiler: disconnect closure cont from closure location. 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,7 @@
 * Lib: make the Wasm version of Json.output work with native ints and JavaScript objects (#1872)
 * Compiler: static evaluation of more primitives (#1912)
 * Compiler: faster compilation by stopping sooner when optimizations become unproductive (#1939)
+* Compiler: improve debug/sourcemap location of closures (#1947)
 * Runtime: use Dataview to convert between floats and bit representation
 
 ## Bug fixes

--- a/compiler/bin-js_of_ocaml/build_fs.ml
+++ b/compiler/bin-js_of_ocaml/build_fs.ml
@@ -82,7 +82,6 @@ function jsoo_create_file_extern(name,content){
           ~link:`Needed
           ~formatter:pfs_fmt
           ~source_map:false
-          (Parse_bytecode.Debug.create ~include_cmis:false false)
           code
       in
       ())

--- a/compiler/bin-js_of_ocaml/compile.ml
+++ b/compiler/bin-js_of_ocaml/compile.ml
@@ -277,7 +277,6 @@ let run
             ~wrap_with_fun
             ~source_map:(source_map_enabled source_map)
             ~formatter
-            one.debug
             code
       | `File, formatter ->
           let fs_instr1, fs_instr2 =
@@ -301,7 +300,6 @@ let run
               ~wrap_with_fun
               ~source_map:(source_map_enabled source_map)
               ~formatter
-              one.debug
               code
           in
           Option.iter fs_output ~f:(fun file ->
@@ -309,14 +307,7 @@ let run
                   let instr = fs_instr2 in
                   let code = Code.prepend Code.empty instr in
                   let pfs_fmt = Pretty_print.to_out_channel chan in
-                  Driver.f'
-                    ~standalone
-                    ~link:`Needed
-                    ?profile
-                    ~wrap_with_fun
-                    pfs_fmt
-                    one.debug
-                    code));
+                  Driver.f' ~standalone ~link:`Needed ?profile ~wrap_with_fun pfs_fmt code));
           res
     in
     if times () then Format.eprintf "compilation: %a@." Timer.print t;

--- a/compiler/bin-wasm_of_ocaml/compile.ml
+++ b/compiler/bin-wasm_of_ocaml/compile.ml
@@ -240,7 +240,6 @@ let generate_prelude ~out_file =
     Driver.optimize ~profile code
   in
   let context = Generate.start () in
-  let debug = Parse_bytecode.Debug.create ~include_cmis:false false in
   let _ =
     Generate.f
       ~context
@@ -248,7 +247,6 @@ let generate_prelude ~out_file =
       ~live_vars:variable_uses
       ~in_cps
       ~deadcode_sentinal
-      ~debug
       program
   in
   Generate.output ch ~context;
@@ -404,7 +402,6 @@ let run
       Driver.optimize ~profile code
     in
     let context = Generate.start () in
-    let debug = one.debug in
     let toplevel_name, generated_js =
       Generate.f
         ~context
@@ -412,7 +409,6 @@ let run
         ~live_vars:variable_uses
         ~in_cps
         ~deadcode_sentinal
-        ~debug
         program
     in
     if standalone then Generate.add_start_function ~context toplevel_name;

--- a/compiler/lib-wasm/generate.mli
+++ b/compiler/lib-wasm/generate.mli
@@ -27,7 +27,6 @@ val f :
   -> live_vars:int array
   -> in_cps:Effects.in_cps
   -> deadcode_sentinal:Code.Var.t
-  -> debug:Parse_bytecode.Debug.t
   -> Wasm_ast.var * (string list * (string * Javascript.expression) list)
 
 val add_start_function : context:Code_generation.context -> Wasm_ast.var -> unit

--- a/compiler/lib/code.mli
+++ b/compiler/lib/code.mli
@@ -204,7 +204,7 @@ type expr =
       }
   | Block of int * Var.t array * array_or_not * mutability
   | Field of Var.t * int * field_type
-  | Closure of Var.t list * cont
+  | Closure of Var.t list * cont * Parse_info.t option
   | Constant of constant
   | Prim of prim * prim_arg list
   | Special of special
@@ -266,24 +266,34 @@ type 'c fold_blocs = block Addr.Map.t -> Addr.t -> (Addr.t -> 'c -> 'c) -> 'c ->
 type fold_blocs_poly = { fold : 'a. 'a fold_blocs } [@@unboxed]
 
 val fold_closures :
-  program -> (Var.t option -> Var.t list -> cont -> 'd -> 'd) -> 'd -> 'd
+     program
+  -> (Var.t option -> Var.t list -> cont -> Parse_info.t option -> 'd -> 'd)
+  -> 'd
+  -> 'd
 (** [fold_closures p f init] folds [f] over all closures in the program [p],
     starting from the initial value [init]. For each closure, [f] is called
     with the following arguments: the closure name (enclosed in
     {!Stdlib.Some}), its parameter list, the address and parameter instantiation
-    of its first block, and the current accumulator. In addition, [f] is called
-    on the initial block [p.start], with [None] as the closure name.
-    All closures in all blocks of [p] are included in the fold, not only the
-    ones reachable from [p.start]. *)
+    of its first block, the optional closure location and the current accumulator.
+    In addition, [f] is called on the initial block [p.start], with
+    [None] as the closure name.  All closures in all blocks of [p] are
+    included in the fold, not only the ones reachable from
+    [p.start]. *)
 
 val fold_closures_innermost_first :
-  program -> (Var.t option -> Var.t list -> cont -> 'd -> 'd) -> 'd -> 'd
+     program
+  -> (Var.t option -> Var.t list -> cont -> Parse_info.t option -> 'd -> 'd)
+  -> 'd
+  -> 'd
 (** Similar to {!fold_closures}, but applies the fold function to the
     innermost closures first. Unlike with {!fold_closures}, only the closures
     reachable from [p.start] are considered. *)
 
 val fold_closures_outermost_first :
-  program -> (Var.t option -> Var.t list -> cont -> 'd -> 'd) -> 'd -> 'd
+     program
+  -> (Var.t option -> Var.t list -> cont -> Parse_info.t option -> 'd -> 'd)
+  -> 'd
+  -> 'd
 (** Similar to {!fold_closures}, but applies the fold function to the
     outermost closures first. Unlike with {!fold_closures}, only the closures
     reachable from [p.start] are considered. *)

--- a/compiler/lib/deadcode.ml
+++ b/compiler/lib/deadcode.ml
@@ -72,7 +72,7 @@ and mark_expr st e =
       List.iter args ~f:(fun x -> mark_var st x)
   | Block (_, a, _, _) -> Array.iter a ~f:(fun x -> mark_var st x)
   | Field (x, _, _) -> mark_var st x
-  | Closure (_, (pc, _)) -> mark_reachable st pc
+  | Closure (_, (pc, _), _) -> mark_reachable st pc
   | Special _ -> ()
   | Prim (_, l) ->
       List.iter l ~f:(fun x ->
@@ -140,7 +140,8 @@ let filter_cont blocks st (pc, args) =
 
 let filter_closure blocks st i =
   match i with
-  | Let (x, Closure (l, cont)) -> Let (x, Closure (l, filter_cont blocks st cont))
+  | Let (x, Closure (l, cont, gloc)) ->
+      Let (x, Closure (l, filter_cont blocks st cont, gloc))
   | _ -> i
 
 let filter_live_last blocks st l =

--- a/compiler/lib/driver.ml
+++ b/compiler/lib/driver.ml
@@ -205,7 +205,6 @@ let round2 = flow +> specialize' +> eval +> deadcode +> o1
 let o3 = loop 10 "tailcall+inline" round1 1 +> loop 10 "flow" round2 1 +> print
 
 let generate
-    d
     ~exported_runtime
     ~wrap_with_fun
     ~warn_on_unhandled_effect
@@ -221,7 +220,6 @@ let generate
     ~should_export
     ~warn_on_unhandled_effect
     ~deadcode_sentinal
-    d
 
 let debug_linker = Debug.find "linker"
 
@@ -716,11 +714,11 @@ let optimize ~profile p =
   let () = if times () then Format.eprintf " optimizations : %a@." Timer.print t in
   { program; variable_uses; trampolined_calls; in_cps; deadcode_sentinal }
 
-let full ~standalone ~wrap_with_fun ~profile ~link ~source_map ~formatter d p =
+let full ~standalone ~wrap_with_fun ~profile ~link ~source_map ~formatter p =
   let optimized_code = optimize ~profile p in
   let exported_runtime = not standalone in
   let emit formatter =
-    generate d ~exported_runtime ~wrap_with_fun ~warn_on_unhandled_effect:standalone
+    generate ~exported_runtime ~wrap_with_fun ~warn_on_unhandled_effect:standalone
     +> link_and_pack ~standalone ~wrap_with_fun ~link
     +> simplify_js
     +> name_variables
@@ -728,9 +726,9 @@ let full ~standalone ~wrap_with_fun ~profile ~link ~source_map ~formatter d p =
   in
   emit formatter optimized_code
 
-let full_no_source_map ~formatter ~standalone ~wrap_with_fun ~profile ~link d p =
+let full_no_source_map ~formatter ~standalone ~wrap_with_fun ~profile ~link p =
   let (_ : Source_map.info) =
-    full ~standalone ~wrap_with_fun ~profile ~link ~source_map:false ~formatter d p
+    full ~standalone ~wrap_with_fun ~profile ~link ~source_map:false ~formatter p
   in
   ()
 
@@ -741,22 +739,20 @@ let f
     ~link
     ~source_map
     ~formatter
-    d
     p =
-  full ~standalone ~wrap_with_fun ~profile ~link ~source_map ~formatter d p
+  full ~standalone ~wrap_with_fun ~profile ~link ~source_map ~formatter p
 
-let f' ?(standalone = true) ?(wrap_with_fun = `Iife) ?(profile = O1) ~link formatter d p =
-  full_no_source_map ~formatter ~standalone ~wrap_with_fun ~profile ~link d p
+let f' ?(standalone = true) ?(wrap_with_fun = `Iife) ?(profile = O1) ~link formatter p =
+  full_no_source_map ~formatter ~standalone ~wrap_with_fun ~profile ~link p
 
 let from_string ~prims ~debug s formatter =
-  let p, d = Parse_bytecode.from_string ~prims ~debug s in
+  let p = Parse_bytecode.from_string ~prims ~debug s in
   full_no_source_map
     ~formatter
     ~standalone:false
     ~wrap_with_fun:`Anonymous
     ~profile:O1
     ~link:`No
-    d
     p
 
 let profiles = [ 1, O1; 2, O2; 3, O3 ]

--- a/compiler/lib/driver.mli
+++ b/compiler/lib/driver.mli
@@ -39,7 +39,6 @@ val f :
   -> link:[ `All | `All_from of string list | `Needed | `No ]
   -> source_map:bool
   -> formatter:Pretty_print.t
-  -> Parse_bytecode.Debug.t
   -> Code.program
   -> Source_map.info
 
@@ -49,7 +48,6 @@ val f' :
   -> ?profile:profile
   -> link:[ `All | `All_from of string list | `Needed | `No ]
   -> Pretty_print.t
-  -> Parse_bytecode.Debug.t
   -> Code.program
   -> unit
 

--- a/compiler/lib/flow.ml
+++ b/compiler/lib/flow.ml
@@ -103,7 +103,7 @@ let cont_deps blocks vars deps defs (pc, args) =
 let expr_deps blocks vars deps defs x e =
   match e with
   | Constant _ | Apply _ | Prim _ | Special _ -> ()
-  | Closure (l, cont) ->
+  | Closure (l, cont, _) ->
       List.iter l ~f:(fun x -> add_param_def vars defs x);
       cont_deps blocks vars deps defs cont
   | Block (_, a, _, _) -> Array.iter a ~f:(fun y -> add_dep deps x y)

--- a/compiler/lib/generate.mli
+++ b/compiler/lib/generate.mli
@@ -27,7 +27,6 @@ val f :
   -> should_export:bool
   -> warn_on_unhandled_effect:bool
   -> deadcode_sentinal:Code.Var.t
-  -> Parse_bytecode.Debug.t
   -> Javascript.program
 
 val init : unit -> unit

--- a/compiler/lib/generate_closure.ml
+++ b/compiler/lib/generate_closure.ml
@@ -156,7 +156,7 @@ module Trampoline = struct
     in
     block
 
-  let wrapper_closure pc args = Closure (args, (pc, []), None)
+  let wrapper_closure pc args cloc = Closure (args, (pc, []), cloc)
 
   let f free_pc blocks closures_map component =
     match component with
@@ -199,7 +199,9 @@ module Trampoline = struct
                 wrapper_block new_f ~args:new_args ~counter:new_counter start_loc
               in
               let blocks = Addr.Map.add wrapper_pc wrapper_block blocks in
-              let instr_wrapper = Let (ci.f_name, wrapper_closure wrapper_pc new_args) in
+              let instr_wrapper =
+                Let (ci.f_name, wrapper_closure wrapper_pc new_args ci.cloc)
+              in
               let instr_real =
                 match counter with
                 | None -> Let (new_f, Closure (ci.args, ci.cont, ci.cloc))

--- a/compiler/lib/lambda_lifting.ml
+++ b/compiler/lib/lambda_lifting.ml
@@ -159,7 +159,7 @@ let rec traverse var_depth (program, functions) pc depth limit =
         in
         let rec rewrite_body first st l =
           match l with
-          | (Let (f, (Closure (_, (pc', _), cloc) as cl)) as i) :: rem
+          | (Let (f, (Closure (_, (pc', _), _) as cl)) as i) :: rem
             when first && does_not_start_with_closure rem ->
               let threshold = Config.Param.lambda_lifting_threshold () in
               let program, functions =
@@ -197,7 +197,7 @@ let rec traverse var_depth (program, functions) pc depth limit =
                   }
                 in
                 let functions =
-                  Let (f'', Closure (List.map s ~f:snd, (pc'', []), cloc)) :: functions
+                  Let (f'', Closure (List.map s ~f:snd, (pc'', []), None)) :: functions
                 in
                 let rem', st = rewrite_body false (program, functions) rem in
                 ( Let (f, Apply { f = f''; args = List.map ~f:fst s; exact = true })

--- a/compiler/lib/lambda_lifting.ml
+++ b/compiler/lib/lambda_lifting.ml
@@ -76,7 +76,7 @@ let rec compute_depth program pc =
       let block = Code.Addr.Map.find pc program.blocks in
       List.fold_left block.body ~init:d ~f:(fun d i ->
           match i with
-          | Let (_, Closure (_, (pc', _))) ->
+          | Let (_, Closure (_, (pc', _), _)) ->
               let d' = compute_depth program pc' in
               max d (d' + 1)
           | _ -> d))
@@ -103,7 +103,7 @@ let collect_free_vars program var_depth depth pc =
           block;
         List.iter block.body ~f:(fun i ->
             match i with
-            | Let (_, Closure (_, (pc', _))) -> traverse pc'
+            | Let (_, Closure (_, (pc', _), _)) -> traverse pc'
             | _ -> ()))
       pc
       program.blocks
@@ -116,7 +116,7 @@ let mark_bound_variables var_depth block depth =
   Freevars.iter_block_bound_vars (fun x -> var_depth.(Var.idx x) <- depth) block;
   List.iter block.body ~f:(fun i ->
       match i with
-      | Let (_, Closure (params, _)) ->
+      | Let (_, Closure (params, _, _)) ->
           List.iter params ~f:(fun x -> var_depth.(Var.idx x) <- depth + 1)
       | _ -> ())
 
@@ -133,7 +133,7 @@ let rec traverse var_depth (program, functions) pc depth limit =
         let program, body =
           List.fold_right block.body ~init:(program, []) ~f:(fun i (program, rem) ->
               match i with
-              | Let (_, Closure (_, (pc', _))) as i ->
+              | Let (_, Closure (_, (pc', _), _)) as i ->
                   let program, functions =
                     traverse var_depth (program, []) pc' (depth + 1) limit
                   in
@@ -145,7 +145,7 @@ let rec traverse var_depth (program, functions) pc depth limit =
       then
         List.fold_left block.body ~init:(program, functions) ~f:(fun st i ->
             match i with
-            | Let (_, Closure (_, (pc', _))) ->
+            | Let (_, Closure (_, (pc', _), _)) ->
                 traverse var_depth st pc' (depth + 1) limit
             | _ -> st)
       else
@@ -159,7 +159,7 @@ let rec traverse var_depth (program, functions) pc depth limit =
         in
         let rec rewrite_body first st l =
           match l with
-          | (Let (f, (Closure (_, (pc', _)) as cl)) as i) :: rem
+          | (Let (f, (Closure (_, (pc', _), cloc) as cl)) as i) :: rem
             when first && does_not_start_with_closure rem ->
               let threshold = Config.Param.lambda_lifting_threshold () in
               let program, functions =
@@ -197,7 +197,7 @@ let rec traverse var_depth (program, functions) pc depth limit =
                   }
                 in
                 let functions =
-                  Let (f'', Closure (List.map s ~f:snd, (pc'', []))) :: functions
+                  Let (f'', Closure (List.map s ~f:snd, (pc'', []), cloc)) :: functions
                 in
                 let rem', st = rewrite_body false (program, functions) rem in
                 ( Let (f, Apply { f = f''; args = List.map ~f:fst s; exact = true })
@@ -206,7 +206,7 @@ let rec traverse var_depth (program, functions) pc depth limit =
               else
                 let rem', st = rewrite_body false (program, functions) rem in
                 i :: rem', st
-          | (Let (_, Closure (_, (pc', _))) as i) :: rem ->
+          | (Let (_, Closure (_, (pc', _), _)) as i) :: rem ->
               let st = traverse var_depth st pc' (depth + 1) limit in
               let rem', st = rewrite_body false st rem in
               i :: rem', st

--- a/compiler/lib/lambda_lifting_simple.ml
+++ b/compiler/lib/lambda_lifting_simple.ml
@@ -122,7 +122,7 @@ and rewrite_body
   (* We lift possibly mutually recursive closures (that are created by contiguous
      statements) together. Isolated closures are lambda-lifted normally. *)
   match body with
-  | Let (f, (Closure (_, (pc', _), cloc) as cl)) :: rem
+  | Let (f, (Closure (_, (pc', _), _) as cl)) :: rem
     when List.is_empty current_contiguous
          && (inside_lifted || Var.Set.mem f to_lift)
          && not (starts_with_closure rem) ->
@@ -166,7 +166,7 @@ and rewrite_body
       in
       (* Add to returned list of lifter functions definitions *)
       let functions =
-        Let (f'', Closure (List.map s ~f:snd, (pc'', []), cloc)) :: functions
+        Let (f'', Closure (List.map s ~f:snd, (pc'', []), None)) :: functions
       in
       let lifters = Var.Map.add f f' lifters in
       rewrite_body

--- a/compiler/lib/link_js.ml
+++ b/compiler/lib/link_js.ml
@@ -419,13 +419,7 @@ let link ~output ~linkall ~mklib ~toplevel ~files ~resolve_sourcemap_url ~source
           let b = Buffer.create 100 in
           let fmt = Pretty_print.to_buffer b in
           Driver.configure fmt;
-          Driver.f'
-            ~standalone:false
-            ~link:`No
-            ~wrap_with_fun:`Iife
-            fmt
-            (Parse_bytecode.Debug.create ~include_cmis:false false)
-            code;
+          Driver.f' ~standalone:false ~link:`No ~wrap_with_fun:`Iife fmt code;
           let content = Buffer.contents b in
           Line_writer.write_lines oc content;
           Line_writer.write oc "");

--- a/compiler/lib/parse_bytecode.ml
+++ b/compiler/lib/parse_bytecode.ml
@@ -1212,7 +1212,13 @@ and compile infos pc state (instrs : instr list) =
           infos
           (pc + 3)
           state
-          (Let (x, Closure (List.rev params, (addr, args))) :: instrs)
+          (Let
+             ( x
+             , Closure
+                 ( List.rev params
+                 , (addr, args)
+                 , Debug.find_loc infos.debug ~position:After addr ) )
+          :: instrs)
     | CLOSUREREC ->
         let nfuncs = getu code (pc + 1) in
         let nvars = getu code (pc + 2) in
@@ -1263,7 +1269,13 @@ and compile infos pc state (instrs : instr list) =
               let args = State.stack_vars state' in
               let state'', _, _ = Addr.Map.find addr !compiled_blocks in
               Debug.propagate (State.stack_vars state'') args;
-              Let (x, Closure (List.rev params, (addr, args))) :: instr)
+              Let
+                ( x
+                , Closure
+                    ( List.rev params
+                    , (addr, args)
+                    , Debug.find_loc infos.debug ~position:After addr ) )
+              :: instr)
         in
         compile infos (pc + 3 + nfuncs) (State.acc (nfuncs - 1) state) instrs
     | OFFSETCLOSUREM3 ->
@@ -2773,7 +2785,7 @@ let from_bytes ~prims ~debug (code : bytecode) =
     then Let (gdata, Prim (Extern "caml_get_global_data", [])) :: body
     else body
   in
-  prepend p body, debug_data
+  prepend p body
 
 let from_string ~prims ~debug (code : string) = from_bytes ~prims ~debug code
 

--- a/compiler/lib/parse_bytecode.mli
+++ b/compiler/lib/parse_bytecode.mli
@@ -23,13 +23,7 @@ open Stdlib
 module Debug : sig
   type t
 
-  type position =
-    | Before
-    | After
-
   val create : include_cmis:bool -> bool -> t
-
-  val find_loc : t -> position:position -> Code.Addr.t -> Parse_info.t option
 
   val is_empty : t -> bool
 
@@ -81,10 +75,7 @@ val from_channel :
   -> [ `Cmo of Cmo_format.compilation_unit | `Cma of Cmo_format.library | `Exe ]
 
 val from_string :
-     prims:string array
-  -> debug:Instruct.debug_event list array
-  -> string
-  -> Code.program * Debug.t
+  prims:string array -> debug:Instruct.debug_event list array -> string -> Code.program
 
 val predefined_exceptions : unit -> Code.program * Unit_info.t
 

--- a/compiler/lib/partial_cps_analysis.ml
+++ b/compiler/lib/partial_cps_analysis.ml
@@ -109,7 +109,7 @@ let block_deps ~info ~vars ~tail_deps ~deps ~blocks ~fun_name pc =
 let program_deps ~info ~vars ~tail_deps ~deps p =
   fold_closures
     p
-    (fun fun_name _ (pc, _) _ ->
+    (fun fun_name _ (pc, _) _ () ->
       traverse
         { fold = Code.fold_children }
         (fun pc () ->

--- a/compiler/lib/phisimpl.ml
+++ b/compiler/lib/phisimpl.ml
@@ -52,7 +52,7 @@ let cont_deps blocks vars deps defs (pc, args) =
 let expr_deps blocks vars deps defs x e =
   match e with
   | Constant _ | Apply _ | Prim _ | Special _ -> ()
-  | Closure (_, cont) -> cont_deps blocks vars deps defs cont
+  | Closure (_, cont, _) -> cont_deps blocks vars deps defs cont
   | Block (_, a, _, _) -> Array.iter a ~f:(fun y -> add_dep deps x y)
   | Field (y, _, _) -> add_dep deps x y
 

--- a/compiler/lib/pure_fun.ml
+++ b/compiler/lib/pure_fun.ml
@@ -66,7 +66,7 @@ and block blocks pc pure visited funs =
   List.fold_left b.body ~init:(pure, visited, funs) ~f:(fun (pure, visited, funs) i ->
       let visited, funs =
         match i with
-        | Let (x, Closure (_, (pc, _))) ->
+        | Let (x, Closure (_, (pc, _), _)) ->
             let pure, visited, funs = traverse blocks pc visited funs in
             visited, if pure then Var.Set.add x funs else funs
         | _ -> visited, funs

--- a/compiler/lib/specialize.ml
+++ b/compiler/lib/specialize.ml
@@ -27,7 +27,7 @@ let function_arity info x =
       info
       (fun x ->
         match Flow.Info.def info x with
-        | Some (Closure (l, _)) -> Some (List.length l)
+        | Some (Closure (l, _, _)) -> Some (List.length l)
         | Some (Special (Alias_prim prim)) -> (
             try Some (Primitive.arity prim) with Not_found -> None)
         | Some (Apply { f; args; _ }) -> (
@@ -85,7 +85,7 @@ let specialize_instr function_arity ((acc, free_pc, extra), loc) i =
             ; branch = Return return'
             }
           in
-          ( Let (x, Closure (missing, (free_pc, missing))) :: acc
+          ( Let (x, Closure (missing, (free_pc, missing), None)) :: acc
           , free_pc + 1
           , (free_pc, block) :: extra )
       | _ -> i :: acc, free_pc, extra)

--- a/compiler/lib/subst.ml
+++ b/compiler/lib/subst.ml
@@ -31,7 +31,7 @@ module Excluding_Binders = struct
         Apply { f = s f; args = List.map args ~f:(fun x -> s x); exact }
     | Block (n, a, k, mut) -> Block (n, Array.map a ~f:(fun x -> s x), k, mut)
     | Field (x, n, typ) -> Field (s x, n, typ)
-    | Closure (l, pc) -> Closure (l, subst_cont s pc)
+    | Closure (l, pc, loc) -> Closure (l, subst_cont s pc, loc)
     | Special _ -> e
     | Prim (p, l) ->
         Prim
@@ -81,7 +81,7 @@ module Excluding_Binders = struct
       let blocks, visited =
         List.fold_left b.body ~init:(blocks, visited) ~f:(fun (blocks, visited) instr ->
             match instr with
-            | Let (_, Closure (_, (pc, _))) -> cont' s pc blocks visited
+            | Let (_, Closure (_, (pc, _), _)) -> cont' s pc blocks visited
             | _ -> blocks, visited)
       in
       Code.fold_children
@@ -118,7 +118,7 @@ module Including_Binders = struct
     | Apply { f; args; exact } -> Apply { f = s f; args = List.map args ~f:s; exact }
     | Block (n, a, k, mut) -> Block (n, Array.map a ~f:s, k, mut)
     | Field (x, n, typ) -> Field (s x, n, typ)
-    | Closure (l, pc) -> Closure (List.map l ~f:s, subst_cont s pc)
+    | Closure (l, pc, loc) -> Closure (List.map l ~f:s, subst_cont s pc, loc)
     | Special _ -> e
     | Prim (p, l) ->
         Prim

--- a/compiler/lib/tailcall.ml
+++ b/compiler/lib/tailcall.ml
@@ -79,7 +79,7 @@ let f p =
   let blocks =
     fold_closures
       p
-      (fun f params (pc, args) blocks ->
+      (fun f params (pc, args) _ blocks ->
         match f with
         | Some f when List.length params = List.length args ->
             let _, blocks = traverse (f, params, pc, args) pc Addr.Set.empty blocks in

--- a/compiler/tests-full/stdlib.cma.expected.js
+++ b/compiler/tests-full/stdlib.cma.expected.js
@@ -17615,7 +17615,7 @@
    function make_printf(k, acc, fmt){
      /*<<camlinternalFormat.ml:1518:17>>*/ return  /*<<?>>*/ caml_trampoline
             ( /*<<camlinternalFormat.ml:1518:17>>*/ make_printf$0
-              (0, k, acc, fmt)) /*<<?>>*/ ;
+              (0, k, acc, fmt)) /*<<camlinternalFormat.ml:1605:9>>*/ ;
    }
    function make_ignored_param$0(counter, k, acc, ign, fmt){
      /*<<camlinternalFormat.ml:1613:21>>*/ if(typeof ign === "number")
@@ -17715,7 +17715,7 @@
    function make_ignored_param(k, acc, ign, fmt){
      /*<<camlinternalFormat.ml:1613:21>>*/ return  /*<<?>>*/ caml_trampoline
             ( /*<<camlinternalFormat.ml:1613:21>>*/ make_ignored_param$0
-              (0, k, acc, ign, fmt)) /*<<?>>*/ ;
+              (0, k, acc, ign, fmt)) /*<<camlinternalFormat.ml:1629:65>>*/ ;
    }
    function make_from_fmtty$0(counter, k, acc, fmtty, fmt){
      /*<<camlinternalFormat.ml:1637:23>>*/ if(typeof fmtty !== "number")
@@ -17810,7 +17810,7 @@
    function make_from_fmtty(k, acc, fmtty, fmt){
      /*<<camlinternalFormat.ml:1637:23>>*/ return  /*<<?>>*/ caml_trampoline
             ( /*<<camlinternalFormat.ml:1637:23>>*/ make_from_fmtty$0
-              (0, k, acc, fmtty, fmt)) /*<<?>>*/ ;
+              (0, k, acc, fmtty, fmt)) /*<<camlinternalFormat.ml:1655:61>>*/ ;
    }
    function make_invalid_arg(counter, k, acc, fmt){
     var
@@ -17997,7 +17997,7 @@
    function make_custom(k, acc, rest, arity, f){
      /*<<camlinternalFormat.ml:1778:28>>*/ return  /*<<?>>*/ caml_trampoline
             ( /*<<camlinternalFormat.ml:1778:28>>*/ make_custom$0
-              (0, k, acc, rest, arity, f)) /*<<?>>*/ ;
+              (0, k, acc, rest, arity, f)) /*<<camlinternalFormat.ml:1782:40>>*/ ;
    }
    function make_iprintf$0(counter, k, o, fmt){
     var k$0 =  /*<<camlinternalFormat.ml:1788:17>>*/ k, fmt$0 = fmt;
@@ -18284,7 +18284,7 @@
    function make_iprintf(k, o, fmt){
      /*<<camlinternalFormat.ml:1788:17>>*/ return  /*<<?>>*/ caml_trampoline
             ( /*<<camlinternalFormat.ml:1788:17>>*/ make_iprintf$0
-              (0, k, o, fmt)) /*<<?>>*/ ;
+              (0, k, o, fmt)) /*<<camlinternalFormat.ml:1858:11>>*/ ;
    }
    function fn_of_padding_precision(k, o, fmt, pad, prec){
      /*<<camlinternalFormat.ml:1863:26>>*/ if(typeof pad === "number"){
@@ -18376,7 +18376,7 @@
    function fn_of_custom_arity(k, o, fmt, param){
      /*<<camlinternalFormat.ml:1882:4>>*/ return  /*<<?>>*/ caml_trampoline
             ( /*<<camlinternalFormat.ml:1882:4>>*/ fn_of_custom_arity$0
-              (0, k, o, fmt, param)) /*<<?>>*/ ;
+              (0, k, o, fmt, param)) /*<<camlinternalFormat.ml:1889:48>>*/ ;
    }
    function output_acc(o, acc){
     var acc$0 =  /*<<camlinternalFormat.ml:1897:27>>*/ acc;
@@ -19949,7 +19949,7 @@
              (str_ind, end_ind, c){
                /*<<camlinternalFormat.ml:2755:6>>*/ return  /*<<?>>*/ caml_trampoline
                       ( /*<<camlinternalFormat.ml:2755:6>>*/ parse_char_set_after_char$0
-                        (0, str_ind, end_ind, c)) /*<<?>>*/ ;
+                        (0, str_ind, end_ind, c)) /*<<camlinternalFormat.ml:2771:58>>*/ ;
              };
            /*<<camlinternalFormat.ml:2793:4>>*/ if(str_ind === end_ind)
             /*<<camlinternalFormat.ml:2092:4>>*/ invalid_format_message
@@ -29797,7 +29797,7 @@
     }
     function find_stop(width){
       /*<<scanf.ml:1063:10>>*/ return  /*<<?>>*/ caml_trampoline
-             ( /*<<scanf.ml:1063:10>>*/ find_stop$0(0, width)) /*<<?>>*/ ;
+             ( /*<<scanf.ml:1063:10>>*/ find_stop$0(0, width)) /*<<scanf.ml:1066:53>>*/ ;
     }
     function skip_spaces(counter, width){
      var width$0 =  /*<<scanf.ml:1080:10>>*/ width;
@@ -30046,7 +30046,7 @@
     /*<<scanf.ml:1198:45>>*/ }
    function take_format_readers(k, fmt){
      /*<<scanf.ml:1161:13>>*/ return  /*<<?>>*/ caml_trampoline
-            ( /*<<scanf.ml:1161:13>>*/ take_format_readers$0(0, k, fmt)) /*<<?>>*/ ;
+            ( /*<<scanf.ml:1161:13>>*/ take_format_readers$0(0, k, fmt)) /*<<scanf.ml:1198:45>>*/ ;
    }
    function take_fmtty_format_readers$0(counter, k, fmtty, fmt){
     var fmtty$0 =  /*<<scanf.ml:1204:19>>*/ fmtty;
@@ -30145,7 +30145,7 @@
    function take_fmtty_format_readers(k, fmtty, fmt){
      /*<<scanf.ml:1204:19>>*/ return  /*<<?>>*/ caml_trampoline
             ( /*<<scanf.ml:1204:19>>*/ take_fmtty_format_readers$0
-              (0, k, fmtty, fmt)) /*<<?>>*/ ;
+              (0, k, fmtty, fmt)) /*<<scanf.ml:1228:58>>*/ ;
    }
    function make_scanf(ib, fmt, readers){
     var fmt$0 =  /*<<scanf.ml:1266:22>>*/ fmt;
@@ -35263,7 +35263,7 @@
      /*<<filename.ml:175:48>>*/ }
     function loop(i){
       /*<<filename.ml:171:6>>*/ return  /*<<?>>*/ caml_trampoline
-             ( /*<<filename.ml:171:6>>*/ loop$0(0, i)) /*<<?>>*/ ;
+             ( /*<<filename.ml:171:6>>*/ loop$0(0, i)) /*<<filename.ml:175:48>>*/ ;
     }
     function loop_bs(counter, n, i){
      var n$0 =  /*<<filename.ml:177:6>>*/ n, i$0 = i;

--- a/toplevel/bin/jsoo_mkcmis.ml
+++ b/toplevel/bin/jsoo_mkcmis.ml
@@ -96,8 +96,4 @@ let () =
   in
   let pfs_fmt = Js_of_ocaml_compiler.Pretty_print.to_out_channel oc in
   Js_of_ocaml_compiler.Config.Flag.enable "pretty";
-  Js_of_ocaml_compiler.Driver.f'
-    pfs_fmt
-    ~link:`Needed
-    (Js_of_ocaml_compiler.Parse_bytecode.Debug.create ~include_cmis:false false)
-    program
+  Js_of_ocaml_compiler.Driver.f' pfs_fmt ~link:`Needed program


### PR DESCRIPTION
This gives us more freedom to do code manipulation without losing debug info / sourcemap.

This refactoring also means that we no longer need debug information after parsing bytecode, which simplifies  code a bit.