### PR TITLE
Fix invariant

### DIFF
--- a/compiler/lib/lambda_lifting.ml
+++ b/compiler/lib/lambda_lifting.ml
@@ -225,15 +225,16 @@ let rec traverse var_depth (program, functions) pc depth limit =
     program.blocks
     (program, functions)
 
-let f program =
+let f p =
   let t = Timer.make () in
   let nv = Var.count () in
   let var_depth = Array.make nv (-1) in
-  let program, functions =
+  let p, functions =
     let threshold = Config.Param.lambda_lifting_threshold () in
     let baseline = Config.Param.lambda_lifting_baseline () in
-    traverse var_depth (program, []) program.start 0 (baseline + threshold)
+    traverse var_depth (p, []) p.start 0 (baseline + threshold)
   in
   assert (List.is_empty functions);
   if Debug.find "times" () then Format.eprintf "  lambda lifting: %a@." Timer.print t;
-  program
+  Code.invariant p;
+  p

--- a/compiler/lib/specialize_js.ml
+++ b/compiler/lib/specialize_js.ml
@@ -448,7 +448,9 @@ let f_once_before p =
   let blocks =
     Addr.Map.map (fun block -> { block with Code.body = loop [] block.body }) p.blocks
   in
-  { p with blocks }
+  let p = { p with blocks } in
+  Code.invariant p;
+  p
 
 let rec args_equal xs ys =
   match xs, ys with
@@ -485,11 +487,13 @@ let f_once_after p =
     | i -> i
   in
   if first_class_primitives
-  then
+  then (
     let blocks =
       Addr.Map.map
         (fun block -> { block with Code.body = List.map block.body ~f })
         p.blocks
     in
-    Deadcode.remove_unused_blocks { p with blocks }
+    let p = Deadcode.remove_unused_blocks { p with blocks } in
+    Code.invariant p;
+    p)
   else p

--- a/dune-workspace
+++ b/dune-workspace
@@ -7,5 +7,5 @@
    (runtest_alias runtest-wasm))
   (js_of_ocaml
 ;; enable for debugging
-;; (flags (:standard --debug stats-debug --debug invariant))
+   (flags (:standard --debug stats-debug --debug invariant))
    (runtest_alias runtest-js))))


### PR DESCRIPTION
## Effects
The effects pass was previously  leaving unused blocks behind.

## Inlining
### The issue
I do not have a good grasp on what's is going on but it seems that a parent closure can sometimes be optimized before the closures it contains (recursive cycles).

```
function A () 
   fun B() {  A () }
   fun C() { B () }
   C();
}
```
- We first optimize A and decide nothing happens
- Then C and decide to inline B and B becomes dead
- We need to cleanup A but we already visited it

### The fix
- We maintain a table for a closure to the block it is declared into.
- We collect the names of all inlined closures, filter out the one that are still live
- We map the dead closures to their block and rewrite theses blocks only.  