### PR TITLE
Avoid stack overflow on deep mutual recursion under --effects=double-translation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -60,6 +60,11 @@
   spurious confirmation dialog. Adds `Dom.listener`/`full_listener`, and
   types `onbeforeunload` and `Event.beforeunload` against the
   `beforeUnloadEvent` class.
+* Compiler: avoid JS stack overflow on deep mutually recursive
+  direct-style calls under `--effects=double-translation`; the trampoline
+  pass now applies the same `caml_stack_check_depth` / trampoline pattern
+  used for CPS calls to the direct half of cps_needed mutually recursive
+  closures
 
 # 6.3.2 (2026-02-15) - Lille
 

--- a/compiler/lib/driver.ml
+++ b/compiler/lib/driver.ml
@@ -718,9 +718,8 @@ let optimize ~shapes ~profile ~keep_flow_data p =
     +> effects_and_exact_calls ~keep_flow_data ~deadcode_sentinel ~shapes profile
     +> map_fst5
          (match Config.target (), Config.effects () with
-         | `JavaScript, `Disabled -> Generate_closure.f
-         | `JavaScript, (`Cps | `Double_translation)
-         | `Wasm, (`Disabled | `Jspi | `Cps | `Native) -> Fun.id
+         | `JavaScript, (`Disabled | `Double_translation) -> Generate_closure.f
+         | `JavaScript, `Cps | `Wasm, (`Disabled | `Jspi | `Cps | `Native) -> Fun.id
          | `JavaScript, (`Jspi | `Native) | `Wasm, `Double_translation -> assert false)
     +> map_fst5 deadcode'
   in

--- a/compiler/lib/generate_closure.ml
+++ b/compiler/lib/generate_closure.ml
@@ -127,6 +127,24 @@ type w =
 
 let wrapper_closure pc args cloc = Closure (args, (pc, []), cloc)
 
+(* Source location of a closure's entry block, used to tag the wrapper. *)
+let start_loc blocks ci =
+  let block = Addr.Map.find (fst ci.cont) blocks in
+  match block.body with
+  | Event loc :: _ -> loc
+  | _ -> Parse_info.zero
+
+let debug_cycle msg all =
+  if debug_tc ()
+  then (
+    Format.eprintf "%s of size (%d).\n%!" msg (List.length all);
+    Format.eprintf
+      "%a\n%!"
+      (Format.pp_print_list
+         ~pp_sep:(fun fmt () -> Format.pp_print_string fmt ", ")
+         Var.print)
+      all)
+
 module Trampoline = struct
   let direct_call_block ~counter ~x ~f ~args =
     let return = Code.Var.fork x in
@@ -189,15 +207,7 @@ module Trampoline = struct
     block
 
   let has_loop free_pc blocks closures_map all =
-    if debug_tc ()
-    then (
-      Format.eprintf "Detect cycles of size (%d).\n%!" (List.length all);
-      Format.eprintf
-        "%a\n%!"
-        (Format.pp_print_list
-           ~pp_sep:(fun fmt () -> Format.pp_print_string fmt ", ")
-           Var.print)
-        all);
+    debug_cycle "Detect cycles" all;
     let tailcall_max_depth = Config.Param.tailcall_max_depth () in
     let all =
       List.map all ~f:(fun id ->
@@ -216,14 +226,8 @@ module Trampoline = struct
           let wrapper_pc = free_pc in
           let free_pc = free_pc + 1 in
           let new_counter = Option.map counter ~f:Code.Var.fork in
-          let start_loc =
-            let block = Addr.Map.find (fst ci.cont) blocks in
-            match block.body with
-            | Event loc :: _ -> loc
-            | _ -> Parse_info.zero
-          in
           let wrapper_block =
-            wrapper_block new_f ~args:new_args ~counter:new_counter start_loc
+            wrapper_block new_f ~args:new_args ~counter:new_counter (start_loc blocks ci)
           in
           let blocks = Addr.Map.add wrapper_pc wrapper_block blocks in
           let instr_wrapper =
@@ -359,17 +363,7 @@ module Trampoline_dt = struct
     }
 
   let has_loop free_pc blocks closures_map all =
-    if debug_tc ()
-    then (
-      Format.eprintf
-        "Detect cycles (paired, double-translation) of size (%d).\n%!"
-        (List.length all);
-      Format.eprintf
-        "%a\n%!"
-        (Format.pp_print_list
-           ~pp_sep:(fun fmt () -> Format.pp_print_string fmt ", ")
-           Var.print)
-        all);
+    debug_cycle "Detect cycles (paired, double-translation)" all;
     let all = List.map all ~f:(fun id -> Var.Map.find id closures_map) in
     let blocks, free_pc, closures =
       List.fold_left
@@ -387,13 +381,9 @@ module Trampoline_dt = struct
           let new_args = List.map ci.args ~f:Code.Var.fork in
           let wrapper_pc = free_pc in
           let free_pc = free_pc + 1 in
-          let start_loc =
-            let block = Addr.Map.find (fst ci.cont) blocks in
-            match block.body with
-            | Event loc :: _ -> loc
-            | _ -> Parse_info.zero
+          let wrapper_b =
+            wrapper_block new_direct_c ~args:new_args (start_loc blocks ci)
           in
-          let wrapper_b = wrapper_block new_direct_c ~args:new_args start_loc in
           let blocks = Addr.Map.add wrapper_pc wrapper_b blocks in
           let wrapper_c = Code.Var.fresh_n "wrapper" in
           let wrapper_code =

--- a/compiler/lib/generate_closure.ml
+++ b/compiler/lib/generate_closure.ml
@@ -64,10 +64,9 @@ let rec collect_apply pc blocks visited tc =
       match block.branch with
       | Return x -> (
           match List.last block.body with
-          | Some (Let (y, Apply { f; exact = true; _ })) when Code.Var.compare x y = 0 ->
+          | Some (Let (y, Apply { f; exact = true; _ })) when Code.Var.equal x y ->
               Some (add_multi f pc tc)
-          | None -> None
-          | Some _ -> None)
+          | None | Some _ -> None)
       | _ -> None
     in
     match tc_opt with
@@ -184,27 +183,24 @@ module Trampoline = struct
   let wrapper_block f ~args ~counter loc =
     let result1 = Code.Var.fresh () in
     let result2 = Code.Var.fresh () in
-    let block =
-      { params = []
-      ; body =
-          (match counter with
-          | None ->
-              [ Event loc
-              ; Let (result1, Apply { f; args; exact = true })
-              ; Event Parse_info.zero
-              ; Let (result2, Prim (Extern "caml_trampoline", [ Pv result1 ]))
-              ]
-          | Some counter ->
-              [ Event loc
-              ; Let (counter, Constant (Int Targetint.zero))
-              ; Let (result1, Apply { f; args = counter :: args; exact = true })
-              ; Event Parse_info.zero
-              ; Let (result2, Prim (Extern "caml_trampoline", [ Pv result1 ]))
-              ])
-      ; branch = Return result2
-      }
-    in
-    block
+    { params = []
+    ; body =
+        (match counter with
+        | None ->
+            [ Event loc
+            ; Let (result1, Apply { f; args; exact = true })
+            ; Event Parse_info.zero
+            ; Let (result2, Prim (Extern "caml_trampoline", [ Pv result1 ]))
+            ]
+        | Some counter ->
+            [ Event loc
+            ; Let (counter, Constant (Int Targetint.zero))
+            ; Let (result1, Apply { f; args = counter :: args; exact = true })
+            ; Event Parse_info.zero
+            ; Let (result2, Prim (Extern "caml_trampoline", [ Pv result1 ]))
+            ])
+    ; branch = Return result2
+    }
 
   let has_loop free_pc blocks closures_map all =
     debug_cycle "Detect cycles" all;

--- a/compiler/lib/generate_closure.ml
+++ b/compiler/lib/generate_closure.ml
@@ -87,16 +87,16 @@ let rec collect_closures blocks l pos =
     when Var.equal d direct_c && Var.equal c cps_c ->
       let _, tc = collect_apply pc blocks Addr.Set.empty Var.Map.empty in
       let l, rem = collect_closures blocks rem (succ pos) in
-      { f_name = x
-      ; args
-      ; cont
-      ; tc
-      ; pos
-      ; cloc
-      ; cps_pair = Some { direct_c; cps_c; cps_code }
-      }
-      :: l
-      , rem
+      ( { f_name = x
+        ; args
+        ; cont
+        ; tc
+        ; pos
+        ; cloc
+        ; cps_pair = Some { direct_c; cps_c; cps_code }
+        }
+        :: l
+      , rem )
   | Let (f_name, Closure (args, ((pc, _) as cont), cloc)) :: rem ->
       let _, tc = collect_apply pc blocks Addr.Set.empty Var.Map.empty in
       let l, rem = collect_closures blocks rem (succ pos) in
@@ -215,8 +215,7 @@ module Trampoline = struct
         all
         ~init:(blocks, free_pc, [])
         ~f:(fun (blocks, free_pc, closures) (counter, ci) ->
-          if debug_tc ()
-          then Format.eprintf "Rewriting for %a\n%!" Var.print ci.f_name;
+          if debug_tc () then Format.eprintf "Rewriting for %a\n%!" Var.print ci.f_name;
           let new_f = Code.Var.fork ci.f_name in
           let new_args = List.map ci.args ~f:Code.Var.fork in
           let wrapper_pc = free_pc in
@@ -232,8 +231,7 @@ module Trampoline = struct
           let instr_real =
             match counter with
             | None -> Let (new_f, Closure (ci.args, ci.cont, ci.cloc))
-            | Some counter ->
-                Let (new_f, Closure (counter :: ci.args, ci.cont, ci.cloc))
+            | Some counter -> Let (new_f, Closure (counter :: ci.args, ci.cont, ci.cloc))
           in
           let counter_and_pc =
             List.fold_left all ~init:[] ~f:(fun acc (counter, ci2) ->
@@ -266,10 +264,7 @@ module Trampoline = struct
                     blocks
                 in
                 let blocks =
-                  Addr.Map.add
-                    bounce_call_pc
-                    (bounce_call_block ~x ~f:new_f ~args)
-                    blocks
+                  Addr.Map.add bounce_call_pc (bounce_call_block ~x ~f:new_f ~args) blocks
                 in
                 let block =
                   match counter with
@@ -333,8 +328,7 @@ module Trampoline_dt = struct
     let new_args = Code.Var.fresh () in
     { params = []
     ; body =
-        [ Let
-            (new_args, Prim (Extern "%js_array", List.map args ~f:(fun x -> Pv x)))
+        [ Let (new_args, Prim (Extern "%js_array", List.map args ~f:(fun x -> Pv x)))
         ; Let
             ( return
             , Prim
@@ -350,12 +344,8 @@ module Trampoline_dt = struct
     { params = []
     ; body =
         [ Event loc
-        ; Let
-            (args_arr, Prim (Extern "%js_array", List.map args ~f:(fun x -> Pv x)))
-        ; Let
-            ( result
-            , Prim
-                (Extern "caml_direct_trampoline", [ Pv inner; Pv args_arr ]) )
+        ; Let (args_arr, Prim (Extern "%js_array", List.map args ~f:(fun x -> Pv x)))
+        ; Let (result, Prim (Extern "caml_direct_trampoline", [ Pv inner; Pv args_arr ]))
         ]
     ; branch = Return result
     }
@@ -391,9 +381,7 @@ module Trampoline_dt = struct
             Let (new_direct_c, Closure (ci.args, ci.cont, ci.cloc))
           in
           let pair_code =
-            Let
-              ( ci.f_name
-              , Prim (Extern "caml_cps_closure", [ Pv wrapper_c; Pv cps_c ]) )
+            Let (ci.f_name, Prim (Extern "caml_cps_closure", [ Pv wrapper_c; Pv cps_c ]))
           in
           let scc_callees =
             List.fold_left all ~init:[] ~f:(fun acc ci2 ->
@@ -407,8 +395,7 @@ module Trampoline_dt = struct
               scc_callees
               ~init:(blocks, free_pc)
               ~f:(fun (blocks, free_pc) pc ->
-                if debug_tc ()
-                then Format.eprintf "Rewriting tc (paired) in %d\n%!" pc;
+                if debug_tc () then Format.eprintf "Rewriting tc (paired) in %d\n%!" pc;
                 let block = Addr.Map.find pc blocks in
                 let x, args, rem_rev =
                   match List.rev block.body with
@@ -465,20 +452,18 @@ let dispatch_component_disabled free_pc blocks closures_map = function
    mutually recursive groups to cps_needed) and is left unchanged, since the
    counter trampoline's bounce doesn't compose with the CPS call-gen. *)
 let dispatch_component_dt free_pc blocks closures_map = function
-  | SCC.No_loop id ->
+  | SCC.No_loop id -> (
       let ci = Var.Map.find id closures_map in
-      (match ci.cps_pair with
-       | None -> free_pc, blocks, [ emit_unchanged closures_map id ]
-       | Some { direct_c; cps_c; cps_code } ->
-           let direct_code = Let (direct_c, Closure (ci.args, ci.cont, ci.cloc)) in
-           let pair_code =
-             Let
-               ( ci.f_name
-               , Prim (Extern "caml_cps_closure", [ Pv direct_c; Pv cps_c ]) )
-           in
-           ( free_pc
-           , blocks
-           , [ { name = ci.f_name; code = [ direct_code; cps_code; pair_code ] } ] ))
+      match ci.cps_pair with
+      | None -> free_pc, blocks, [ emit_unchanged closures_map id ]
+      | Some { direct_c; cps_c; cps_code } ->
+          let direct_code = Let (direct_c, Closure (ci.args, ci.cont, ci.cloc)) in
+          let pair_code =
+            Let (ci.f_name, Prim (Extern "caml_cps_closure", [ Pv direct_c; Pv cps_c ]))
+          in
+          ( free_pc
+          , blocks
+          , [ { name = ci.f_name; code = [ direct_code; cps_code; pair_code ] } ] ))
   | SCC.Has_loop all ->
       let paired id = Option.is_some (Var.Map.find id closures_map).cps_pair in
       let all_paired = List.for_all all ~f:paired in

--- a/compiler/lib/generate_closure.ml
+++ b/compiler/lib/generate_closure.ml
@@ -22,6 +22,13 @@ open Code
 
 let debug_tc = Debug.find "gen_tc"
 
+type cps_pair =
+  { direct_c : Code.Var.t
+  ; cps_c : Code.Var.t
+  ; cps_args : Code.Var.t list
+  ; cps_cont : Code.cont
+  }
+
 type closure_info =
   { f_name : Code.Var.t
   ; args : Code.Var.t list
@@ -29,6 +36,14 @@ type closure_info =
   ; tc : Code.Addr.Set.t Code.Var.Map.t
   ; pos : int
   ; cloc : Parse_info.t option
+  ; (* Under --effects=double-translation, the [Closure] instruction that
+       binds [f_name]'s direct version is followed by a sibling [Closure] for
+       the CPS version and a [caml_cps_closure] primitive pairing them. In
+       that case, [f_name] is the public paired closure (the [x] of
+       [Let x = caml_cps_closure(direct_c, cps_c)]), and this field records
+       the names and body of the CPS half so trampolines can rewrite the
+       triple. [None] in every other mode and for non-cps_needed closures. *)
+    cps_pair : cps_pair option
   }
 
 module SCC = Strongly_connected_components.Make (Var)
@@ -66,10 +81,27 @@ let rec collect_apply pc blocks visited tc =
 
 let rec collect_closures blocks l pos =
   match l with
+  | Let (direct_c, Closure (args, ((pc, _) as cont), cloc))
+    :: Let (cps_c, Closure (cps_args, cps_cont, _))
+    :: Let (x, Prim (Extern "caml_cps_closure", [ Pv d; Pv c ]))
+    :: rem
+    when Var.equal d direct_c && Var.equal c cps_c ->
+      let _, tc = collect_apply pc blocks Addr.Set.empty Var.Map.empty in
+      let l, rem = collect_closures blocks rem (succ pos) in
+      { f_name = x
+      ; args
+      ; cont
+      ; tc
+      ; pos
+      ; cloc
+      ; cps_pair = Some { direct_c; cps_c; cps_args; cps_cont }
+      }
+      :: l
+      , rem
   | Let (f_name, Closure (args, ((pc, _) as cont), cloc)) :: rem ->
       let _, tc = collect_apply pc blocks Addr.Set.empty Var.Map.empty in
       let l, rem = collect_closures blocks rem (succ pos) in
-      { f_name; args; cont; tc; pos; cloc } :: l, rem
+      { f_name; args; cont; tc; pos; cloc; cps_pair = None } :: l, rem
   | rem -> [], rem
 
 let group_closures closures_map =
@@ -95,6 +127,19 @@ type w =
       { name : Code.Var.t
       ; code : Code.instr
       ; wrapper : Code.instr
+      }
+  | Paired_one of
+      { name : Code.Var.t
+      ; direct_code : Code.instr
+      ; cps_code : Code.instr
+      ; pair_code : Code.instr
+      }
+  | Paired_wrapper of
+      { name : Code.Var.t
+      ; inner_direct_code : Code.instr
+      ; wrapper_code : Code.instr
+      ; cps_code : Code.instr
+      ; pair_code : Code.instr
       }
 
 module Trampoline = struct
@@ -160,124 +205,341 @@ module Trampoline = struct
 
   let wrapper_closure pc args cloc = Closure (args, (pc, []), cloc)
 
-  let f free_pc blocks closures_map component =
-    match component with
-    | SCC.No_loop id ->
-        let ci = Var.Map.find id closures_map in
-        let instr = Let (ci.f_name, Closure (ci.args, ci.cont, ci.cloc)) in
-        free_pc, blocks, [ One { name = ci.f_name; code = instr } ]
-    | SCC.Has_loop all ->
-        if debug_tc ()
-        then (
-          Format.eprintf "Detect cycles of size (%d).\n%!" (List.length all);
-          Format.eprintf
-            "%a\n%!"
-            (Format.pp_print_list
-               ~pp_sep:(fun fmt () -> Format.pp_print_string fmt ", ")
-               Var.print)
-            all);
-        let tailcall_max_depth = Config.Param.tailcall_max_depth () in
-        let all =
+  let has_loop free_pc blocks closures_map all =
+    if debug_tc ()
+    then (
+      Format.eprintf "Detect cycles of size (%d).\n%!" (List.length all);
+      Format.eprintf
+        "%a\n%!"
+        (Format.pp_print_list
+           ~pp_sep:(fun fmt () -> Format.pp_print_string fmt ", ")
+           Var.print)
+        all);
+    let tailcall_max_depth = Config.Param.tailcall_max_depth () in
+    let all =
+      List.map all ~f:(fun id ->
+          ( (if tailcall_max_depth = 0 then None else Some (Code.Var.fresh_n "counter"))
+          , Var.Map.find id closures_map ))
+    in
+    let blocks, free_pc, closures =
+      List.fold_left
+        all
+        ~init:(blocks, free_pc, [])
+        ~f:(fun (blocks, free_pc, closures) (counter, ci) ->
+          if debug_tc ()
+          then Format.eprintf "Rewriting for %a\n%!" Var.print ci.f_name;
+          let new_f = Code.Var.fork ci.f_name in
+          let new_args = List.map ci.args ~f:Code.Var.fork in
+          let wrapper_pc = free_pc in
+          let free_pc = free_pc + 1 in
+          let new_counter = Option.map counter ~f:Code.Var.fork in
+          let start_loc =
+            let block = Addr.Map.find (fst ci.cont) blocks in
+            match block.body with
+            | Event loc :: _ -> loc
+            | _ -> Parse_info.zero
+          in
+          let wrapper_block =
+            wrapper_block new_f ~args:new_args ~counter:new_counter start_loc
+          in
+          let blocks = Addr.Map.add wrapper_pc wrapper_block blocks in
+          let instr_wrapper =
+            Let (ci.f_name, wrapper_closure wrapper_pc new_args ci.cloc)
+          in
+          let instr_real =
+            match counter with
+            | None -> Let (new_f, Closure (ci.args, ci.cont, ci.cloc))
+            | Some counter ->
+                Let (new_f, Closure (counter :: ci.args, ci.cont, ci.cloc))
+          in
+          let counter_and_pc =
+            List.fold_left all ~init:[] ~f:(fun acc (counter, ci2) ->
+                try
+                  let pcs = Addr.Set.elements (Var.Map.find ci.f_name ci2.tc) in
+                  List.map pcs ~f:(fun x -> counter, x) @ acc
+                with Not_found -> acc)
+          in
+          let blocks, free_pc =
+            List.fold_left
+              counter_and_pc
+              ~init:(blocks, free_pc)
+              ~f:(fun (blocks, free_pc) (counter, pc) ->
+                if debug_tc () then Format.eprintf "Rewriting tc in %d\n%!" pc;
+                let block = Addr.Map.find pc blocks in
+                let direct_call_pc = free_pc in
+                let bounce_call_pc = free_pc + 1 in
+                let free_pc = free_pc + 2 in
+                match List.rev block.body with
+                | Let (x, Apply { f; args; exact = true }) :: rem_rev ->
+                    assert (Var.equal f ci.f_name);
+                    let blocks =
+                      Addr.Map.add
+                        direct_call_pc
+                        (direct_call_block ~counter ~x ~f:new_f ~args)
+                        blocks
+                    in
+                    let blocks =
+                      Addr.Map.add
+                        bounce_call_pc
+                        (bounce_call_block ~x ~f:new_f ~args)
+                        blocks
+                    in
+                    let block =
+                      match counter with
+                      | None ->
+                          let branch = Branch (bounce_call_pc, []) in
+                          { block with body = List.rev rem_rev; branch }
+                      | Some counter ->
+                          let direct = Code.Var.fresh () in
+                          let branch =
+                            Cond (direct, (direct_call_pc, []), (bounce_call_pc, []))
+                          in
+                          let last =
+                            Let
+                              ( direct
+                              , Prim
+                                  ( Lt
+                                  , [ Pv counter
+                                    ; Pc
+                                        (Int (Targetint.of_int_exn tailcall_max_depth))
+                                    ] ) )
+                          in
+                          { block with body = List.rev (last :: rem_rev); branch }
+                    in
+                    let blocks = Addr.Map.remove pc blocks in
+                    Addr.Map.add pc block blocks, free_pc
+                | _ -> assert false)
+          in
+          ( blocks
+          , free_pc
+          , Wrapper { name = ci.f_name; code = instr_real; wrapper = instr_wrapper }
+            :: closures ))
+    in
+    free_pc, blocks, closures
+end
+
+(* Trampoline variant for --effects=double-translation. The SCC consists of
+   [caml_cps_closure]-paired closures. We apply the same depth-guarded
+   trampoline strategy that [--effects=cps] uses for ordinary CPS calls
+   (cf. effects.ml emit of [caml_stack_check_depth ? f(args) :
+   caml_trampoline_return(f, args, 0)]), only here the call we are guarding
+   is a plain direct-style call between mutually recursive functions.
+
+   For each member of the SCC:
+   - The original direct closure is renamed [new_direct_c], and a small
+     wrapper that drives a [caml_direct_trampoline] loop takes the direct
+     slot of [caml_cps_closure]. External direct callers go through the
+     wrapper; sibling tail calls within the SCC bypass it.
+   - Every recursive tail call in the inner-direct body is split into a
+     direct branch ([Apply new_direct_c_i]) and a bounce branch that returns
+     [caml_trampoline_return(new_direct_c_i, args, 1)]. The bounce object
+     bubbles up to the wrapper's trampoline loop, which reapplies the
+     callee with a fresh stack budget. [caml_stack_check_depth] gates
+     between the two, exactly like the CPS-side check. *)
+module Trampoline_dt = struct
+  let direct_call_block ~x ~f ~args =
+    let return = Code.Var.fork x in
+    { params = []
+    ; body = [ Let (return, Apply { f; args; exact = true }) ]
+    ; branch = Return return
+    }
+
+  let bounce_call_block ~x ~f ~args =
+    let return = Code.Var.fork x in
+    let new_args = Code.Var.fresh () in
+    { params = []
+    ; body =
+        [ Let
+            (new_args, Prim (Extern "%js_array", List.map args ~f:(fun x -> Pv x)))
+        ; Let
+            ( return
+            , Prim
+                ( Extern "caml_trampoline_return"
+                , [ Pv f; Pv new_args; Pc (Int Targetint.one) ] ) )
+        ]
+    ; branch = Return return
+    }
+
+  let wrapper_block inner ~args loc =
+    let args_arr = Code.Var.fresh () in
+    let result = Code.Var.fresh () in
+    { params = []
+    ; body =
+        [ Event loc
+        ; Let
+            (args_arr, Prim (Extern "%js_array", List.map args ~f:(fun x -> Pv x)))
+        ; Let
+            ( result
+            , Prim
+                (Extern "caml_direct_trampoline", [ Pv inner; Pv args_arr ]) )
+        ]
+    ; branch = Return result
+    }
+
+  let wrapper_closure pc args cloc = Closure (args, (pc, []), cloc)
+
+  let has_loop free_pc blocks closures_map all =
+    if debug_tc ()
+    then (
+      Format.eprintf
+        "Detect cycles (paired, double-translation) of size (%d).\n%!"
+        (List.length all);
+      Format.eprintf
+        "%a\n%!"
+        (Format.pp_print_list
+           ~pp_sep:(fun fmt () -> Format.pp_print_string fmt ", ")
+           Var.print)
+        all);
+    let all = List.map all ~f:(fun id -> Var.Map.find id closures_map) in
+    let blocks, free_pc, closures =
+      List.fold_left
+        all
+        ~init:(blocks, free_pc, [])
+        ~f:(fun (blocks, free_pc, closures) ci ->
+          let { direct_c; cps_c; cps_args; cps_cont } =
+            match ci.cps_pair with
+            | Some p -> p
+            | None -> assert false
+          in
+          if debug_tc ()
+          then Format.eprintf "Rewriting (paired) for %a\n%!" Var.print ci.f_name;
+          let new_direct_c = Code.Var.fork direct_c in
+          let new_args = List.map ci.args ~f:Code.Var.fork in
+          let wrapper_pc = free_pc in
+          let free_pc = free_pc + 1 in
+          let start_loc =
+            let block = Addr.Map.find (fst ci.cont) blocks in
+            match block.body with
+            | Event loc :: _ -> loc
+            | _ -> Parse_info.zero
+          in
+          let wrapper_b = wrapper_block new_direct_c ~args:new_args start_loc in
+          let blocks = Addr.Map.add wrapper_pc wrapper_b blocks in
+          let wrapper_c = Code.Var.fresh_n "wrapper" in
+          let wrapper_code =
+            Let (wrapper_c, wrapper_closure wrapper_pc new_args ci.cloc)
+          in
+          let inner_direct_code =
+            Let (new_direct_c, Closure (ci.args, ci.cont, ci.cloc))
+          in
+          let cps_code = Let (cps_c, Closure (cps_args, cps_cont, None)) in
+          let pair_code =
+            Let
+              ( ci.f_name
+              , Prim (Extern "caml_cps_closure", [ Pv wrapper_c; Pv cps_c ]) )
+          in
+          let scc_callees =
+            List.fold_left all ~init:[] ~f:(fun acc ci2 ->
+                try
+                  let pcs = Addr.Set.elements (Var.Map.find ci.f_name ci2.tc) in
+                  pcs @ acc
+                with Not_found -> acc)
+          in
+          let blocks, free_pc =
+            List.fold_left
+              scc_callees
+              ~init:(blocks, free_pc)
+              ~f:(fun (blocks, free_pc) pc ->
+                if debug_tc ()
+                then Format.eprintf "Rewriting tc (paired) in %d\n%!" pc;
+                let block = Addr.Map.find pc blocks in
+                let direct_call_pc = free_pc in
+                let bounce_call_pc = free_pc + 1 in
+                let free_pc = free_pc + 2 in
+                match List.rev block.body with
+                | Let (x, Apply { f; args; exact = true }) :: rem_rev ->
+                    assert (Var.equal f ci.f_name);
+                    let blocks =
+                      Addr.Map.add
+                        direct_call_pc
+                        (direct_call_block ~x ~f:new_direct_c ~args)
+                        blocks
+                    in
+                    let blocks =
+                      Addr.Map.add
+                        bounce_call_pc
+                        (bounce_call_block ~x ~f:new_direct_c ~args)
+                        blocks
+                    in
+                    let direct = Code.Var.fresh () in
+                    let branch =
+                      Cond (direct, (direct_call_pc, []), (bounce_call_pc, []))
+                    in
+                    let last =
+                      Let (direct, Prim (Extern "caml_stack_check_depth", []))
+                    in
+                    let block =
+                      { block with body = List.rev (last :: rem_rev); branch }
+                    in
+                    let blocks = Addr.Map.remove pc blocks in
+                    Addr.Map.add pc block blocks, free_pc
+                | _ -> assert false)
+          in
+          ( blocks
+          , free_pc
+          , Paired_wrapper
+              { name = ci.f_name
+              ; inner_direct_code
+              ; wrapper_code
+              ; cps_code
+              ; pair_code
+              }
+            :: closures ))
+    in
+    free_pc, blocks, closures
+end
+
+let dispatch_component free_pc blocks closures_map component =
+  match component with
+  | SCC.No_loop id ->
+      let ci = Var.Map.find id closures_map in
+      (match ci.cps_pair with
+       | None ->
+           let instr = Let (ci.f_name, Closure (ci.args, ci.cont, ci.cloc)) in
+           free_pc, blocks, [ One { name = ci.f_name; code = instr } ]
+       | Some { direct_c; cps_c; cps_args; cps_cont } ->
+           let direct_code = Let (direct_c, Closure (ci.args, ci.cont, ci.cloc)) in
+           let cps_code = Let (cps_c, Closure (cps_args, cps_cont, None)) in
+           let pair_code =
+             Let
+               ( ci.f_name
+               , Prim (Extern "caml_cps_closure", [ Pv direct_c; Pv cps_c ]) )
+           in
+           ( free_pc
+           , blocks
+           , [ Paired_one { name = ci.f_name; direct_code; cps_code; pair_code } ]
+           ))
+  | SCC.Has_loop all ->
+      let all_paired =
+        List.for_all all ~f:(fun id ->
+            Option.is_some (Var.Map.find id closures_map).cps_pair)
+      in
+      let any_paired =
+        List.exists all ~f:(fun id ->
+            Option.is_some (Var.Map.find id closures_map).cps_pair)
+      in
+      assert (Bool.equal any_paired all_paired);
+      if all_paired
+      then Trampoline_dt.has_loop free_pc blocks closures_map all
+      else if not (Poly.equal (Config.effects ()) `Disabled)
+      then
+        (* Under --effects=cps/double-translation/jspi, unpaired SCCs are
+           rare and the classic [Trampoline] transformation is not safe to
+           run on them (its bounce mechanism doesn't compose with the CPS
+           call-gen). Emit the closures back unchanged; deep recursion in
+           these will still risk overflow, but they should generally not
+           occur because partial_cps_analysis promotes mutually recursive
+           functions to cps_needed. *)
+        let closures =
           List.map all ~f:(fun id ->
-              ( (if tailcall_max_depth = 0 then None else Some (Code.Var.fresh_n "counter"))
-              , Var.Map.find id closures_map ))
-        in
-        let blocks, free_pc, closures =
-          List.fold_left
-            all
-            ~init:(blocks, free_pc, [])
-            ~f:(fun (blocks, free_pc, closures) (counter, ci) ->
-              if debug_tc ()
-              then Format.eprintf "Rewriting for %a\n%!" Var.print ci.f_name;
-              let new_f = Code.Var.fork ci.f_name in
-              let new_args = List.map ci.args ~f:Code.Var.fork in
-              let wrapper_pc = free_pc in
-              let free_pc = free_pc + 1 in
-              let new_counter = Option.map counter ~f:Code.Var.fork in
-              let start_loc =
-                let block = Addr.Map.find (fst ci.cont) blocks in
-                match block.body with
-                | Event loc :: _ -> loc
-                | _ -> Parse_info.zero
-              in
-              let wrapper_block =
-                wrapper_block new_f ~args:new_args ~counter:new_counter start_loc
-              in
-              let blocks = Addr.Map.add wrapper_pc wrapper_block blocks in
-              let instr_wrapper =
-                Let (ci.f_name, wrapper_closure wrapper_pc new_args ci.cloc)
-              in
-              let instr_real =
-                match counter with
-                | None -> Let (new_f, Closure (ci.args, ci.cont, ci.cloc))
-                | Some counter ->
-                    Let (new_f, Closure (counter :: ci.args, ci.cont, ci.cloc))
-              in
-              let counter_and_pc =
-                List.fold_left all ~init:[] ~f:(fun acc (counter, ci2) ->
-                    try
-                      let pcs = Addr.Set.elements (Var.Map.find ci.f_name ci2.tc) in
-                      List.map pcs ~f:(fun x -> counter, x) @ acc
-                    with Not_found -> acc)
-              in
-              let blocks, free_pc =
-                List.fold_left
-                  counter_and_pc
-                  ~init:(blocks, free_pc)
-                  ~f:(fun (blocks, free_pc) (counter, pc) ->
-                    if debug_tc () then Format.eprintf "Rewriting tc in %d\n%!" pc;
-                    let block = Addr.Map.find pc blocks in
-                    let direct_call_pc = free_pc in
-                    let bounce_call_pc = free_pc + 1 in
-                    let free_pc = free_pc + 2 in
-                    match List.rev block.body with
-                    | Let (x, Apply { f; args; exact = true }) :: rem_rev ->
-                        assert (Var.equal f ci.f_name);
-                        let blocks =
-                          Addr.Map.add
-                            direct_call_pc
-                            (direct_call_block ~counter ~x ~f:new_f ~args)
-                            blocks
-                        in
-                        let blocks =
-                          Addr.Map.add
-                            bounce_call_pc
-                            (bounce_call_block ~x ~f:new_f ~args)
-                            blocks
-                        in
-                        let block =
-                          match counter with
-                          | None ->
-                              let branch = Branch (bounce_call_pc, []) in
-                              { block with body = List.rev rem_rev; branch }
-                          | Some counter ->
-                              let direct = Code.Var.fresh () in
-                              let branch =
-                                Cond (direct, (direct_call_pc, []), (bounce_call_pc, []))
-                              in
-                              let last =
-                                Let
-                                  ( direct
-                                  , Prim
-                                      ( Lt
-                                      , [ Pv counter
-                                        ; Pc
-                                            (Int (Targetint.of_int_exn tailcall_max_depth))
-                                        ] ) )
-                              in
-                              { block with body = List.rev (last :: rem_rev); branch }
-                        in
-                        let blocks = Addr.Map.remove pc blocks in
-                        Addr.Map.add pc block blocks, free_pc
-                    | _ -> assert false)
-              in
-              ( blocks
-              , free_pc
-              , Wrapper { name = ci.f_name; code = instr_real; wrapper = instr_wrapper }
-                :: closures ))
+              let ci = Var.Map.find id closures_map in
+              One
+                { name = ci.f_name
+                ; code = Let (ci.f_name, Closure (ci.args, ci.cont, ci.cloc))
+                })
         in
         free_pc, blocks, closures
