### PR TITLE
Wasm/runtime: put back caml_string_of_array

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,9 @@
 ## Features/Changes
 * Compiler: exit-loop-early in more cases (#2077)
 
+## Bug fixes
+* Runtime/wasm: add back legacy function caml_string_of_array (#2081)
+
 # 6.1.1 (2025-07-07) - Lille
 
 ## Bug fixes

--- a/runtime/wasm/bigarray.wat
+++ b/runtime/wasm/bigarray.wat
@@ -2037,6 +2037,7 @@
       (ref.i31 (i32.const 0)))
 
    (export "caml_bytes_of_uint8_array" (func $caml_string_of_uint8_array))
+   (export "caml_string_of_array" (func $caml_string_of_uint8_array)) ;; Used by brr
    (func $caml_string_of_uint8_array (export "caml_string_of_uint8_array")
       (param (ref eq)) (result (ref eq))
       ;; used to convert a typed array to a string


### PR DESCRIPTION
Brr is using this function. This is an alias for `caml_string_of_uint8_array`.