### PR TITLE
Output a Wasm binary module rather than a text file when possible

### DIFF
--- a/benchmarks/benchmark-fiat-crypto/Makefile
+++ b/benchmarks/benchmark-fiat-crypto/Makefile
@@ -10,8 +10,9 @@ bench:
 	$(MAKE) perform COMPILER=wasm_of_ocaml EXTRA_ARGS="" KIND=wasm
 	@date -u +"%FT%TZ - $(NAME): done"
 
+# Add --source-map back once we support source-map in wasm binary file.
 perform: bedrock2_fiat_crypto.byte
-	/usr/bin/time -f "%E %R" $(COMPILER) --debug times --source-map $(EXTRA_ARGS) $< -o out.js 2>&1 | \
+	/usr/bin/time -f "%E %R" $(COMPILER) --debug times $(EXTRA_ARGS) $< -o out.js 2>&1 | \
 	ocaml -I +str str.cma ../utils/compilation_metrics.ml $(COMPILER) $(NAME) out.js | \
 	sh ../utils/aggregate.sh $(KIND)
 

--- a/compiler/bin-wasm_of_ocaml/compile.ml
+++ b/compiler/bin-wasm_of_ocaml/compile.ml
@@ -246,23 +246,14 @@ let generate_prelude ~out_file =
       ~deadcode_sentinal
       program
   in
-  Generate.output ch ~context;
+  Generate.wasm_output ch ~context;
   uinfo.provides
 
 let build_prelude z =
   Fs.with_intermediate_file (Filename.temp_file "prelude" ".wasm")
   @@ fun prelude_file ->
-  Fs.with_intermediate_file (Filename.temp_file "prelude_file" ".wasm")
-  @@ fun tmp_prelude_file ->
   let predefined_exceptions = generate_prelude ~out_file:prelude_file in
-  Binaryen.optimize
-    ~profile:Profile.O1
-    ~input_file:prelude_file
-    ~output_file:tmp_prelude_file
-    ~opt_input_sourcemap:None
-    ~opt_output_sourcemap:None
-    ();
-  Zip.add_file z ~name:"prelude.wasm" ~file:tmp_prelude_file;
+  Zip.add_file z ~name:"prelude.wasm" ~file:prelude_file;
   predefined_exceptions
 
 let build_js_runtime ~primitives ?runtime_arguments () =
@@ -408,7 +399,7 @@ let run
         program
     in
     if standalone then Generate.add_start_function ~context toplevel_name;
-    Generate.output ch ~context;
+    Generate.output ch ~enable_source_maps ~context;
     if times () then Format.eprintf "compilation: %a@." Timer.print t;
     generated_js
   in

--- a/compiler/lib-wasm/generate.ml
+++ b/compiler/lib-wasm/generate.ml
@@ -1315,10 +1315,12 @@ let add_start_function = G.add_start_function
 
 let add_init_function = G.add_init_function
 
-let output ch ~context =
+let output ch ~enable_source_maps ~context =
   let t = Timer.make () in
   let fields = G.output ~context in
-  Wat_output.f ch fields;
+  if enable_source_maps || Debug.find "wat" ()
+  then Wat_output.f ch fields
+  else Wasm_output.f ch fields;
   if times () then Format.eprintf "  output: %a@." Timer.print t
 
 let wasm_output ch ~context =

--- a/compiler/lib-wasm/generate.mli
+++ b/compiler/lib-wasm/generate.mli
@@ -33,6 +33,7 @@ val add_start_function : context:Code_generation.context -> Wasm_ast.var -> unit
 
 val add_init_function : context:Code_generation.context -> to_link:string list -> unit
 
-val output : out_channel -> context:Code_generation.context -> unit
+val output :
+  out_channel -> enable_source_maps:bool -> context:Code_generation.context -> unit
 
 val wasm_output : out_channel -> context:Code_generation.context -> unit


### PR DESCRIPTION
This is faster to write a binary file, and then for binaryen to parse a binary file.

We still output a Wasm text file when source maps are enabled (we don't yet supported writing a source map file together with a Wasm binary module) or when `--debug wat` is set.