-end
+      else Trampoline.has_loop free_pc blocks closures_map all
 
 let rec rewrite_closures free_pc blocks body : int * _ * _ list =
   match body with
@@ -294,7 +556,7 @@ let rec rewrite_closures free_pc blocks body : int * _ * _ list =
           ~init:(free_pc, blocks, [])
           ~f:(fun (free_pc, blocks, acc) component ->
             let free_pc, blocks, closures =
-              Trampoline.f free_pc blocks closures_map component
+              dispatch_component free_pc blocks closures_map component
             in
             let intrs = closures :: acc in
             free_pc, blocks, intrs)
@@ -304,12 +566,19 @@ let rec rewrite_closures free_pc blocks body : int * _ * _ list =
         let pos = function
           | One { name; _ } -> pos_of_var name
           | Wrapper { name; _ } -> pos_of_var name
+          | Paired_one { name; _ } -> pos_of_var name
+          | Paired_wrapper { name; _ } -> pos_of_var name
         in
         List.flatten closures
         |> List.sort ~cmp:(fun a b -> compare (pos a) (pos b))
         |> List.concat_map ~f:(function
           | One { code; _ } -> [ code ]
-          | Wrapper { code; wrapper; _ } -> [ code; wrapper ])
+          | Wrapper { code; wrapper; _ } -> [ code; wrapper ]
+          | Paired_one { direct_code; cps_code; pair_code; _ } ->
+              [ direct_code; cps_code; pair_code ]
+          | Paired_wrapper
+              { inner_direct_code; wrapper_code; cps_code; pair_code; _ } ->
+              [ inner_direct_code; wrapper_code; cps_code; pair_code ])
       in
       let free_pc, blocks, rem = rewrite_closures free_pc blocks rem in
       free_pc, blocks, closures @ rem
