### PR TITLE
Compiler: Merge blocks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@
 * Compiler: faster compilation by stopping sooner when optimizations become unproductive (#1939)
 * Compiler: improve debug/sourcemap location of closures (#1947)
 * Compiler: improve tailcall optimization (#1943)
+* Compiler: improve deadcode optimization (#1963, #1962, #1967)
 * Runtime: use Dataview to convert between floats and bit representation
 * Compiler: speed-up compilation by improving the scheduling of optimization passes (#1962)
 

--- a/compiler/lib/deadcode.ml
+++ b/compiler/lib/deadcode.ml
@@ -227,6 +227,113 @@ let empty_body b =
   | [] | [ Event _ ] -> true
   | _ -> false
 
+let merge_blocks p =
+  let previous_p = p in
+  let t = Timer.make () in
+  let preds = Array.make p.free_pc 0 in
+  let assigned = ref Var.Set.empty in
+  let merged = ref 0 in
+  let subst =
+    let nv = Var.count () in
+    Array.init nv ~f:(fun i -> Var.of_idx i)
+  in
+  let () =
+    let makr_cont (pc', _) = preds.(pc') <- preds.(pc') + 1 in
+    Addr.Map.iter
+      (fun _ { body; branch; _ } ->
+        List.iter body ~f:(function
+          | Let (_, Closure (_, cont, _)) -> makr_cont cont
+          | Assign (x, _) -> assigned := Var.Set.add x !assigned
+          | _ -> ());
+        match branch with
+        | Branch cont -> makr_cont cont
+        | Cond (_, cont1, cont2) ->
+            makr_cont cont1;
+            makr_cont cont2
+        | Switch (_, a1) -> Array.iter ~f:makr_cont a1
+        | Pushtrap (cont1, _, cont2) ->
+            makr_cont cont1;
+            makr_cont cont2
+        | Poptrap cont -> makr_cont cont
+        | Return _ | Raise _ | Stop -> ())
+      p.blocks
+  in
+  let p =
+    let visited = BitSet.create' p.free_pc in
+    let rec process_branch pc blocks =
+      let block = Addr.Map.find pc blocks in
+      match block.branch with
+      | Branch (pc_, args) when preds.(pc_) = 1 ->
+          let to_inline = Addr.Map.find pc_ blocks in
+          if List.exists to_inline.params ~f:(fun x -> Var.Set.mem x !assigned)
+          then block, blocks
+          else (
+            incr merged;
+            List.iter2 args to_inline.params ~f:(fun arg param ->
+                Code.Var.propagate_name param arg;
+                subst.(Code.Var.idx param) <- arg);
+            let to_inline, blocks = process_branch pc_ blocks in
+            let block =
+              { params = block.params
+              ; branch = to_inline.branch
+              ; body =
+                  (let[@tail_mod_cons] rec aux = function
+                     | [ (Event _ as ev) ] -> (
+                         match to_inline.body with
+                         | Event _ :: _ -> to_inline.body
+                         | _ -> ev :: to_inline.body)
+                     | [] -> to_inline.body
+                     | x :: rest -> x :: aux rest
+                   in
+                   aux block.body)
+              }
+            in
+            let blocks = Addr.Map.remove pc_ blocks in
+            let blocks = Addr.Map.add pc block blocks in
+            block, blocks)
+      | _ -> block, blocks
+    in
+    let rec traverse pc blocks =
+      if BitSet.mem visited pc
+      then blocks
+      else
+        let () = BitSet.set visited pc in
+        let block, blocks = process_branch pc blocks in
+        match block.branch with
+        | Return _ | Raise _ | Stop -> blocks
+        | Branch (pc', _) | Poptrap (pc', _) -> traverse pc' blocks
+        | Pushtrap ((pc', _), _, (pc_h, _)) ->
+            let blocks = traverse pc' blocks in
+            let blocks = traverse pc_h blocks in
+            blocks
+        | Cond (_, (pc1, _), (pc2, _)) ->
+            let blocks = traverse pc1 blocks in
+            let blocks = traverse pc2 blocks in
+            blocks
+        | Switch (_, a1) ->
+            Array.fold_right ~init:blocks ~f:(fun (pc, _) blocks -> traverse pc blocks) a1
+    in
+    let blocks =
+      Code.fold_closures p (fun _ _ (pc, _) _ blocks -> traverse pc blocks) p.blocks
+    in
+    { p with blocks }
+  in
+  let p =
+    if !merged = 0
+    then p
+    else
+      let rec rename x =
+        let y = subst.(Code.Var.idx x) in
+        if Code.Var.equal x y then y else rename y
+      in
+      Subst.Excluding_Binders.program rename p
+  in
+  if times () then Format.eprintf "  merge block: %a@." Timer.print t;
+  if stats () then Format.eprintf "Stats - merge block: merged %d@." !merged;
+  if debug_stats ()
+  then Code.check_updates ~name:"merge block" previous_p p ~updates:!merged;
+  p
+
 let remove_empty_blocks st (p : Code.program) : Code.program =
   let shortcuts = Hashtbl.create 16 in
   let rec resolve_rec visited ((pc, args) as cont) =

--- a/compiler/lib/deadcode.ml
+++ b/compiler/lib/deadcode.ml
@@ -269,10 +269,10 @@ let merge_blocks p =
           then block, blocks
           else (
             incr merged;
+            let to_inline, blocks = process_branch pc_ blocks in
             List.iter2 args to_inline.params ~f:(fun arg param ->
                 Code.Var.propagate_name param arg;
                 subst.(Code.Var.idx param) <- arg);
-            let to_inline, blocks = process_branch pc_ blocks in
             let block =
               { params = block.params
               ; branch = to_inline.branch

--- a/compiler/lib/deadcode.mli
+++ b/compiler/lib/deadcode.mli
@@ -24,3 +24,5 @@ type variable_uses =
 val f : Code.program -> Code.program * variable_uses
 
 val remove_unused_blocks : Code.program -> Code.program
+
+val merge_blocks : Code.program -> Code.program

--- a/compiler/lib/driver.ml
+++ b/compiler/lib/driver.ml
@@ -51,8 +51,9 @@ let deadcode' p =
   Deadcode.f p
 
 let deadcode p =
-  let r, _ = deadcode' p in
-  r
+  let p, _ = deadcode' p in
+  let p = Deadcode.merge_blocks p in
+  p
 
 let inline p =
   if Config.Flag.inline () && Config.Flag.deadcode ()

--- a/compiler/tests-compiler/gh1768.ml
+++ b/compiler/tests-compiler/gh1768.ml
@@ -54,8 +54,7 @@ let () =
         dummy = 0,
         global_data = runtime.caml_get_global_data(),
         Assert_failure = global_data.Assert_failure,
-        _a_ = [0, caml_string_of_jsbytes("test.ml"), 4, 27],
-        _b_ = [0, caml_string_of_jsbytes("test.ml"), 8, 2];
+        _a_ = [0, caml_string_of_jsbytes("test.ml"), 4, 27];
        function h(x){x[1] = function(x, y){return x + y | 0;};}
        function f(param){
         return [0,
@@ -66,6 +65,7 @@ let () =
        var x = f();
        function g(param){return caml_call1(x[1], 7);}
        h(x);
+       var _b_ = [0, caml_string_of_jsbytes("test.ml"), 8, 2];
        if(10 !== caml_call1(g(), 3))
         throw caml_maybe_attach_backtrace([0, Assert_failure, _b_], 1);
        var Test = [0];
@@ -73,4 +73,5 @@ let () =
        return;
       }
       (globalThis));
-    //end |}]
+    //end
+    |}]

--- a/compiler/tests-compiler/lambda_lifting.ml
+++ b/compiler/tests-compiler/lambda_lifting.ml
@@ -25,14 +25,15 @@ Printf.printf "%d\n" (f 3)
        var
         runtime = globalThis.jsoo_runtime,
         global_data = runtime.caml_get_global_data(),
-        Stdlib_Printf = global_data.Stdlib__Printf,
-        _e_ =
-          [0, [4, 0, 0, 0, [12, 10, 0]], runtime.caml_string_of_jsbytes("%d\n")];
+        Stdlib_Printf = global_data.Stdlib__Printf;
        function h(x, y){function h(z){return (x + y | 0) + z | 0;} return h;}
        function g(x){function g(y){var h$0 = h(x, y); return h$0(7);} return g;}
        function f(x){var g$0 = g(x); return g$0(5);}
        var _d_ = f(3);
-       runtime.caml_callback(Stdlib_Printf[2], [_e_, _d_]);
+       runtime.caml_callback
+        (Stdlib_Printf[2],
+         [[0, [4, 0, 0, 0, [12, 10, 0]], runtime.caml_string_of_jsbytes("%d\n")],
+          _d_]);
        var Test = [0];
        runtime.caml_register_global(2, Test, "Test");
        return;

--- a/compiler/tests-full/stdlib.cma.expected.js
+++ b/compiler/tests-full/stdlib.cma.expected.js
@@ -12799,20 +12799,20 @@
    function add_buffer(b, bs){
      /*<<buffer.ml:182:2>>*/ return add_subbytes(b, bs[1][1], 0, bs[2]) /*<<buffer.ml:182:46>>*/ ;
    }
-   function add_channel(b, ic, to_read$1){
+   function add_channel(b, ic, len){
     var
-     _o_ =  /*<<buffer.ml:208:2>>*/ to_read$1 < 0 ? 1 : 0,
-     _p_ = _o_ || (Stdlib_Sys[12] < to_read$1 ? 1 : 0);
+     _o_ =  /*<<buffer.ml:208:2>>*/ len < 0 ? 1 : 0,
+     _p_ = _o_ || (Stdlib_Sys[12] < len ? 1 : 0);
     if(_p_)
       /*<<buffer.ml:209:4>>*/ caml_call1(Stdlib[1], cst_Buffer_add_channel);
-     /*<<buffer.ml:202:2>>*/ if(b[1][2] < (b[2] + to_read$1 | 0))
-      /*<<buffer.ml:202:44>>*/ resize(b, to_read$1);
+     /*<<buffer.ml:202:2>>*/ if(b[1][2] < (b[2] + len | 0))
+      /*<<buffer.ml:202:44>>*/ resize(b, len);
     var
      ofs$1 =  /*<<buffer.ml:203:2>>*/ b[2],
      buf = b[1][1],
      already_read =  /*<<buffer.ml:198:5>>*/ 0,
      ofs = ofs$1,
-     to_read = to_read$1;
+     to_read = len;
     for(;;){
       /*<<buffer.ml:187:4>>*/ if(0 !== to_read){
       var
@@ -12831,7 +12831,7 @@
       }
      }
       /*<<buffer.ml:204:2>>*/ b[2] = b[2] + already_read | 0;
-      /*<<buffer.ml:213:2>>*/ if(already_read < to_read$1)
+      /*<<buffer.ml:213:2>>*/ if(already_read < len)
        /*<<buffer.ml:213:18>>*/ throw caml_maybe_attach_backtrace
              (Stdlib[12], 1);
       /*<<buffer.ml:214:2>>*/ return 0;
@@ -13454,15 +13454,12 @@
      /*<<domain.ml:161:26>>*/ if(oldval !== none)
       /*<<domain.ml:75:25>>*/ return oldval;
     var
-     new_obj =  /*<<domain.ml:164:18>>*/ caml_call1(init, 0),
+     v =  /*<<domain.ml:164:18>>*/ caml_call1(init, 0),
      st$0 =  /*<<domain.ml:175:6>>*/ caml_domain_dls_get(0),
      curval =  /*<<domain.ml:152:17>>*/ caml_check_bound(st$0, idx)[1 + idx],
      _d_ =
-        /*<<domain.ml:153:4>>*/ curval === oldval
-        ? (st$0[1 + idx] = new_obj, 1)
-        : 0;
-     /*<<domain.ml:176:49>>*/ if(_d_)
-      /*<<domain.ml:177:11>>*/ return new_obj;
+        /*<<domain.ml:153:4>>*/ curval === oldval ? (st$0[1 + idx] = v, 1) : 0;
+     /*<<domain.ml:176:49>>*/ if(_d_)  /*<<domain.ml:177:11>>*/ return v;
     var
      updated_obj =
         /*<<domain.ml:181:26>>*/ caml_check_bound(st$0, idx)[1 + idx];
@@ -26829,7 +26826,7 @@
      match$0 =  /*<<format.ml:489:41>>*/ match[1],
      queue_elem = match$0[2],
      left_total = match$0[1],
-     size =  /*<<format.ml:492:4>>*/ queue_elem[1];
+     x =  /*<<format.ml:492:4>>*/ queue_elem[1];
      /*<<format.ml:494:4>>*/ if(left_total < state[12])
       /*<<format.ml:495:6>>*/ return initialize_scan_stack(state[1]) /*<<format.ml:510:10>>*/ ;
     var _a6_ =  /*<<format.ml:497:6>>*/ queue_elem[2];
@@ -26837,16 +26834,16 @@
      switch(_a6_[0]){
        case 4:
          /*<<format.ml:504:8>>*/ if(1 - ty){
-         var x$0 =  /*<<format.ml:504:23>>*/ state[13] + size | 0;
-          /*<<format.ml:505:70>>*/ queue_elem[1] = x$0;
+         var x$1 =  /*<<format.ml:504:23>>*/ state[13] + x | 0;
+          /*<<format.ml:505:70>>*/ queue_elem[1] = x$1;
           /*<<format.ml:506:10>>*/ caml_call1(Stdlib_Stack[5], state[1]);
         }
          /*<<format.ml:504:8>>*/ return;
        case 2:
        case 3:
          /*<<format.ml:499:8>>*/ if(ty){
-         var x =  /*<<format.ml:499:19>>*/ state[13] + size | 0;
-          /*<<format.ml:500:70>>*/ queue_elem[1] = x;
+         var x$0 =  /*<<format.ml:499:19>>*/ state[13] + x | 0;
+          /*<<format.ml:500:70>>*/ queue_elem[1] = x$0;
           /*<<format.ml:501:10>>*/ caml_call1(Stdlib_Stack[5], state[1]);
         }
          /*<<format.ml:499:8>>*/ return;
@@ -26864,8 +26861,8 @@
      /*<<format.ml:526:2>>*/ state[14] = state[14] + 1 | 0;
      /*<<format.ml:527:2>>*/ if(state[14] < state[15]){
      var
-      size =  /*<<format.ml:528:4>>*/ - state[13] | 0,
-      elem =  /*<<format.ml:529:4>>*/ [0, size, [4, indent, br_ty], 0];
+      x$0 =  /*<<format.ml:528:4>>*/ - state[13] | 0,
+      elem =  /*<<format.ml:529:4>>*/ [0, x$0, [4, indent, br_ty], 0];
       /*<<format.ml:530:4>>*/ return scan_push(state, 0, elem) /*<<format.ml:532:45>>*/ ;
     }
     var _a5_ =  /*<<format.ml:531:2>>*/ state[14] === state[15] ? 1 : 0;
@@ -27077,13 +27074,13 @@
      _aV_ =  /*<<format.ml:715:2>>*/ state[14] < state[15] ? 1 : 0;
     if(! _aV_) return _aV_;
     var
-     size =  /*<<format.ml:716:4>>*/ - state[13] | 0,
+     x =  /*<<format.ml:716:4>>*/ - state[13] | 0,
      token =  /*<<format.ml:717:4>>*/ [2, fits, breaks],
      length =
         /*<<format.ml:718:4>>*/ (caml_ml_string_length(before) + width | 0)
        + caml_ml_string_length(after)
        | 0,
-     elem =  /*<<format.ml:719:4>>*/ [0, size, token, length];
+     elem =  /*<<format.ml:719:4>>*/ [0, x, token, length];
      /*<<format.ml:720:4>>*/ return scan_push(state, 1, elem) /*<<format.ml:720:29>>*/ ;
    }
    function pp_print_break(state, width, offset){
@@ -27124,8 +27121,8 @@
     var _aQ_ =  /*<<format.ml:762:2>>*/ state[14] < state[15] ? 1 : 0;
     if(! _aQ_) return _aQ_;
     var
-     size =  /*<<format.ml:763:4>>*/ - state[13] | 0,
-     elem =  /*<<format.ml:764:4>>*/ [0, size, [3, width, offset], width];
+     x =  /*<<format.ml:763:4>>*/ - state[13] | 0,
+     elem =  /*<<format.ml:764:4>>*/ [0, x, [3, width, offset], width];
      /*<<format.ml:765:4>>*/ return scan_push(state, 1, elem) /*<<format.ml:765:29>>*/ ;
    }
    function pp_print_tab(state, param){
@@ -29244,7 +29241,16 @@
                (width$1, ib) /*<<scanf.ml:697:49>>*/ ;
       case 4:
         /*<<scanf.ml:696:20>>*/ return scan_decimal_digit_plus(width$1, ib) /*<<scanf.ml:697:49>>*/ ;
-      case 2:
+      case 0:
+        /*<<scanf.ml:634:22>>*/ return scan_digit_plus
+               (cst_binary, is_binary_digit, width$1, ib) /*<<scanf.ml:697:49>>*/ ;
+      case 3:
+        /*<<scanf.ml:641:21>>*/ return scan_digit_plus
+               (cst_octal, is_octal_digit, width$1, ib) /*<<scanf.ml:697:49>>*/ ;
+      case 5:
+        /*<<scanf.ml:648:27>>*/ return scan_digit_plus
+               (cst_hexadecimal, is_hexa_digit, width$1, ib) /*<<scanf.ml:697:49>>*/ ;
+      default:
        var
         width$0 =  /*<<scanf.ml:686:14>>*/ scan_sign(width$1, ib),
         c =  /*<<scanf.ml:671:8>>*/ checked_peek_char(ib);
@@ -29283,15 +29289,6 @@
                  ib) /*<<scanf.ml:697:49>>*/ ;
        }
         /*<<scanf.ml:681:11>>*/ return scan_decimal_digit_star(width, ib) /*<<scanf.ml:697:49>>*/ ;
-      case 0:
-        /*<<scanf.ml:634:22>>*/ return scan_digit_plus
-               (cst_binary, is_binary_digit, width$1, ib) /*<<scanf.ml:697:49>>*/ ;
-      case 3:
-        /*<<scanf.ml:641:21>>*/ return scan_digit_plus
-               (cst_octal, is_octal_digit, width$1, ib) /*<<scanf.ml:697:49>>*/ ;
-      default:
-        /*<<scanf.ml:648:27>>*/ return scan_digit_plus
-               (cst_hexadecimal, is_hexa_digit, width$1, ib) /*<<scanf.ml:697:49>>*/ ;
     }
    }
    function scan_fractional_part(width, ib){
@@ -29688,12 +29685,13 @@
             : c /*<<scanf.ml:998:3>>*/ ;
    }
    function scan_backslash_char(width, ib){
-    var c0 =  /*<<scanf.ml:1001:31>>*/ check_next_char(cst_a_Char, width, ib);
+    var
+     c$1 =  /*<<scanf.ml:1001:31>>*/ check_next_char(cst_a_Char, width, ib);
     a:
     {
-      /*<<scanf.ml:1005:41>>*/ if(40 <= c0){
-      if(58 > c0){
-       if(48 > c0) break a;
+      /*<<scanf.ml:1005:41>>*/ if(40 <= c$1){
+      if(58 > c$1){
+       if(48 > c$1) break a;
        var
         get_digit$0 =
            /*<<scanf.ml:1009:4>>*/ function(param){
@@ -29705,7 +29703,7 @@
         c1$0 =  /*<<scanf.ml:1015:13>>*/ get_digit$0(0),
         c2$0 =  /*<<scanf.ml:1016:13>>*/ get_digit$0(0),
         c =
-           /*<<scanf.ml:956:34>>*/ ((100 * (c0 - 48 | 0) | 0)
+           /*<<scanf.ml:956:34>>*/ ((100 * (c$1 - 48 | 0) | 0)
           + (10 * (c1$0 - 48 | 0) | 0)
           | 0)
           + (c2$0 - 48 | 0)
@@ -29720,11 +29718,11 @@
          _ab_ =
             /*<<scanf.ml:962:60>>*/ bad_input
             ( /*<<scanf.ml:961:6>>*/ caml_call4
-              (Stdlib_Printf[4], _l_, c0, c1$0, c2$0));
+              (Stdlib_Printf[4], _l_, c$1, c1$0, c2$0));
        }
         /*<<scanf.ml:1017:71>>*/ return store_char(width - 2 | 0, ib, _ab_) /*<<scanf.ml:1028:22>>*/ ;
       }
-      var switcher =  /*<<scanf.ml:1005:41>>*/ c0 - 92 | 0;
+      var switcher =  /*<<scanf.ml:1005:41>>*/ c$1 - 92 | 0;
       if(28 < switcher >>> 0) break a;
       switch(switcher){
         case 28:
@@ -29772,33 +29770,31 @@
         default: break a;
       }
      }
-     else if(34 !== c0 && 39 > c0) break a;
-      /*<<scanf.ml:942:25>>*/ if(110 <= c0)
-      if(117 <= c0)
-       var _$_ = c0;
+     else if(34 !== c$1 && 39 > c$1) break a;
+      /*<<scanf.ml:942:25>>*/ if(110 <= c$1)
+      if(117 <= c$1)
+       var _$_ = c$1;
       else
-       switch(c0 - 110 | 0){
+       switch(c$1 - 110 | 0){
          case 0:
           var _$_ =  /*<<scanf.ml:943:11>>*/ 10; break;
          case 4:
           var _$_ =  /*<<scanf.ml:944:11>>*/ 13; break;
          case 6:
           var _$_ =  /*<<scanf.ml:946:11>>*/ 9; break;
-         default: var _$_ =  /*<<scanf.ml:942:25>>*/ c0;
+         default: var _$_ =  /*<<scanf.ml:942:25>>*/ c$1;
        }
      else
-      var _$_ = 98 === c0 ? 8 : c0;
+      var _$_ = 98 === c$1 ? 8 : c$1;
       /*<<scanf.ml:1007:55>>*/ return store_char(width, ib, _$_) /*<<scanf.ml:1028:22>>*/ ;
     }
-     /*<<scanf.ml:1028:4>>*/ return bad_input_escape(c0) /*<<scanf.ml:1028:22>>*/ ;
+     /*<<scanf.ml:1028:4>>*/ return bad_input_escape(c$1) /*<<scanf.ml:1028:22>>*/ ;
    }
    function scan_caml_string(width, ib){
     function find_stop$0(counter, width){
-     var width$0 =  /*<<scanf.ml:1063:10>>*/ width;
+     var width$0 =  /*<<scanf.ml:1002:33>>*/ width;
      for(;;){
-      var
-       c =
-          /*<<scanf.ml:1002:33>>*/ check_next_char(cst_a_String, width$0, ib);
+      var c = check_next_char(cst_a_String, width$0, ib);
        /*<<scanf.ml:1063:45>>*/ if(34 === c)
         /*<<scanf.ml:1064:14>>*/ return ignore_char(width$0, ib) /*<<scanf.ml:1066:53>>*/ ;
        /*<<scanf.ml:1063:45>>*/ if(92 === c){
@@ -29839,14 +29835,13 @@
      }
     }
     function find_stop(width){
-      /*<<scanf.ml:1063:10>>*/ return  /*<<?>>*/ caml_trampoline
-             ( /*<<scanf.ml:1063:10>>*/ find_stop$0(0, width)) /*<<scanf.ml:1066:53>>*/ ;
+      /*<<scanf.ml:1002:33>>*/ return  /*<<?>>*/ caml_trampoline
+             ( /*<<scanf.ml:1002:33>>*/ find_stop$0(0, width)) /*<<scanf.ml:1066:53>>*/ ;
     }
     function skip_spaces(counter, width){
-     var width$0 =  /*<<scanf.ml:1080:10>>*/ width;
+     var width$0 =  /*<<scanf.ml:1002:33>>*/ width;
      for(;;){
-       /*<<scanf.ml:1002:33>>*/ if
-       (32 !== check_next_char(cst_a_String, width$0, ib)){
+      if(32 !== check_next_char(cst_a_String, width$0, ib)){
         /*<<scanf.ml:1082:11>>*/ if(counter >= 50)
         return caml_trampoline_return(find_stop$0, [0, width$0]) /*<<scanf.ml:1082:26>>*/ ;
        var counter$0 =  /*<<scanf.ml:1082:11>>*/ counter + 1 | 0;
@@ -29864,11 +29859,9 @@
    }
    function scan_chars_in_char_set(char_set, scan_indic, width, ib){
     function scan_chars(i$1, stp){
-     var i =  /*<<scanf.ml:1104:4>>*/ i$1;
+     var i =  /*<<scanf.ml:1104:12>>*/ i$1;
      for(;;){
-      var
-       c =  /*<<scanf.ml:1104:12>>*/ peek_char(ib),
-       _U_ =  /*<<scanf.ml:1105:4>>*/ 0 < i ? 1 : 0;
+      var c = peek_char(ib), _U_ =  /*<<scanf.ml:1105:4>>*/ 0 < i ? 1 : 0;
       if(_U_){
        var _V_ =  /*<<scanf.ml:1105:37>>*/ 1 - ib[1];
        if(_V_)

--- a/compiler/tests-full/stdlib.cma.expected.js
+++ b/compiler/tests-full/stdlib.cma.expected.js
@@ -5976,7 +5976,7 @@
     var max =  /*<<bytes.ml:740:2>>*/ caml_ml_bytes_length(b) - 1 | 0, i = 0;
     for(;;){
       /*<<bytes.ml:683:4>>*/ if(max < i)  /*<<bytes.ml:683:20>>*/ return 1;
-     var match =  /*<<bytes.ml:683:4>>*/ caml_bytes_unsafe_get(b, i);
+     var match =  /*<<bytes.ml:685:26>>*/ caml_bytes_unsafe_get(b, i);
      a:
      {
        /*<<bytes.ml:685:35>>*/ if(224 <= match){
@@ -12799,20 +12799,20 @@
    function add_buffer(b, bs){
      /*<<buffer.ml:182:2>>*/ return add_subbytes(b, bs[1][1], 0, bs[2]) /*<<buffer.ml:182:46>>*/ ;
    }
-   function add_channel(b, ic, len){
+   function add_channel(b, ic, to_read$1){
     var
-     _o_ =  /*<<buffer.ml:208:2>>*/ len < 0 ? 1 : 0,
-     _p_ = _o_ || (Stdlib_Sys[12] < len ? 1 : 0);
+     _o_ =  /*<<buffer.ml:208:2>>*/ to_read$1 < 0 ? 1 : 0,
+     _p_ = _o_ || (Stdlib_Sys[12] < to_read$1 ? 1 : 0);
     if(_p_)
       /*<<buffer.ml:209:4>>*/ caml_call1(Stdlib[1], cst_Buffer_add_channel);
-     /*<<buffer.ml:202:2>>*/ if(b[1][2] < (b[2] + len | 0))
-      /*<<buffer.ml:202:44>>*/ resize(b, len);
+     /*<<buffer.ml:202:2>>*/ if(b[1][2] < (b[2] + to_read$1 | 0))
+      /*<<buffer.ml:202:44>>*/ resize(b, to_read$1);
     var
      ofs$1 =  /*<<buffer.ml:203:2>>*/ b[2],
      buf = b[1][1],
      already_read =  /*<<buffer.ml:198:5>>*/ 0,
      ofs = ofs$1,
-     to_read = len;
+     to_read = to_read$1;
     for(;;){
       /*<<buffer.ml:187:4>>*/ if(0 !== to_read){
       var
@@ -12831,7 +12831,7 @@
       }
      }
       /*<<buffer.ml:204:2>>*/ b[2] = b[2] + already_read | 0;
-      /*<<buffer.ml:213:2>>*/ if(already_read < len)
+      /*<<buffer.ml:213:2>>*/ if(already_read < to_read$1)
        /*<<buffer.ml:213:18>>*/ throw caml_maybe_attach_backtrace
              (Stdlib[12], 1);
       /*<<buffer.ml:214:2>>*/ return 0;
@@ -13454,12 +13454,15 @@
      /*<<domain.ml:161:26>>*/ if(oldval !== none)
       /*<<domain.ml:75:25>>*/ return oldval;
     var
-     v =  /*<<domain.ml:164:18>>*/ caml_call1(init, 0),
+     new_obj =  /*<<domain.ml:164:18>>*/ caml_call1(init, 0),
      st$0 =  /*<<domain.ml:175:6>>*/ caml_domain_dls_get(0),
      curval =  /*<<domain.ml:152:17>>*/ caml_check_bound(st$0, idx)[1 + idx],
      _d_ =
-        /*<<domain.ml:153:4>>*/ curval === oldval ? (st$0[1 + idx] = v, 1) : 0;
-     /*<<domain.ml:176:49>>*/ if(_d_)  /*<<domain.ml:177:11>>*/ return v;
+        /*<<domain.ml:153:4>>*/ curval === oldval
+        ? (st$0[1 + idx] = new_obj, 1)
+        : 0;
+     /*<<domain.ml:176:49>>*/ if(_d_)
+      /*<<domain.ml:177:11>>*/ return new_obj;
     var
      updated_obj =
         /*<<domain.ml:181:26>>*/ caml_check_bound(st$0, idx)[1 + idx];
@@ -19913,9 +19916,9 @@
                   return caml_trampoline_return
                           (parse_char_set_content, [0, _aG_, end_ind]) /*<<camlinternalFormat.ml:2771:58>>*/ ;
                  var
-                  counter$2 =
+                  counter$0 =
                      /*<<camlinternalFormat.ml:2763:19>>*/ counter + 1 | 0;
-                 return parse_char_set_content(counter$2, _aG_, end_ind) /*<<camlinternalFormat.ml:2771:58>>*/ ;
+                 return parse_char_set_content(counter$0, _aG_, end_ind) /*<<camlinternalFormat.ml:2771:58>>*/ ;
                 }
                }
                 /*<<camlinternalFormat.ml:2766:8>>*/ if(37 === c)
@@ -19960,9 +19963,9 @@
                 return caml_trampoline_return
                         (parse_char_set_content, [0, _aH_, end_ind]) /*<<camlinternalFormat.ml:2771:58>>*/ ;
                var
-                counter$1 =
+                counter$2 =
                    /*<<camlinternalFormat.ml:2785:26>>*/ counter + 1 | 0;
-               return parse_char_set_content(counter$1, _aH_, end_ind) /*<<camlinternalFormat.ml:2771:58>>*/ ;
+               return parse_char_set_content(counter$2, _aH_, end_ind) /*<<camlinternalFormat.ml:2771:58>>*/ ;
               }
                /*<<camlinternalFormat.ml:2776:25>>*/ if(93 === c$1){
                 /*<<camlinternalFormat.ml:2721:6>>*/ add_in_char_set
@@ -19977,9 +19980,9 @@
                return caml_trampoline_return
                        (parse_char_set_content, [0, _aI_, end_ind]) /*<<camlinternalFormat.ml:2771:58>>*/ ;
               var
-               counter$0 =
+               counter$1 =
                   /*<<camlinternalFormat.ml:2790:22>>*/ counter + 1 | 0;
-              return parse_char_set_content(counter$0, _aI_, end_ind) /*<<camlinternalFormat.ml:2771:58>>*/ ;
+              return parse_char_set_content(counter$1, _aI_, end_ind) /*<<camlinternalFormat.ml:2771:58>>*/ ;
              },
            parse_char_set_after_char =
               /*<<camlinternalFormat.ml:2736:4>>*/ function
@@ -22409,7 +22412,7 @@
         /*<<printexc.ml:352:9>>*/ caml_call1(Stdlib[103], 0);
       }
       catch(exn){}
-       /*<<printexc.ml:352:4>>*/ try{
+       /*<<printexc.ml:353:4>>*/ try{
        var
         _z_ =
            /*<<printexc.ml:354:6>>*/ caml_call2
@@ -25086,7 +25089,7 @@
      old_trav =  /*<<hashtbl.ml:196:17>>*/ ongoing_traversal(h);
      /*<<hashtbl.ml:197:2>>*/ if(1 - old_trav)
       /*<<hashtbl.ml:197:23>>*/ flip_ongoing_traversal(h);
-     /*<<hashtbl.ml:197:2>>*/ try{
+     /*<<hashtbl.ml:198:2>>*/ try{
      var _P_ = d.length - 2 | 0, _O_ = 0;
      if(_P_ >= 0){
       var i = _O_;
@@ -26826,7 +26829,7 @@
      match$0 =  /*<<format.ml:489:41>>*/ match[1],
      queue_elem = match$0[2],
      left_total = match$0[1],
-     x =  /*<<format.ml:492:4>>*/ queue_elem[1];
+     size =  /*<<format.ml:492:4>>*/ queue_elem[1];
      /*<<format.ml:494:4>>*/ if(left_total < state[12])
       /*<<format.ml:495:6>>*/ return initialize_scan_stack(state[1]) /*<<format.ml:510:10>>*/ ;
     var _a6_ =  /*<<format.ml:497:6>>*/ queue_elem[2];
@@ -26834,16 +26837,16 @@
      switch(_a6_[0]){
        case 4:
          /*<<format.ml:504:8>>*/ if(1 - ty){
-         var x$1 =  /*<<format.ml:504:23>>*/ state[13] + x | 0;
-          /*<<format.ml:505:70>>*/ queue_elem[1] = x$1;
+         var x$0 =  /*<<format.ml:504:23>>*/ state[13] + size | 0;
+          /*<<format.ml:505:70>>*/ queue_elem[1] = x$0;
           /*<<format.ml:506:10>>*/ caml_call1(Stdlib_Stack[5], state[1]);
         }
          /*<<format.ml:504:8>>*/ return;
        case 2:
        case 3:
          /*<<format.ml:499:8>>*/ if(ty){
-         var x$0 =  /*<<format.ml:499:19>>*/ state[13] + x | 0;
-          /*<<format.ml:500:70>>*/ queue_elem[1] = x$0;
+         var x =  /*<<format.ml:499:19>>*/ state[13] + size | 0;
+          /*<<format.ml:500:70>>*/ queue_elem[1] = x;
           /*<<format.ml:501:10>>*/ caml_call1(Stdlib_Stack[5], state[1]);
         }
          /*<<format.ml:499:8>>*/ return;
@@ -26861,8 +26864,8 @@
      /*<<format.ml:526:2>>*/ state[14] = state[14] + 1 | 0;
      /*<<format.ml:527:2>>*/ if(state[14] < state[15]){
      var
-      x$0 =  /*<<format.ml:528:4>>*/ - state[13] | 0,
-      elem =  /*<<format.ml:529:4>>*/ [0, x$0, [4, indent, br_ty], 0];
+      size =  /*<<format.ml:528:4>>*/ - state[13] | 0,
+      elem =  /*<<format.ml:529:4>>*/ [0, size, [4, indent, br_ty], 0];
       /*<<format.ml:530:4>>*/ return scan_push(state, 0, elem) /*<<format.ml:532:45>>*/ ;
     }
     var _a5_ =  /*<<format.ml:531:2>>*/ state[14] === state[15] ? 1 : 0;
@@ -27074,13 +27077,13 @@
      _aV_ =  /*<<format.ml:715:2>>*/ state[14] < state[15] ? 1 : 0;
     if(! _aV_) return _aV_;
     var
-     x =  /*<<format.ml:716:4>>*/ - state[13] | 0,
+     size =  /*<<format.ml:716:4>>*/ - state[13] | 0,
      token =  /*<<format.ml:717:4>>*/ [2, fits, breaks],
      length =
         /*<<format.ml:718:4>>*/ (caml_ml_string_length(before) + width | 0)
        + caml_ml_string_length(after)
        | 0,
-     elem =  /*<<format.ml:719:4>>*/ [0, x, token, length];
+     elem =  /*<<format.ml:719:4>>*/ [0, size, token, length];
      /*<<format.ml:720:4>>*/ return scan_push(state, 1, elem) /*<<format.ml:720:29>>*/ ;
    }
    function pp_print_break(state, width, offset){
@@ -27121,8 +27124,8 @@
     var _aQ_ =  /*<<format.ml:762:2>>*/ state[14] < state[15] ? 1 : 0;
     if(! _aQ_) return _aQ_;
     var
-     x =  /*<<format.ml:763:4>>*/ - state[13] | 0,
-     elem =  /*<<format.ml:764:4>>*/ [0, x, [3, width, offset], width];
+     size =  /*<<format.ml:763:4>>*/ - state[13] | 0,
+     elem =  /*<<format.ml:764:4>>*/ [0, size, [3, width, offset], width];
      /*<<format.ml:765:4>>*/ return scan_push(state, 1, elem) /*<<format.ml:765:29>>*/ ;
    }
    function pp_print_tab(state, param){
@@ -29859,9 +29862,11 @@
    }
    function scan_chars_in_char_set(char_set, scan_indic, width, ib){
     function scan_chars(i$1, stp){
-     var i =  /*<<scanf.ml:1104:12>>*/ i$1;
+     var i =  /*<<scanf.ml:1104:4>>*/ i$1;
      for(;;){
-      var c = peek_char(ib), _U_ =  /*<<scanf.ml:1105:4>>*/ 0 < i ? 1 : 0;
+      var
+       c =  /*<<scanf.ml:1104:12>>*/ peek_char(ib),
+       _U_ =  /*<<scanf.ml:1105:4>>*/ 0 < i ? 1 : 0;
       if(_U_){
        var _V_ =  /*<<scanf.ml:1105:37>>*/ 1 - ib[1];
        if(_V_)


### PR DESCRIPTION
On top of #1962, this PR adds an optimization to merged blocks that are not necessary for control_flow.
When tried on the lwt toplevel, the first pass merges 34493 blocks out of  124770.
This should hopefully speedup others passes.

