### PR TITLE
Js_traverse.simpl: fix optimization ordering

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
 * Compiler/wasm: preserve physical identity of empty closures (#2207)
 * Compiler/wasm: fix crash when compiling some function calls (#2208)
 * Compiler: fix missing conditional simplification (#2217)
+* Compiler: fix Js_assign.simpl (#2218)
 
 
 # 6.3.2 (2026-02-15) - Lille

--- a/compiler/lib/js_traverse.ml
+++ b/compiler/lib/js_traverse.ml
@@ -1927,11 +1927,6 @@ class clean =
       | s -> s
   end
 
-let opt_cons b l =
-  match b with
-  | Some b -> b :: l
-  | None -> l
-
 let use_fun_context l =
   let exception True in
   try
@@ -2122,6 +2117,20 @@ class simpl =
       (* Process a single statement: var->expr conversion and if simplifications.
          Returns (acc, is_var) where is_var indicates if result is a var statement. *)
       let process_one acc prev_is_var st loc =
+        (* Drop branches of if-statements with constant conditions before
+           visiting, so that variables declared in dropped branches are not
+           added to the [declared] set. *)
+        let st, loc =
+          match st with
+          (* if (1) e1 ... --> e1 *)
+          | If_statement (ENum n, (iftrue, iftrue_loc), _) when Num.is_one n ->
+              iftrue, iftrue_loc
+          (* if (0) e1 else e2 --> e2 *)
+          | If_statement (ENum n, _, Some (iffalse, iffalse_loc)) when Num.is_zero n ->
+              iffalse, iffalse_loc
+          | If_statement (ENum n, _, None) when Num.is_zero n -> Empty_statement, loc
+          | _ -> st, loc
+        in
         let st = m#with_in_var_sequence prev_is_var m#statement st in
         let is_var =
           match st with
@@ -2131,10 +2140,6 @@ class simpl =
         in
         let acc =
           match st with
-          (* if (1) e1 ... --> e1 *)
-          | If_statement (ENum n, iftrue, _) when Num.is_one n -> iftrue :: acc
-          (* if (0) e1 else e2 --> e2 *)
-          | If_statement (ENum n, _, iffalse) when Num.is_zero n -> opt_cons iffalse acc
           (* if (e1) return e2 else return e3 --> return e1 ? e2 : e3 *)
           | If_statement
               ( cond

--- a/compiler/tests-compiler/dune.inc
+++ b/compiler/tests-compiler/dune.inc
@@ -540,6 +540,21 @@
   (pps ppx_expect)))
 
 (library
+ ;; compiler/tests-compiler/gh2218.ml
+ (name gh2218_15)
+ (enabled_if true)
+ (modules gh2218)
+ (libraries js_of_ocaml_compiler unix str jsoo_compiler_expect_tests_helper)
+ (inline_tests
+  (enabled_if true)
+  (deps
+   (file %{project_root}/compiler/bin-js_of_ocaml/js_of_ocaml.exe)
+   (file %{project_root}/compiler/bin-jsoo_minify/jsoo_minify.exe)))
+ (flags (:standard -open Jsoo_compiler_expect_tests_helper))
+ (preprocess
+  (pps ppx_expect)))
+
+(library
  ;; compiler/tests-compiler/gh747.ml
  (name gh747_15)
  (enabled_if true)

--- a/compiler/tests-compiler/gh2218.ml
+++ b/compiler/tests-compiler/gh2218.ml
@@ -33,23 +33,11 @@ let f () =
   in
   let p = compile_and_parse ~flags:[ "--debug=invariant" ] p in
   print_fun_decl p (Some "f");
-  [%expect.unreachable]
-[@@expect.uncaught_exn
-  {|
-  (* CR expect_test_collector: This test expectation appears to contain a backtrace.
-     This is strongly discouraged as backtraces are fragile.
-     Please change this test to not include a backtrace. *)
-  (Failure "non-zero exit code")
-  Raised at Stdlib__Buffer.add_channel in file "buffer.ml", line 213, characters 18-35
-  Called from Jsoo_compiler_expect_tests_helper__Util.channel_to_string.loop in file "compiler/tests-compiler/util/util.ml", line 169, characters 4-52
-  Called from Jsoo_compiler_expect_tests_helper__Util.channel_to_string in file "compiler/tests-compiler/util/util.ml", line 172, characters 7-14
-
-  Trailing output
-  ---------------
-  Some variables escaped (#1). Use [--debug js_assign] for more info.
-  /home/jerome/js_of_ocaml/_build/default/compiler/bin-js_of_ocaml/js_of_ocaml.exe: You found a bug. Please report it at https://github.com/ocsigen/js_of_ocaml/issues :
-  Error: File "compiler/lib/js_assign.ml", line 503, characters 5-11: Assertion failed
-
-  process exited with error code 125
-   /home/jerome/js_of_ocaml/_build/default/compiler/bin-js_of_ocaml/js_of_ocaml.exe --pretty --debug var --sourcemap --effects=disabled --disable=use-js-string --disable header --debug=invariant --Werror test.cmo -o test.js
-  |}]
+  [%expect
+    {|
+    function f(param){
+     var f = Stdlib[46];
+     return function(string){var _a_ = string; return caml_call1(f, _a_);};
+    }
+    //end
+    |}]

--- a/compiler/tests-compiler/gh2218.ml
+++ b/compiler/tests-compiler/gh2218.ml
@@ -1,0 +1,55 @@
+(* Js_of_ocaml compiler
+ * http://www.ocsigen.org/js_of_ocaml/
+ * Copyright (C) 2026 Jérôme Vouillon
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+
+open Util
+
+let%expect_test "Js_traverse.simpl ordering" =
+  let p =
+    {|
+let f () =
+  let rec process b s = if b then s ^ "" else process true s in
+  let maybe_process ?(b = false) string =
+    if b then process false string else string in
+  let wrap f = fun ?b string -> f (maybe_process ?b string) in
+  let print_endline = wrap print_endline in
+  fun string -> print_endline string
+   |}
+  in
+  let p = compile_and_parse ~flags:[ "--debug=invariant" ] p in
+  print_fun_decl p (Some "f");
+  [%expect.unreachable]
+[@@expect.uncaught_exn
+  {|
+  (* CR expect_test_collector: This test expectation appears to contain a backtrace.
+     This is strongly discouraged as backtraces are fragile.
+     Please change this test to not include a backtrace. *)
+  (Failure "non-zero exit code")
+  Raised at Stdlib__Buffer.add_channel in file "buffer.ml", line 213, characters 18-35
+  Called from Jsoo_compiler_expect_tests_helper__Util.channel_to_string.loop in file "compiler/tests-compiler/util/util.ml", line 169, characters 4-52
+  Called from Jsoo_compiler_expect_tests_helper__Util.channel_to_string in file "compiler/tests-compiler/util/util.ml", line 172, characters 7-14
+
+  Trailing output
+  ---------------
+  Some variables escaped (#1). Use [--debug js_assign] for more info.
+  /home/jerome/js_of_ocaml/_build/default/compiler/bin-js_of_ocaml/js_of_ocaml.exe: You found a bug. Please report it at https://github.com/ocsigen/js_of_ocaml/issues :
+  Error: File "compiler/lib/js_assign.ml", line 503, characters 5-11: Assertion failed
+
+  process exited with error code 125
+   /home/jerome/js_of_ocaml/_build/default/compiler/bin-js_of_ocaml/js_of_ocaml.exe --pretty --debug var --sourcemap --effects=disabled --disable=use-js-string --disable header --debug=invariant --Werror test.cmo -o test.js
+  |}]


### PR DESCRIPTION
When simplifying conditionals, we should eliminate dead branches without visiting them. Otherwise, we may remove later on a `var` for a variable which has not actually been declared yet.