### PR TITLE
String conversion fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@
   operator; JavaScript `+` is not commutative for strings, which made
   whole-program builds emit reversed `Filename.concat` operands and
   silently broke `Filename.temp_file`
+* Runtime/wasm: fix string conversion from JS to OCaml (#2230)
 
 
 # 6.3.2 (2026-02-15) - Lille

--- a/runtime/wasm/runtime.js
+++ b/runtime/wasm/runtime.js
@@ -699,6 +699,8 @@
     decodeStringFromUTF8Array: () => "",
     encodeStringToUTF8Array: () => 0,
     fromCharCodeArray: () => "",
+    length: (s) => s.length,
+    intoCharCodeArray: () => 0,
   };
   const imports = Object.assign(
     {


### PR DESCRIPTION
Ensures the wasm:js-string imports always resolve, even when the engine lacks the JS String Builtins proposal.

Note that this proposal has been supported by all major browsers for quite some time already, and is supported by Node 23 and higher.