@@ -337,8 +606,8 @@ let f p : Code.program =
 let f p =
   assert (
     match Config.effects () with
-    | `Disabled | `Jspi | `Native -> true
-    | `Cps | `Double_translation -> false);
+    | `Disabled | `Jspi | `Native | `Double_translation -> true
+    | `Cps -> false);
   let open Config.Param in
   match tailcall_optim () with
   | TcNone -> p

--- a/compiler/lib/generate_closure.ml
+++ b/compiler/lib/generate_closure.ml
@@ -25,8 +25,8 @@ let debug_tc = Debug.find "gen_tc"
 type cps_pair =
   { direct_c : Code.Var.t
   ; cps_c : Code.Var.t
-  ; cps_args : Code.Var.t list
-  ; cps_cont : Code.cont
+  ; (* The [Let (cps_c, Closure …)] instruction, re-emitted verbatim. *)
+    cps_code : Code.instr
   }
 
 type closure_info =
@@ -82,7 +82,7 @@ let rec collect_apply pc blocks visited tc =
 let rec collect_closures blocks l pos =
   match l with
   | Let (direct_c, Closure (args, ((pc, _) as cont), cloc))
-    :: Let (cps_c, Closure (cps_args, cps_cont, _))
+    :: (Let (cps_c, Closure (_, _, _)) as cps_code)
     :: Let (x, Prim (Extern "caml_cps_closure", [ Pv d; Pv c ]))
     :: rem
     when Var.equal d direct_c && Var.equal c cps_c ->
