### PR TITLE
Wasm runtime: move JavaString hash function from wasm:js-string to bindings

### DIFF
--- a/runtime/wasm/jsstring.wat
+++ b/runtime/wasm/jsstring.wat
@@ -20,8 +20,6 @@
       (func $compare_strings (param externref externref) (result i32)))
    (import "wasm:js-string" "test"
       (func $is_string (param externref) (result i32)))
-   (import "wasm:js-string" "hash"
-      (func $hash_string (param i32) (param anyref) (result i32)))
    (import "wasm:js-string" "fromCharCodeArray"
       (func $fromCharCodeArray
          (param (ref null $wstring)) (param i32) (param i32)
@@ -35,6 +33,8 @@
       (func $encodeStringToUTF8Array
          (param externref) (result (ref $bytes))))
 
+   (import "bindings" "hash_string"
+      (func $hash_string (param i32) (param anyref) (result i32)))
    (import "bindings" "read_string"
       (func $read_string (param i32) (result anyref)))
    (import "bindings" "read_string_stream"

--- a/runtime/wasm/runtime.js
+++ b/runtime/wasm/runtime.js
@@ -552,12 +552,12 @@
     },
     map_set: (m, x, v) => m.set(x, v),
     map_delete: (m, x) => m.delete(x),
+    hash_string,
     log: (x) => console.log(x),
   };
   const string_ops = {
     test: (v) => +(typeof v === "string"),
     compare: (s1, s2) => (s1 < s2 ? -1 : +(s1 > s2)),
-    hash: hash_string,
     decodeStringFromUTF8Array: () => "",
     encodeStringToUTF8Array: () => 0,
     fromCharCodeArray: () => "",


### PR DESCRIPTION
For compatibility with Firefox which does not allow additional functions in builtin modules.