### PR TITLE
Extract loops from toplevel function into helper functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@
   asynchronous toplevel originally contributed in the unmerged #435 (#66, #833)
 * Lib: add `FontFace` module — partial binding to the CSS Font Loading
   API, plus a `fonts` property on `Dom_html.document` (#2255)
+* Extract loops from toplevel function into helper functions (#2245)
 
 ## Bug fixes
 * Wasm: embed cmis when building a toplevel with separate compilation.

--- a/compiler/lib/code.ml
+++ b/compiler/lib/code.ml
@@ -794,6 +794,15 @@ let poptraps blocks pc =
   in
   loop blocks pc Addr.Set.empty 0 Addr.Set.empty |> fst
 
+let map_branch_conts f branch =
+  match branch with
+  | Branch c -> Branch (f c)
+  | Cond (x, c1, c2) -> Cond (x, f c1, f c2)
+  | Switch (x, a) -> Switch (x, Array.map a ~f)
+  | Pushtrap (c1, x, c2) -> Pushtrap (f c1, x, f c2)
+  | Poptrap c -> Poptrap (f c)
+  | (Return _ | Raise _ | Stop) as b -> b
+
 let fold_children blocks pc f accu =
   let block = Addr.Map.find pc blocks in
   match block.branch with

--- a/compiler/lib/code.mli
+++ b/compiler/lib/code.mli
@@ -291,6 +291,10 @@ val fold_closures_outermost_first :
     outermost closures first. Unlike with {!fold_closures}, only the closures
     reachable from [p.start] are considered. *)
 
+val map_branch_conts : (cont -> cont) -> last -> last
+(** Apply [f] to every continuation in [branch], leaving non-branching
+    terminators unchanged. *)
+
 val fold_children : 'c fold_blocs
 
 val fold_children_skip_try_body : 'c fold_blocs

--- a/compiler/lib/driver.ml
+++ b/compiler/lib/driver.ml
@@ -718,6 +718,7 @@ let optimize ~shapes ~profile ~keep_flow_data p =
       | O2 -> o2
       | O3 -> o3)
     +> specialize_js_once_after