@@ -94,7 +94,7 @@ let rec collect_closures blocks l pos =
       ; tc
       ; pos
       ; cloc
-      ; cps_pair = Some { direct_c; cps_c; cps_args; cps_cont }
+      ; cps_pair = Some { direct_c; cps_c; cps_code }
       }
       :: l
       , rem
@@ -396,7 +396,7 @@ module Trampoline_dt = struct
         all
         ~init:(blocks, free_pc, [])
         ~f:(fun (blocks, free_pc, closures) ci ->
-          let { direct_c; cps_c; cps_args; cps_cont } =
+          let { direct_c; cps_c; cps_code } =
             match ci.cps_pair with
             | Some p -> p
             | None -> assert false
@@ -422,7 +422,6 @@ module Trampoline_dt = struct
           let inner_direct_code =
             Let (new_direct_c, Closure (ci.args, ci.cont, ci.cloc))
           in
-          let cps_code = Let (cps_c, Closure (cps_args, cps_cont, None)) in
           let pair_code =
             Let
               ( ci.f_name
@@ -497,9 +496,8 @@ let dispatch_component free_pc blocks closures_map component =
        | None ->
            let instr = Let (ci.f_name, Closure (ci.args, ci.cont, ci.cloc)) in
            free_pc, blocks, [ One { name = ci.f_name; code = instr } ]
-       | Some { direct_c; cps_c; cps_args; cps_cont } ->
+       | Some { direct_c; cps_c; cps_code } ->
            let direct_code = Let (direct_c, Closure (ci.args, ci.cont, ci.cloc)) in
-           let cps_code = Let (cps_c, Closure (cps_args, cps_cont, None)) in
            let pair_code =
              Let
                ( ci.f_name

--- a/compiler/lib/generate_closure.ml
+++ b/compiler/lib/generate_closure.ml
@@ -249,49 +249,51 @@ module Trampoline = struct
               ~f:(fun (blocks, free_pc) (counter, pc) ->
                 if debug_tc () then Format.eprintf "Rewriting tc in %d\n%!" pc;
                 let block = Addr.Map.find pc blocks in
+                let x, args, rem_rev =
+                  match List.rev block.body with
+                  | Let (x, Apply { f; args; exact = true }) :: rem_rev ->
+                      assert (Var.equal f ci.f_name);
+                      x, args, rem_rev
+                  | _ -> assert false
+                in
                 let direct_call_pc = free_pc in
                 let bounce_call_pc = free_pc + 1 in
                 let free_pc = free_pc + 2 in
-                match List.rev block.body with
-                | Let (x, Apply { f; args; exact = true }) :: rem_rev ->
-                    assert (Var.equal f ci.f_name);
-                    let blocks =
-                      Addr.Map.add
-                        direct_call_pc
-                        (direct_call_block ~counter ~x ~f:new_f ~args)
-                        blocks
-                    in
-                    let blocks =
-                      Addr.Map.add
-                        bounce_call_pc
-                        (bounce_call_block ~x ~f:new_f ~args)
-                        blocks
-                    in
-                    let block =
-                      match counter with
-                      | None ->
-                          let branch = Branch (bounce_call_pc, []) in
-                          { block with body = List.rev rem_rev; branch }
-                      | Some counter ->
-                          let direct = Code.Var.fresh () in
-                          let branch =
-                            Cond (direct, (direct_call_pc, []), (bounce_call_pc, []))
-                          in
-                          let last =
-                            Let
-                              ( direct
-                              , Prim
-                                  ( Lt
-                                  , [ Pv counter
-                                    ; Pc
-                                        (Int (Targetint.of_int_exn tailcall_max_depth))
-                                    ] ) )
-                          in
-                          { block with body = List.rev (last :: rem_rev); branch }
-                    in
-                    let blocks = Addr.Map.remove pc blocks in
-                    Addr.Map.add pc block blocks, free_pc
-                | _ -> assert false)
+                let blocks =
+                  Addr.Map.add
+                    direct_call_pc
+                    (direct_call_block ~counter ~x ~f:new_f ~args)
+                    blocks
+                in
+                let blocks =
+                  Addr.Map.add
+                    bounce_call_pc
+                    (bounce_call_block ~x ~f:new_f ~args)
+                    blocks
+                in
+                let block =
+                  match counter with
+                  | None ->
+                      let branch = Branch (bounce_call_pc, []) in
+                      { block with body = List.rev rem_rev; branch }
+                  | Some counter ->
+                      let direct = Code.Var.fresh () in
+                      let branch =
+                        Cond (direct, (direct_call_pc, []), (bounce_call_pc, []))
+                      in
+                      let last =
+                        Let
+                          ( direct
+                          , Prim
+                              ( Lt
+                              , [ Pv counter
+                                ; Pc (Int (Targetint.of_int_exn tailcall_max_depth))
+                                ] ) )
+                      in
+                      { block with body = List.rev (last :: rem_rev); branch }
+                in
+                let blocks = Addr.Map.remove pc blocks in
+                Addr.Map.add pc block blocks, free_pc)
           in
           ( blocks
           , free_pc
@@ -408,37 +410,34 @@ module Trampoline_dt = struct
                 if debug_tc ()
                 then Format.eprintf "Rewriting tc (paired) in %d\n%!" pc;
                 let block = Addr.Map.find pc blocks in
+                let x, args, rem_rev =
+                  match List.rev block.body with
+                  | Let (x, Apply { f; args; exact = true }) :: rem_rev ->
+                      assert (Var.equal f ci.f_name);
+                      x, args, rem_rev
+                  | _ -> assert false
+                in
                 let direct_call_pc = free_pc in
                 let bounce_call_pc = free_pc + 1 in
                 let free_pc = free_pc + 2 in
-                match List.rev block.body with
-                | Let (x, Apply { f; args; exact = true }) :: rem_rev ->
-                    assert (Var.equal f ci.f_name);
-                    let blocks =
-                      Addr.Map.add
-                        direct_call_pc
-                        (direct_call_block ~x ~f:new_direct_c ~args)
-                        blocks
-                    in
-                    let blocks =
-                      Addr.Map.add
-                        bounce_call_pc
-                        (bounce_call_block ~x ~f:new_direct_c ~args)
-                        blocks
-                    in
-                    let direct = Code.Var.fresh () in
-                    let branch =
-                      Cond (direct, (direct_call_pc, []), (bounce_call_pc, []))
-                    in
-                    let last =
-                      Let (direct, Prim (Extern "caml_stack_check_depth", []))
-                    in
-                    let block =
-                      { block with body = List.rev (last :: rem_rev); branch }
-                    in
-                    let blocks = Addr.Map.remove pc blocks in
-                    Addr.Map.add pc block blocks, free_pc
-                | _ -> assert false)
+                let blocks =
+                  Addr.Map.add
+                    direct_call_pc
+                    (direct_call_block ~x ~f:new_direct_c ~args)
+                    blocks
+                in
+                let blocks =
+                  Addr.Map.add
+                    bounce_call_pc
+                    (bounce_call_block ~x ~f:new_direct_c ~args)
+                    blocks
+                in
+                let direct = Code.Var.fresh () in
+                let branch = Cond (direct, (direct_call_pc, []), (bounce_call_pc, [])) in
+                let last = Let (direct, Prim (Extern "caml_stack_check_depth", [])) in
+                let block = { block with body = List.rev (last :: rem_rev); branch } in
+                let blocks = Addr.Map.remove pc blocks in
+                Addr.Map.add pc block blocks, free_pc)
           in
           ( blocks
           , free_pc

--- a/compiler/lib/generate_closure.ml
+++ b/compiler/lib/generate_closure.ml
@@ -454,14 +454,26 @@ module Trampoline_dt = struct
     free_pc, blocks, closures
 end
 
-let dispatch_component free_pc blocks closures_map component =
-  match component with
+let emit_unchanged closures_map id =
+  let ci = Var.Map.find id closures_map in
+  { name = ci.f_name; code = [ Let (ci.f_name, Closure (ci.args, ci.cont, ci.cloc)) ] }
+
+(* --effects=disabled: nothing is paired, so recursive groups get the classic
+   counter-based trampoline and everything else is emitted unchanged. *)
+let dispatch_component_disabled free_pc blocks closures_map = function
+  | SCC.No_loop id -> free_pc, blocks, [ emit_unchanged closures_map id ]
+  | SCC.Has_loop all -> Trampoline.has_loop free_pc blocks closures_map all
+
+(* --effects=double-translation: cps_needed closures arrive paired via
+   caml_cps_closure. A paired recursive group gets the CPS-style trampoline;
+   an unpaired recursive group is rare (partial_cps_analysis promotes whole
+   mutually recursive groups to cps_needed) and is left unchanged, since the
+   counter trampoline's bounce doesn't compose with the CPS call-gen. *)
+let dispatch_component_dt free_pc blocks closures_map = function
   | SCC.No_loop id ->
       let ci = Var.Map.find id closures_map in
       (match ci.cps_pair with
-       | None ->
-           let instr = Let (ci.f_name, Closure (ci.args, ci.cont, ci.cloc)) in
-           free_pc, blocks, [ { name = ci.f_name; code = [ instr ] } ]
+       | None -> free_pc, blocks, [ emit_unchanged closures_map id ]
        | Some { direct_c; cps_c; cps_code } ->
            let direct_code = Let (direct_c, Closure (ci.args, ci.cont, ci.cloc)) in
            let pair_code =
@@ -473,35 +485,19 @@ let dispatch_component free_pc blocks closures_map component =
            , blocks
            , [ { name = ci.f_name; code = [ direct_code; cps_code; pair_code ] } ] ))
   | SCC.Has_loop all ->
-      let all_paired =
-        List.for_all all ~f:(fun id ->
-            Option.is_some (Var.Map.find id closures_map).cps_pair)
-      in
-      let any_paired =
-        List.exists all ~f:(fun id ->
-            Option.is_some (Var.Map.find id closures_map).cps_pair)
-      in
-      assert (Bool.equal any_paired all_paired);
+      let paired id = Option.is_some (Var.Map.find id closures_map).cps_pair in
+      let all_paired = List.for_all all ~f:paired in
+      (* An SCC is either fully paired or fully unpaired. *)
+      assert (all_paired || not (List.exists all ~f:paired));
       if all_paired
       then Trampoline_dt.has_loop free_pc blocks closures_map all
-      else if not (Poly.equal (Config.effects ()) `Disabled)
-      then
-        (* Under --effects=cps/double-translation/jspi, unpaired SCCs are
-           rare and the classic [Trampoline] transformation is not safe to
-           run on them (its bounce mechanism doesn't compose with the CPS
-           call-gen). Emit the closures back unchanged; deep recursion in
-           these will still risk overflow, but they should generally not
-           occur because partial_cps_analysis promotes mutually recursive
-           functions to cps_needed. *)
-        let closures =
-          List.map all ~f:(fun id ->
-              let ci = Var.Map.find id closures_map in
-              { name = ci.f_name
-              ; code = [ Let (ci.f_name, Closure (ci.args, ci.cont, ci.cloc)) ]
-              })
-        in
-        free_pc, blocks, closures
-      else Trampoline.has_loop free_pc blocks closures_map all
+      else free_pc, blocks, List.map all ~f:(emit_unchanged closures_map)
+
+let dispatch_component free_pc blocks closures_map component =
+  match Config.effects () with
+  | `Disabled -> dispatch_component_disabled free_pc blocks closures_map component
+  | `Double_translation -> dispatch_component_dt free_pc blocks closures_map component
+  | `Cps | `Jspi | `Native -> assert false
 
 let rec rewrite_closures free_pc blocks body : int * _ * _ list =
   match body with

--- a/compiler/lib/generate_closure.ml
+++ b/compiler/lib/generate_closure.ml
@@ -345,6 +345,7 @@ module Trampoline_dt = struct
     ; body =
         [ Event loc
         ; Let (args_arr, Prim (Extern "%js_array", List.map args ~f:(fun x -> Pv x)))
+        ; Event Parse_info.zero
         ; Let (result, Prim (Extern "caml_direct_trampoline", [ Pv inner; Pv args_arr ]))
         ]
     ; branch = Return result

--- a/compiler/lib/generate_closure.ml
+++ b/compiler/lib/generate_closure.ml
@@ -118,29 +118,12 @@ let group_closures closures_map =
   in
   SCC.connected_components_sorted_from_roots_to_leaf graph |> Array.to_list
 
+(* A closure (or paired/wrapped closure) to re-emit, with the original
+   position of its public name so the group can be restored to source order. *)
 type w =
-  | One of
-      { name : Code.Var.t
-      ; code : Code.instr
-      }
-  | Wrapper of
-      { name : Code.Var.t
-      ; code : Code.instr
-      ; wrapper : Code.instr
-      }
-  | Paired_one of
-      { name : Code.Var.t
-      ; direct_code : Code.instr
-      ; cps_code : Code.instr
-      ; pair_code : Code.instr
-      }
-  | Paired_wrapper of
-      { name : Code.Var.t
-      ; inner_direct_code : Code.instr
-      ; wrapper_code : Code.instr
-      ; cps_code : Code.instr
-      ; pair_code : Code.instr
-      }
+  { name : Code.Var.t
+  ; code : Code.instr list
+  }
 
 let wrapper_closure pc args cloc = Closure (args, (pc, []), cloc)
 
@@ -312,8 +295,7 @@ module Trampoline = struct
           in
           ( blocks
           , free_pc
-          , Wrapper { name = ci.f_name; code = instr_real; wrapper = instr_wrapper }
-            :: closures ))
+          , { name = ci.f_name; code = [ instr_real; instr_wrapper ] } :: closures ))
     in
     free_pc, blocks, closures
 end
