### PR TITLE
More check points for code.invariant. 

### DIFF
--- a/compiler/lib/code.ml
+++ b/compiler/lib/code.ml
@@ -777,6 +777,12 @@ let fold_closures_outermost_first { start; blocks; _ } f accu =
   let accu = f None [] (start, []) None accu in
   visit blocks start f accu
 
+let rec last_instr l =
+  match l with
+  | [] | [ Event _ ] -> None
+  | [ i ] | [ i; Event _ ] -> Some i
+  | _ :: rem -> last_instr rem
+
 let equal p1 p2 =
   p1.start = p2.start
   && Addr.Map.equal

--- a/compiler/lib/code.ml
+++ b/compiler/lib/code.ml
@@ -835,8 +835,6 @@ let cont_compare (pc, args) (pc', args') =
 
 let with_invariant = Debug.find "invariant"
 
-let check_defs = false
-
 let do_compact { blocks; start; free_pc = _ } =
   let remap =
     let max = fst (Addr.Map.max_binding blocks) in
@@ -913,6 +911,8 @@ let used_blocks p =
   in
   mark_used p.start;
   visited
+
+let check_defs = true
 
 let invariant ({ blocks; start; _ } as p) =
   if with_invariant ()

--- a/compiler/lib/code.mli
+++ b/compiler/lib/code.mli
@@ -301,6 +301,9 @@ val traverse :
 val preorder_traverse :
   fold_blocs_poly -> (Addr.t -> 'c -> 'c) -> Addr.t -> block Addr.Map.t -> 'c -> 'c
 
+val last_instr : instr list -> instr option
+(** Last instruction of a block body, ignoring events *)
+
 val used_blocks : program -> BitSet.t
 
 val prepend : program -> instr list -> program

--- a/compiler/lib/deadcode.ml
+++ b/compiler/lib/deadcode.ml
@@ -384,6 +384,7 @@ let remove_empty_blocks st (p : Code.program) : Code.program =
 
 let f ({ blocks; _ } as p : Code.program) =
   let previous_p = p in
+  Code.invariant p;
   let t = Timer.make () in
   let nv = Var.count () in
   let defs = Array.make nv [] in
@@ -483,4 +484,5 @@ let f ({ blocks; _ } as p : Code.program) =
     let total = Var.count () in
     let ratio = float !live /. float total *. 100. in
     Format.eprintf "Stats - live variables: %d/%d = %.1f%%@." !live total ratio);
+  Code.invariant p;
   p, st.live

--- a/compiler/lib/duplicate.mli
+++ b/compiler/lib/duplicate.mli
@@ -18,14 +18,11 @@
 
 val closure :
      Code.program
-  -> bound_vars:Code.Var.Set.t
   -> f:Code.Var.t
   -> params:Code.Var.t list
   -> cont:int * Code.Var.t list
   -> Code.program * Code.Var.t * Code.Var.t list * (int * Code.Var.t list)
-(** Given a program and a closure [f] -- defined by its name, parameters, and its
-    continuation --, return a program in which the body of [f] has been updated with fresh
-    variable names to replace elements of [bound_vars]. Also returns the new name of [f]
-    (fresh if [f] is in [bound_vars]), and the similarly substituted parameter list and
-    continuation.
-  *)
+(** Given a program and a closure [f] -- defined by its name,
+    parameters, and its continuation --, return a program with a copy
+    of [f]. Also returns the new name of [f], and the similarly
+    substituted parameter list and continuation. *)

--- a/compiler/lib/effects.ml
+++ b/compiler/lib/effects.ml
@@ -142,13 +142,6 @@ let dominance_frontier g idom =
     g.preds;
   frontiers
 
-(* Last instruction of a block, ignoring events *)
-let rec last_instr l =
-  match l with
-  | [] -> None
-  | [ i ] | [ i; Event _ ] -> Some i
-  | _ :: rem -> last_instr rem
-
 (* Split a block, separating the last instruction from the preceeding
    ones, ignoring events *)
 let block_split_last xs =