+    +> Hoist_loops.f
     +> effects_and_exact_calls ~keep_flow_data ~deadcode_sentinel ~shapes profile
     +> map_fst5
          (match Config.target (), Config.effects () with

--- a/compiler/lib/hoist_loops.ml
+++ b/compiler/lib/hoist_loops.ml
@@ -1,0 +1,437 @@
+(* Js_of_ocaml compiler
+ * http://www.ocsigen.org/js_of_ocaml/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+
+(* Extract outermost loops of the entry function into separate helper
+   closures, so engines tier up the small helpers instead of the huge
+   toplevel. See [Hoist_loops.f] for the entry point. *)
+
+open! Stdlib
+open Code
+
+let debug = Debug.find "hoist-loops"
+
+let times = Debug.find "times"
+
+let stats = Debug.find "stats"
+
+(* {1 Small utilities} *)
+
+(* Build a substitution that forks each variable in [vs]. *)
+let fork_set vs = Var.Set.fold (fun v m -> Var.Map.add v (Var.fork v) m) vs Var.Map.empty
+
+(* Pack a list of values into a single result value to be returned from the
+   helper. Always uses a [Block] when there is at least one value to make
+   the call site's unpacking uniform. *)
+let pack_for_return values =
+  match values with
+  | [] ->
+      let u = Var.fresh () in
+      [ Let (u, Constant (Int Targetint.zero)) ], u
+  | _ ->
+      let t = Var.fresh () in
+      let arr = Array.of_list values in
+      [ Let (t, Block (0, arr, NotArray, Immutable)) ], t
+
+(* {1 Loop discovery} *)
+
+(* Walk the dominator tree from [root] and collect the headers of outermost
+   loops (those not nested inside another loop). When we hit a loop header,
+   we record it and stop descending. *)
+let outermost_loop_headers ~g ~dom ~root =
+  let rec walk pc acc =
+    if Structure.is_loop_header g pc
+    then pc :: acc
+    else Addr.Set.fold walk (Structure.get_edges dom pc) acc
+  in
+  walk root []
+
+(* Loop body of [h]: every block in the dominator-tree subtree rooted at
+   [h]. [Structure.build_graph] runs [shrink_loops] on the graph before
+   computing the dominator tree, which adds artificial predecessors from
+   outside the loop to "non-small" post-loop blocks. Those blocks then
+   fall out of [h]'s dom-subtree, leaving the natural loop body plus any
+   small chain blocks (typical of OCaml [match] arms that bind a constant
+   and branch to a post-match join) — which is what we want to extract. *)
+let loop_body ~dom ~h =
+  let rec walk pc acc =
+    Addr.Set.fold walk (Structure.get_edges dom pc) (Addr.Set.add pc acc)
+  in
+  walk h Addr.Set.empty
+
+(* {1 Body-set analyses} *)
+
+(* Variables bound in [body_set]. Nested closures' bodies are not descended
+   into; their bindings aren't visible outside the closure. *)
+let bound_in_body blocks body_set =
+  let acc = ref Var.Set.empty in
+  Addr.Set.iter
+    (fun pc ->
+      Freevars.iter_block_bound_vars
+        (fun v -> acc := Var.Set.add v !acc)
+        (Addr.Map.find pc blocks))
+    body_set;
+  !acc
+
+(* Live-out: variables bound in [body_set] that are referenced from a
+   [p.start]-level block outside [body_set]. These must be returned from
+   the helper and rebound in the dispatch block under their original
+   names; otherwise their uses elsewhere in the function would dangle once
+   the binder moved into the helper.
+
+   [uses] only records [p.start]-level blocks ([compute_uses] attributes
+   every use to the outermost closure-defining block via [attribute_to]),
+   so a use of [v] from inside a closure defined in [body_set] shows up
+   here as a use by that closure's defining block — which lives in
+   [body_set] and is correctly classified as "inside". No separate
+   inner-closure filter is needed.
+
+   [uses] is computed once at the start of the pass and never updated. As
+   later loops are extracted, some recorded uses get renamed to forks
+   inside already-built helpers, but those user-blocks still sit outside
+   any yet-to-be-processed loop's body, so [v] is at worst over-
+   approximated as live-out rather than dropped. *)
+let live_out_of_loop ~uses ~body_set ~bound =
+  Var.Set.filter
+    (fun v ->
+      match Var.Hashtbl.find_opt uses v with
+      | None -> false
+      | Some user_blocks -> not (Addr.Set.subset user_blocks body_set))
+    bound
+
+(* The body contains an [Assign] whose target is bound outside the loop —
+   the helper can't observe that side-effect on the caller's binding. *)
+let has_outer_assign blocks body_set bound =
+  Addr.Set.exists
+    (fun pc ->
+      let block = Addr.Map.find pc blocks in
+      List.exists block.body ~f:(function
+        | Assign (x, _) -> not (Var.Set.mem x bound)
+        | _ -> false))
+    body_set
+
+(* [Extractable None]: the loop never exits normally.
+   [Extractable (Some pc)]: every exit edge targets [pc]. *)
+type exit_class =
+  | Extractable of Addr.t option
+  | Not_extractable
+
+let classify_exits blocks body_set =
+  let targets =
+    Addr.Set.fold
+      (fun pc acc ->
+        let block = Addr.Map.find pc blocks in
+        let add_target (pc', _) acc =
+          if Addr.Set.mem pc' body_set then acc else Addr.Set.add pc' acc
+        in
+        match block.branch with
+        | Return _ | Raise _ | Stop -> acc
+        | Branch c | Poptrap c -> add_target c acc
+        | Cond (_, c1, c2) -> acc |> add_target c1 |> add_target c2
+        | Switch (_, a) -> Array.fold_left ~init:acc ~f:(fun acc c -> add_target c acc) a
+        | Pushtrap (c1, _, c2) -> acc |> add_target c1 |> add_target c2)
+      body_set
+      Addr.Set.empty
+  in
+  match Addr.Set.cardinal targets with
+  | 0 -> Extractable None
+  | 1 -> Extractable (Some (Addr.Set.choose targets))
+  | _ -> Not_extractable
+
+(* {1 Program-wide analyses} *)
+
+(* Variables bound in any block belonging to some loop reachable from
+   [p.start]. These are the only variables that can ever appear in a
+   [bound_in_body] set, so [compute_uses] only needs to track these.
+
+   Walks the dom-subtree of each outermost loop header — the very same set
+   of blocks each call to [loop_body] later visits — so [tracked] is
+   exactly the union of every [body_set]'s bound vars. *)
+let loop_bound_vars ~dom ~headers p =
+  let acc = ref Var.Set.empty in
+  let add v = acc := Var.Set.add v !acc in
+  let rec walk pc =
+    Freevars.iter_block_bound_vars add (Addr.Map.find pc p.blocks);
+    Addr.Set.iter walk (Structure.get_edges dom pc)
+  in
+  List.iter headers ~f:walk;
+  !acc
+
+(* "var -> set of blocks that use it" map, restricted to variables in
+   [tracked]. A block at the [p.start] level is recorded as a user of [v]
+   either if [v] appears free in the block itself or if [v] appears free in
+   a closure (transitively) defined in that block — in which case the use
+   is attributed to the outermost closure-defining block (the one at
+   [p.start] level), since that is what [live_out_of_loop] checks against
+   [body_set].
+
+   The walk traverses every block reachable from [p.start] — practically
+   the whole program. The benefit over a preliminary [Freevars.f] pass is
+   that we never materialise a full per-closure free-var set: the
+   [tracked] filter at [add] discards uses we don't care about as we go,
+   keeping only the variables that any [body_set] could bind. *)
+let compute_uses ~tracked p =
+  let uses = Var.Hashtbl.create 64 in
+  let add pc v =
+    if Var.Set.mem v tracked
+    then
+      let set = Var.Hashtbl.find_opt uses v |> Option.value ~default:Addr.Set.empty in
+      Var.Hashtbl.replace uses v (Addr.Set.add pc set)
+  in
+  let visited = BitSet.create' p.free_pc in
+  let rec walk ~attribute_to pc =
+    if not (BitSet.mem visited pc)
+    then (
+      BitSet.set visited pc;
+      let block = Addr.Map.find pc p.blocks in
+      let user_pc = Option.value attribute_to ~default:pc in
+      Freevars.iter_block_free_vars (add user_pc) block;
+      List.iter block.body ~f:(function
+        | Let (_, Closure (_, (pc_clo, _), _)) -> walk ~attribute_to:(Some user_pc) pc_clo
+        | _ -> ());
+      fold_children p.blocks pc (fun pc' () -> walk ~attribute_to pc') ())
+  in
+  walk ~attribute_to:None p.start;
+  uses
+
+(* Outside-of-body predecessors of [h]. The [Structure.t] built once at the
+   start of the pass gives the original predecessors in O(preds(h)); we
+   union with [extra_preds.(h)], which tracks new edges introduced by
+   earlier loop extractions (each dispatch block branches to its loop's
+   exit, possibly landing on a future loop's header). *)
+let outside_preds_current ~g ~extra_preds ~h ~body_set =
+  let extra =
+    Addr.Hashtbl.find_opt extra_preds h |> Option.value ~default:Addr.Set.empty
+  in
+  Addr.Set.diff (Addr.Set.union (Structure.preds g h) extra) body_set
+
+(* {1 Body rewriting} *)
+
+(* Rewrite the [last] instruction of a body block after the caller has
+   already substituted its variable references via [Including_Binders.block].
+   For each cont whose target leaves [body_set], redirect to a freshly-
+   synthesised [Return] block that packs the cont args together with the
+   helper's live-out forks and returns the result.
+
+   A [Poptrap] whose [leave_pc] is outside [body_set] indicates that the
+   matching [Pushtrap] lives outside the helper, so popping it from inside
+   would unbalance the caller's trap stack. Convert it to a plain [Branch]
+   so the helper exits without touching the trap stack. *)
+let rewrite_branch ~body_set ~live_out_forks ~make_return_block branch =
+  let redirect (pc, args) =
+    if Addr.Set.mem pc body_set
+    then pc, args
+    else make_return_block (args @ live_out_forks)
+  in
+  match branch with
+  | Poptrap ((leave_pc, _) as c) when not (Addr.Set.mem leave_pc body_set) ->
+      Branch (redirect c)
+  | Return _ ->
+      (* The entry function has no [Return] terminator. *)
+      assert false
+  | _ -> map_branch_conts redirect branch
+
+(* {1 Main pass} *)
+
+let try_extract_loop ~g ~dom ~uses ~extra_preds ~h p =
+  let body_set = loop_body ~dom ~h in
+  let bound = bound_in_body p.blocks body_set in
+  let skip reason =
+    if debug () then Format.eprintf "SKIP loop @%d: %s@." h reason;
+    p, false
+  in
+  if has_outer_assign p.blocks body_set bound
+  then skip "outer-assign"
+  else
+    match classify_exits p.blocks body_set with
+    | Not_extractable -> skip "multi-exit"
+    | Extractable exit_pc_opt ->
+        (* Capture outside predecessors of [h] *before* we add new blocks
+           below — [entry_pc] also branches to [h] and would otherwise show
+           up here as a spurious outside-pred. *)
+        let outside = outside_preds_current ~g ~extra_preds ~h ~body_set in
+        let live_out = live_out_of_loop ~uses ~body_set ~bound in
+        (* Fork the [bound] vars (Let / block-params / Pushtrap exn) so the
+           dispatch block can rebind [live_out] vars under their original
+           names without double-binding. Live-in vars are not forked: they
+           remain free in the helper closure body and the JS / wasm backend
+           captures them lexically from the enclosing scope. *)
+        let fork_map = fork_set bound in
+        let s = Subst.from_map fork_map in
+        let lookup_fork v = Var.Map.find v fork_map in
+        let live_out_list = Var.Set.elements live_out in
+        let live_out_forks = List.map live_out_list ~f:lookup_fork in
+        let h_block = Addr.Map.find h p.blocks in
+        let fresh_for_h_params name =
+          List.map h_block.params ~f:(fun _ -> Var.fresh_n name)
+        in
+        let helper_init_args = fresh_for_h_params "loop_init" in
+        let free_pc = ref p.free_pc in
+        let alloc_pc () =
+          let n = !free_pc in
+          incr free_pc;
+          n
+        in
+        let entry_pc = alloc_pc () in
+        let disp_pc = alloc_pc () in
+        let new_blocks = ref Addr.Map.empty in
+        let make_return_block packed_args =
+          let pc = alloc_pc () in
+          let body, ret = pack_for_return packed_args in
+          let blk = { params = []; body; branch = Return ret } in
+          new_blocks := Addr.Map.add pc blk !new_blocks;
+          pc, []
+        in
+        (* Rewrite each body block: [Including_Binders] renames its binders
+           and uses; [rewrite_branch] redirects exit edges to Return blocks.
+           For closures defined in the body, [Excluding_Binders.cont']
+           substitutes uses inside the closure body (binders inside the
+           closure stay put). *)
+        let updated_body =
+          Addr.Set.fold
+            (fun pc m ->
+              let b = Addr.Map.find pc p.blocks in
+              let new_b = Subst.Including_Binders.block s b in
+              let branch =
+                rewrite_branch ~body_set ~live_out_forks ~make_return_block new_b.branch
+              in
+              let m = Addr.Map.add pc { new_b with branch } m in
+              List.fold_left b.body ~init:m ~f:(fun m i ->
+                  match i with
+                  | Let (_, Closure (_, (pc_clo, _), _)) ->
+                      let m, _ =
+                        Subst.Excluding_Binders.cont' s pc_clo m Addr.Set.empty
+                      in
+                      m
+                  | _ -> m))
+            body_set
+            p.blocks
+        in
+        let updated_body = Addr.Map.fold Addr.Map.add !new_blocks updated_body in
+        (* Helper entry: branch to [h] passing the closure's "initial args"
+           parameters as values for h's (now renamed) block params. *)
+        let entry_block =
+          { params = []; body = []; branch = Branch (h, helper_init_args) }
+        in
+        let updated_body = Addr.Map.add entry_pc entry_block updated_body in
+        let helper_var = Var.fresh_n "loop_helper" in
+        let helper_closure = Closure (helper_init_args, (entry_pc, []), (None, None)) in
+        (* Dispatch block: define the helper, call it, unpack the return,
+           and branch to the loop's exit (or [Stop] if there isn't one). *)
+        let disp_params = fresh_for_h_params "disp_arg" in
+        let ret_var = Var.fresh_n "loop_ret" in
+        let setup =
+          [ Let (helper_var, helper_closure)
+          ; Let (ret_var, Apply { f = helper_var; args = disp_params; exact = true })
+          ]
+        in
+        let unpack_body, disp_branch, branch_target =
+          match exit_pc_opt with
+          | None ->
+              (* No exit edges from the body: every path ends in [Return],
+                 [Raise], or [Stop]. In well-formed SSA, no block outside
+                 [body_set] can reach a body-bound binder, so [live_out] is
+                 empty and there's nothing to unpack. The dispatch's branch
+                 is unreachable in practice. *)
+              assert (List.is_empty live_out_list);
+              [], Stop, None
+          | Some exit_pc ->
+              let exit_arity = List.length (Addr.Map.find exit_pc updated_body).params in
+              let m = List.length live_out_list in
+              if exit_arity + m = 0
+              then [], Branch (exit_pc, []), Some exit_pc
+              else
+                (* Unpack the [exit_args ++ live_out_forks] tuple that
+                   [pack_for_return] built. *)
+                let exit_unpack =
+                  List.init ~len:exit_arity ~f:(fun i ->
+                      let x = Var.fresh_n "loop_unpack" in
+                      x, Let (x, Field (ret_var, i, Non_float)))
+                in
+                let live_out_unpack =
+                  List.mapi live_out_list ~f:(fun j v ->
+                      Let (v, Field (ret_var, exit_arity + j, Non_float)))
+                in
+                let branch_args = List.map ~f:fst exit_unpack in
+                ( List.map ~f:snd exit_unpack @ live_out_unpack
+                , Branch (exit_pc, branch_args)
+                , Some exit_pc )
+        in
+        let disp_block =
+          { params = disp_params; body = setup @ unpack_body; branch = disp_branch }
+        in
+        let updated_body = Addr.Map.add disp_pc disp_block updated_body in
+        (* Register the dispatch's outgoing edge so a future loop whose
+           header is reachable from there sees [disp_pc] as a predecessor. *)
+        Option.iter branch_target ~f:(fun target ->
+            let s =
+              Addr.Hashtbl.find_opt extra_preds target
+              |> Option.value ~default:Addr.Set.empty
+            in
+            Addr.Hashtbl.replace extra_preds target (Addr.Set.add disp_pc s));
+        (* Redirect outside predecessors of [h] from [h] to [disp_pc]. *)
+        let redirect_to_disp (pc, args) = if pc = h then disp_pc, args else pc, args in
+        let updated_body =
+          Addr.Set.fold
+            (fun s_pc blocks ->
+              let b = Addr.Map.find s_pc blocks in
+              let branch = map_branch_conts redirect_to_disp b.branch in
+              Addr.Map.add s_pc { b with branch } blocks)
+            outside
+            updated_body
+        in
+        if debug ()
+        then
+          Format.eprintf
+            "HOIST loop @%d (body=%d, live_out=%d)@."
+            h
+            (Addr.Set.cardinal body_set)
+            (Var.Set.cardinal live_out);
+        { p with blocks = updated_body; free_pc = !free_pc }, true
+
+let f p =
+  let t = Timer.make () in
+  let p = Structure.norm p in
+  let g = Structure.build_graph p.blocks p.start in
+  let dom = Structure.dominator_tree g in
+  let headers = outermost_loop_headers ~g ~dom ~root:p.start in
+  let p =
+    match headers with
+    | [] -> p
+    | _ :: _ ->
+        let hoisted = ref 0 in
+        let left_in_place = ref 0 in
+        let tracked = loop_bound_vars ~dom ~headers p in
+        let uses = compute_uses ~tracked p in
+        let extra_preds = Addr.Hashtbl.create 16 in
+        let p =
+          List.fold_left headers ~init:p ~f:(fun p h ->
+              let p, did = try_extract_loop ~g ~dom ~uses ~extra_preds ~h p in
+              if did then incr hoisted else incr left_in_place;
+              p)
+        in
+        if stats ()
+        then
+          Format.eprintf
+            "Stats - loop hoisting: hoisted %d, left in place %d@."
+            !hoisted
+            !left_in_place;
+        p
+  in
+  if times () then Format.eprintf "  loop hoisting: %a@." Timer.print t;
+  Code.invariant p;
+  p

--- a/compiler/lib/hoist_loops.mli
+++ b/compiler/lib/hoist_loops.mli
@@ -1,0 +1,27 @@
+(* Js_of_ocaml compiler
+ * http://www.ocsigen.org/js_of_ocaml/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+
+(** Extract outermost loops of the program's entry function into separate
+    helper closures.
+
+    Engines like V8 tier up (compile to optimised native code) functions that
+    contain loops. The OCaml unit-initialisation function is large and
+    typically called only once, so we want to avoid tiering it up. Extracting
+    its loops into smaller helpers lets the engine tier up just the helpers. *)
+
+val f : Code.program -> Code.program

--- a/compiler/lib/structure.ml
+++ b/compiler/lib/structure.ml
@@ -32,6 +32,8 @@ let get_nodes g =
     ~f:(fun s pc -> Addr.Set.add pc s)
     g.reverse_post_order
 
+let preds g pc = Addr.Hashtbl.find_opt g.preds pc |> Option.value ~default:Addr.Set.empty
+
 let block_order g pc = Addr.Hashtbl.find g.block_order pc
 
 let is_backward g pc pc' =

--- a/compiler/lib/structure.mli
+++ b/compiler/lib/structure.mli
@@ -7,6 +7,8 @@ type t
 
 val get_edges : graph -> Addr.t -> Addr.Set.t
 
+val preds : t -> Addr.t -> Addr.Set.t
+
 val is_backward : t -> Addr.t -> Addr.t -> bool
 
 val is_forward : t -> Addr.t -> Addr.t -> bool

--- a/compiler/tests-compiler/hoist_loops.ml
+++ b/compiler/tests-compiler/hoist_loops.ml
@@ -1,0 +1,544 @@
+(* Js_of_ocaml compiler
+ * http://www.ocsigen.org/js_of_ocaml/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+
+(* End-to-end tests for the IR-level loop hoisting pass.
+
+   The pass extracts the body of an outermost loop of the toplevel
+   "unit-init" function into a helper closure. Each test compiles a small
+   OCaml program and checks that:
+   - the toplevel contains a call to a freshly-defined inner function (the
+     loop helper),
+   - the helper contains the loop itself,
+   - the value computed by the loop is correctly threaded back to the
+     toplevel, both for the [Apply] return value and for variables that are
+     bound inside the loop body and read again after it. *)
+
+let%expect_test "simple for-loop is extracted into a helper" =
+  let prog =
+    Util.compile_and_parse
+      {|
+      let r = ref 0
+      let () =
+        for i = 1 to 10 do
+          r := !r + i
+        done
+      let () = print_int !r
+      |}
+  in
+  Util.print_program prog;
+  [%expect
+    {|
+    (function(globalThis){
+       "use strict";
+       var runtime = globalThis.jsoo_runtime;
+       function caml_call1(f, a0){
+        return (f.l >= 0 ? f.l : f.l = f.length) === 1
+                ? f(a0)
+                : runtime.caml_call_gen(f, [a0]);
+       }
+       var Stdlib = runtime.caml_get_global("Stdlib"), r = [0, 0];
+       (function(_a_){
+          var i = _a_;
+          for(;;){
+           r[1] = r[1] + i | 0;
+           _a_ = i + 1 | 0;
+           if(10 === i){
+            caml_call1(Stdlib[44], r[1]);
+            runtime.caml_register_global([0, r], "Test");
+            return;
+           }
+           i = _a_;
+          }
+         }
+         (1));
+       return;
+      }
+      (globalThis));
+    //end
+    |}]
+
+let%expect_test "two independent loops, each with its own helper" =
+  let prog =
+    Util.compile_and_parse
+      {|
+      let s = ref 0 and t = ref 0
+      let () =
+        for i = 1 to 5 do s := !s + i done;
+        for j = 1 to 5 do t := !t + (2 * j) done
+      let () = print_int (!s + !t)
+      |}
+  in
+  Util.print_program prog;
+  [%expect
+    {|
+    (function(globalThis){
+       "use strict";
+       var runtime = globalThis.jsoo_runtime;
+       function caml_call1(f, a0){
+        return (f.l >= 0 ? f.l : f.l = f.length) === 1
+                ? f(a0)
+                : runtime.caml_call_gen(f, [a0]);
+       }
+       var Stdlib = runtime.caml_get_global("Stdlib"), dummy = 0, s = [0, 0];
+       (function(_a_){
+          var i = _a_;
+          for(;;){
+           s[1] = s[1] + i | 0;
+           _a_ = i + 1 | 0;
+           if(5 === i) return;
+           i = _a_;
+          }
+         }
+         (1));
+       var t = [0, 0];
+       (function(_a_){
+          var j = _a_;
+          for(;;){
+           t[1] = t[1] + (2 * j | 0) | 0;
+           _a_ = j + 1 | 0;
+           if(5 === j){
+            caml_call1(Stdlib[44], s[1] + t[1] | 0);
+            runtime.caml_register_global([0, s, t], "Test");
+            return;
+           }
+           j = _a_;
+          }
+         }
+         (1));
+       return;
+      }
+      (globalThis));
+    //end
+    |}]
+
+let%expect_test "loop body containing a closure: the closure moves with the body" =
+  let prog =
+    Util.compile_and_parse
+      {|
+      let acc = ref []
+      let () =
+        for i = 1 to 3 do
+          let v = i in
+          acc := (fun () -> v) :: !acc
+        done
+      let () =
+        let rec run = function
+          | [] -> ()
+          | f :: t -> print_int (f ()); run t
+        in
+        run !acc
+      |}
+  in
+  Util.print_program prog;
+  [%expect
+    {|
+    (function(globalThis){
+       "use strict";
+       var runtime = globalThis.jsoo_runtime;
+       function caml_call1(f, a0){
+        return (f.l >= 0 ? f.l : f.l = f.length) === 1
+                ? f(a0)
+                : runtime.caml_call_gen(f, [a0]);
+       }
+       var dummy = 0, Stdlib = runtime.caml_get_global("Stdlib"), acc = [0, 0];
+       (function(_a_){
+          var i = _a_;
+          for(;;){
+           let i$0 = i;
+           acc[1] = [0, function(param){return i$0;}, acc[1]];
+           _a_ = i + 1 | 0;
+           if(3 === i) return;
+           i = _a_;
+          }
+         }
+         (1));
+       function run(_a_){
+        for(;;){
+         if(! _a_) return;
+         var t = _a_[2], f = _a_[1], _a_ = caml_call1(f, 0);
+         caml_call1(Stdlib[44], _a_);
+         _a_ = t;
+        }
+       }
+       run(acc[1]);
+       runtime.caml_register_global([0, acc], "Test");
+       return;
+      }
+      (globalThis));
+    //end
+    |}]
+
+let%expect_test "while loop" =
+  let prog =
+    Util.compile_and_parse
+      {|
+      let r = ref 0
+      let () =
+        let i = ref 1 in
+        while !i <= 10 do
+          r := !r + !i;
+          incr i
+        done
+      let () = print_int !r
+      |}
+  in
+  Util.print_program prog;
+  [%expect
+    {|
+    (function(globalThis){
+       "use strict";
+       var runtime = globalThis.jsoo_runtime;
+       function caml_call1(f, a0){
+        return (f.l >= 0 ? f.l : f.l = f.length) === 1
+                ? f(a0)
+                : runtime.caml_call_gen(f, [a0]);
+       }
+       var Stdlib = runtime.caml_get_global("Stdlib"), r = [0, 0];
+       (function(loop_init){
+          var i = loop_init;
+          for(;;){
+           if(10 < i){
+            caml_call1(Stdlib[44], r[1]);
+            runtime.caml_register_global([0, r], "Test");
+            return;
+           }
+           r[1] = r[1] + i | 0;
+           var i$0 = i + 1 | 0;
+           i = i$0;
+          }
+         }
+         (1));
+       return;
+      }
+      (globalThis));
+    //end
+    |}]
+
+let%expect_test "loop with a Switch in the body" =
+  let prog =
+    Util.compile_and_parse
+      {|
+      let r = ref 0
+      let () =
+        for i = 0 to 9 do
+          match i mod 4 with
+          | 0 -> r := !r + 1
+          | 1 -> r := !r + 10
+          | 2 -> r := !r + 100
+          | _ -> r := !r + 1000
+        done
+      let () = print_int !r
+      |}
+  in
+  Util.print_program prog;
+  [%expect
+    {|
+    (function(globalThis){
+       "use strict";
+       var runtime = globalThis.jsoo_runtime;
+       function caml_call1(f, a0){
+        return (f.l >= 0 ? f.l : f.l = f.length) === 1
+                ? f(a0)
+                : runtime.caml_call_gen(f, [a0]);
+       }
+       var Stdlib = runtime.caml_get_global("Stdlib"), r = [0, 0];
+       (function(_a_){
+          var i = _a_;
+          for(;;){
+           _a_ = i % 4 | 0;
+           if(2 < _a_ >>> 0)
+            r[1] = r[1] + 1000 | 0;
+           else
+            switch(_a_){
+              case 0:
+               r[1] = r[1] + 1 | 0; break;
+              case 1:
+               r[1] = r[1] + 10 | 0; break;
+              default: r[1] = r[1] + 100 | 0;
+            }
+           _a_ = i + 1 | 0;
+           if(9 === i){
+            caml_call1(Stdlib[44], r[1]);
+            runtime.caml_register_global([0, r], "Test");
+            return;
+           }
+           i = _a_;
+          }
+         }
+         (0));
+       return;
+      }
+      (globalThis));
+    //end
+    |}]
+
+let%expect_test "non-trivial live-out: value computed in loop, used after" =
+  (* The post-loop region is large enough that [shrink_loops] keeps it
+     outside [body_set]. The sum [n] computed in the loop body is then
+     a live-out variable: the helper must return it (packed together with
+     any exit-cont args), and the dispatch block must unpack and rebind
+     it under its original name so the post-loop code keeps working. *)
+  let prog =
+    Util.compile_and_parse
+      {|
+      let () =
+        let n = ref 0 in
+        for i = 1 to 5 do n := !n + i done;
+        let v = !n in
+        print_string "Sum: "; print_int v; print_newline ();
+        print_string "Doubled: "; print_int (2 * v); print_newline ();
+        print_string "Tripled: "; print_int (3 * v); print_newline ();
+        print_string "Quadrupled: "; print_int (4 * v); print_newline ()
+      |}
+  in
+  Util.print_program prog;
+  [%expect
+    {|
+    (function(globalThis){
+       "use strict";
+       var
+        runtime = globalThis.jsoo_runtime,
+        caml_string_of_jsbytes = runtime.caml_string_of_jsbytes;
+       function caml_call1(f, a0){
+        return (f.l >= 0 ? f.l : f.l = f.length) === 1
+                ? f(a0)
+                : runtime.caml_call_gen(f, [a0]);
+       }
+       var
+        Stdlib = runtime.caml_get_global("Stdlib"),
+        n =
+          function(loop_init, _a_){
+             var n$0 = loop_init, i = _a_;
+             for(;;){
+              var n = n$0 + i | 0, _a_ = i + 1 | 0;
+              if(5 === i) return [0, n];
+              n$0 = n;
+              i = _a_;
+             }
+            }
+            (0, 1)
+           [1];
+       caml_call1(Stdlib[42], caml_string_of_jsbytes("Sum: "));
+       caml_call1(Stdlib[44], n);
+       caml_call1(Stdlib[47], 0);
+       caml_call1(Stdlib[42], caml_string_of_jsbytes("Doubled: "));
+       caml_call1(Stdlib[44], 2 * n | 0);
+       caml_call1(Stdlib[47], 0);
+       caml_call1(Stdlib[42], caml_string_of_jsbytes("Tripled: "));
+       caml_call1(Stdlib[44], 3 * n | 0);
+       caml_call1(Stdlib[47], 0);
+       caml_call1(Stdlib[42], caml_string_of_jsbytes("Quadrupled: "));
+       caml_call1(Stdlib[44], 4 * n | 0);
+       caml_call1(Stdlib[47], 0);
+       runtime.caml_register_global([0], "Test");
+       return;
+      }
+      (globalThis));
+    //end
+    |}]
+
+let%expect_test "post-loop closure captures a loop-bound value" =
+  (* A closure defined *after* the loop captures the loop's final value.
+     The closure-defining block lives outside [body_set] and outside
+     [in_loop] (it's the post-loop region). [compute_uses] still must
+     attribute the closure's tracked-var captures to that defining block,
+     otherwise the value would not be marked live-out and the post-loop
+     closure would reference an unbound variable. *)
+  let prog =
+    Util.compile_and_parse
+      {|
+      let () =
+        let n = ref 0 in
+        for i = 1 to 5 do n := !n + i done;
+        let v = !n in
+        let display () = print_int v; print_newline () in
+        display (); display (); display ()
+      |}
+  in
+  Util.print_program prog;
+  [%expect
+    {|
+    (function(globalThis){
+       "use strict";
+       var runtime = globalThis.jsoo_runtime;
+       function caml_call1(f, a0){
+        return (f.l >= 0 ? f.l : f.l = f.length) === 1
+                ? f(a0)
+                : runtime.caml_call_gen(f, [a0]);
+       }
+       var
+        Stdlib = runtime.caml_get_global("Stdlib"),
+        n =
+          function(loop_init, _a_){
+             var n$0 = loop_init, i = _a_;
+             for(;;){
+              var n = n$0 + i | 0, _a_ = i + 1 | 0;
+              if(5 === i) return [0, n];
+              n$0 = n;
+              i = _a_;
+             }
+            }
+            (0, 1)
+           [1];
+       function display(param){
+        caml_call1(Stdlib[44], n);
+        return caml_call1(Stdlib[47], 0);
+       }
+       display(0);
+       display(0);
+       display(0);
+       runtime.caml_register_global([0], "Test");
+       return;
+      }
+      (globalThis));
+    //end
+    |}]
+
+let%expect_test "try-with inside loop body" =
+  (* [raise_notrace] keeps the raise-kind argument to
+     [caml_maybe_attach_backtrace] stable across compilers; plain [raise] of an
+     immediately-caught exception is translated as a "reraise" by OCaml but as
+     a regular raise by OxCaml, which makes the snapshot diverge. *)
+  let prog =
+    Util.compile_and_parse
+      {|
+      let r = ref 0
+      let () =
+        for i = 1 to 10 do
+          try
+            if i = 7 then raise_notrace Exit;
+            r := !r + i
+          with Exit -> r := !r + 100
+        done
+      let () = print_int !r
+      |}
+  in
+  Util.print_program prog;
+  [%expect
+    {|
+    (function(globalThis){
+       "use strict";
+       var
+        runtime = globalThis.jsoo_runtime,
+        caml_maybe_attach_backtrace = runtime.caml_maybe_attach_backtrace,
+        caml_wrap_exception = runtime.caml_wrap_exception;
+       function caml_call1(f, a0){
+        return (f.l >= 0 ? f.l : f.l = f.length) === 1
+                ? f(a0)
+                : runtime.caml_call_gen(f, [a0]);
+       }
+       var Stdlib = runtime.caml_get_global("Stdlib"), r = [0, 0];
+       (function(_a_){
+          var i = _a_;
+          for(;;){
+           try{if(7 === i) throw Stdlib[3]; r[1] = r[1] + i | 0;}
+           catch(exn$0){
+            var exn = caml_wrap_exception(exn$0);
+            if(exn !== Stdlib[3]) throw caml_maybe_attach_backtrace(exn, 0);
+            r[1] = r[1] + 100 | 0;
+           }
+           _a_ = i + 1 | 0;
+           if(10 === i){
+            caml_call1(Stdlib[44], r[1]);
+            runtime.caml_register_global([0, r], "Test");
+            return;
+           }
+           i = _a_;
+          }
+         }
+         (1));
+       return;
+      }
+      (globalThis));
+    //end
+    |}]
+
+let%expect_test "nested loops: only the outermost is hoisted" =
+  let prog =
+    Util.compile_and_parse
+      {|
+      let r = ref 0
+      let () =
+        for i = 1 to 3 do
+          for j = 1 to 3 do
+            r := !r + i * j
+          done
+        done
+      let () = print_int !r
+      |}
+  in
+  Util.print_program prog;
+  [%expect
+    {|
+    (function(globalThis){
+       "use strict";
+       var runtime = globalThis.jsoo_runtime;
+       function caml_call1(f, a0){
+        return (f.l >= 0 ? f.l : f.l = f.length) === 1
+                ? f(a0)
+                : runtime.caml_call_gen(f, [a0]);
+       }
+       var Stdlib = runtime.caml_get_global("Stdlib"), r = [0, 0];
+       (function(_a_){
+          var i = _a_;
+          for(;;){
+           var j = 1;
+           for(;;){
+            r[1] = r[1] + runtime.caml_mul(i, j) | 0;
+            _a_ = j + 1 | 0;
+            if(3 === j){
+             _a_ = i + 1 | 0;
+             if(3 !== i){i = _a_; break;}
+             caml_call1(Stdlib[44], r[1]);
+             runtime.caml_register_global([0, r], "Test");
+             return;
+            }
+            j = _a_;
+           }
+          }
+         }
+         (1));
+       return;
+      }
+      (globalThis));
+    //end
+    |}]
+
+let%expect_test "no loop at toplevel: early-exit path leaves code unchanged" =
+  let prog = Util.compile_and_parse {|
+      let () = print_int 42
+      |} in
+  Util.print_program prog;
+  [%expect
+    {|
+    (function(globalThis){
+       "use strict";
+       var runtime = globalThis.jsoo_runtime;
+       function caml_call1(f, a0){
+        return (f.l >= 0 ? f.l : f.l = f.length) === 1
+                ? f(a0)
+                : runtime.caml_call_gen(f, [a0]);
+       }
+       var Stdlib = runtime.caml_get_global("Stdlib");
+       caml_call1(Stdlib[44], 42);
+       runtime.caml_register_global([0], "Test");
+       return;
+      }
+      (globalThis));
+    //end
+    |}]

--- a/compiler/tests-compiler/side_effect.ml
+++ b/compiler/tests-compiler/side_effect.ml
@@ -172,7 +172,8 @@ let%expect_test "infinite loop is not treated as pure" =
        "use strict";
        var runtime = globalThis.jsoo_runtime;
        runtime.caml_get_global("Stdlib");
-       for(;;) ;
+       (function(){for(;;) ;}());
+       return;
       }
       (globalThis));
     //end


### PR DESCRIPTION
Extract outermost loops of the entry function into helper closures, so engines tier up the small helpers instead of the giant initialization code. The pass benefits both JavaScript and WebAssembly output.