### PR TITLE
Fix Int64.of_string

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@
 * Compiler: fix missing conditional simplification (#2217)
 * Compiler: fix Js_assign.simpl (#2218)
 * Runtime: fix caml_oo_cache_id (#2224)
+* Runtime/wasm: fix Int64.of_string (#2223)
 
 
 # 6.3.2 (2026-02-15) - Lille

--- a/compiler/tests-wasm_of_ocaml/dune
+++ b/compiler/tests-wasm_of_ocaml/dune
@@ -1,5 +1,5 @@
 (tests
- (names gh38 gh46 gh107 gh112 gh1904 gh2034)
+ (names gh38 gh46 gh107 gh112 gh1904 gh2034 int64_of_string)
  (modes js wasm)
  (js_of_ocaml
   (flags :standard --disable optcall --no-inline))

--- a/compiler/tests-wasm_of_ocaml/int64_of_string.ml
+++ b/compiler/tests-wasm_of_ocaml/int64_of_string.ml
@@ -1,0 +1,19 @@
+let raises_failure f =
+  try
+    let _ = f () in
+    false
+  with Failure _ -> true
+
+let () =
+  assert (raises_failure (fun () -> Int64.of_string ""));
+  assert (raises_failure (fun () -> Int64.of_string "+"));
+  assert (raises_failure (fun () -> Int64.of_string "-"));
+  assert (raises_failure (fun () -> Int64.of_string "0x"));
+  assert (raises_failure (fun () -> Int64.of_string "0o"));
+  assert (raises_failure (fun () -> Int64.of_string "0b"));
+  assert (raises_failure (fun () -> Int64.of_string "0u"));
+  assert (raises_failure (fun () -> Int64.of_string "+0x"));
+  assert (raises_failure (fun () -> Int64.of_string "-0b"));
+  assert (Int64.equal (Int64.of_string "42") 42L);
+  assert (Int64.equal (Int64.of_string "-42") (-42L));
+  assert (Int64.equal (Int64.of_string "0x2a") 42L)

--- a/runtime/wasm/int64.wat
+++ b/runtime/wasm/int64.wat
@@ -142,7 +142,7 @@
       (local $len i32) (local $d i32) (local $c i32)
       (local $res i64) (local $threshold i64)
       (local.set $len (array.len (local.get $s)))
-      (if (i32.eqz (local.get $len))
+      (if (i32.ge_s (local.get $i) (local.get $len))
         (then (call $caml_failwith (local.get $errmsg))))
       (local.set $threshold
          (i64.div_u (i64.const -1) (i64.extend_i32_u (local.get $base))))


### PR DESCRIPTION
The empty-input check in `$caml_i64_of_digits` only fires when the whole string is empty; for inputs like `"+"`, `"-"` or `"0x"` the digit cursor sits past the end of the string, and the next `array.get_u traps`. Guard on `$i >= $len` so `caml_failwith` fires cleanly.