### PR TITLE
Use more precise types in function environments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,7 @@
 * Compiler: rewrote inlining pass (#1935, #2018, #2027)
 * Compiler/wasm: optimize integer operations (#2032)
 * Compiler/wasm: use type analysis to remove some unnecessary uses of JavasScript strict equality (#2040)
+* Compiler/wasm: use more precise environment types (#2041)
 
 ## Bug fixes
 * Compiler: fix stack overflow issues with double translation (#1869)

--- a/compiler/lib-wasm/generate.ml
+++ b/compiler/lib-wasm/generate.ml
@@ -1303,7 +1303,7 @@ module Generate (Target : Target_sig.S) = struct
            | Some loc -> event loc
            | None -> return ())
     in
-    let body = post_process_function_body ~param_names ~locals body in
+    let locals, body = post_process_function_body ~param_names ~locals body in
     W.Function
       { name =
           (match name_opt with

--- a/compiler/lib-wasm/initialize_locals.ml
+++ b/compiler/lib-wasm/initialize_locals.ml
@@ -110,6 +110,112 @@ and scan_instructions ctx l =
   let ctx = fork_context ctx in
   List.iter ~f:(fun i -> scan_instruction ctx i) l
 
+let rec rewrite_expression uninitialized (e : Wasm_ast.expression) =
+  match e with
+  | Const _ | GlobalGet _ | Pop _ | RefFunc _ | RefNull _ -> e
+  | UnOp (op, e') -> UnOp (op, rewrite_expression uninitialized e')
+  | I32WrapI64 e' -> I32WrapI64 (rewrite_expression uninitialized e')
+  | I64ExtendI32 (s, e') -> I64ExtendI32 (s, rewrite_expression uninitialized e')
+  | F32DemoteF64 e' -> F32DemoteF64 (rewrite_expression uninitialized e')
+  | F64PromoteF32 e' -> F64PromoteF32 (rewrite_expression uninitialized e')
+  | RefI31 e' -> RefI31 (rewrite_expression uninitialized e')
+  | I31Get (s, e') -> I31Get (s, rewrite_expression uninitialized e')
+  | ArrayLen e' -> ArrayLen (rewrite_expression uninitialized e')
+  | StructGet (s, ty, i, e') -> StructGet (s, ty, i, rewrite_expression uninitialized e')
+  | RefCast (ty, e') -> RefCast (ty, rewrite_expression uninitialized e')
+  | RefTest (ty, e') -> RefTest (ty, rewrite_expression uninitialized e')
+  | Br_on_cast (i, ty, ty', e') ->
+      Br_on_cast (i, ty, ty', rewrite_expression uninitialized e')
+  | Br_on_cast_fail (i, ty, ty', e') ->
+      Br_on_cast_fail (i, ty, ty', rewrite_expression uninitialized e')
+  | Br_on_null (i, e') -> Br_on_null (i, rewrite_expression uninitialized e')
+  | BinOp (op, e', e'') ->
+      BinOp (op, rewrite_expression uninitialized e', rewrite_expression uninitialized e'')
+  | ArrayNew (ty, e', e'') ->
+      ArrayNew
+        (ty, rewrite_expression uninitialized e', rewrite_expression uninitialized e'')
+  | ArrayNewData (ty, i, e', e'') ->
+      ArrayNewData
+        (ty, i, rewrite_expression uninitialized e', rewrite_expression uninitialized e'')
+  | ArrayGet (s, ty, e', e'') ->
+      ArrayGet
+        (s, ty, rewrite_expression uninitialized e', rewrite_expression uninitialized e'')
+  | RefEq (e', e'') ->
+      RefEq (rewrite_expression uninitialized e', rewrite_expression uninitialized e'')
+  | LocalGet i ->
+      if Code.Var.Hashtbl.mem uninitialized i
+      then RefCast (Code.Var.Hashtbl.find uninitialized i, e)
+      else e
+  | LocalTee (i, e') ->
+      let e = Wasm_ast.LocalTee (i, rewrite_expression uninitialized e') in
+      if Code.Var.Hashtbl.mem uninitialized i
+      then RefCast (Code.Var.Hashtbl.find uninitialized i, e)
+      else e
+  | Call_ref (f, e', l) ->
+      Call_ref
+        (f, rewrite_expression uninitialized e', rewrite_expressions uninitialized l)
+  | Call (f, l) -> Call (f, rewrite_expressions uninitialized l)
+  | ArrayNewFixed (ty, l) -> ArrayNewFixed (ty, rewrite_expressions uninitialized l)
+  | StructNew (ty, l) -> StructNew (ty, rewrite_expressions uninitialized l)
+  | BlockExpr (ty, l) -> BlockExpr (ty, rewrite_instructions uninitialized l)
+  | Seq (l, e') ->
+      Seq (rewrite_instructions uninitialized l, rewrite_expression uninitialized e')
+  | IfExpr (ty, cond, e1, e2) ->
+      IfExpr
+        ( ty
+        , rewrite_expression uninitialized cond
+        , rewrite_expression uninitialized e1
+        , rewrite_expression uninitialized e2 )
+  | Try (ty, body, catches) -> Try (ty, rewrite_instructions uninitialized body, catches)
+  | ExternConvertAny e' -> ExternConvertAny (rewrite_expression uninitialized e')
+  | AnyConvertExtern e' -> AnyConvertExtern (rewrite_expression uninitialized e')
+
+and rewrite_expressions uninitialized l =
+  List.map ~f:(fun e -> rewrite_expression uninitialized e) l
+
+and rewrite_instruction uninitialized i =
+  match i with
+  | Wasm_ast.Drop e -> Wasm_ast.Drop (rewrite_expression uninitialized e)
+  | GlobalSet (x, e) -> GlobalSet (x, rewrite_expression uninitialized e)
+  | Br (i, Some e) -> Br (i, Some (rewrite_expression uninitialized e))
+  | Br_if (i, e) -> Br_if (i, rewrite_expression uninitialized e)
+  | Br_table (e, l, i) -> Br_table (rewrite_expression uninitialized e, l, i)
+  | Throw (t, e) -> Throw (t, rewrite_expression uninitialized e)
+  | Return (Some e) -> Return (Some (rewrite_expression uninitialized e))
+  | Push e -> Push (rewrite_expression uninitialized e)
+  | StructSet (ty, i, e, e') ->
+      StructSet
+        (ty, i, rewrite_expression uninitialized e, rewrite_expression uninitialized e')
+  | LocalSet (i, e) -> LocalSet (i, rewrite_expression uninitialized e)
+  | Loop (ty, l) -> Loop (ty, rewrite_instructions uninitialized l)
+  | Block (ty, l) -> Block (ty, rewrite_instructions uninitialized l)
+  | If (ty, e, l, l') ->
+      If
+        ( ty
+        , rewrite_expression uninitialized e
+        , rewrite_instructions uninitialized l
+        , rewrite_instructions uninitialized l' )
+  | CallInstr (f, l) -> CallInstr (f, rewrite_expressions uninitialized l)
+  | Return_call (f, l) -> Return_call (f, rewrite_expressions uninitialized l)
+  | Br (_, None) | Return None | Rethrow _ | Nop | Unreachable | Event _ -> i
+  | ArraySet (ty, e, e', e'') ->
+      ArraySet
+        ( ty
+        , rewrite_expression uninitialized e
+        , rewrite_expression uninitialized e'
+        , rewrite_expression uninitialized e'' )
+  | Return_call_ref (f, e', l) ->
+      Return_call_ref
+        (f, rewrite_expression uninitialized e', rewrite_expressions uninitialized l)
+
+and rewrite_instructions uninitialized l =
+  List.map ~f:(fun i -> rewrite_instruction uninitialized i) l
+
+let has_default (ty : Wasm_ast.heap_type) =
+  match ty with
+  | Any | Eq | I31 -> true
+  | Func | Extern | Array | Struct | None_ | Type _ -> false
+
 let f ~param_names ~locals instrs =
   let ctx =
     { initialized = Code.Var.Set.empty; uninitialized = ref Code.Var.Set.empty }
@@ -122,7 +228,31 @@ let f ~param_names ~locals instrs =
       | Ref { nullable = false; _ } -> ())
     locals;
   scan_instructions ctx instrs;
-  List.map
-    ~f:(fun i -> Wasm_ast.LocalSet (i, RefI31 (Const (I32 0l))))
-    (Code.Var.Set.elements !(ctx.uninitialized))
-  @ instrs
+  let local_types = Code.Var.Hashtbl.create 16 in
+  let locals =
+    List.map
+      ~f:(fun ((var, typ) as local) ->
+        match typ with
+        | Ref ({ nullable = false; typ } as ref_typ) ->
+            if Code.Var.Set.mem var !(ctx.uninitialized) && not (has_default typ)
+            then (
+              Code.Var.Hashtbl.add local_types var ref_typ;
+              var, Wasm_ast.Ref { nullable = true; typ })
+            else local
+        | I32 | I64 | F32 | F64 | Ref { nullable = true; _ } -> local)
+      locals
+  in
+  let initializations =
+    List.filter_map
+      ~f:(fun i ->
+        if Code.Var.Hashtbl.mem local_types i
+        then None
+        else Some (Wasm_ast.LocalSet (i, RefI31 (Const (I32 0l)))))
+      (Code.Var.Set.elements !(ctx.uninitialized))
+  in
+  let instrs =
+    if Code.Var.Hashtbl.length local_types = 0
+    then instrs
+    else rewrite_instructions local_types instrs
+  in
+  locals, initializations @ instrs

--- a/compiler/lib-wasm/initialize_locals.mli
+++ b/compiler/lib-wasm/initialize_locals.mli
@@ -20,4 +20,4 @@ val f :
      param_names:Wasm_ast.var list
   -> locals:(Wasm_ast.var * Wasm_ast.value_type) list
   -> Wasm_ast.instruction list
-  -> Wasm_ast.instruction list
+  -> (Wasm_ast.var * Wasm_ast.value_type) list * Wasm_ast.instruction list

--- a/compiler/lib-wasm/target_sig.ml
+++ b/compiler/lib-wasm/target_sig.ml
@@ -280,7 +280,7 @@ module type S = sig
        param_names:Wasm_ast.var list
     -> locals:(Wasm_ast.var * Wasm_ast.value_type) list
     -> Wasm_ast.instruction list
-    -> Wasm_ast.instruction list
+    -> (Wasm_ast.var * Wasm_ast.value_type) list * Wasm_ast.instruction list
 
   val entry_point :
        toplevel_fun:Wasm_ast.var


### PR DESCRIPTION
This refines the type of locals based on the expression they are initialized with. The main motivation for this is that the environment types get refined as well, which binaryen is not able to do. In turn, some casts become unnecessary. On `ocamlc.byte`, we get the following number of casts:

| Before | After
|-|-
| 37949 | 35553