### PR TITLE
Wasm: complete OCaml 5.5 support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 # dev
 
 ## Features/Changes
-* Compiler: initial support for OCaml 5.5.0~alpha0 (#2197)
+* Compiler: initial support for OCaml 5.5.0 (#2197, #2220)
 * Compiler: added a variable coalescing pass (#2166)
 * Wasm dynlink/toplevel support (#2186)
 * OxCaml support (#2105)

--- a/compiler/bin-wasm_of_ocaml/compile.ml
+++ b/compiler/bin-wasm_of_ocaml/compile.ml
@@ -562,8 +562,7 @@ let run
          then
            let paths =
              include_dirs
-             @ StringSet.elements
-                 (Parse_bytecode.Debug.paths code.debug ~units:code.cmis)
+             @ StringSet.elements (Parse_bytecode.Debug.paths code.debug ~units:code.cmis)
            in
            Pseudo_fs.collect_cmis ~cmis:code.cmis ~paths
          else []
@@ -752,7 +751,13 @@ let run
            List.fold_right
              ~f:(fun cmo cont l ->
                compile_cmo cmo
-               @@ fun unit_data unit_name tmp_wasm_file opt_tmp_map_file shapes cmi_files ->
+               @@ fun unit_data
+                      unit_name
+                      tmp_wasm_file
+                      opt_tmp_map_file
+                      shapes
+                      cmi_files
+                    ->
                cont
                  (( unit_data
                   , unit_name
@@ -760,7 +765,7 @@ let run
                   , opt_tmp_map_file
                   , shapes
                   , cmi_files )
-                  :: l))
+                 :: l))
              cma.lib_units
              ~init:(fun l ->
                Fs.with_intermediate_file (Filename.temp_file "wasm" ".wasm")
@@ -799,9 +804,7 @@ let run
                if enable_source_maps
                then
                  add_source_map sourcemap_don't_inline_content z (`Source_map source_map);
-               let cmi_files =
-                 List.concat_map ~f:(fun (_, _, _, _, _, cmis) -> cmis) l
-               in
+               let cmi_files = List.concat_map ~f:(fun (_, _, _, _, _, cmis) -> cmis) l in
                if not (List.is_empty cmi_files)
                then
                  Zip.add_entry

--- a/compiler/bin-wasm_of_ocaml/compile.ml
+++ b/compiler/bin-wasm_of_ocaml/compile.ml
@@ -546,10 +546,27 @@ let run
        let include_dirs = Filename.dirname input_file :: include_dirs in
        res, ch, (fun () -> close_in ch), include_dirs
      in
+     let include_cmis = toplevel && not no_cmis in
      let compile_cmo cmo cont =
        let t1 = Timer.make () in
        let code =
-         Parse_bytecode.from_cmo ~includes:include_dirs ~debug:need_debug cmo ic
+         Parse_bytecode.from_cmo
+           ~includes:include_dirs
+           ~include_cmis
+           ~debug:need_debug
+           cmo
+           ic
+       in
+       let cmi_files =
+         if include_cmis
+         then
+           let paths =
+             include_dirs
+             @ StringSet.elements
+                 (Parse_bytecode.Debug.paths code.debug ~units:code.cmis)
+           in
+           Pseudo_fs.collect_cmis ~cmis:code.cmis ~paths
+         else []
        in
        let unit_info = Unit_info.of_cmo cmo in
        let (Global_name.Compunit unit_name) = Ocaml_compiler.Cmo_format.name cmo in
@@ -589,12 +606,11 @@ let run
            ();
          { Link.unit_name; unit_info; fragments }, shapes
        in
-       cont unit_data unit_name tmp_wasm_file opt_tmp_map_file shapes
+       cont unit_data unit_name tmp_wasm_file opt_tmp_map_file shapes cmi_files
      in
      (match kind with
      | `Exe ->
          let t1 = Timer.make () in
-         let include_cmis = toplevel && not no_cmis in
          let dynlink = toplevel || dynlink in
          let code =
            Parse_bytecode.from_exe
@@ -711,11 +727,17 @@ let run
          let compile_cmo' z cmo =
            compile_cmo
              cmo
-             (fun unit_data unit_name tmp_wasm_file opt_tmp_map_file shapes ->
+             (fun unit_data unit_name tmp_wasm_file opt_tmp_map_file shapes cmi_files ->
                Zip.add_file z ~name:"code.wasm" ~file:tmp_wasm_file;
                Zip.add_entry z ~name:"link_order" ~contents:unit_name;
                Zip.add_entry z ~name:"shapes.sexp" ~contents:(string_of_shapes shapes);
                add_source_map sourcemap_don't_inline_content z (`File opt_tmp_map_file);
+               if not (List.is_empty cmi_files)
+               then
+                 Zip.add_entry
+                   z
+                   ~name:"embedded_files"
+                   ~contents:(Marshal.to_string cmi_files []);
                unit_data)
          in
          let unit_data = [ compile_cmo' z cmo ] in
@@ -730,8 +752,15 @@ let run
            List.fold_right
              ~f:(fun cmo cont l ->
                compile_cmo cmo
-               @@ fun unit_data unit_name tmp_wasm_file opt_tmp_map_file shapes ->
-               cont ((unit_data, unit_name, tmp_wasm_file, opt_tmp_map_file, shapes) :: l))
+               @@ fun unit_data unit_name tmp_wasm_file opt_tmp_map_file shapes cmi_files ->
+               cont
+                 (( unit_data
+                  , unit_name
+                  , tmp_wasm_file
+                  , opt_tmp_map_file
+                  , shapes
+                  , cmi_files )
+                  :: l))
              cma.lib_units
              ~init:(fun l ->
                Fs.with_intermediate_file (Filename.temp_file "wasm" ".wasm")
@@ -740,7 +769,7 @@ let run
                let source_map =
                  Wasm_link.f
                    (List.map
-                      ~f:(fun (_, _, file, opt_source_map, _) ->
+                      ~f:(fun (_, _, file, opt_source_map, _, _) ->
                         { Wasm_link.module_name = "OCaml"
                         ; file
                         ; code = None
@@ -759,18 +788,27 @@ let run
                  ~contents:
                    (String.concat
                       ~sep:"\x00"
-                      (List.map ~f:(fun (_, unit_name, _, _, _) -> unit_name) l));
+                      (List.map ~f:(fun (_, unit_name, _, _, _, _) -> unit_name) l));
                let shapes =
                  List.fold_left
                    ~init:StringMap.empty
-                   ~f:(fun acc (_, _, _, _, shapes) -> merge_shape acc shapes)
+                   ~f:(fun acc (_, _, _, _, shapes, _) -> merge_shape acc shapes)
                    l
                in
                Zip.add_entry z ~name:"shapes.sexp" ~contents:(string_of_shapes shapes);
                if enable_source_maps
                then
                  add_source_map sourcemap_don't_inline_content z (`Source_map source_map);
-               List.map ~f:(fun (unit_data, _, _, _, _) -> unit_data) l)
+               let cmi_files =
+                 List.concat_map ~f:(fun (_, _, _, _, _, cmis) -> cmis) l
+               in
+               if not (List.is_empty cmi_files)
+               then
+                 Zip.add_entry
+                   z
+                   ~name:"embedded_files"
+                   ~contents:(Marshal.to_string cmi_files []);
+               List.map ~f:(fun (unit_data, _, _, _, _, _) -> unit_data) l)
              []
          in
          Link.add_info z ~build_info:(Build_info.create `Cma) ~unit_data ();

--- a/compiler/lib-wasm/link.ml
+++ b/compiler/lib-wasm/link.ml
@@ -738,9 +738,18 @@ let build_dynlink_init ~to_link ~all_primitives =
   let wasm_binary, _fragments = Generate.compile ~unit_name:(Some "_link_info") code in
   wasm_binary
 
+let read_embedded_files file =
+  Zip.with_open_in file (fun z ->
+      if Zip.has_entry z ~name:"embedded_files"
+      then Marshal.from_string (Zip.read_entry z ~name:"embedded_files") 0
+      else [])
+
 let link ~output_file ~linkall ~enable_source_maps ~embedded_files ~files =
   if times () then Format.eprintf "linking@.";
   let t = Timer.make () in
+  let embedded_files =
+    embedded_files @ List.concat_map ~f:read_embedded_files files
+  in
   let files = load_information files in
   (match files with
   | [] -> assert false

--- a/compiler/lib-wasm/link.ml
+++ b/compiler/lib-wasm/link.ml
@@ -747,9 +747,7 @@ let read_embedded_files file =
 let link ~output_file ~linkall ~enable_source_maps ~embedded_files ~files =
   if times () then Format.eprintf "linking@.";
   let t = Timer.make () in
-  let embedded_files =
-    embedded_files @ List.concat_map ~f:read_embedded_files files
-  in
+  let embedded_files = embedded_files @ List.concat_map ~f:read_embedded_files files in
   let files = load_information files in
   (match files with
   | [] -> assert false

--- a/runtime/wasm/dynlink.wat
+++ b/runtime/wasm/dynlink.wat
@@ -99,4 +99,11 @@
    (func (export "caml_dynlink_get_current_libs")
       (param (ref eq)) (result (ref eq))
       (array.new_fixed $block 1 (ref.i31 (i32.const 0))))
+
+(@if (>= ocaml_version (5 5 0))
+(@then
+   (func (export "caml_dynlink_parse_ld_conf")
+      (param (ref eq)) (result (ref eq))
+      (ref.i31 (i32.const 0)))
+))
 )


### PR DESCRIPTION
## Summary
- Embed cmis in separate-compilation toplevel `.wasmo` bundles. OCaml 5.5 resolves `Config.standard_library` at runtime via `caml_sys_const_standard_library_default` (returning `/static/cmis`) instead of baking the host build path into compiler-libs, so the previous accidental host-fs fallback no longer works. Mirrors the long-standing js_of_ocaml behavior: `~include_cmis` on `Parse_bytecode.from_cmo`, `Pseudo_fs.collect_cmis`, stored in the zip and unioned at link time.
- Stub `caml_dynlink_parse_ld_conf` in `runtime/wasm/dynlink.wat` so the runtime links against OCaml ≥ 5.5.

## Test plan
- [ ] `make tests-wasm` with an OCaml 5.5 switch
- [ ] Build a `--toplevel` separate-compilation wasm bundle and confirm cmis are present in the produced `.wasmo`
- [ ] Confirm dynlink-using programs link on OCaml 5.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)