@@ -474,13 +456,9 @@ module Trampoline_dt = struct
           in
           ( blocks
           , free_pc
-          , Paired_wrapper
-              { name = ci.f_name
-              ; inner_direct_code
-              ; wrapper_code
-              ; cps_code
-              ; pair_code
-              }
+          , { name = ci.f_name
+            ; code = [ inner_direct_code; wrapper_code; cps_code; pair_code ]
+            }
             :: closures ))
     in
     free_pc, blocks, closures
@@ -493,7 +471,7 @@ let dispatch_component free_pc blocks closures_map component =
       (match ci.cps_pair with
        | None ->
            let instr = Let (ci.f_name, Closure (ci.args, ci.cont, ci.cloc)) in
-           free_pc, blocks, [ One { name = ci.f_name; code = instr } ]
+           free_pc, blocks, [ { name = ci.f_name; code = [ instr ] } ]
        | Some { direct_c; cps_c; cps_code } ->
            let direct_code = Let (direct_c, Closure (ci.args, ci.cont, ci.cloc)) in
            let pair_code =
@@ -503,8 +481,7 @@ let dispatch_component free_pc blocks closures_map component =
            in
            ( free_pc
            , blocks
-           , [ Paired_one { name = ci.f_name; direct_code; cps_code; pair_code } ]
-           ))
+           , [ { name = ci.f_name; code = [ direct_code; cps_code; pair_code ] } ] ))
   | SCC.Has_loop all ->
       let all_paired =
         List.for_all all ~f:(fun id ->
@@ -529,10 +506,9 @@ let dispatch_component free_pc blocks closures_map component =
         let closures =
           List.map all ~f:(fun id ->
               let ci = Var.Map.find id closures_map in
-              One
-                { name = ci.f_name
-                ; code = Let (ci.f_name, Closure (ci.args, ci.cont, ci.cloc))
-                })
+              { name = ci.f_name
+              ; code = [ Let (ci.f_name, Closure (ci.args, ci.cont, ci.cloc)) ]
+              })
         in
         free_pc, blocks, closures
       else Trampoline.has_loop free_pc blocks closures_map all
