### PR TITLE
Deadcode elimination: fix missing conditional simplification

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
 * Compiler/wasm: fix int division return type to Unnormalized (#2197)
 * Compiler/wasm: preserve physical identity of empty closures (#2207)
 * Compiler/wasm: fix crash when compiling some function calls (#2208)
+* Compiler: fix missing conditional simplification (#2217)
 
 
 # 6.3.2 (2026-02-15) - Lille

--- a/compiler/lib/deadcode.ml
+++ b/compiler/lib/deadcode.ml
@@ -376,7 +376,12 @@ let remove_empty_blocks st (p : Code.program) : Code.program =
         if
           match block.branch with
           | Branch (pc, _) | Poptrap (pc, _) -> not (Addr.Hashtbl.mem shortcuts pc)
-          | Cond (_, (pc1, _), (pc2, _)) | Pushtrap ((pc1, _), _, (pc2, _)) ->
+          | Cond (_, ((pc1, _) as cont1), ((pc2, _) as cont2)) ->
+              not
+                (Addr.Hashtbl.mem shortcuts pc1
+                || Addr.Hashtbl.mem shortcuts pc2
+                || Code.cont_equal cont1 cont2)
+          | Pushtrap ((pc1, _), _, (pc2, _)) ->
               not (Addr.Hashtbl.mem shortcuts pc1 || Addr.Hashtbl.mem shortcuts pc2)
           | Switch (_, a) ->
               not (Array.exists ~f:(fun (pc, _) -> Addr.Hashtbl.mem shortcuts pc) a)

--- a/compiler/tests-compiler/dune.inc
+++ b/compiler/tests-compiler/dune.inc
@@ -525,6 +525,21 @@
   (pps ppx_expect)))
 
 (library
+ ;; compiler/tests-compiler/gh2217.ml
+ (name gh2217_15)
+ (enabled_if true)
+ (modules gh2217)
+ (libraries js_of_ocaml_compiler unix str jsoo_compiler_expect_tests_helper)
+ (inline_tests
+  (enabled_if true)
+  (deps
+   (file %{project_root}/compiler/bin-js_of_ocaml/js_of_ocaml.exe)
+   (file %{project_root}/compiler/bin-jsoo_minify/jsoo_minify.exe)))
+ (flags (:standard -open Jsoo_compiler_expect_tests_helper))
+ (preprocess
+  (pps ppx_expect)))
+
+(library
  ;; compiler/tests-compiler/gh747.ml
  (name gh747_15)
  (enabled_if true)

--- a/compiler/tests-compiler/gh2217.ml
+++ b/compiler/tests-compiler/gh2217.ml
@@ -1,0 +1,50 @@
+(* Js_of_ocaml compiler
+ * http://www.ocsigen.org/js_of_ocaml/
+ * Copyright (C) 2026 Jérôme Vouillon
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+
+open Util
+
+let%expect_test "conditional simplification" =
+  let p =
+    {|
+let g () =
+  let f b = let x = if b then "a" else "b" in (b, x) in
+  (fst (f true), fst (f false))
+   |}
+  in
+  let p = compile_and_parse ~flags:[ "--debug=invariant" ] p in
+  print_fun_decl p (Some "g");
+  [%expect.unreachable]
+[@@expect.uncaught_exn {|
+  (* CR expect_test_collector: This test expectation appears to contain a backtrace.
+     This is strongly discouraged as backtraces are fragile.
+     Please change this test to not include a backtrace. *)
+  (Failure "non-zero exit code")
+  Raised at Stdlib__Buffer.add_channel in file "buffer.ml", line 213, characters 18-35
+  Called from Jsoo_compiler_expect_tests_helper__Util.channel_to_string.loop in file "compiler/tests-compiler/util/util.ml", line 169, characters 4-52
+  Called from Jsoo_compiler_expect_tests_helper__Util.channel_to_string in file "compiler/tests-compiler/util/util.ml", line 172, characters 7-14
+
+  Trailing output
+  ---------------
+  ZZZ 1
+  /home/jerome/js_of_ocaml/_build/default/compiler/bin-js_of_ocaml/js_of_ocaml.exe: You found a bug. Please report it at https://github.com/ocsigen/js_of_ocaml/issues :
+  Error: File "compiler/lib/code.ml", line 1103, characters 10-16: Assertion failed
+
+  process exited with error code 125
+   /home/jerome/js_of_ocaml/_build/default/compiler/bin-js_of_ocaml/js_of_ocaml.exe --pretty --debug var --sourcemap --effects=disabled --disable=use-js-string --disable header --debug=invariant --Werror test.cmo -o test.js
+  |}]

--- a/compiler/tests-compiler/gh2217.ml
+++ b/compiler/tests-compiler/gh2217.ml
@@ -29,22 +29,12 @@ let g () =
   in
   let p = compile_and_parse ~flags:[ "--debug=invariant" ] p in
   print_fun_decl p (Some "g");
-  [%expect.unreachable]
-[@@expect.uncaught_exn {|
-  (* CR expect_test_collector: This test expectation appears to contain a backtrace.
-     This is strongly discouraged as backtraces are fragile.
-     Please change this test to not include a backtrace. *)
-  (Failure "non-zero exit code")
-  Raised at Stdlib__Buffer.add_channel in file "buffer.ml", line 213, characters 18-35
-  Called from Jsoo_compiler_expect_tests_helper__Util.channel_to_string.loop in file "compiler/tests-compiler/util/util.ml", line 169, characters 4-52
-  Called from Jsoo_compiler_expect_tests_helper__Util.channel_to_string in file "compiler/tests-compiler/util/util.ml", line 172, characters 7-14
-
-  Trailing output
-  ---------------
-  ZZZ 1
-  /home/jerome/js_of_ocaml/_build/default/compiler/bin-js_of_ocaml/js_of_ocaml.exe: You found a bug. Please report it at https://github.com/ocsigen/js_of_ocaml/issues :
-  Error: File "compiler/lib/code.ml", line 1103, characters 10-16: Assertion failed
-
-  process exited with error code 125
-   /home/jerome/js_of_ocaml/_build/default/compiler/bin-js_of_ocaml/js_of_ocaml.exe --pretty --debug var --sourcemap --effects=disabled --disable=use-js-string --disable header --debug=invariant --Werror test.cmo -o test.js
-  |}]
+  [%expect
+    {|
+    function g(_a_){
+     function f(b){return [0, b];}
+     var _a_ = f(0)[1];
+     return [0, f(1)[1], _a_];
+    }
+    //end
+    |}]


### PR DESCRIPTION
The two continuations of a conditional can become identical when some unused arguments are removed. The generated code is not incorrect but that breaks our code invariant.