### PR TITLE
Faster queue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,7 @@
 * Compiler: remove empty blocks (#1934)
 * Compiler: improve coloring optimization (#1971, #1984, #1986, #1989)
 * Compiler: faster constant sharing (#1988)
-* Compiler: faster js code generation (#1985)
+* Compiler: faster js code generation (#1985, #2066)
 * Compiler: improve performance of Javascript linking
 * Compiler: more efficient code generation from bytecode (#1972)
 * Compiler: faster compilation by improving the scheduling of optimization passes (#1962, #2001, #2012, #2027)

--- a/compiler/lib/generate.ml
+++ b/compiler/lib/generate.ml
@@ -645,22 +645,19 @@ end = struct
             } )
       | Mutator ->
           let flush = ref [] in
-          let muts =
-            Var.Set.filter
-              (fun x ->
-                let elt = Var.Map.find x queue.map in
+          let muts = Var.Set.empty in
+          Var.Set.iter
+            (fun x ->
+              let elt = Var.Map.find x queue.map in
+              assert (
                 match elt.prop with
-                | Mutator | Mutable | Flush ->
-                    flush := (x, elt) :: !flush;
-                    false
-                | _ -> true)
-              queue.muts
-          in
+                | Mutator | Mutable | Flush -> true
+                | Const -> false);
+              flush := (x, elt) :: !flush)
+            queue.muts;
           ( !flush
           , { muts
-            ; map =
-                List.fold_left !flush ~init:queue.map ~f:(fun acc (x, _) ->
-                    Var.Map.remove x acc)
+            ; map = Var.Set.fold (fun x acc -> Var.Map.remove x acc) queue.muts queue.map
             ; rank = queue.rank
             } )
     in


### PR DESCRIPTION
Get rid of the quadratic behavior for expression queue when generate js code.
Here are speedups for the code generation pass:
- fiat-crypto -60% 
- ocamlc -14%
- partial-render-table -47%