@@ -210,7 +203,7 @@ let compute_needed_transformations ~cfg ~idom ~cps_needed ~blocks ~start =
       let block = Addr.Map.find pc blocks in
       (match block.branch with
       | Branch (dst, _) -> (
-          match last_instr block.body with
+          match Code.last_instr block.body with
           | Some (Let (x, e))
             when effect_primitive_or_application e && Var.Set.mem x cps_needed ->
               (* The block after a function application that needs to

--- a/compiler/lib/effects.ml
+++ b/compiler/lib/effects.ml
@@ -1105,6 +1105,7 @@ let split_blocks ~cps_needed (p : Code.program) =
 (****)
 
 let f ~flow_info ~live_vars p =
+  Code.invariant p;
   let t = Timer.make () in
   let cps_needed = Partial_cps_analysis.f p flow_info in
   let p, cps_needed =

--- a/compiler/lib/eval.ml
+++ b/compiler/lib/eval.ml
@@ -808,6 +808,7 @@ let eval update_count update_branch inline_constant ~target info blocks =
     blocks
 
 let f info p =
+  Code.invariant p;
   let previous_p = p in
   let update_count = ref 0 in
   let update_branch = ref 0 in
@@ -843,4 +844,5 @@ let f info p =
       p
       ~updates:(!update_count + !inline_constant + !drop_count + !update_branch);
   let p = Deadcode.remove_unused_blocks p in
+  Code.invariant p;
   p

--- a/compiler/lib/generate_closure.ml
+++ b/compiler/lib/generate_closure.ml
@@ -325,7 +325,6 @@ let f p : Code.program =
       p.blocks
       (p.blocks, p.free_pc)
   in
-  (* Code.invariant (pc, blocks, free_pc); *)
   let p = { p with blocks; free_pc } in
   Code.invariant p;
   p

--- a/compiler/lib/global_deadcode.ml
+++ b/compiler/lib/global_deadcode.ml
@@ -558,7 +558,11 @@ let f p ~deadcode_sentinal global_info =
   Code.invariant p;
   let t = Timer.make () in
   (* Add sentinal variable *)
-  let p = add_sentinal p deadcode_sentinal in
+  let p =
+    match global_info.Global_flow.info_defs.(Var.idx deadcode_sentinal) with
+    | Expr _ -> p
+    | _ -> add_sentinal p deadcode_sentinal
+  in
   (* Compute definitions *)
   let defs = definitions p in
   (* Compute initial liveness *)
@@ -583,4 +587,5 @@ let f p ~deadcode_sentinal global_info =
     Format.eprintf "After Zeroing:@.";
     Code.Print.program Format.err_formatter (fun _ _ -> "") p);
   if times () then Format.eprintf "  global dead code elim.: %a@." Timer.print t;
+  Code.invariant p;
   p

--- a/compiler/lib/inline.ml
+++ b/compiler/lib/inline.ml
@@ -230,7 +230,7 @@ let inline inline_count live_vars closures pc (outer, p) =
               [], (outer, Branch (fresh_addr, args), { p with blocks; free_pc }))
             else
               match cl_simpl with
-              | Some (bound_vars, free_vars, recursive, tc_params)
+              | Some (_, free_vars, recursive, tc_params)
               (* We inline/duplicate
                  - single instruction functions (f_size = 1)
                  - small funtions that call one of their arguments in
@@ -255,8 +255,7 @@ let inline inline_count live_vars closures pc (outer, p) =
                     live_vars.(Var.idx f) <- live_vars.(Var.idx f) - 1
                   in
                   let p, f, params, clos_cont =
-                    let bound_vars = Var.Set.add f bound_vars in
-                    Duplicate.closure p ~bound_vars ~f ~params ~cont:clos_cont
+                    Duplicate.closure p ~f ~params ~cont:clos_cont
                   in
                   if recursive
                   then

--- a/compiler/lib/phisimpl.ml
+++ b/compiler/lib/phisimpl.ml
@@ -154,6 +154,7 @@ let solver1 vars deps defs =
 
 let f p =
   let previous_p = p in
+  Code.invariant p;
   let t = Timer.make () in
   let t' = Timer.make () in
   let vars, deps, defs = program_deps p in
@@ -182,4 +183,5 @@ let f p =
   if times () then Format.eprintf "  phi-simpl.: %a@." Timer.print t;
   if stats () then Format.eprintf "Stats - phi updates: %d@." !count_uniq;
   if debug_stats () then Code.check_updates ~name:"phi" previous_p p ~updates:!count_uniq;
+  Code.invariant p;
   p

--- a/compiler/lib/specialize.ml
+++ b/compiler/lib/specialize.ml
@@ -133,6 +133,7 @@ let specialize_instrs ~function_arity opt_count p =
   { p with blocks; free_pc }
 
 let f ~function_arity p =
+  Code.invariant p;
   let previous_p = p in
   let t = Timer.make () in
   let opt_count = ref 0 in
@@ -143,6 +144,7 @@ let f ~function_arity p =
   if stats () then Format.eprintf "Stats - optcall: %d@." !opt_count;
   if debug_stats ()
   then Code.check_updates ~name:"optcall" previous_p p ~updates:!opt_count;
+  Code.invariant p;
   p
 
 (***)

--- a/compiler/lib/specialize_js.ml
+++ b/compiler/lib/specialize_js.ml
@@ -396,6 +396,7 @@ let specialize_all_instrs ~target opt_count info p =
 (****)
 
 let f info p =
+  Code.invariant p;
   let previous_p = p in
   let t = Timer.make () in
   let opt_count = ref 0 in
@@ -404,6 +405,7 @@ let f info p =
   if stats () then Format.eprintf "Stats - specialize_js: %d@." !opt_count;
   if debug_stats ()
   then Code.check_updates ~name:"specialize_js" previous_p p ~updates:!opt_count;
+  Code.invariant p;
   p
 
 let f_once_before p =

--- a/compiler/lib/tailcall.ml
+++ b/compiler/lib/tailcall.ml
@@ -92,6 +92,7 @@ let rec traverse update_count f pc visited blocks =
 
 let f p =
   let previous_p = p in
+  Code.invariant p;
   let free_pc = ref p.free_pc in
   let blocks = ref p.blocks in
   let update_count = ref 0 in
@@ -152,4 +153,5 @@ let f p =
   if stats () then Format.eprintf "Stats - tail calls: %d optimizations@." !update_count;
   if debug_stats ()
   then Code.check_updates ~name:"tailcall" previous_p p ~updates:!update_count;
+  Code.invariant p;
   p


### PR DESCRIPTION
The PR fixes `inline.ml` to respect the invariant. includes a prefix of #1935  and borrow its cleanup logic.
The goal is to merge this PR before #1935.  
