### PR TITLE
Closure optimization: omit code pointer when not used

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 * Compiler: exit-loop-early in more cases (#2077)
 * Runtime: support rename in fake filesystem (#2080)
 * Compiler: remove reserved keyword in ecmascript 3
+* Compiler/wasm: omit code pointer from closures when not used (#2059)
 
 ## Bug fixes
 * Compiler: Fix inlining. do not inline recursive functions (#2084)

--- a/compiler/lib-wasm/call_graph_analysis.ml
+++ b/compiler/lib-wasm/call_graph_analysis.ml
@@ -1,0 +1,61 @@
+open! Stdlib
+open Code
+
+let debug = Debug.find "call-graph"
+
+let get_approx info x =
+  (* Specialization can add some variables *)
+  if Var.idx x < Var.Tbl.length info.Global_flow.info_approximation
+  then Var.Tbl.get info.Global_flow.info_approximation x
+  else Top
+
+let block_deps ~info ~non_escaping ~ambiguous ~blocks pc =
+  let block = Addr.Map.find pc blocks in
+  List.iter block.body ~f:(fun i ->
+      match i with
+      | Let (_, Apply { f; _ }) -> (
+          match get_approx info f with
+          | Top -> ()
+          | Values { known; others } ->
+              if others || Var.Set.cardinal known > 1
+              then Var.Set.iter (fun x -> Var.Hashtbl.replace ambiguous x ()) known;
+              if debug ()
+              then
+                Format.eprintf "CALL others:%b known:%d@." others (Var.Set.cardinal known)
+          )
+      | Let (x, Closure _) -> (
+          match get_approx info x with
+          | Top -> ()
+          | Values { known; others } ->
+              if Var.Set.cardinal known = 1 && (not others) && Var.Set.mem x known
+              then (
+                let may_escape = Var.ISet.mem info.Global_flow.info_may_escape x in
+                if debug () then Format.eprintf "CLOSURE may-escape:%b@." may_escape;
+                if not may_escape then Var.Hashtbl.replace non_escaping x ()))
+      | Let (_, (Prim _ | Block _ | Constant _ | Field _ | Special _))
+      | Event _ | Assign _ | Set_field _ | Offset_ref _ | Array_set _ -> ())
+
+type t = { unambiguous_non_escaping : unit Var.Hashtbl.t }
+
+let direct_calls_only info f =
+  Config.Flag.optcall () && Var.Hashtbl.mem info.unambiguous_non_escaping f
+
+let f p info =
+  let non_escaping = Var.Hashtbl.create 128 in
+  let ambiguous = Var.Hashtbl.create 128 in
+  fold_closures
+    p
+    (fun _ _ (pc, _) _ () ->
+      traverse
+        { fold = Code.fold_children }
+        (fun pc () -> block_deps ~info ~non_escaping ~ambiguous ~blocks:p.blocks pc)
+        pc
+        p.blocks
+        ())
+    ();
+  if debug ()
+  then Format.eprintf "SUMMARY non-escaping:%d" (Var.Hashtbl.length non_escaping);
+  Var.Hashtbl.iter (fun x () -> Var.Hashtbl.remove non_escaping x) ambiguous;
+  if debug ()
+  then Format.eprintf " unambiguous-non-escaping:%d@." (Var.Hashtbl.length non_escaping);
+  { unambiguous_non_escaping = non_escaping }

--- a/compiler/lib-wasm/call_graph_analysis.ml
+++ b/compiler/lib-wasm/call_graph_analysis.ml
@@ -3,6 +3,8 @@ open Code
 
 let debug = Debug.find "call-graph"
 
+let times = Debug.find "times"
+
 let get_approx info x =
   (* Specialization can add some variables *)
   if Var.idx x < Var.Tbl.length info.Global_flow.info_approximation
@@ -41,6 +43,7 @@ let direct_calls_only info f =
   Config.Flag.optcall () && Var.Hashtbl.mem info.unambiguous_non_escaping f
 
 let f p info =
+  let t = Timer.make () in
   let non_escaping = Var.Hashtbl.create 128 in
   let ambiguous = Var.Hashtbl.create 128 in
   fold_closures
@@ -58,4 +61,5 @@ let f p info =
   Var.Hashtbl.iter (fun x () -> Var.Hashtbl.remove non_escaping x) ambiguous;
   if debug ()
   then Format.eprintf " unambiguous-non-escaping:%d@." (Var.Hashtbl.length non_escaping);
+  if times () then Format.eprintf "  call graph analysis: %a@." Timer.print t;
   { unambiguous_non_escaping = non_escaping }

--- a/compiler/lib-wasm/call_graph_analysis.mli
+++ b/compiler/lib-wasm/call_graph_analysis.mli
@@ -1,0 +1,5 @@
+type t
+
+val direct_calls_only : t -> Code.Var.t -> bool
+
+val f : Code.program -> Global_flow.info -> t

--- a/compiler/lib-wasm/target_sig.ml
+++ b/compiler/lib-wasm/target_sig.ml
@@ -174,6 +174,7 @@ module type S = sig
          context:Code_generation.context
       -> closures:Closure_conversion.closure Code.Var.Map.t
       -> cps:bool
+      -> no_code_pointer:bool
       -> Code.Var.t
       -> expression
 
@@ -181,6 +182,7 @@ module type S = sig
          context:Code_generation.context
       -> closures:Closure_conversion.closure Code.Var.Map.t
       -> cps:bool
+      -> no_code_pointer:bool
       -> Code.Var.t
       -> unit Code_generation.t
 

--- a/compiler/lib-wasm/typing.ml
+++ b/compiler/lib-wasm/typing.ml
@@ -4,6 +4,8 @@ open Global_flow
 
 let debug = Debug.find "typing"
 
+let times = Debug.find "times"
+
 module Integer = struct
   type kind =
     | Ref
@@ -420,10 +422,12 @@ let solver st =
   Solver.f () g (propagate st)
 
 let f ~state ~info ~deadcode_sentinal p =
+  let t = Timer.make () in
   update_deps state p;
   let function_parameters = mark_function_parameters p in
   let typ = solver { state; info; function_parameters } in
   Var.Tbl.set typ deadcode_sentinal (Int Normalized);
+  if times () then Format.eprintf "  type analysis: %a@." Timer.print t;
   if debug ()
   then (
     Var.ISet.iter

--- a/runtime/wasm/effect.wat
+++ b/runtime/wasm/effect.wat
@@ -45,7 +45,7 @@
    (type $block (array (mut (ref eq))))
    (type $bytes (array (mut i8)))
    (type $function_1 (func (param (ref eq) (ref eq)) (result (ref eq))))
-   (type $closure (sub (struct (;(field i32);) (field (ref $function_1)))))
+   (type $closure (sub (struct (field (ref $function_1)))))
    (type $function_3
       (func (param (ref eq) (ref eq) (ref eq) (ref eq)) (result (ref eq))))
    (type $closure_3

--- a/runtime/wasm/obj.wat
+++ b/runtime/wasm/obj.wat
@@ -34,11 +34,9 @@
    (type $float (struct (field f64)))
    (type $float_array (array (mut f64)))
    (type $function_1 (func (param (ref eq) (ref eq)) (result (ref eq))))
-   (type $closure (sub (struct (;(field i32);) (field (ref $function_1)))))
-   (type $closure_last_arg
-      (sub $closure (struct (;(field i32);) (field (ref $function_1)))))
-   (type $function_2
-      (func (param (ref eq) (ref eq) (ref eq)) (result (ref eq))))
+   (type $closure (sub (struct (field (ref $function_1)))))
+   (type $closure_last_arg (sub $closure (struct (field (ref $function_1)))))
+   (type $function_2 (func (param (ref eq) (ref eq) (ref eq)) (result (ref eq))))
    (type $cps_closure (sub (struct (field (ref $function_2)))))
    (type $cps_closure_last_arg
       (sub $cps_closure (struct (field (ref $function_2)))))


### PR DESCRIPTION
This reduces the amount of memory allocated. But I think this also allows Binaryen to make more optimizations, since it becomes clear that the function is only called from known places. 