### PR TITLE
Adjust some microbenmarks

### DIFF
--- a/benchmarks/sources/js/binary_trees.js
+++ b/benchmarks/sources/js/binary_trees.js
@@ -28,7 +28,7 @@ function bottomUpTree(item,depth){
 
 
 var minDepth = 4;
-var n = 0; //arguments[0];
+var n = 17; //arguments[0];
 var maxDepth = Math.max(minDepth + 2, n);
 var stretchDepth = maxDepth + 1;
 

--- a/benchmarks/sources/js/fft.js
+++ b/benchmarks/sources/js/fft.js
@@ -174,4 +174,4 @@ function test (np) {
   if (Math.abs( zr) <= 1e-8 && Math.abs( zi) <= 1e-8) {} else throw "ERROR";
 }
 
-var np = 16; for (var i = 1; i<= 16; i++) { test (np); np = np*2; }
+var np = 16; for (var i = 1; i<= 19; i++) { test (np); np = np*2; }

--- a/benchmarks/sources/js/raytrace.js
+++ b/benchmarks/sources/js/raytrace.js
@@ -903,4 +903,4 @@ function renderScene(){
   raytracer.renderScene(scene, null, 0);
 }
 
-for (var i = 1; i <= 100; i++) { renderScene(); };
+for (var i = 1; i <= 2000; i++) { renderScene(); };

--- a/benchmarks/sources/ml/binary_trees.ml
+++ b/benchmarks/sources/ml/binary_trees.ml
@@ -55,8 +55,9 @@ let () =
   (*
   flush stdout;
 *)
-  loop_depths min_depth max_depth;
-  Printf.printf
+  loop_depths min_depth max_depth
+(* Printf.printf
     "long lived tree of depth %i\t check: %i\n"
     max_depth
     (check long_lived_tree)
+   *)

--- a/benchmarks/sources/ml/binary_trees.ml
+++ b/benchmarks/sources/ml/binary_trees.ml
@@ -24,7 +24,7 @@ let rec check = function
 let min_depth = 4
 
 let max_depth =
-  let n = try int_of_string Sys.argv.(1) with _ -> 10 in
+  let n = try int_of_string Sys.argv.(1) with _ -> 17 in
   max (min_depth + 2) n
 
 let stretch_depth = max_depth + 1
@@ -38,25 +38,25 @@ let () =
 
 let long_lived_tree = make 0 max_depth
 
-let loop_depths d =
-  for i = 0 to ((max_depth - d) / 2) + 1 - 1 do
-    let d = d + (i * 2) in
-    let niter = 1 lsl (max_depth - d + min_depth) in
+let rec loop_depths depth max_depth =
+  if depth <= max_depth
+  then (
+    let niter = 1 lsl (max_depth - depth + min_depth) in
     let c = ref 0 in
     for i = 1 to niter do
-      c := !c + check (make i d) + check (make (-i) d)
+      c := !c + check (make i depth) + check (make (-i) depth)
     done;
     ( (*
       Printf.printf "%i\t trees of depth %i\t check: %i\n" (2 * niter) d !c;
- *) )
-  done
+ *) );
+    loop_depths (depth + 2) max_depth)
 
 let () =
   (*
   flush stdout;
 *)
-  loop_depths min_depth;
-  ( (*
-  Printf.printf "long lived tree of depth %i\t check: %i\n"
-    max_depth (check long_lived_tree)
- *) )
+  loop_depths min_depth max_depth;
+  Printf.printf
+    "long lived tree of depth %i\t check: %i\n"
+    max_depth
+    (check long_lived_tree)

--- a/benchmarks/sources/ml/fft.ml
+++ b/benchmarks/sources/ml/fft.ml
@@ -173,7 +173,7 @@ let test np =
 
 let _ =
   let np = ref 16 in
-  for _ = 1 to 16 do
+  for _ = 1 to 19 do
     test !np;
     np := !np * 2
   done

--- a/benchmarks/sources/ml/quicksort.ml
+++ b/benchmarks/sources/ml/quicksort.ml
@@ -102,8 +102,8 @@ let test_sort sort_fun size =
 (*print_string "failed"; print_newline()*)
 
 let main () =
-  test_sort qsort 500000;
-  test_sort qsort2 500000
+  test_sort qsort 2_000_000;
+  test_sort qsort2 2_000_000
 
 let _ = main ()
 

--- a/benchmarks/sources/ml/raytrace.ml
+++ b/benchmarks/sources/ml/raytrace.ml
@@ -510,6 +510,6 @@ let render_scene () =
   Engine.render_scene engine scene None
 
 let _ =
-  for _ = 0 to 99 do
+  for _ = 1 to 2000 do
     render_scene ()
   done