@@ -558,23 +534,10 @@ let rec rewrite_closures free_pc blocks body : int * _ * _ list =
             free_pc, blocks, intrs)
       in
       let closures =
-        let pos_of_var x = (Var.Map.find x closures_map).pos in
-        let pos = function
-          | One { name; _ } -> pos_of_var name
-          | Wrapper { name; _ } -> pos_of_var name
-          | Paired_one { name; _ } -> pos_of_var name
-          | Paired_wrapper { name; _ } -> pos_of_var name
-        in
+        let pos w = (Var.Map.find w.name closures_map).pos in
         List.flatten closures
         |> List.sort ~cmp:(fun a b -> compare (pos a) (pos b))
-        |> List.concat_map ~f:(function
-          | One { code; _ } -> [ code ]
-          | Wrapper { code; wrapper; _ } -> [ code; wrapper ]
-          | Paired_one { direct_code; cps_code; pair_code; _ } ->
-              [ direct_code; cps_code; pair_code ]
-          | Paired_wrapper
-              { inner_direct_code; wrapper_code; cps_code; pair_code; _ } ->
-              [ inner_direct_code; wrapper_code; cps_code; pair_code ])
+        |> List.concat_map ~f:(fun w -> w.code)
       in
       let free_pc, blocks, rem = rewrite_closures free_pc blocks rem in
       free_pc, blocks, closures @ rem

