### PR TITLE
Compiler: don't rewrite [x = e + x] as [x += e] for Plus

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,10 @@
 * Compiler: fix Js_assign.simpl (#2218)
 * Runtime: fix caml_oo_cache_id (#2224)
 * Runtime/wasm: fix Int64.of_string (#2223)
+* Compiler: don't rewrite `x = e + x` into `x += e` for the `Plus`
+  operator; JavaScript `+` is not commutative for strings, which made
+  whole-program builds emit reversed `Filename.concat` operands and
+  silently broke `Filename.temp_file`
 
 
 # 6.3.2 (2026-02-15) - Lille

--- a/compiler/lib/js_traverse.ml
+++ b/compiler/lib/js_traverse.ml
@@ -2033,7 +2033,11 @@ class simpl =
       in
       let is_commutative_op op =
         match op with
-        | Mul | Plus | Band | Bxor | Bor -> true
+        (* [Plus] is excluded: JavaScript [+] doubles as string
+           concatenation, which is not commutative. Rewriting [x = e + x]
+           into [x += e] would silently reverse the operands when [e]
+           and [x] are strings. *)
+        | Mul | Band | Bxor | Bor -> true
         | _ -> false
       in
       match e with

--- a/compiler/tests-compiler/dune.inc
+++ b/compiler/tests-compiler/dune.inc
@@ -811,6 +811,19 @@
   (pps ppx_expect)))
 
 (library
+ ;; compiler/tests-compiler/string_concat_eq.ml
+ (name string_concat_eq_15)
+ (modules string_concat_eq)
+ (libraries js_of_ocaml_compiler unix str jsoo_compiler_expect_tests_helper)
+ (inline_tests
+  (deps
+   (file %{project_root}/compiler/bin-js_of_ocaml/js_of_ocaml.exe)
+   (file %{project_root}/compiler/bin-jsoo_minify/jsoo_minify.exe)))
+ (flags (:standard -open Jsoo_compiler_expect_tests_helper))
+ (preprocess
+  (pps ppx_expect)))
+
+(library
  ;; compiler/tests-compiler/sys_command.ml
  (name sys_command_15)
  (modules sys_command)

--- a/compiler/tests-compiler/string_concat_eq.ml
+++ b/compiler/tests-compiler/string_concat_eq.ml
@@ -47,7 +47,7 @@ let%expect_test "inspect" =
        var Stdlib = runtime.caml_get_global("Stdlib");
        function _a_(_c_, _b_){
         _b_ = "@";
-        _b_ += _b_ + "=";
+        _b_ = _b_ + "=" + _b_;
         return _c_ ? _b_ : _b_ + "2";
        }
        var _b_ = _a_(1, 0);
@@ -64,6 +64,6 @@ let%expect_test "inspect" =
 let%expect_test "x = a + \"=\" + a is mis-rewritten by the [x = e + x] peephole" =
   Util.compile_and_run ~debug:false ~use_js_string:true prog;
   [%expect {|
-    @@=
-    @@=2
+    @=@
+    @=@2
     |}]

--- a/compiler/tests-compiler/string_concat_eq.ml
+++ b/compiler/tests-compiler/string_concat_eq.ml
@@ -1,0 +1,69 @@
+(* Js_of_ocaml tests
+ * http://www.ocsigen.org/js_of_ocaml/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+
+(* Regression test for the [x = e + x] -> [x += e] peephole in
+   [js_traverse]: it must not fire on string [+], which is not
+   commutative. *)
+let prog =
+  {|
+external ( ^ ) : string -> string -> string = "caml_string_concat"
+
+let f cond () =
+  let a = "@" in
+  let b = a ^ "=" ^ a in
+  if cond then b else b ^ "2"
+
+let () = print_endline (f true ())
+let () = print_endline (f false ())|}
+
+let%expect_test "inspect" =
+  let program = Util.compile_and_parse ~debug:false ~use_js_string:true prog in
+  Util.print_program program;
+  [%expect
+    {|
+    (function(globalThis){
+       "use strict";
+       var runtime = globalThis.jsoo_runtime;
+       function caml_call1(f, a0){
+        return (f.l >= 0 ? f.l : f.l = f.length) === 1
+                ? f(a0)
+                : runtime.caml_call_gen(f, [a0]);
+       }
+       var Stdlib = runtime.caml_get_global("Stdlib");
+       function _a_(_c_, _b_){
+        _b_ = "@";
+        _b_ += _b_ + "=";
+        return _c_ ? _b_ : _b_ + "2";
+       }
+       var _b_ = _a_(1, 0);
+       caml_call1(Stdlib[46], _b_);
+       _b_ = _a_(0, 0);
+       caml_call1(Stdlib[46], _b_);
+       runtime.caml_register_global([0, _a_], "Test");
+       return;
+      }
+      (globalThis));
+    //end
+    |}]
+
+let%expect_test "x = a + \"=\" + a is mis-rewritten by the [x = e + x] peephole" =
+  Util.compile_and_run ~debug:false ~use_js_string:true prog;
+  [%expect {|
+    @@=
+    @@=2
+    |}]


### PR DESCRIPTION
## Summary

`js_traverse`'s peephole rewrites `x = e + x` into `x += e` when the operator is flagged as commutative — but `Plus` was wrongly in that list. JavaScript `+` is non-commutative on strings, so the rewrite reversed operands. Drop `Plus`; the unconditional `x = x + e` -> `x += e` direction is unaffected.

In the wild this surfaced as `Filename.temp_file` returning paths of the form `<filename>/<temp_dir>` under whole-program compilation with `use-js-string`.

The two commits are split test-first / fix-second so the regression test can be reviewed against the buggy snapshot.

## Test plan

- [x] `compiler/tests-compiler/string_concat_eq.ml`
- [x] `make tests` (only the pre-existing `using`-keyword failure remains)
- [x] `CHANGES.md` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
