### PR TITLE
Fix substitution bug in reference unboxing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 * Runtime/wasm: optimized some bigstring primitives (#2144)
 
 ## Bug fixes
+* Compiler: fix reference unboxing (#2210)
 * Compiler/wasm: fix int division return type to Unnormalized (#2197)
 * Compiler/wasm: preserve physical identity of empty closures (#2207)
 * Compiler/wasm: fix crash when compiling some function calls (#2208)

--- a/compiler/lib/ref_unboxing.ml
+++ b/compiler/lib/ref_unboxing.ml
@@ -43,7 +43,9 @@ let rewrite_body unboxed_refs body ref_contents subst =
       ~f:(fun (ref_contents, subst, acc) i ->
         match i with
         | Let (x, Block (0, [| y |], (NotArray | Unknown), Maybe_mutable))
-          when Var.Set.mem x unboxed_refs -> Var.Map.add x y ref_contents, subst, acc
+          when Var.Set.mem x unboxed_refs ->
+            let y = try Var.Map.find y subst with Not_found -> y in
+            Var.Map.add x y ref_contents, subst, acc
         | Let (y, Field (x, 0, Non_float)) when Var.Map.mem x ref_contents ->
             ref_contents, Var.Map.add y (Var.Map.find x ref_contents) subst, acc
         | Offset_ref (x, n) when Var.Map.mem x ref_contents ->
@@ -59,6 +61,7 @@ let rewrite_body unboxed_refs body ref_contents subst =
                       ] ) )
               :: acc )
         | Set_field (x, 0, Non_float, y) when Var.Map.mem x ref_contents ->
+            let y = try Var.Map.find y subst with Not_found -> y in
             Var.Map.add x y ref_contents, subst, acc
         | Event _ -> (
             ( ref_contents

--- a/compiler/tests-jsoo/ref_unboxing.ml
+++ b/compiler/tests-jsoo/ref_unboxing.ml
@@ -9,3 +9,15 @@ let f () =
     if Random.int 3 < 0 then incr r else decr r;
     !r
   with _ -> assert false
+
+(* Test: while loop with cross-assignment between refs.
+   This is the pattern from #2209: i := !pi followed by
+   reading !i (which should be the old !pi value). *)
+let loop_cross_assign () =
+  let i = ref 4 in
+  let pi = ref 2 in
+  while !i > 0 do
+    i := !pi;
+    pi := !i - 1
+  done;
+  !i


### PR DESCRIPTION
When storing a value into ref_contents (via Set_field or Block creation), the value variable may have already been eliminated by a prior Field read (and added to the subst map). Resolve the value through the current substitution before storing it in ref_contents.

Fixes #2209