### PR TITLE
Make test independent from build directory state

### DIFF
--- a/compiler/tests-ocaml/lib-unix/common/append.ml
+++ b/compiler/tests-ocaml/lib-unix/common/append.ml
@@ -27,6 +27,7 @@ let append () =
   Unix.close fd
 
 let () =
+  (try Unix.unlink "append.txt" with Unix.(Unix_error (ENOENT, _, _)) -> ());
   append ();
   append ();
   let fd = Unix.openfile "append.txt" [ Unix.O_RDONLY ] 0o644 in


### PR DESCRIPTION
The modified test could fail if the directory it's run in already contained a file named `append.txt`, which sometimes happened when the test has already been run previously by Dune, possibly with a different backend or profile.