### PR TITLE
Lib: fix onbeforeunload handler breaking navigation (#1436)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,12 @@
   `canvasElement.toDataURL_type_compression` (called `toDataURL_type`).
   Renamed to `_BYTES_PER_ELEMENT_`, `_MAX_RENDERBUFFER_SIZE_`, and
   `toDataURL_compression` respectively
+* Lib: fix `onbeforeunload` handler breaking navigation (#1436). The
+  `event_listener` return type is now `bool t optdef`, with `undefined`
+  meaning "no opinion" so `beforeunload` handlers don't trigger a
+  spurious confirmation dialog. Adds `Dom.listener`/`full_listener`, and
+  types `onbeforeunload` and `Event.beforeunload` against the new
+  `beforeUnloadEvent` class.
 
 # 6.3.2 (2026-02-15) - Lille
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -57,7 +57,7 @@
   `event_listener` return type is now `bool t optdef`, with `undefined`
   meaning "no opinion" so `beforeunload` handlers don't trigger a
   spurious confirmation dialog. Adds `Dom.listener`/`full_listener`, and
-  types `onbeforeunload` and `Event.beforeunload` against the new
+  types `onbeforeunload` and `Event.beforeunload` against the
   `beforeUnloadEvent` class.
 
 # 6.3.2 (2026-02-15) - Lille

--- a/lib/js_of_ocaml/dom.ml
+++ b/lib/js_of_ocaml/dom.ml
@@ -389,10 +389,16 @@ module CoerceTo = struct
   let documentType e : documentType Js.t Js.opt = cast e DOCUMENT_TYPE
 end
 
-type ('a, 'b) event_listener = ('a, 'b -> bool t) meth_callback opt
+type ('a, 'b) event_listener = ('a, 'b -> bool t optdef) meth_callback opt
 (** The type of event listener functions.  The first type parameter
       ['a] is the type of the target object; the second parameter
-      ['b] is the type of the event object. *)
+      ['b] is the type of the event object.
+
+      Handlers return [bool t optdef]: a defined boolean signals an opinion
+      ([false] cancels the default action via [preventDefault]), while
+      [undefined] means "no opinion".  This matters for events like
+      [beforeunload], where the browser interprets any returned non-undefined
+      value as a request to show the confirmation dialog. *)
 
 type event_phase =
   | Phase_none
@@ -445,18 +451,36 @@ let handler f =
   Js.some
     (Js.Unsafe.callback (fun e ->
          let res = f e in
-         if not (Js.to_bool res) then e##preventDefault;
-         res))
+         if Js.to_bool res
+         then Js.undefined
+         else (
+           e##preventDefault;
+           Js.def Js._false)))
 
 let full_handler f =
   Js.some
     (Js.Unsafe.meth_callback (fun this e ->
          let res = f this e in
-         if not (Js.to_bool res) then e##preventDefault;
-         res))
+         if Js.to_bool res
+         then Js.undefined
+         else (
+           e##preventDefault;
+           Js.def Js._false)))
+
+let listener f : ('a, 'b) event_listener =
+  Js.some
+    (Js.Unsafe.callback (fun e ->
+         f e;
+         if Js.to_bool e##.defaultPrevented then Js.def Js._false else Js.undefined))
+
+let full_listener f : ('a, 'b) event_listener =
+  Js.some
+    (Js.Unsafe.meth_callback (fun this e ->
+         f this e;
+         if Js.to_bool e##.defaultPrevented then Js.def Js._false else Js.undefined))
 
 let invoke_handler (f : ('a, 'b) event_listener) (this : 'a) (event : 'b) : bool t =
-  Js.Unsafe.call f this [| Js.Unsafe.inject event |]
+  Js.Optdef.get (Js.Unsafe.call f this [| Js.Unsafe.inject event |]) (fun () -> Js._true)
 
 let eventTarget (e : (< .. > as 'a) #event t) : 'a t =
   Opt.get e##.target (fun () -> Opt.get e##.srcElement (fun () -> raise Not_found))

--- a/lib/js_of_ocaml/dom.mli
+++ b/lib/js_of_ocaml/dom.mli
@@ -463,20 +463,32 @@ val no_handler : ('a, 'b) event_listener
 
 val handler : (('e #event t as 'b) -> bool t) -> ('a, 'b) event_listener
 (** Create an event handler that invokes the provided function.
-      If the handler returns false, the default action is prevented. *)
+    If the handler returns false, the default action is prevented. *)
 
 val full_handler : ('a -> ('e #event t as 'b) -> bool t) -> ('a, 'b) event_listener
 (** Create an event handler that invokes the provided function.
-      The event target (implicit parameter [this]) is also passed as
-      argument to the function.  *)
+    The event target (implicit parameter [this]) is also passed as
+    argument to the function.  *)
+
+val listener : (('e #event t as 'b) -> unit) -> ('a, 'b) event_listener
+(** Create an event listener that invokes the provided function and lets
+    the browser decide what to do based on whether [preventDefault] was
+    called.  Unlike [handler], the listener returns no opinion when
+    [preventDefault] was not called — which is what events like
+    [beforeunload] require to avoid spurious confirmation dialogs. *)
+
+val full_listener : ('a -> ('e #event t as 'b) -> unit) -> ('a, 'b) event_listener
+(** Same as [listener] but also passes the event target (implicit
+    parameter [this]) to the function. *)
 
 val invoke_handler : ('a, 'b) event_listener -> 'a -> 'b -> bool t
-(** Invoke an existing handler.  Useful to chain event handlers. *)
+(** Invoke an existing handler.  Useful to chain event handlers.
+    Listeners that return no opinion are normalized to [Js._true]. *)
 
 val eventTarget : (< .. > as 'a) #event t -> 'a t
 (** Returns which object is the target of this event.
-      It raises [Not_found] in case there is no target
-      (if the event has not been triggered yet) *)
+    It raises [Not_found] in case there is no target
+    (if the event has not been triggered yet) *)
 
 type event_listener_id
 

--- a/lib/js_of_ocaml/dom.mli
+++ b/lib/js_of_ocaml/dom.mli
@@ -471,11 +471,11 @@ val full_handler : ('a -> ('e #event t as 'b) -> bool t) -> ('a, 'b) event_liste
     argument to the function.  *)
 
 val listener : (('e #event t as 'b) -> unit) -> ('a, 'b) event_listener
-(** Create an event listener that invokes the provided function and lets
-    the browser decide what to do based on whether [preventDefault] was
-    called.  Unlike [handler], the listener returns no opinion when
-    [preventDefault] was not called — which is what events like
-    [beforeunload] require to avoid spurious confirmation dialogs. *)
+  (** Create an event listener from a [unit]-returning function.  Unlike
+      [handler], which signals "prevent default" via a [false] return,
+      the callback here must call [preventDefault] explicitly on the event.
+      Convenient for events like [beforeunload] where there is no natural
+      boolean to return. *)
 
 val full_listener : ('a -> ('e #event t as 'b) -> unit) -> ('a, 'b) event_listener
 (** Same as [listener] but also passes the event target (implicit

--- a/lib/js_of_ocaml/dom.mli
+++ b/lib/js_of_ocaml/dom.mli
@@ -410,8 +410,8 @@ end
 
 type (-'a, -'b) event_listener
 (** The type of event listener functions.  The first type parameter
-      ['a] is the type of the target object; the second parameter
-      ['b] is the type of the event object. *)
+    ['a] is the type of the target object; the second parameter
+    ['b] is the type of the event object. *)
 
 type event_phase =
   | Phase_none
@@ -471,11 +471,11 @@ val full_handler : ('a -> ('e #event t as 'b) -> bool t) -> ('a, 'b) event_liste
     argument to the function.  *)
 
 val listener : (('e #event t as 'b) -> unit) -> ('a, 'b) event_listener
-  (** Create an event listener from a [unit]-returning function.  Unlike
-      [handler], which signals "prevent default" via a [false] return,
-      the callback here must call [preventDefault] explicitly on the event.
-      Convenient for events like [beforeunload] where there is no natural
-      boolean to return. *)
+(** Create an event listener from a [unit]-returning function.  Unlike
+    [handler], which signals "prevent default" via a [false] return,
+    the callback here must call [preventDefault] explicitly on the event.
+    Convenient for events like [beforeunload] where there is no natural
+    boolean to return. *)
 
 val full_listener : ('a -> ('e #event t as 'b) -> unit) -> ('a, 'b) event_listener
 (** Same as [listener] but also passes the event target (implicit

--- a/lib/js_of_ocaml/dom_html.ml
+++ b/lib/js_of_ocaml/dom_html.ml
@@ -1448,6 +1448,10 @@ let handler = Dom.handler
 
 let full_handler = Dom.full_handler
 
+let listener = Dom.listener
+
+let full_listener = Dom.full_listener
+
 let invoke_handler = Dom.invoke_handler
 
 module Event = struct
@@ -3591,7 +3595,7 @@ class type window = object
 
   method onunload : (window t, event t) event_listener prop
 
-  method onbeforeunload : (window t, event t) event_listener prop
+  method onbeforeunload : (window t, beforeUnloadEvent t) event_listener prop
 
   method onblur : (window t, focusEvent t) event_listener prop
 

--- a/lib/js_of_ocaml/dom_html.mli
+++ b/lib/js_of_ocaml/dom_html.mli
@@ -3461,7 +3461,7 @@ class type window = object
 
   method onunload : (window t, event t) event_listener prop
 
-  method onbeforeunload : (window t, event t) event_listener prop
+  method onbeforeunload : (window t, beforeUnloadEvent t) event_listener prop
 
   method onblur : (window t, focusEvent t) event_listener prop
 
@@ -3572,6 +3572,12 @@ val handler : ((#event t as 'b) -> bool t) -> ('a, 'b) event_listener
 val full_handler : ('a -> (#event t as 'b) -> bool t) -> ('a, 'b) event_listener
 (** see [Dom.full_handler] *)
 
+val listener : ((#event t as 'b) -> unit) -> ('a, 'b) event_listener
+(** see [Dom.listener] *)
+
+val full_listener : ('a -> (#event t as 'b) -> unit) -> ('a, 'b) event_listener
+(** see [Dom.full_listener] *)
+
 val invoke_handler : ('a, 'b) event_listener -> 'a -> 'b -> bool t
 (** see [Dom.invoke_handler] *)
 
@@ -3663,7 +3669,7 @@ module Event : sig
 
   val unload : event t typ
 
-  val beforeunload : event t typ
+  val beforeunload : beforeUnloadEvent t typ
 
   val resize : event t typ
 

--- a/lib/lwt/lwt_js_events.mli
+++ b/lib/lwt/lwt_js_events.mli
@@ -1166,7 +1166,7 @@ val domContentLoaded : unit -> unit Lwt.t
 
 val onunload : unit -> Dom_html.event Js.t Lwt.t
 
-val onbeforeunload : unit -> Dom_html.event Js.t Lwt.t
+val onbeforeunload : unit -> Dom_html.beforeUnloadEvent Js.t Lwt.t
 
 val onresize : unit -> Dom_html.event Js.t Lwt.t
 

--- a/lib/tests-browser/test_beforeunload.ml
+++ b/lib/tests-browser/test_beforeunload.ml
@@ -12,12 +12,11 @@ let clear_log () =
   Js.Opt.iter el (fun el -> el##.innerHTML := Js.string "")
 
 (* Strategy 1: Dom.handler returning Js._false (block navigation)
-   - handler calls preventDefault and sets returnValue for beforeunload
-   - Returns false to JS (non-undefined) — triggers dialog *)
+   - calls preventDefault — triggers dialog *)
 let set_strategy_1 () =
   clear_log ();
   Dom_html.window##.onbeforeunload
-  := Dom_html.handler (fun (_e : Dom_html.event Js.t) ->
+  := Dom_html.handler (fun (_e : Dom_html.beforeUnloadEvent Js.t) ->
       log "handler called, returning Js._false (block)";
       Js._false);
   log "Strategy 1: handler returning Js._false (block)";
@@ -25,12 +24,11 @@ let set_strategy_1 () =
   log "Now try to navigate away (click a link or close the tab)"
 
 (* Strategy 2: Dom.handler returning Js._true (allow navigation)
-   - handler detects beforeunload and returns undefined instead of true
-   - Should allow navigation on all browsers *)
+   - returns Js.undefined to JS — no dialog *)
 let set_strategy_2 () =
   clear_log ();
   Dom_html.window##.onbeforeunload
-  := Dom_html.handler (fun (_e : Dom_html.event Js.t) ->
+  := Dom_html.handler (fun (_e : Dom_html.beforeUnloadEvent Js.t) ->
       log "handler called, returning Js._true (allow)";
       Js._true);
   log "Strategy 2: handler returning Js._true (allow)";
@@ -44,7 +42,7 @@ let should_block = ref true
 let set_strategy_3 () =
   clear_log ();
   Dom_html.window##.onbeforeunload
-  := Dom_html.handler (fun (_e : Dom_html.event Js.t) ->
+  := Dom_html.handler (fun (_e : Dom_html.beforeUnloadEvent Js.t) ->
       log (Printf.sprintf "handler called, should_block=%b" !should_block);
       Js.bool (not !should_block));
   log "Strategy 3: handler with conditional logic";


### PR DESCRIPTION
## Summary

Alternative to #2159, following @vouillon's [suggestion](https://github.com/ocsigen/js_of_ocaml/pull/2159#issuecomment-4555792459).

Fixes #1436.

Change `event_listener` to return `bool t optdef` instead of `bool t`, so a handler can return `undefined` ("no opinion") in addition to a boolean. The browser interprets any non-undefined return value from a `beforeunload` listener as a request to show the confirmation dialog — so under the old type, returning `Js._true` to allow navigation surfaced a spurious dialog. With the new shape, "allow" maps to `Js.undefined` and the dialog only appears when the handler returns `Js._false` (which also calls `preventDefault`).

Unlike #2159 this avoids the runtime `event.type === "beforeunload"` sniffing in `Dom.handler`.

## Changes

- `Dom.event_listener`: now `('a, 'b -> bool t optdef) meth_callback opt`.
- `Dom.handler` / `full_handler`: return `Js.undefined` on `Js._true`; return `Js.def Js._false` (+ `preventDefault`) on `Js._false`.
- `Dom.invoke_handler`: normalize `undefined` → `Js._true` via `Js.Optdef.get`.
- Add `Dom.listener` / `Dom.full_listener` for void-returning listeners (return `Js.def Js._false` only if the user code already called `preventDefault`).
- Retype `Dom_html.window##.onbeforeunload` and `Dom_html.Event.beforeunload` against the existing `beforeUnloadEvent` class; corresponding update in `lwt_js_events.mli`.
- Refresh the `lib/tests-browser/test_beforeunload.ml` strategies to use the new shape.

## Test plan

- [ ] `dune build`
- [ ] `dune build @lib/runtest`
- [ ] `dune build @compiler/tests-jsoo/runtest`
- [ ] Manually exercise `lib/tests-browser/test_beforeunload.ml` in a current browser (preventDefault path) — the dialog still appears for "block" strategies and is absent for "allow".
- [ ] Confirm Jane Street virtual_dom tests pass (the previous PR broke them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)