### PR TITLE
Misc: fix Node.js 26 support

### DIFF
--- a/tools/node_wrapper.ml
+++ b/tools/node_wrapper.ml
@@ -1,8 +1,4 @@
-let extra_args_for_wasoo =
-  [ "--experimental-wasm-imported-strings"
-  ; "--experimental-wasm-stack-switching"
-  ; "--stack-size=10000"
-  ]
+let extra_args_for_wasoo = [ "--stack-size=10000" ]
 
 let extra_args_for_jsoo = []
 


### PR DESCRIPTION
## Summary
- Node.js 26 dropped `--experimental-wasm-imported-strings` and `--experimental-wasm-stack-switching` since the corresponding Wasm features are now enabled by default. Passing the flags causes the test wrapper to fail with "bad option".
- Drop those flags from `tools/node_wrapper.ml`, keeping only `--stack-size=10000` for the wasm_of_ocaml runs.

## Test plan
- [ ] `make tests` on Node.js 26
- [ ] `make tests-wasm` on Node.js 26