### PR TITLE
Microbenchmarks: disable Wasm baseline compiler

### DIFF
--- a/benchmarks/run.config
+++ b/benchmarks/run.config
@@ -1,6 +1,8 @@
 #
 #interpreter v8 / node: apt-get install nodejs
-interpreter node /usr/bin/env node
+# We disable the Wasm baseline compiler since we are interested in the
+# performance of optimized code
+interpreter node /usr/bin/env node --no-liftoff
 #
 #SpiderMonkey: apt-get install libmozjs-91-dev
 interpreter sm /usr/bin/env js91 -f


### PR DESCRIPTION
We are interested in the performance of optimized code. But V8 is currently not able to switch to optimized code while executing a loop in Wasm. So, we can get stuck running unoptimized code.