### PR TITLE
Lib: add Dom_html.onload for load handling (#1948)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 * Compiler: js-parser: support html-comments
 * Runtime: improved handling of NaNs (#2110)
 * Lib: allow to reference values from the runtime (#2086)
+* Lib: add `Dom_html.onload` for WASM-safe load handling (#1948)
 * Runtime: make eval functions more robust (#2108)
 
 

--- a/lib/js_of_ocaml/dom_html.ml
+++ b/lib/js_of_ocaml/dom_html.ml
@@ -3735,6 +3735,20 @@ let clearTimeout (id : timeout_id_safe) =
       id := None;
       window##clearTimeout x
 
+let onload f =
+  let complete = Js.string "complete" in
+  if document##.readyState == complete
+  then f ()
+  else
+    ignore
+      (Dom.addEventListener
+         window
+         Event.load
+         (handler (fun _ ->
+              f ();
+              Js._true))
+         Js._false)
+
 let js_array_of_collection (c : #element collection Js.t) : #element Js.t Js.js_array Js.t
     =
   Js.Unsafe.(meth_call (js_expr "[].slice") "call" [| inject c |])

--- a/lib/js_of_ocaml/dom_html.mli
+++ b/lib/js_of_ocaml/dom_html.mli
@@ -3255,6 +3255,11 @@ val setTimeout : (unit -> unit) -> float -> timeout_id_safe
 
 val clearTimeout : timeout_id_safe -> unit
 
+val onload : (unit -> unit) -> unit
+(** Register a callback to run when the page finishes loading.
+    If the page has already loaded (e.g. when running as WebAssembly),
+    the callback is invoked immediately. *)
+
 val js_array_of_collection : #element collection Js.t -> #element Js.t Js.js_array Js.t
 (** Convert a [Dom_html.collection] to a Js array *)
 

--- a/toplevel/examples/lwt_toplevel/toplevel.ml
+++ b/toplevel/examples/lwt_toplevel/toplevel.ml
@@ -486,8 +486,4 @@ let run _ =
         (Js.string (Printexc.to_string exc))
         exc
 
-let _ =
-  Dom_html.window##.onload :=
-    Dom_html.handler (fun _ ->
-        run ();
-        Js._false)
+let _ = Dom_html.onload (fun () -> run ())


### PR DESCRIPTION
In WASM mode, the load event fires before OCaml code runs. Add a helper that checks document.readyState first and calls the callback immediately if the page has already loaded, otherwise registers a load event listener.

fix #1948