### PR TITLE
CI fix with dune 3.23

### DIFF
--- a/js_of_ocaml-compiler.opam
+++ b/js_of_ocaml-compiler.opam
@@ -22,7 +22,7 @@ depends: [
   "cmdliner" {>= "2.0"}
   "sedlex" {>= "3.3"}
   "qcheck" {with-test}
-  "menhir"
+  "menhir" {>= "20180523"}
   "menhirLib"
   "menhirSdk"
   "yojson" {>= "2.1"}

--- a/js_of_ocaml-lwt.opam
+++ b/js_of_ocaml-lwt.opam
@@ -21,6 +21,7 @@ depends: [
   "ppx_expect" {>= "v0.14.2" & with-test}
   "re" {>= "1.9.0" & with-test}
   "odoc" {with-doc}
+  "menhir" {>= "20180523"}
 ]
 depopts: ["graphics" "lwt_log"]
 dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"

--- a/js_of_ocaml-ppx.opam
+++ b/js_of_ocaml-ppx.opam
@@ -20,6 +20,7 @@ depends: [
   "ppx_expect" {>= "v0.14.2" & with-test}
   "re" {>= "1.9.0" & with-test}
   "odoc" {with-doc}
+  "menhir" {>= "20180523"}
 ]
 dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
 x-maintenance-intent: ["(latest)"]

--- a/js_of_ocaml-ppx_deriving_json.opam
+++ b/js_of_ocaml-ppx_deriving_json.opam
@@ -20,6 +20,7 @@ depends: [
   "ppx_expect" {>= "v0.14.2" & with-test}
   "re" {>= "1.9.0" & with-test}
   "odoc" {with-doc}
+  "menhir" {>= "20180523"}
 ]
 dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
 x-maintenance-intent: ["(latest)"]

--- a/js_of_ocaml-toplevel.opam
+++ b/js_of_ocaml-toplevel.opam
@@ -22,6 +22,7 @@ depends: [
   "ppxlib" {>= "0.33"}
   "re" {>= "1.9.0" & with-test}
   "odoc" {with-doc}
+  "menhir" {>= "20180523"}
 ]
 dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
 x-maintenance-intent: ["(latest)"]

--- a/js_of_ocaml-tyxml.opam
+++ b/js_of_ocaml-tyxml.opam
@@ -23,6 +23,7 @@ depends: [
   "ppx_expect" {>= "v0.14.2" & with-test}
   "re" {>= "1.9.0" & with-test}
   "odoc" {with-doc}
+  "menhir" {>= "20180523"}
 ]
 dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
 x-maintenance-intent: ["(latest)"]

--- a/js_of_ocaml.opam
+++ b/js_of_ocaml.opam
@@ -20,6 +20,7 @@ depends: [
   "ppxlib" {>= "0.33"}
   "re" {>= "1.9.0" & with-test}
   "odoc" {with-doc}
+  "menhir" {>= "20180523"}
 ]
 dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
 x-maintenance-intent: ["(latest)"]

--- a/wasm_of_ocaml-compiler.opam
+++ b/wasm_of_ocaml-compiler.opam
@@ -22,7 +22,7 @@ depends: [
   "cmdliner" {>= "2.0"}
   "opam-format" {with-test}
   "sedlex" {>= "2.3"}
-  "menhir"
+  "menhir" {>= "20180523"}
   "menhirLib"
   "menhirSdk"
   "yojson" {>= "2.1"}


### PR DESCRIPTION
dune 3.23 adds a lower bound to the menhir dependency (ocaml/dune#14168).