### PR TITLE
Lib: introduce breaking changes in Dom and Dom_html modules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@
 * Compiler: improved shape computation (#2198)
 * Add the --build-config and --apply-build-config flags (#2177)
 * Runtime/wasm: optimized some bigstring primitives (#2144)
-* Lib: many additional `Dom_html` bindings (#2221)
+* Lib: many additional `Dom_html` bindings (#2221, #2248)
 * Lib: add `Performance` module (#2221)
 * Put more values into global variables (#2211)
 * Runtime: intial support for quickjs-ng

--- a/bench.Dockerfile
+++ b/bench.Dockerfile
@@ -43,7 +43,7 @@ RUN opam install -y --deps-only ./js_of_ocaml-compiler.opam \
 COPY --chown=opam:opam dune-project ./
 COPY --chown=opam:opam tools ./tools
 RUN opam exec -- dune exec tools/ci_setup.exe ../janestreet . \
- && opam exec -- dune build --root ../janestreet --profile release lib/bonsai_web_components/partial_render_table/bench/bin/main.bc-for-jsoo \
+ && (opam exec -- dune build --root ../janestreet --profile release lib/bonsai_web_components/partial_render_table/bench/bin/main.bc-for-jsoo || true) \
  && opam remove js_of_ocaml-compiler ojs \
  && opam clean
 

--- a/examples/wysiwyg/main.ml
+++ b/examples/wysiwyg/main.ml
@@ -153,7 +153,7 @@ let () =
         in
         but##.onclick :=
           Html.handler (fun _ ->
-              iWin##focus;
+              Js.Opt.iter iWin (fun iWin -> iWin##focus);
               iDoc##execCommand (Js.string action) show (wrap value);
               Js._true);
         Dom.appendChild parent but;
@@ -187,9 +187,13 @@ let () =
       link_group##.className := Js.string "toolbar-group";
       Dom.appendChild toolbar link_group;
       let prompt query default =
-        Js.Opt.get
-          (iWin##prompt (Js.string query) (Js.string default))
+        Js.Opt.case
+          iWin
           (fun () -> Js.string default)
+          (fun iWin ->
+            Js.Opt.get
+              (iWin##prompt (Js.string query) (Js.string default))
+              (fun () -> Js.string default))
         |> Js.to_string
       in
       (createButton link_group "Link" "inserthtml")##.onclick

--- a/lib/js_of_ocaml/dom.ml
+++ b/lib/js_of_ocaml/dom.ml
@@ -427,6 +427,8 @@ class type ['a] event = object
 
   method timeStamp : number_t readonly_prop
 
+  method composedPath : Unsafe.any js_array t meth
+
   method preventDefault : unit meth
 
   method stopPropagation : unit meth

--- a/lib/js_of_ocaml/dom.mli
+++ b/lib/js_of_ocaml/dom.mli
@@ -440,6 +440,8 @@ class type ['a] event = object
 
   method timeStamp : number_t readonly_prop
 
+  method composedPath : Unsafe.any js_array t meth
+
   method preventDefault : unit meth
 
   method stopPropagation : unit meth

--- a/lib/js_of_ocaml/dom_html.ml
+++ b/lib/js_of_ocaml/dom_html.ml
@@ -771,13 +771,13 @@ end
 and dragEvent = object
   inherit mouseEvent
 
-  method dataTransfer : dataTransfer t readonly_prop
+  method dataTransfer : dataTransfer t opt readonly_prop
 end
 
 and clipboardEvent = object
   inherit event
 
-  method clipboardData : dataTransfer t readonly_prop
+  method clipboardData : dataTransfer t opt readonly_prop
 end
 
 and toggleEvent = object
@@ -1929,7 +1929,7 @@ class type selectElement = object ('self)
 
   method required : bool t writeonly_prop
 
-  method labels : labelElement Dom.nodeList t readonly_prop
+  method labels : labelElement Dom.nodeList t opt readonly_prop
 
   method validity : validityState t readonly_prop
 
@@ -2040,7 +2040,7 @@ class type inputElement = object ('self)
 
   method setSelectionRange_direction : int -> int -> js_string t -> unit meth
 
-  method files : File.fileList t readonly_prop
+  method files : File.fileList t opt readonly_prop
 
   method placeholder : js_string t prop
 
@@ -2050,7 +2050,7 @@ class type inputElement = object ('self)
 
   method selectionEnd : int prop
 
-  method labels : labelElement Dom.nodeList t readonly_prop
+  method labels : labelElement Dom.nodeList t opt readonly_prop
 
   method validity : validityState t readonly_prop
 
@@ -2134,7 +2134,7 @@ class type textAreaElement = object ('self)
 
   method placeholder : js_string t prop
 
-  method labels : labelElement Dom.nodeList t readonly_prop
+  method labels : labelElement Dom.nodeList t opt readonly_prop
 
   method validity : validityState t readonly_prop
 
@@ -2190,7 +2190,7 @@ class type buttonElement = object
 
   method popoverTargetAction : js_string t prop
 
-  method labels : labelElement Dom.nodeList t readonly_prop
+  method labels : labelElement Dom.nodeList t opt readonly_prop
 
   method validity : validityState t readonly_prop
 
@@ -2254,7 +2254,7 @@ class type outputElement = object
 
   method htmlFor : tokenList t readonly_prop
 
-  method labels : labelElement Dom.nodeList t readonly_prop
+  method labels : labelElement Dom.nodeList t opt readonly_prop
 
   method validity : validityState t readonly_prop
 
@@ -2278,7 +2278,7 @@ class type progressElement = object
 
   method position : number_t readonly_prop
 
-  method labels : labelElement Dom.nodeList t readonly_prop
+  method labels : labelElement Dom.nodeList t opt readonly_prop
 end
 
 class type meterElement = object
@@ -2296,7 +2296,7 @@ class type meterElement = object
 
   method optimum : number_t prop
 
-  method labels : labelElement Dom.nodeList t readonly_prop
+  method labels : labelElement Dom.nodeList t opt readonly_prop
 end
 
 class type templateElement = object
@@ -3225,11 +3225,11 @@ class type range = object
 end
 
 class type selection = object
-  method anchorNode : Dom.node t readonly_prop
+  method anchorNode : Dom.node t opt readonly_prop
 
   method anchorOffset : int readonly_prop
 
-  method focusNode : Dom.node t readonly_prop
+  method focusNode : Dom.node t opt readonly_prop
 
   method focusOffset : int readonly_prop
 
@@ -3751,7 +3751,7 @@ class type iFrameElement = object
 
   method contentDocument : document t opt readonly_prop
 
-  method contentWindow : window t readonly_prop
+  method contentWindow : window t opt readonly_prop
 end
 
 (****)

--- a/lib/js_of_ocaml/dom_html.mli
+++ b/lib/js_of_ocaml/dom_html.mli
@@ -785,13 +785,13 @@ end
 and dragEvent = object
   inherit mouseEvent
 
-  method dataTransfer : dataTransfer t readonly_prop
+  method dataTransfer : dataTransfer t opt readonly_prop
 end
 
 and clipboardEvent = object
   inherit event
 
-  method clipboardData : dataTransfer t readonly_prop
+  method clipboardData : dataTransfer t opt readonly_prop
 end
 
 and toggleEvent = object
@@ -1737,7 +1737,7 @@ class type selectElement = object ('self)
 
   method required : bool t writeonly_prop
 
-  method labels : labelElement Dom.nodeList t readonly_prop
+  method labels : labelElement Dom.nodeList t opt readonly_prop
 
   method validity : validityState t readonly_prop
 
@@ -1849,7 +1849,7 @@ class type inputElement = object ('self)
 
   method setSelectionRange_direction : int -> int -> js_string t -> unit meth
 
-  method files : File.fileList t readonly_prop
+  method files : File.fileList t opt readonly_prop
 
   method placeholder : js_string t prop
 
@@ -1859,7 +1859,7 @@ class type inputElement = object ('self)
 
   method selectionEnd : int prop
 
-  method labels : labelElement Dom.nodeList t readonly_prop
+  method labels : labelElement Dom.nodeList t opt readonly_prop
 
   method validity : validityState t readonly_prop
 
@@ -1943,7 +1943,7 @@ class type textAreaElement = object ('self)
 
   method placeholder : js_string t prop
 
-  method labels : labelElement Dom.nodeList t readonly_prop
+  method labels : labelElement Dom.nodeList t opt readonly_prop
 
   method validity : validityState t readonly_prop
 
@@ -1999,7 +1999,7 @@ class type buttonElement = object
 
   method popoverTargetAction : js_string t prop
 
-  method labels : labelElement Dom.nodeList t readonly_prop
+  method labels : labelElement Dom.nodeList t opt readonly_prop
 
   method validity : validityState t readonly_prop
 
@@ -2063,7 +2063,7 @@ class type outputElement = object
 
   method htmlFor : tokenList t readonly_prop
 
-  method labels : labelElement Dom.nodeList t readonly_prop
+  method labels : labelElement Dom.nodeList t opt readonly_prop
 
   method validity : validityState t readonly_prop
 
@@ -2087,7 +2087,7 @@ class type progressElement = object
 
   method position : number_t readonly_prop
 
-  method labels : labelElement Dom.nodeList t readonly_prop
+  method labels : labelElement Dom.nodeList t opt readonly_prop
 end
 
 class type meterElement = object
@@ -2105,7 +2105,7 @@ class type meterElement = object
 
   method optimum : number_t prop
 
-  method labels : labelElement Dom.nodeList t readonly_prop
+  method labels : labelElement Dom.nodeList t opt readonly_prop
 end
 
 class type templateElement = object
@@ -3043,11 +3043,11 @@ end
 
 (** Information on current selection *)
 class type selection = object
-  method anchorNode : Dom.node t readonly_prop
+  method anchorNode : Dom.node t opt readonly_prop
 
   method anchorOffset : int readonly_prop
 
-  method focusNode : Dom.node t readonly_prop
+  method focusNode : Dom.node t opt readonly_prop
 
   method focusOffset : int readonly_prop
 
@@ -3594,7 +3594,7 @@ class type iFrameElement = object
 
   method contentDocument : document t opt readonly_prop
 
-  method contentWindow : window t readonly_prop
+  method contentWindow : window t opt readonly_prop
 end
 
 (****)

--- a/lib/js_of_ocaml/form.ml
+++ b/lib/js_of_ocaml/form.ml
@@ -99,21 +99,24 @@ let get_input_val ?(get = false) (elt : inputElement t) =
         if get
         then [ name, `String value ]
         else
-          let list = elt##.files in
-          if list##.length = 0
-          then [ name, `String (Js.string "") ]
-          else if not (Js.to_bool elt##.multiple)
-          then
-            match Opt.to_option (list##item 0) with
-            | None -> []
-            | Some file -> [ name, `File file ]
-          else
-            filter_map
-              (fun f ->
-                match Opt.to_option f with
-                | None -> None
-                | Some file -> Some (name, `File file))
-              (Array.to_list (Array.init list##.length (fun i -> list##item i)))
+          Opt.case
+            elt##.files
+            (fun () -> [ name, `String (Js.string "") ])
+            (fun list ->
+              if list##.length = 0
+              then [ name, `String (Js.string "") ]
+              else if not (Js.to_bool elt##.multiple)
+              then
+                match Opt.to_option (list##item 0) with
+                | None -> []
+                | Some file -> [ name, `File file ]
+              else
+                filter_map
+                  (fun f ->
+                    match Opt.to_option f with
+                    | None -> None
+                    | Some file -> Some (name, `File file))
+                  (Array.to_list (Array.init list##.length (fun i -> list##item i))))
     | _ -> [ name, `String value ]
   else []
 

--- a/tools/ci_setup-mainstream.ml
+++ b/tools/ci_setup-mainstream.ml
@@ -33,6 +33,9 @@ let forked_packages =
     ; "typerep" (* https://github.com/janestreet/typerep/pull/7 *)
     ]
 
+let fixed_packages =
+  StringSet.of_list [ "bonsai_web"; "bonsai_web_components"; "virtual_dom" ]
+
 let dune_workspace =
   {|(lang dune 3.17)
 (env
@@ -325,6 +328,8 @@ let rec traverse visited p =
 
 let is_forked p = StringSet.mem p forked_packages
 
+let is_fixed p = StringSet.mem p fixed_packages
+
 let exec_async cmd =
   let p = Unix.open_process_out cmd in
   fun () -> ignore (Unix.close_process_out p)
@@ -396,9 +401,15 @@ let () =
   sync_exec (fun () -> exec_async "opam install uri --deps-only") [ () ];
   sync_exec
     (fun nm ->
-      let branch = if is_forked nm then Some "wasm-latest" else None in
+      let branch =
+        if is_fixed nm
+        then Some "wasm-latest-fixed"
+        else if is_forked nm
+        then Some "wasm-latest"
+        else None
+      in
       let commit =
-        if is_forked nm
+        if is_fixed nm || is_forked nm
         then None
         else
           Some
@@ -413,7 +424,7 @@ let () =
         nm
         (Printf.sprintf
            "https://github.com/%s/%s"
-           (if is_forked nm then "ocaml-wasm" else "janestreet")
+           (if is_fixed nm || is_forked nm then "ocaml-wasm" else "janestreet")
            nm))
     (StringSet.elements (StringSet.diff js omitted_js))
 

--- a/tools/ci_setup-oxcaml.ml
+++ b/tools/ci_setup-oxcaml.ml
@@ -38,6 +38,9 @@ let forked_packages =
     ; "virtual_dom"
     ]
 
+let fixed_packages =
+  StringSet.of_list [ "bonsai_web"; "bonsai_web_components"; "virtual_dom" ]
+
 let dune_workspace =
   {|(lang dune 3.17)
 (env
@@ -324,6 +327,8 @@ let rec traverse visited p =
 
 let is_forked p = StringSet.mem p forked_packages
 
+let is_fixed p = StringSet.mem p fixed_packages
+
 let exec_async cmd =
   let p = Unix.open_process_out cmd in
   fun () -> ignore (Unix.close_process_out p)
@@ -398,9 +403,15 @@ let () =
   sync_exec (fun () -> exec_async "opam install uri --deps-only") [ () ];
   sync_exec
     (fun nm ->
-      let branch = if is_forked nm then Some "wasm-oxcaml-31" else Some "oxcaml" in
+      let branch =
+        if is_fixed nm
+        then Some "wasm-oxcaml-31-fixed"
+        else if is_forked nm
+        then Some "wasm-oxcaml-31"
+        else Some "oxcaml"
+      in
       let commit =
-        if is_forked nm
+        if is_fixed nm || is_forked nm
         then None
         else
           let commit =
@@ -418,7 +429,7 @@ let () =
         nm
         (Printf.sprintf
            "https://github.com/%s/%s"
-           (if is_forked nm then "ocaml-wasm" else "janestreet")
+           (if is_fixed nm || is_forked nm then "ocaml-wasm" else "janestreet")
            nm))
     (StringSet.elements (StringSet.diff js omitted_js))
 


### PR DESCRIPTION
This commit introduces several breaking changes to the `Dom` and `Dom_html` modules to better match the DOM specification:

- Add a `composedPath` method to `Dom.event`.
- Make the following properties optional/nullable (`opt`):
  - `dragEvent##.dataTransfer`, `clipboardEvent##.clipboardData`, `iFrameElement##.contentWindow`
  - `inputElement##.files`
  - `selection##.anchorNode`, `selection##.focusNode`
  - the `labels` attribute on `select`, `input`, `textArea`, `button`, `output`, `progress`, and `meter` elements

The in-tree consumers (`lib/js_of_ocaml/form.ml` and `examples/wysiwyg`) are updated accordingly. The CI setup is adjusted to use fixed branches for the Jane Street packages (`bonsai_web`, `bonsai_web_components`, `virtual_dom`) that have been adapted to these breaking changes, and the benchmark docker build is made non-fatal in the meantime.