--- a/benchmarks/sources/ml/soli.ml
+++ b/benchmarks/sources/ml/soli.ml
@@ -17,33 +17,18 @@ type peg =
   | Empty
   | Peg
 
-let board =
-  [| [| Out; Out; Out; Out; Out; Out; Out; Out; Out |]
-   ; [| Out; Out; Out; Peg; Peg; Peg; Out; Out; Out |]
-   ; [| Out; Out; Out; Peg; Peg; Peg; Out; Out; Out |]
-   ; [| Out; Peg; Peg; Peg; Peg; Peg; Peg; Peg; Out |]
-   ; [| Out; Peg; Peg; Peg; Empty; Peg; Peg; Peg; Out |]
-   ; [| Out; Peg; Peg; Peg; Peg; Peg; Peg; Peg; Out |]
-   ; [| Out; Out; Out; Peg; Peg; Peg; Out; Out; Out |]
-   ; [| Out; Out; Out; Peg; Peg; Peg; Out; Out; Out |]
-   ; [| Out; Out; Out; Out; Out; Out; Out; Out; Out |]
-  |]
-
-(*
 let print_peg = function
-    Out -> print_string "."
+  | Out -> print_string "."
   | Empty -> print_string " "
   | Peg -> print_string "$"
 
-
 let print_board board =
- for i=0 to 8 do
-   for j=0 to 8 do
-    print_peg board.(i).(j)
-   done;
-   print_newline()
- done
-*)
+  for i = 0 to 8 do
+    for j = 0 to 8 do
+      print_peg board.(i).(j)
+    done;
+    print_newline ()
+  done
 
 type direction =
   { dx : int
@@ -60,13 +45,9 @@ type move =
   ; y2 : int
   }
 
-let moves = Array.make 31 { x1 = 0; y1 = 0; x2 = 0; y2 = 0 }
-
-let counter = ref 0
-
 exception Found
 
-let rec solve m =
+let rec solve board moves counter m =
   counter := !counter + 1;
   if m = 31
   then
@@ -75,11 +56,6 @@ let rec solve m =
     | _ -> false
   else
     try
-      (*
-      if !counter mod 500 = 0 then begin
-        print_int !counter; print_newline()
-      end;
-*)
       for i = 1 to 7 do
         for j = 1 to 7 do
           match board.(i).(j) with
@@ -95,15 +71,10 @@ let rec solve m =
                 | Peg -> (
                     match board.(i2).(j2) with
                     | Empty ->
-                        (*
-                      print_int i; print_string ", ";
-                      print_int j; print_string ") dir ";
-                      print_int k; print_string "\n";
-*)
                         board.(i).(j) <- Empty;
                         board.(i1).(j1) <- Empty;
                         board.(i2).(j2) <- Peg;
-                        if solve (m + 1)
+                        if solve board moves counter (m + 1)
                         then (
                           moves.(m) <- { x1 = i; y1 = j; x2 = i2; y2 = j2 };
                           raise Found);
@@ -119,4 +90,29 @@ let rec solve m =
       false
     with Found -> true
 
-let _ = if solve 0 then ( (*print_string "\n"; print_board board*) ) else assert false
+let solve () =
+  let board =
+    [| [| Out; Out; Out; Out; Out; Out; Out; Out; Out |]
+     ; [| Out; Out; Out; Peg; Peg; Peg; Out; Out; Out |]
+     ; [| Out; Out; Out; Peg; Peg; Peg; Out; Out; Out |]
+     ; [| Out; Peg; Peg; Peg; Peg; Peg; Peg; Peg; Out |]
+     ; [| Out; Peg; Peg; Peg; Empty; Peg; Peg; Peg; Out |]
+     ; [| Out; Peg; Peg; Peg; Peg; Peg; Peg; Peg; Out |]
+     ; [| Out; Out; Out; Peg; Peg; Peg; Out; Out; Out |]
+     ; [| Out; Out; Out; Peg; Peg; Peg; Out; Out; Out |]
+     ; [| Out; Out; Out; Out; Out; Out; Out; Out; Out |]
+    |]
+  in
+  let moves = Array.make 31 { x1 = 0; y1 = 0; x2 = 0; y2 = 0 } in
+  let counter = ref 0 in
+  solve board moves counter 0, board
+
+let _ =
+  for _ = 0 to 200 do
+    let solved, board = solve () in
+    if solved
+    then ()
+    else (
+      print_string "Failed:\n";
+      print_board board)
+  done


### PR DESCRIPTION
Some benchmarks terminate very fast and are very noisy due to startup overhead. The PR make soli, binary_trees and fft do more work so that take in the order of a second to finish. 