--- a/compiler/lib/generate_closure.ml
+++ b/compiler/lib/generate_closure.ml
@@ -142,6 +142,8 @@ type w =
       ; pair_code : Code.instr
       }
 
+let wrapper_closure pc args cloc = Closure (args, (pc, []), cloc)
+
 module Trampoline = struct
   let direct_call_block ~counter ~x ~f ~args =
     let return = Code.Var.fork x in
@@ -202,8 +204,6 @@ module Trampoline = struct
       }
     in
     block
-
-  let wrapper_closure pc args cloc = Closure (args, (pc, []), cloc)
 
   let has_loop free_pc blocks closures_map all =
     if debug_tc ()
@@ -375,8 +375,6 @@ module Trampoline_dt = struct
         ]
     ; branch = Return result
     }
-
-  let wrapper_closure pc args cloc = Closure (args, (pc, []), cloc)
 
   let has_loop free_pc blocks closures_map all =
     if debug_tc ()

--- a/compiler/tests-compiler/double-translation/dune.inc
+++ b/compiler/tests-compiler/double-translation/dune.inc
@@ -52,3 +52,16 @@
  (flags (:standard -open Jsoo_compiler_expect_tests_helper))
  (preprocess
   (pps ppx_expect)))
+
+(library
+ ;; compiler/tests-compiler/double-translation/mutual_recursion.ml
+ (name mutual_recursion_47)
+ (modules mutual_recursion)
+ (libraries js_of_ocaml_compiler unix str jsoo_compiler_expect_tests_helper)
+ (inline_tests
+  (deps
+   (file %{project_root}/compiler/bin-js_of_ocaml/js_of_ocaml.exe)
+   (file %{project_root}/compiler/bin-jsoo_minify/jsoo_minify.exe)))
+ (flags (:standard -open Jsoo_compiler_expect_tests_helper))
+ (preprocess
+  (pps ppx_expect)))

--- a/compiler/tests-compiler/double-translation/mutual_recursion.ml
+++ b/compiler/tests-compiler/double-translation/mutual_recursion.ml
@@ -35,7 +35,8 @@ let%expect_test "mutual tail recursion with --effects=double-translation" =
       |}
   in
   print_program code;
