### PR TITLE
 Fix WAT debug output (take 2)

### DIFF
--- a/compiler/lib-wasm/curry.ml
+++ b/compiler/lib-wasm/curry.ml
@@ -359,7 +359,6 @@ module Make (Target : Target_sig.S) = struct
       }
 
   let f ~context =
-    let context = { context with other_fields = context.other_fields } in
     IntMap.iter
       (fun arity name ->
         let f = apply ~context ~arity ~name in
@@ -389,6 +388,5 @@ module Make (Target : Target_sig.S) = struct
       (fun arity name ->
         let f = dummy ~context ~cps:true ~arity ~name in
         context.other_fields <- f :: context.other_fields)
-      context.cps_dummy_funs;
-    context
+      context.cps_dummy_funs
 end

--- a/compiler/lib-wasm/curry.mli
+++ b/compiler/lib-wasm/curry.mli
@@ -17,5 +17,5 @@
  *)
 
 module Make (_ : Target_sig.S) : sig
-  val f : context:Code_generation.context -> Code_generation.context
+  val f : context:Code_generation.context -> unit
 end

--- a/compiler/lib-wasm/generate.ml
+++ b/compiler/lib-wasm/generate.ml
@@ -1439,10 +1439,10 @@ module Generate (Target : Target_sig.S) = struct
     global_context.other_fields <- List.rev_append functions global_context.other_fields;
     let js_code = StringMap.bindings global_context.fragments in
     global_context.fragments <- StringMap.empty;
+    Curry.f ~context:global_context;
     toplevel_name, js_code
 
   let output ~context =
-    Curry.f ~context;
     let imports =
       List.concat
         (List.map

--- a/compiler/lib-wasm/generate.ml
+++ b/compiler/lib-wasm/generate.ml
@@ -1442,7 +1442,7 @@ module Generate (Target : Target_sig.S) = struct
     toplevel_name, js_code
 
   let output ~context =
-    let context = Curry.f ~context in
+    Curry.f ~context;
     let imports =
       List.concat
         (List.map


### PR DESCRIPTION
The previous fix was not working since we were making only a shallow copy of the context and `Curry.f` modified a shared part of the context. So, we now move `Curry.f` sooner, at a place where it will be called just once.