### PR TITLE
Compiler: compact program Addr.t

### DIFF
--- a/compiler/lib/code.ml
+++ b/compiler/lib/code.ml
@@ -887,7 +887,7 @@ let compact p =
       card
       max
       ratio
-      (if not do_it then "- ignored" else "");
+      (if not do_it then " - ignored" else "");
   p
 
 let used_blocks p =

--- a/compiler/lib/code.mli
+++ b/compiler/lib/code.mli
@@ -307,6 +307,8 @@ val prepend : program -> instr list -> program
 
 val empty : program
 
+val compact : program -> program
+
 val is_empty : program -> bool
 
 val equal : program -> program -> bool

--- a/compiler/lib/driver.ml
+++ b/compiler/lib/driver.ml
@@ -53,6 +53,7 @@ let deadcode' p =
 let deadcode p =
   let p, _ = deadcode' p in
   let p = Deadcode.merge_blocks p in
+  let p = Code.compact p in
   p
 
 let inline p =

--- a/compiler/lib/parse_bytecode.ml
+++ b/compiler/lib/parse_bytecode.ml
@@ -2525,13 +2525,13 @@ let parse_bytecode code globals debug_data =
             })
           !compiled_blocks
       in
-      let free_pc = String.length code / 4 in
+      let free_pc = (Addr.Map.max_binding blocks |> fst) + 1 in
       { start; blocks; free_pc })
     else Code.empty
   in
   compiled_blocks := Addr.Map.empty;
   tagged_blocks := Addr.Map.empty;
-  p
+  Code.compact p
 
 module Toc : sig
   type t

--- a/compiler/lib/stdlib.ml
+++ b/compiler/lib/stdlib.ml
@@ -1100,6 +1100,18 @@ module In_channel = struct
 end
 [@@if ocaml_version >= (4, 14, 0)]
 
+module Seq = struct
+  include Seq
+
+  let rec mapi_aux f i xs () =
+    match xs () with
+    | Nil -> Nil
+    | Cons (x, xs) -> Cons (f i x, mapi_aux f (i + 1) xs)
+
+  (* Available since OCaml 4.14 *)
+  let[@inline] mapi f xs = mapi_aux f 0 xs
+end
+
 let split_lines s =
   if String.equal s ""
   then []


### PR DESCRIPTION
Blocks `Addr.t` are sparse in a program. This can be wasteful when using bitset to encode visited blocks.
The PR propose to "compact" `Addr.t` in a program if needed. 