### PR TITLE
Revert "Runtime: fix annotation of caml_compare"

### DIFF
--- a/runtime/js/compare.js
+++ b/runtime/js/compare.js
@@ -251,7 +251,7 @@ function caml_compare_val(a, b, total) {
     b = b[i];
   }
 }
-//Provides: caml_compare mutable (const, const)
+//Provides: caml_compare (const, const)
 //Requires: caml_compare_val
 function caml_compare(a, b) {
   return caml_compare_val(a, b, true);


### PR DESCRIPTION
This reverts commit 3ceafdf42b62c96225f0d482fa29ca0f1ab589f9: `caml_compare` can raise `Invalid_argument`.

Fixes #2089.