### PR TITLE
Compiler: add more debug stats

### DIFF
--- a/compiler/lib/code.mli
+++ b/compiler/lib/code.mli
@@ -317,7 +317,11 @@ val empty : program
 
 val is_empty : program -> bool
 
-val eq : program -> program -> bool
+val equal : program -> program -> bool
+
+val print_diff : program -> program -> unit
+
+val check_updates : name:string -> program -> program -> updates:int -> unit
 
 val invariant : program -> unit
 

--- a/compiler/lib/driver.ml
+++ b/compiler/lib/driver.ml
@@ -151,7 +151,7 @@ let rec loop max name round i (p : 'a) : 'a =
   then (
     if times () then Format.eprintf "%s#%d: couldn't reach fix point.@." name i;
     p')
-  else if Code.eq p' p
+  else if Code.equal p' p
   then (
     if times () then Format.eprintf "%s#%d: fix-point reached.@." name i;
     p')

--- a/compiler/lib/eval.ml
+++ b/compiler/lib/eval.ml
@@ -25,6 +25,8 @@ let times = Debug.find "times"
 
 let stats = Debug.find "stats"
 
+let debug_stats = Debug.find "stats-debug"
+
 let static_env = Hashtbl.create 17
 
 let clear_static_env () = Hashtbl.clear static_env
@@ -763,6 +765,7 @@ let eval update_count update_branch ~target info blocks =
     blocks
 
 let f info p =
+  let previous_p = p in
   let update_count = ref 0 in
   let update_branch = ref 0 in
   let drop_count = ref 0 in
@@ -778,4 +781,11 @@ let f info p =
       !update_count
       !drop_count
       !update_branch;
+  if debug_stats ()
+  then
+    Code.check_updates
+      ~name:"eval"
+      previous_p
+      p
+      ~updates:(!update_count + !drop_count + !update_branch);
   p

--- a/compiler/lib/flow.ml
+++ b/compiler/lib/flow.ml
@@ -494,13 +494,6 @@ let build_subst (info : Info.t) vars =
 
 (****)
 
-let print_stats s =
-  let count = ref 0 in
-  for i = 0 to Array.length s - 1 do
-    if not (Var.equal (Var.of_idx i) s.(i)) then incr count
-  done;
-  Format.eprintf "Stats - flow updates: %d@." !count
-
 let f p =
   Code.invariant p;
   let t = Timer.make () in
@@ -543,6 +536,14 @@ let f p =
   let p = Subst.Excluding_Binders.program (Subst.from_array s) p in
   if times () then Format.eprintf "    flow analysis 5: %a@." Timer.print t5;
   if times () then Format.eprintf "  flow analysis: %a@." Timer.print t;
-  if stats () then print_stats s;
+  let updates =
+    lazy
+      (let count = ref 0 in
+       for i = 0 to Array.length s - 1 do
+         if not (Var.equal (Var.of_idx i) s.(i)) then incr count
+       done;
+       !count)
+  in
+  if stats () then Format.eprintf "Stats - flow updates: %d@." (Lazy.force updates);
   Code.invariant p;
   p, info

--- a/compiler/lib/inline.ml
+++ b/compiler/lib/inline.ml
@@ -306,7 +306,10 @@ let times = Debug.find "times"
 
 let stats = Debug.find "stats"
 
+let debug_stats = Debug.find "stats-debug"
+
 let f p live_vars =
+  let previous_p = p in
   let inline_count = ref 0 in
   Code.invariant p;
   let t = Timer.make () in
@@ -339,5 +342,7 @@ let f p live_vars =
   in
   if times () then Format.eprintf "  inlining: %a@." Timer.print t;
   if stats () then Format.eprintf "Stats - inline: %d optimizations@." !inline_count;
+  if debug_stats ()
+  then Code.check_updates ~name:"inline" previous_p p ~updates:!inline_count;
   Code.invariant p;
   p

--- a/compiler/lib/phisimpl.ml
+++ b/compiler/lib/phisimpl.ml
@@ -150,13 +150,6 @@ let solver1 vars deps defs =
       | Some y -> repr reprs y
       | None -> Var.of_idx idx)
 
-let print_stats s =
-  let count = ref 0 in
-  for i = 0 to Array.length s - 1 do
-    if not (Var.equal (Var.of_idx i) s.(i)) then incr count
-  done;
-  Format.eprintf "Stats - phi updates: %d@." !count
-
 let f p =
   let t = Timer.make () in
   let t' = Timer.make () in
@@ -169,5 +162,13 @@ let f p =
       if Var.idx y = idx then () else Code.Var.propagate_name (Var.of_idx idx) y);
   let p = Subst.Excluding_Binders.program (Subst.from_array subst) p in
   if times () then Format.eprintf "  phi-simpl.: %a@." Timer.print t;
-  if stats () then print_stats subst;
+  let updates =
+    lazy
+      (let count = ref 0 in
+       for i = 0 to Array.length subst - 1 do
+         if not (Var.equal (Var.of_idx i) subst.(i)) then incr count
+       done;
+       !count)
+  in
+  if stats () then Format.eprintf "Stats - phi updates: %d@." (Lazy.force updates);
   p

--- a/compiler/lib/specialize.ml
+++ b/compiler/lib/specialize.ml
@@ -25,6 +25,8 @@ let times = Debug.find "times"
 
 let stats = Debug.find "stats"
 
+let debug_stats = Debug.find "stats-debug"
+
 let function_arity info x =
   let rec arity info x acc =
     get_approx
@@ -124,11 +126,14 @@ let specialize_instrs ~function_arity opt_count p =
   { p with blocks; free_pc }
 
 let f ~function_arity p =
+  let previous_p = p in
   let t = Timer.make () in
   let opt_count = ref 0 in
   let p = specialize_instrs ~function_arity opt_count p in
   if times () then Format.eprintf "  optcall: %a@." Timer.print t;
   if stats () then Format.eprintf "Stats - optcall: %d@." !opt_count;
+  if debug_stats ()
+  then Code.check_updates ~name:"optcall" previous_p p ~updates:!opt_count;
   p
 
 (***)
@@ -163,6 +168,7 @@ let find_outlier_index arr =
           | `Distinguished _ -> `Many_cases))
 
 let switches p =