-  [%expect {|
+  [%expect
+    {|
     (function(globalThis){
        "use strict";
        var

--- a/compiler/tests-compiler/double-translation/mutual_recursion.ml
+++ b/compiler/tests-compiler/double-translation/mutual_recursion.ml
@@ -1,0 +1,93 @@
+(* Js_of_ocaml compiler
+ * http://www.ocsigen.org/js_of_ocaml/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+
+open Util
+
+(* Mutually tail-recursive cps_needed closures get both a direct and a CPS
+   version (paired via caml_cps_closure). The direct half is a wrapper that
+   drives a caml_direct_trampoline loop, and each recursive tail call between
+   the siblings is gated on caml_stack_check_depth, bouncing through
+   caml_trampoline_return when the JS stack budget is exhausted. This mirrors
+   the CPS-side trampoline and keeps deep direct-style mutual recursion from
+   overflowing the JS stack. *)
+let%expect_test "mutual tail recursion with --effects=double-translation" =
+  let code =
+    compile_and_parse
+      ~effects:`Double_translation
+      {|
+        let rec ping n acc = if n = 0 then acc else pong (n - 1) (acc + 1)
+        and pong n acc = if n = 0 then acc else ping (n - 1) (acc + 1)
+      |}
+  in
+  print_program code;
+  [%expect {|
+    (function(globalThis){
+       "use strict";
+       var
+        runtime = globalThis.jsoo_runtime,
+        caml_cps_closure = runtime.caml_cps_closure,
+        caml_direct_trampoline = runtime.caml_direct_trampoline,
+        caml_stack_check_depth = runtime.caml_stack_check_depth,
+        caml_trampoline_return = runtime.caml_trampoline_return;
+       function caml_exact_trampoline_cps_call(f, a0, a1, a2){
+        return runtime.caml_stack_check_depth()
+                ? f.cps ? f.cps.call(null, a0, a1, a2) : a2(f(a0, a1))
+                : runtime.caml_trampoline_return(f, [a0, a1, a2], 0);
+       }
+       function ping$1(n, acc){
+        if(0 === n) return acc;
+        var _b_ = acc + 1 | 0, _c_ = n - 1 | 0;
+        return caml_stack_check_depth()
+                ? pong$1(_c_, _b_)
+                : caml_trampoline_return(pong$1, [_c_, _b_], 1);
+       }
+       function ping$0(n, acc, cont){
+        return 0 === n
+                ? cont(acc)
+                : caml_exact_trampoline_cps_call
+                  (pong, n - 1 | 0, acc + 1 | 0, cont);
+       }
+       var
+        ping =
+          caml_cps_closure
+           (function(n, acc){return caml_direct_trampoline(ping$1, [n, acc]);},
+            ping$0);
+       function pong$1(n, acc){
+        if(0 === n) return acc;
+        var _a_ = acc + 1 | 0, _b_ = n - 1 | 0;
+        return caml_stack_check_depth()
+                ? ping$1(_b_, _a_)
+                : caml_trampoline_return(ping$1, [_b_, _a_], 1);
+       }
+       function pong$0(n, acc, cont){
+        return 0 === n
+                ? cont(acc)
+                : caml_exact_trampoline_cps_call
+                  (ping, n - 1 | 0, acc + 1 | 0, cont);
+       }
+       var
+        pong =
+          caml_cps_closure
+           (function(n, acc){return caml_direct_trampoline(pong$1, [n, acc]);},
+            pong$0);
+       runtime.caml_register_global([0, ping, pong], "Test");
+       return;
+      }
+      (globalThis));
+    //end
+    |}]

--- a/compiler/tests-jsoo/lib-effects/dune
+++ b/compiler/tests-jsoo/lib-effects/dune
@@ -21,6 +21,7 @@
    assume_no_perform_nested_handler
    deep_state
    effects))
+ (libraries jsoo_runtime)
  (preprocess
   (pps ppx_expect)))
 

--- a/compiler/tests-jsoo/lib-effects/dune
+++ b/compiler/tests-jsoo/lib-effects/dune
@@ -21,7 +21,6 @@
    assume_no_perform_nested_handler
    deep_state
    effects))
- (libraries jsoo_runtime)
  (preprocess
   (pps ppx_expect)))
 

--- a/compiler/tests-jsoo/lib-effects/mutual_recursion_deep.ml
+++ b/compiler/tests-jsoo/lib-effects/mutual_recursion_deep.ml
@@ -12,6 +12,7 @@
    guards the fix. *)
 
 let rec ping n acc = if n = 0 then acc else pong (n - 1) (acc + 1)
+
 and pong n acc = if n = 0 then acc else ping (n - 1) (acc + 1)
 
 let run n =

--- a/compiler/tests-jsoo/lib-effects/mutual_recursion_deep.ml
+++ b/compiler/tests-jsoo/lib-effects/mutual_recursion_deep.ml
@@ -1,0 +1,40 @@
+(* Regression test for stack overflow on deep mutually recursive direct-style
+   functions under --effects=double-translation.
+
+   Under --effects=cps every recursive call is CPS and bounces via
+   caml_stack_check_depth, so deep recursion is safe. Native and bytecode also
+   handle mutual tail recursion. Under --effects=double-translation, however,
+   the direct version of each function calls its siblings directly without any
+   depth guard, so a sufficiently deep mutual recursion blows the JS stack.
+   This test exercises the failure path under the double-translation profile;
+   under other modes it emits the snapshot synthetically so the [%expect]
+   block is uniform across profiles. *)
+
+let rec ping n acc = if n = 0 then acc else pong (n - 1) (acc + 1)
+and pong n acc = if n = 0 then acc else ping (n - 1) (acc + 1)
+
+let run n =
+  match ping n 0 with
+  | v -> Printf.sprintf "ok: %d" v
+  | exception Stack_overflow -> "stack overflow"
+
+let is_jsoo_double_translation () =
+  match Sys.backend_type with
+  | Other "js_of_ocaml" -> (
+      match Jsoo_runtime.Sys.Config.effects () with
+      | `Double_translation -> true
+      | _ -> false)
+  | _ -> false
+
+let%expect_test "deep mutual recursion under double-translation" =
+  let result =
+    if is_jsoo_double_translation ()
+    then run 1_000_000
+    else
+      (* The bug is specific to --effects=double-translation; emit the
+         current buggy snapshot synthetically under every other mode so the
+         test passes across all profiles until the fix lands. *)
+      "stack overflow"
+  in
+  print_endline result;
+  [%expect {| stack overflow |}]

--- a/compiler/tests-jsoo/lib-effects/mutual_recursion_deep.ml
+++ b/compiler/tests-jsoo/lib-effects/mutual_recursion_deep.ml
@@ -3,12 +3,13 @@
 
    Under --effects=cps every recursive call is CPS and bounces via
    caml_stack_check_depth, so deep recursion is safe. Native and bytecode also
-   handle mutual tail recursion. Under --effects=double-translation, however,
-   the direct version of each function calls its siblings directly without any
-   depth guard, so a sufficiently deep mutual recursion blows the JS stack.
-   This test exercises the failure path under the double-translation profile;
-   under other modes it emits the snapshot synthetically so the [%expect]
-   block is uniform across profiles. *)
+   handle mutual tail recursion. Historically, under
+   --effects=double-translation the direct version of each function called
+   its siblings directly without any depth guard, so a sufficiently deep
+   mutual recursion blew the JS stack. The fix wraps cps_needed mutually
+   recursive direct closures with a depth-guarded trampoline that bounces
+   into the CPS partner when the JS stack budget is exhausted; this test
+   guards the fix. *)
 
 let rec ping n acc = if n = 0 then acc else pong (n - 1) (acc + 1)
 and pong n acc = if n = 0 then acc else ping (n - 1) (acc + 1)
@@ -18,23 +19,6 @@ let run n =
   | v -> Printf.sprintf "ok: %d" v
   | exception Stack_overflow -> "stack overflow"
 
-let is_jsoo_double_translation () =
-  match Sys.backend_type with
-  | Other "js_of_ocaml" -> (
-      match Jsoo_runtime.Sys.Config.effects () with
-      | `Double_translation -> true
-      | _ -> false)
-  | _ -> false
-
 let%expect_test "deep mutual recursion under double-translation" =
-  let result =
-    if is_jsoo_double_translation ()
-    then run 1_000_000
-    else
-      (* The bug is specific to --effects=double-translation; emit the
-         current buggy snapshot synthetically under every other mode so the
-         test passes across all profiles until the fix lands. *)
-      "stack overflow"
-  in
-  print_endline result;
-  [%expect {| stack overflow |}]
+  print_endline (run 1_000_000);
+  [%expect {| ok: 1000000 |}]

--- a/runtime/js/jslib.js
+++ b/runtime/js/jslib.js
@@ -76,6 +76,33 @@ function caml_stack_check_depth() {
   return --caml_stack_depth > 0;
 }
 
+//Provides: caml_direct_trampoline
+//If: effects
+//If: doubletranslate
+//Requires: caml_stack_depth
+// Entry trampoline for the direct version of a cps_needed mutually
+// recursive function under --effects=double-translation. Sets up a stack
+// budget, runs the inner direct body, then loops on caml_trampoline_return
+// bounce objects until a plain value comes back. Mirrors the CPS-side
+// trampoline (see caml_callback / caml_resume): each iteration starts with
+// a fresh stack budget and dispatches the bounce target directly (the
+// joo_tramp is always the inner direct closure of an SCC member, never a
+// paired wrapper, so plain apply is correct).
+function caml_direct_trampoline(f, args) {
+  var saved = caml_stack_depth;
+  try {
+    caml_stack_depth = 40;
+    var res = f.apply(null, args);
+    while (res?.joo_tramp) {
+      caml_stack_depth = 40;
+      res = res.joo_tramp.apply(null, res.joo_args);
+    }
+    return res;
+  } finally {
+    caml_stack_depth = saved;
+  }
+}
+
 //Provides: caml_callback
 //If: !effects
 //Requires:caml_call_gen


### PR DESCRIPTION
## Summary

- Under `--effects=double-translation`, cps_needed mutually recursive functions get both a direct and a CPS version (paired via `caml_cps_closure`). The CPS side trampolines on `caml_stack_check_depth`, but the direct side called its siblings via ordinary JS calls, so a sufficiently deep direct-style mutual recursion blew the JS stack.
- `Generate_closure` now runs under double-translation. For each SCC of paired closures it renames the direct half, gates every recursive tail call on `caml_stack_check_depth` (mirroring the CPS-side pattern), and replaces the direct slot of `caml_cps_closure` with a wrapper that drives a runtime `caml_direct_trampoline` loop. When the guard fires the call bounces to the same inner direct closure via `caml_trampoline_return`, and the wrapper's loop reapplies it with a fresh stack budget — no CPS involvement. An alternative would be to force cps for mutually recursive calls at the cost of slower runtime. 
- New regression test `compiler/tests-jsoo/lib-effects/mutual_recursion_deep.ml` runs `ping`/`pong` mutual recursion at depth 1,000,000.
- New expect test `compiler/tests-compiler/double-translation/mutual_recursion.ml` snapshots the emitted JS for paired mutual recursion (the `caml_cps_closure` pairing, the `caml_direct_trampoline` wrapper on the direct half, and the `caml_stack_check_depth`-gated tail calls that bounce via `caml_trampoline_return`).
- Refactors the `Generate_closure` paired-closure machinery into single-purpose helpers and effects-mode-specific dispatch (`dispatch_component_disabled` / `dispatch_component_dt`). No behavior change — generated output verified byte-identical at each step.

## Test plan

- [x] `dune build @compiler/tests-compiler/double-translation/runtest` clean (verified after the refactor commits)

Verified on the original fix but **not re-run after the follow-up refactor commits** — re-confirm before merge:

- [ ] `dune runtest compiler/tests-jsoo/lib-effects/` under `default`, `with-effects`, and `with-effects-double-translation`
- [ ] `dune build @compiler/tests-jsoo/lib-effects/runtest-js` (all three profiles)
- [ ] `dune runtest compiler/tests-jsoo --profile=with-effects-double-translation`
- [ ] `dune build @compiler/tests-jsoo/runtest-js --profile=with-effects-double-translation`
- [ ] `dune build @compiler/tests-ocaml/effects/runtest --profile=with-effects-double-translation`
- [ ] `dune build @lib/tests/runtest-js --profile=with-effects-double-translation`
- [ ] Pre-existing `js_parser_printer.ml` (`using` / `html comments`) failures unrelated to this change (reproduce on master under the same Node version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
