### PR TITLE
Documentation: targeting older browsers with Babel

### DIFF
--- a/.github/workflows/js_of_ocaml.yml
+++ b/.github/workflows/js_of_ocaml.yml
@@ -187,6 +187,12 @@ jobs:
       - run: opam exec -- make tests
         if: ${{ !matrix.skip-test }}
 
+      - name: Run Babel downleveling test
+        if: ${{ !matrix.skip-test && runner.os == 'Linux' }}
+        run: |
+          npm install
+          opam exec -- make test-babel-downlevel
+
       - run: opam exec -- dune build @all @runtest @runtest-js --profile with-effects
         if: ${{ !matrix.skip-effects }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,7 @@ toplevel/examples/lwt_toplevel_bin/toplevel.js
 toplevel/examples/lwt_toplevel_bin/eval.js
 
 janestreet
+
+# npm (for the Babel downleveling test)
+node_modules
+package-lock.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,8 +63,8 @@ make bench
   - `ppx_deriving_json/` - JSON derivation PPX
 
 - **`/runtime/`** - JavaScript/WebAssembly runtime
-  - `js/` - JavaScript runtime modules
-  - `wasm/` - WebAssembly runtime modules
+  - `js/` - JavaScript runtime modules (`.js` files with `//Provides:` / `//Requires:` / `//If:` / `//Alias:` headers; `//Provides:` accepts flags `const`, `mutable`, `pure`, `shallow` that affect optimization)
+  - `wasm/` - WebAssembly runtime modules (`.wat`); JS and Wasm runtimes are parallel — primitives in one usually need a counterpart in the other
 
 - **`/examples/`** - Example projects
 - **`/toplevel/`** - Web-based OCaml toplevel
@@ -80,7 +80,7 @@ opam install odoc lwt_log yojson ocp-indent graphics higlo
 ```
 
 **Requirements:**
-- OCaml 4.13 to 5.4
+- OCaml 4.13 to 5.5
 - Dune 3.19+
 - For wasm_of_ocaml: Binaryen 119+
 
@@ -116,6 +116,8 @@ dune runtest compiler/tests-jsoo
 dune promote
 ```
 
+`make tests` requires a recent Node.js to be available on `PATH`.
+
 Test directories:
 - `compiler/tests-jsoo/` - JavaScript output tests
 - `compiler/tests-wasm_of_ocaml/` - WebAssembly tests
@@ -125,9 +127,16 @@ Test directories:
 
 ## Key Compiler Flags
 
-- `--effects={cps,double-translation}` - Effect handler support
-- `--enable es6` - ES6 output mode
-- `--compilation_mode separate` - Separate compilation
+- `--effects={disabled,cps,double-translation}` - Effect handler support (JS); wasm accepts `{disabled,cps,jspi}`
+- `--target-env={isomorphic,browser,nodejs}` - Runtime target (default `isomorphic`)
+- `--source-map` / `--debug-info` / `--pretty` - Debug-friendly output
+- `--opt {1,2,3}` - Optimization profile (default 1; 3 iterates to fix-point)
+- `--enable=OPT` / `--disable=OPT` - Toggle individual options (names in `compiler/lib/config.ml`), e.g. `--enable es6` to emit ES6 syntax in generated code
+- `--toplevel` - Compile a toplevel (link against `js_of_ocaml-toplevel`)
+
+### Compilation modes
+
+The `js_of_ocaml` CLI has subcommands `compile` (default), `build-runtime`, and `link`. Whole-program compilation runs `compile` end-to-end; separate compilation builds the runtime, compiles each `.cmo`/`.cma` independently, then links the pieces. Dune picks whole-program for `--profile release` and separate for `dev`. See `manual/compilation-modes.wiki`.
 
 ## Architecture Notes
 
@@ -143,10 +152,12 @@ Key modules in `compiler/lib/`:
 - `generate.ml` - JavaScript code generation
 - `driver.ml` - Compilation driver
 
+Wasm backend lives in `compiler/lib-wasm/` (e.g. `generate.ml`, `code_generation.ml`, `link.ml`).
+
 ## Contributing
 
 1. Create branch from `master`
 2. Write tests for new code
 3. Run `make tests` before submitting
-4. Update `CHANGES.md` with entry
+4. Add a `CHANGES.md` entry under the `# dev` heading, in an appropriate subsection (`Features/Changes`, `Bug fixes`, etc.) with a `(#NNNN)` PR reference
 5. Discuss significant changes via issues first

--- a/ECMASCRIPT.md
+++ b/ECMASCRIPT.md
@@ -35,6 +35,11 @@ Features are grouped by ECMAScript version.
 
 - [Compatibility](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#browser_compatibility)
 
+### Promise
+
+- [Compatibility](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#browser_compatibility)
+- For Wasm_of_ocaml
+
 ### Rest parameters
 
 - [Compatibility](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters#browser_compatibility)
@@ -46,6 +51,10 @@ Features are grouped by ECMAScript version.
 ### Spread syntax (in function call)
 
 - [Compatibility](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax#browser_compatibility)
+
+### Template literals
+
+- [Compatibility](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#browser_compatibility)
 
 ### TypedArray
 
@@ -60,7 +69,7 @@ Features are grouped by ECMAScript version.
 
 - [Compatibility](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView#browser_compatibility)
 
-## ECMAScript 2016
+## ECMAScript 2017
 
 ### async function
 

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,12 @@ tests:
 tests-wasm:
 	WASM_OF_OCAML=true dune build @runtest-wasm
 
+# Validates the Babel downleveling recipe documented in
+# manual/browser-compat.wiki. Requires `npm install` at the repo root
+# for @babel/cli, @babel/preset-env, core-js, and es-check.
+test-babel-downlevel:
+	JSOO_ROOT=$(CURDIR) dune build @runtest-babel-downlevel
+
 test runtest runtests: tests
 
 doc:

--- a/compiler/tests-jsoo/babel-downlevel/downlevel.t
+++ b/compiler/tests-jsoo/babel-downlevel/downlevel.t
@@ -1,0 +1,90 @@
+Validates the recipe in manual/browser-compat.wiki: running js_of_ocaml
+output through Babel + core-js + esbuild yields an ES5-compatible,
+browser-ready bundle that is functionally equivalent to the baseline.
+
+Resolve paths to the babel/esbuild/es-check binaries and core-js
+installed at the repository root (via `npm install`). JSOO_ROOT is set
+by the `make test-babel-downlevel` target and points to the source
+root. A symlink is used so esbuild's module resolver can find core-js.
+
+  $ BABEL="$JSOO_ROOT/node_modules/.bin/babel"
+  $ ESBUILD="$JSOO_ROOT/node_modules/.bin/esbuild"
+  $ ESCHECK="$JSOO_ROOT/node_modules/.bin/es-check"
+  $ ln -s "$JSOO_ROOT/node_modules" node_modules
+
+Write a test program exercising print, Hashtbl, Marshal, and Weak (the
+last covers the runtime's WeakRef feature-detection path).
+
+  $ cat > test.ml <<'EOF'
+  > let () =
+  >   print_endline "hello";
+  >   let h = Hashtbl.create 4 in
+  >   Hashtbl.add h "a" 1;
+  >   Hashtbl.add h "b" 2;
+  >   Printf.printf "hashtbl: a=%d b=%d\n"
+  >     (Hashtbl.find h "a") (Hashtbl.find h "b");
+  >   let buf = Marshal.to_string (42, "x", [ 1; 2; 3 ]) [] in
+  >   let (a, b, c) : int * string * int list = Marshal.from_string buf 0 in
+  >   Printf.printf "marshal: %d %s [%s]\n" a b
+  >     (String.concat ";" (List.map string_of_int c));
+  >   let w = Weak.create 1 in
+  >   Weak.set w 0 (Some "held");
+  >   (match Weak.get w 0 with
+  >    | Some s -> Printf.printf "weak: %s\n" s
+  >    | None -> print_endline "weak: collected")
+  > EOF
+
+  $ ocamlc test.ml -o test.bc
+  $ dune exec -- js_of_ocaml --target-env=browser test.bc -o test.js 2>&1
+
+Baseline (pre-Babel) output runs and produces expected results:
+
+  $ node test.js
+  hello
+  hashtbl: a=1 b=2
+  marshal: 42 x [1;2;3]
+  weak: held
+
+Transpile with Babel (targets ES5 to stress the full pipeline):
+
+  $ cat > babel.config.json <<'EOF'
+  > {
+  >   "presets": [
+  >     ["@babel/preset-env", {
+  >       "targets": "ie 11",
+  >       "useBuiltIns": "usage",
+  >       "corejs": "3.6.5"
+  >     }]
+  >   ]
+  > }
+  > EOF
+  $ NODE_PATH="$JSOO_ROOT/node_modules" \
+  >   "$BABEL" test.js -o test.es5.js 2>&1 | grep -v "^Successfully" | cat
+
+Bundle with esbuild (resolves core-js polyfill imports into a single
+browser-ready file):
+
+  $ "$ESBUILD" test.es5.js --bundle --platform=browser \
+  >   --target=es5 --log-level=error --outfile=test.bundle.js
+
+Bundle is ES5-compatible:
+
+  $ "$ESCHECK" es5 test.bundle.js 2>&1 | grep -oE 'passed![^$]*compatible\.'
+  passed! All files are ES5 compatible.
+
+Bundle runs and matches the baseline:
+
+  $ node test.bundle.js
+  hello
+  hashtbl: a=1 b=2
+  marshal: 42 x [1;2;3]
+  weak: held
+
+Weak still works (as a strong ref) when WeakRef / FinalizationRegistry
+are unavailable — this verifies the documented feature-detection path:
+
+  $ node -e 'delete globalThis.WeakRef; delete globalThis.FinalizationRegistry; require("./test.bundle.js")'
+  hello
+  hashtbl: a=1 b=2
+  marshal: 42 x [1;2;3]
+  weak: held

--- a/compiler/tests-jsoo/babel-downlevel/downlevel.t
+++ b/compiler/tests-jsoo/babel-downlevel/downlevel.t
@@ -46,11 +46,13 @@ the per-iteration capture in the loop above (without it, the same
 binding lowers to `var` plus a hoisted helper).
 
   $ ocamlc test.ml -o test.bc
-  $ dune exec -- js_of_ocaml --pretty --target-env=browser test.bc -o test.js 2>&1
+  $ dune exec -- js_of_ocaml --pretty test.bc -o test.js 2>&1
 
 Baseline (pre-Babel) output runs and produces expected results:
 
-  $ node test.js
+
+
+  $ node test.js 
   hello
   hashtbl: a=1 b=2
   marshal: 42 x [1;2;3]
@@ -74,9 +76,13 @@ Transpile with Babel (targets ES5 to stress the full pipeline):
   >   "$BABEL" test.js -o test.es5.js 2>&1 | grep -v "^Successfully" | cat
 
 Bundle with esbuild (resolves core-js polyfill imports into a single
-browser-ready file):
+browser-ready file). The runtime contains `require("node:*")` calls
+guarded by `fs_node_supported()` etc.; mark them external so esbuild
+leaves them in place rather than failing to resolve them at bundle
+time:
 
   $ "$ESBUILD" test.es5.js --bundle --platform=browser \
+  >   --external:node:* \
   >   --target=es5 --log-level=error --outfile=test.bundle.js
 
 Bundle is ES5-compatible:

--- a/compiler/tests-jsoo/babel-downlevel/downlevel.t
+++ b/compiler/tests-jsoo/babel-downlevel/downlevel.t
@@ -12,8 +12,11 @@ root. A symlink is used so esbuild's module resolver can find core-js.
   $ ESCHECK="$JSOO_ROOT/node_modules/.bin/es-check"
   $ ln -s "$JSOO_ROOT/node_modules" node_modules
 
-Write a test program exercising print, Hashtbl, Marshal, and Weak (the
-last covers the runtime's WeakRef feature-detection path).
+Write a test program exercising print, Hashtbl, Marshal, Weak (the last
+covers the runtime's WeakRef feature-detection path), and a
+closure-in-loop pattern that compiles to `let` per iteration — Babel
+must rewrite the binding for ES5 because each closure captures its own
+copy, not the final value.
 
   $ cat > test.ml <<'EOF'
   > let () =
@@ -31,11 +34,19 @@ last covers the runtime's WeakRef feature-detection path).
   >   Weak.set w 0 (Some "held");
   >   (match Weak.get w 0 with
   >    | Some s -> Printf.printf "weak: %s\n" s
-  >    | None -> print_endline "weak: collected")
+  >    | None -> print_endline "weak: collected");
+  >   let funs = ref [] in
+  >   for i = 0 to 2 do funs := (fun () -> i) :: !funs done;
+  >   List.iter (fun f -> Printf.printf "fn=%d " (f ())) (List.rev !funs);
+  >   print_newline ()
   > EOF
 
+`--pretty` keeps the generated JavaScript readable and emits `let` for
+the per-iteration capture in the loop above (without it, the same
+binding lowers to `var` plus a hoisted helper).
+
   $ ocamlc test.ml -o test.bc
-  $ dune exec -- js_of_ocaml --target-env=browser test.bc -o test.js 2>&1
+  $ dune exec -- js_of_ocaml --pretty --target-env=browser test.bc -o test.js 2>&1
 
 Baseline (pre-Babel) output runs and produces expected results:
 
@@ -44,6 +55,7 @@ Baseline (pre-Babel) output runs and produces expected results:
   hashtbl: a=1 b=2
   marshal: 42 x [1;2;3]
   weak: held
+  fn=0 fn=1 fn=2 
 
 Transpile with Babel (targets ES5 to stress the full pipeline):
 
@@ -79,6 +91,7 @@ Bundle runs and matches the baseline:
   hashtbl: a=1 b=2
   marshal: 42 x [1;2;3]
   weak: held
+  fn=0 fn=1 fn=2 
 
 Weak still works (as a strong ref) when WeakRef / FinalizationRegistry
 are unavailable — this verifies the documented feature-detection path:
@@ -88,3 +101,4 @@ are unavailable — this verifies the documented feature-detection path:
   hashtbl: a=1 b=2
   marshal: 42 x [1;2;3]
   weak: held
+  fn=0 fn=1 fn=2 

--- a/compiler/tests-jsoo/babel-downlevel/dune
+++ b/compiler/tests-jsoo/babel-downlevel/dune
@@ -1,0 +1,11 @@
+; Opt-in test that validates the recipe documented in
+; manual/browser-compat.wiki: post-processing js_of_ocaml output with
+; Babel + core-js for pre-ES2015 targets.
+;
+; Not attached to @runtest — only runs on the dedicated alias.
+; Requires `npm install` at the repository root (adds @babel/cli,
+; @babel/preset-env, core-js, es-check). Run via:
+;   make test-babel-downlevel
+
+(cram
+ (alias runtest-babel-downlevel))

--- a/compiler/tests-jsoo/babel-downlevel/dune
+++ b/compiler/tests-jsoo/babel-downlevel/dune
@@ -8,4 +8,5 @@
 ;   make test-babel-downlevel
 
 (cram
- (alias runtest-babel-downlevel))
+ (alias runtest-babel-downlevel)
+ (runtest_alias false))

--- a/manual/browser-compat.wiki
+++ b/manual/browser-compat.wiki
@@ -39,12 +39,9 @@ matching the engines you need to support.
 Compile your program with js_of_ocaml, then run Babel on the output:
 
 {{{
-js_of_ocaml --target-env=browser program.byte -o program.js
+js_of_ocaml program.byte -o program.js
 npx babel program.js -o program.es5.js
 }}}
-
-{{{--target-env=browser}}} keeps the runtime from pulling in Node-only
-branches, which would otherwise fail to resolve when bundling.
 
 The resulting {{{program.es5.js}}} imports polyfills from {{{core-js}}}
 with {{{require("core-js/modules/...")}}} calls. Before shipping to a
@@ -58,8 +55,13 @@ is a small, zero-config option:
 {{{
 npm install --save-dev esbuild
 npx esbuild program.es5.js --bundle --platform=browser \
-  --outfile=program.bundle.js
+  --external:node:* --outfile=program.bundle.js
 }}}
+
+The runtime contains a few {{{require("node:*")}}} calls (filesystem,
+tty, etc.) guarded by Node-detection branches that never run in a
+browser. {{{--external:node:*}}} tells esbuild to leave those imports
+in place instead of failing to resolve them at bundle time.
 
 Esbuild preserves whatever ES level Babel produced; it just resolves
 {{{require}}} calls and concatenates modules.

--- a/manual/browser-compat.wiki
+++ b/manual/browser-compat.wiki
@@ -1,0 +1,101 @@
+= Targeting older browsers
+
+Js_of_ocaml's generated code and runtime target **ECMAScript 2020 (ES2020)**.
+Out of the box, the output runs on Node.js 16+ and any evergreen browser
+released since early 2020 (Chrome 80+, Firefox 74+, Safari 13.4+, Edge 80+).
+
+If you need to support an older engine, you can post-process the
+generated JavaScript with [[https://babeljs.io|Babel]] and ship
+polyfills with [[https://github.com/zloirock/core-js|core-js]].
+Js_of_ocaml has no built-in downleveling.
+
+==@@id="babel-recipe"@@ Transpiling with Babel
+
+Install Babel and core-js:
+
+{{{
+npm install --save-dev @babel/core @babel/cli @babel/preset-env
+npm install core-js
+}}}
+
+Create a {{{babel.config.json}}} next to your build:
+
+<<code language="json"|
+{
+  "presets": [
+    ["@babel/preset-env", {
+      "targets": "> 0.5%, last 2 versions, not dead",
+      "useBuiltIns": "usage",
+      "corejs": "3.37"
+    }]
+  ]
+}
+>>
+
+Set {{{targets}}} to the
+[[https://github.com/browserslist/browserslist|browserslist query]]
+matching the engines you need to support.
+
+Compile your program with js_of_ocaml, then run Babel on the output:
+
+{{{
+js_of_ocaml --target-env=browser program.byte -o program.js
+npx babel program.js -o program.es5.js
+}}}
+
+{{{--target-env=browser}}} keeps the runtime from pulling in Node-only
+branches, which would otherwise fail to resolve when bundling.
+
+The resulting {{{program.es5.js}}} imports polyfills from {{{core-js}}}
+with {{{require("core-js/modules/...")}}} calls. Before shipping to a
+browser you need to bundle it so those imports are resolved and inlined.
+
+==@@id="bundling"@@ Bundling
+
+Any JavaScript bundler will work; [[https://esbuild.github.io|esbuild]]
+is a small, zero-config option:
+
+{{{
+npm install --save-dev esbuild
+npx esbuild program.es5.js --bundle --platform=browser \
+  --outfile=program.bundle.js
+}}}
+
+Esbuild preserves whatever ES level Babel produced; it just resolves
+{{{require}}} calls and concatenates modules.
+
+Ship {{{program.bundle.js}}} as a single script; no additional polyfills
+are required at load time.
+
+==@@id="dune"@@ With dune
+
+You can wire Babel into your dune rules so it runs automatically:
+
+{{{
+(rule
+ (targets program.es5.js)
+ (deps program.bc.js babel.config.json)
+ (action
+  (run npx babel %{dep:program.bc.js} -o %{targets})))
+}}}
+
+==@@id="caveats"@@ Caveats
+
+* **Code size**: polyfills and transpiled helpers add a non-trivial amount of
+  JavaScript. Expect the output to be noticeably larger.
+* **Performance**: transpiled code tends to run slower than the original
+  ES2020 output, especially the further back you target.
+* **Source maps**: pass {{{--source-map}}} to js_of_ocaml and {{{--source-maps}}}
+  to Babel to keep a mapping back to the OCaml source. Babel will chain the
+  source map through if one is present alongside its input.
+* **Weak references**: core-js does not polyfill {{{WeakRef}}} faithfully.
+  On engines without native {{{WeakRef}}}, {{{Stdlib.Weak}}} and
+  {{{Stdlib.Ephemeron}}} behave as strong references — values held by them
+  will not be collected.
+* **Wasm_of_ocaml**: targeting older browsers is not possible with
+  {{{wasm_of_ocaml}}}, which requires a WebAssembly GC-capable engine.
+
+==@@id="see-also"@@ See also
+
+* <<a_manual chapter="options"|Command line options>> — compiler flags
+* <<a_manual chapter="install"|Installation>> — supported engines

--- a/manual/browser-compat.wiki
+++ b/manual/browser-compat.wiki
@@ -26,7 +26,7 @@ Create a {{{babel.config.json}}} next to your build:
     ["@babel/preset-env", {
       "targets": "> 0.5%, last 2 versions, not dead",
       "useBuiltIns": "usage",
-      "corejs": "3.37"
+      "corejs": 3
     }]
   ]
 }
@@ -55,7 +55,7 @@ is a small, zero-config option:
 {{{
 npm install --save-dev esbuild
 npx esbuild program.es5.js --bundle --platform=browser \
-  --external:node:* --outfile=program.bundle.js
+  --external:node:* --target=es5 --outfile=program.bundle.js
 }}}
 
 The runtime contains a few {{{require("node:*")}}} calls (filesystem,
@@ -63,15 +63,20 @@ tty, etc.) guarded by Node-detection branches that never run in a
 browser. {{{--external:node:*}}} tells esbuild to leave those imports
 in place instead of failing to resolve them at bundle time.
 
-Esbuild preserves whatever ES level Babel produced; it just resolves
-{{{require}}} calls and concatenates modules.
+[[https://esbuild.github.io/api/#target|{{{--target}}}]] is needed even
+when Babel has lowered the input: esbuild's own IIFE wrapper and CommonJS
+helpers use arrow functions and other post-ES5 syntax, and {{{--target}}}
+is what tells it to lower those too. Set it to the lowest syntax level
+your browserslist query implies.
 
 Ship {{{program.bundle.js}}} as a single script; no additional polyfills
 are required at load time.
 
 ==@@id="dune"@@ With dune
 
-You can wire Babel into your dune rules so it runs automatically:
+Assuming dune builds your program to {{{program.bc.js}}} (e.g. from an
+{{{(executable (modes js) ...)}}} stanza), wire the Babel and esbuild
+steps into the build with two rules:
 
 {{{
 (rule
@@ -79,23 +84,15 @@ You can wire Babel into your dune rules so it runs automatically:
  (deps program.bc.js babel.config.json)
  (action
   (run npx babel %{dep:program.bc.js} -o %{targets})))
+
+(rule
+ (targets program.bundle.js)
+ (deps program.es5.js)
+ (action
+  (run npx esbuild %{dep:program.es5.js}
+       --bundle --platform=browser --external:node:*
+       --target=es5 --outfile=%{targets})))
 }}}
-
-==@@id="caveats"@@ Caveats
-
-* **Code size**: polyfills and transpiled helpers add a non-trivial amount of
-  JavaScript. Expect the output to be noticeably larger.
-* **Performance**: transpiled code tends to run slower than the original
-  ES2020 output, especially the further back you target.
-* **Source maps**: pass {{{--source-map}}} to js_of_ocaml and {{{--source-maps}}}
-  to Babel to keep a mapping back to the OCaml source. Babel will chain the
-  source map through if one is present alongside its input.
-* **Weak references**: core-js does not polyfill {{{WeakRef}}} faithfully.
-  On engines without native {{{WeakRef}}}, {{{Stdlib.Weak}}} and
-  {{{Stdlib.Ephemeron}}} behave as strong references — values held by them
-  will not be collected.
-* **Wasm_of_ocaml**: targeting older browsers is not possible with
-  {{{wasm_of_ocaml}}}, which requires a WebAssembly GC-capable engine.
 
 ==@@id="see-also"@@ See also
 

--- a/manual/install.wiki
+++ b/manual/install.wiki
@@ -18,7 +18,7 @@
 
 The generated JavaScript works with:
 * Node.js 16 or later
-* Any modern browser supporting ECMAScript 6 (ES2015)
+* Any modern browser supporting ECMAScript 2020 (ES2020) — Chrome 80+, Firefox 74+, Safari 13.4+, Edge 80+
 
 **Note**: {{{Stdlib.Weak}}} and {{{Stdlib.Ephemeron}}} require {{{WeakRef}}} support (ECMAScript 2021), available in all modern browsers and Node.js 14.6+.
 

--- a/manual/menu.wiki
+++ b/manual/menu.wiki
@@ -22,6 +22,7 @@
 ===[[tailcall|Tailcall optimization]]
 ===[[effects|Effect handlers]]
 ===[[runtime-representation|Runtime representation]]
+===[[browser-compat|Targeting older browsers]]
 
 ==Wasm_of_ocaml
 ===[[wasm_overview|Overview]]

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "devDependencies": {
+    "@babel/cli": "^7.28.6",
+    "@babel/core": "^7.29.0",
+    "@babel/preset-env": "^7.29.2",
+    "es-check": "^9.6.4",
+    "esbuild": "^0.28.0"
+  },
+  "dependencies": {
+    "core-js": "^3.6.5"
+  }
+}


### PR DESCRIPTION
## Summary

- New `manual/browser-compat.wiki` chapter documenting how to make js_of_ocaml output run on older browsers: jsoo targets ES2020 out of the box; use Babel + core-js to downlevel, then esbuild (or another bundler) to inline the polyfill imports.
- Opt-in cram test under `compiler/tests-jsoo/babel-downlevel/` that validates the recipe end-to-end (jsoo → Babel → esbuild → run). Gated on a dedicated `@runtest-babel-downlevel` alias so it stays out of the default `@runtest`, and wired into a `make test-babel-downlevel` target that the CI invokes on Linux.
- Fix `ECMASCRIPT.md`: `async`/`await` are ES2017, not ES2016; add `Promise` and template literals (both ES2015, used in the runtime).

## Test plan

- [ ] `make tests` still passes (alias keeps the Babel test off the default `@runtest`)
- [ ] `npm install && make test-babel-downlevel` passes locally
- [ ] CI's new "Run Babel downleveling test" step passes on the Linux matrix entries
- [ ] `dune build @doc-manual` renders `manual/browser-compat.wiki` without errors and the menu link works