+  let previous_p = p in
   let t = Timer.make () in
   let opt_count = ref 0 in
   let p =
@@ -237,4 +243,6 @@ let switches p =
   in
   if times () then Format.eprintf "  switches: %a@." Timer.print t;
   if stats () then Format.eprintf "Stats - switches: %d@." !opt_count;
+  if debug_stats ()
+  then Code.check_updates ~name:"switches" previous_p p ~updates:!opt_count;
   p

--- a/compiler/lib/specialize_js.ml
+++ b/compiler/lib/specialize_js.ml
@@ -26,6 +26,8 @@ let times = Debug.find "times"
 
 let stats = Debug.find "stats"
 
+let debug_stats = Debug.find "stats-debug"
+
 let specialize_instr opt_count ~target info i =
   match i, target with
   | Let (x, Prim (Extern "caml_format_int", [ y; z ])), `JavaScript -> (
@@ -394,11 +396,14 @@ let specialize_all_instrs ~target opt_count info p =
 (****)
 
 let f info p =
+  let previous_p = p in
   let t = Timer.make () in
   let opt_count = ref 0 in
   let p = specialize_all_instrs ~target:(Config.target ()) opt_count info p in
   if times () then Format.eprintf "  specialize_js: %a@." Timer.print t;
   if stats () then Format.eprintf "Stats - specialize_js: %d@." !opt_count;
+  if debug_stats ()
+  then Code.check_updates ~name:"specialize_js" previous_p p ~updates:!opt_count;
   p
 
 let f_once_before p =

--- a/compiler/lib/tailcall.ml
+++ b/compiler/lib/tailcall.ml
@@ -25,6 +25,8 @@ let times = Debug.find "times"
 
 let stats = Debug.find "stats"
 
+let debug_stats = Debug.find "stats-debug"
+
 open Code
 
 (* FIX: it should be possible to deal with tail-recursion in exception
@@ -89,6 +91,7 @@ let rec traverse update_count f pc visited blocks =
   else visited, blocks
 
 let f p =
+  let previous_p = p in
   let free_pc = ref p.free_pc in
   let blocks = ref p.blocks in
   let update_count = ref 0 in
@@ -147,4 +150,6 @@ let f p =
   let p = { p with blocks = !blocks; free_pc = !free_pc } in
   if times () then Format.eprintf "  tail calls: %a@." Timer.print t;
   if stats () then Format.eprintf "Stats - tail calls: %d optimizations@." !update_count;
+  if debug_stats ()
+  then Code.check_updates ~name:"tailcall" previous_p p ~updates:!update_count;
   p

--- a/compiler/lib/tailcall.ml
+++ b/compiler/lib/tailcall.ml
@@ -144,6 +144,7 @@ let f p =
       in
       if !rewrite_body then blocks := Addr.Map.add pc { block with body } !blocks)
     p.blocks;
+  let p = { p with blocks = !blocks; free_pc = !free_pc } in
   if times () then Format.eprintf "  tail calls: %a@." Timer.print t;
   if stats () then Format.eprintf "Stats - tail calls: %d optimizations@." !update_count;
-  { p with blocks = !blocks; free_pc = !free_pc }
+  p

--- a/dune-workspace
+++ b/dune-workspace
@@ -6,4 +6,6 @@
    (enabled_if %{env:WASM_OF_OCAML=false})
    (runtest_alias runtest-wasm))
   (js_of_ocaml
+;; enable for debugging
+;; (flags (:standard --debug stats-debug))
    (runtest_alias runtest-js))))


### PR DESCRIPTION
Following https://github.com/ocsigen/js_of_ocaml/pull/1950:
- This PR adds debug stats to other optimization passes.
- It also introduces some debug information for the stats logic themselves. We check that, for a given pass, if we report  0 updates, the program is not modified.


~~We also speedup the specialize pass in https://github.com/ocsigen/js_of_ocaml/commit/fe85720aed23663abdb9975e8c7cbf8869e0b09a~~
