### PR TITLE
Lib: implement the Popover API

### DIFF
--- a/API-STATUS.md
+++ b/API-STATUS.md
@@ -114,6 +114,7 @@ This document lists standard JavaScript/Web APIs and their support status in js_
 | Fullscreen API | Yes | Yes | `Dom_html` (`requestFullscreen` / `exitFullscreen`) · Brr: `Brr.El.request_fullscreen`, `Brr.Document.exit_fullscreen` |
 | Gamepad API | No | No | |
 | Pointer Lock API | Yes | Yes | `Dom_html` (`requestPointerLock`) · Brr: `Brr.El.request_pointer_lock` |
+| Popover API | Yes | Partial | `Dom_html` (`showPopover`, `hidePopover`, `togglePopover` with `?force`, `popover` attribute, `popoverTargetElement`/`popoverTargetAction` on input/button, `beforetoggle`/`toggle` events, `ToggleEvent.source`) · Brr: `Brr.El.{show,hide,toggle}_popover` (no `force` arg, no toggle event bindings) |
 | Selection API | Yes | No | `Dom_html` (`selection`, `range`) |
 
 ## Observers

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@
 * Lib: add `Fetch` and `Abort` modules — Fetch API binding with a typed
   `AbortController`/`AbortSignal` primitive for cancellation (#596)
 * Wasm_of_ocaml: alternative effect implementation based on the Stack Switching proposal (#2189)
+* Lib: implement popover API (#1734)
 
 ## Bug fixes
 * Compiler: fix UGEINT bytecode lowering (returned wrong result on

--- a/lib/js_of_ocaml/dom_html.ml
+++ b/lib/js_of_ocaml/dom_html.ml
@@ -786,6 +786,8 @@ and toggleEvent = object
   method newState : js_string t readonly_prop
 
   method oldState : js_string t readonly_prop
+
+  method source : element t opt readonly_prop
 end
 
 and mediaQueryListEvent = object
@@ -892,6 +894,10 @@ and eventTarget = object ('self)
   method onpointerover : ('self t, pointerEvent t) event_listener writeonly_prop
 
   method onpointerup : ('self t, pointerEvent t) event_listener writeonly_prop
+
+  method onbeforetoggle : ('self t, toggleEvent t) event_listener writeonly_prop
+
+  method ontoggle : ('self t, toggleEvent t) event_listener writeonly_prop
 
   method dispatchEvent : event t -> bool t meth
 end
@@ -1296,6 +1302,16 @@ and focusOptions = object
   method preventScroll : bool t writeonly_prop
 end
 
+and showPopover_options = object
+  method source : element t writeonly_prop
+end
+
+and togglePopover_options = object
+  method force : bool t writeonly_prop
+
+  method source : element t writeonly_prop
+end
+
 and element = object
   inherit Dom.element
 
@@ -1385,6 +1401,8 @@ and element = object
 
   method scrollHeight : int readonly_prop
 
+  method popover : js_string t opt prop
+
   method getClientRects : clientRectList t meth
 
   method getBoundingClientRect : clientRect t meth
@@ -1419,6 +1437,18 @@ and element = object
 
   method getAnimations : animation t js_array t meth
 
+  method hidePopover : unit meth
+
+  method showPopover : unit meth
+
+  method showPopover_options : showPopover_options t -> unit meth
+
+  method togglePopover : bool t meth
+
+  method togglePopover_force : bool t -> bool t meth
+
+  method togglePopover_options : togglePopover_options t -> bool t meth
+
   inherit eventTarget
 end
 
@@ -1441,6 +1471,17 @@ and clientRectList = object
 
   method item : int -> clientRect t opt meth
 end
+
+let showPopover_options ?source () : showPopover_options t =
+  let init = Js.Unsafe.obj [||] in
+  Option.iter (fun s -> init##.source := s) source;
+  init
+
+let togglePopover_options ?force ?source () : togglePopover_options t =
+  let init = Js.Unsafe.obj [||] in
+  Option.iter (fun f -> init##.force := Js.bool f) force;
+  Option.iter (fun s -> init##.source := s) source;
+  init
 
 let no_handler : ('a, 'b) event_listener = Dom.no_handler
 
@@ -1642,6 +1683,8 @@ module Event = struct
   let volumechange = Dom.Event.make "volumechange"
 
   let waiting = Dom.Event.make "waiting"
+
+  let beforetoggle = Dom.Event.make "beforetoggle"
 
   let toggle = Dom.Event.make "toggle"
 
@@ -2032,6 +2075,10 @@ class type inputElement = object ('self)
 
   method setCustomValidity : js_string t -> unit meth
 
+  method popoverTarget : element t opt prop
+
+  method popoverTargetAction : js_string t prop
+
   method onselect : ('self t, event t) event_listener prop
 
   method onchange : ('self t, event t) event_listener prop
@@ -2149,6 +2196,10 @@ class type buttonElement = object
   method _type : js_string t readonly_prop
 
   method value : js_string t prop
+
+  method popoverTarget : element t opt prop
+
+  method popoverTargetAction : js_string t prop
 
   method labels : labelElement Dom.nodeList t readonly_prop
 
@@ -2429,8 +2480,6 @@ class type detailsElement = object ('self)
   method open_ : bool t prop
 
   method name : js_string t prop
-
-  method ontoggle : ('self t, toggleEvent t) event_listener prop
 end
 
 class type imageElement = object ('self)

--- a/lib/js_of_ocaml/dom_html.ml
+++ b/lib/js_of_ocaml/dom_html.ml
@@ -1303,13 +1303,13 @@ and focusOptions = object
 end
 
 and showPopover_options = object
-  method source : #element t writeonly_prop
+  method source : element t writeonly_prop
 end
 
 and togglePopover_options = object
   method force : bool t writeonly_prop
 
-  method source : #element t writeonly_prop
+  method source : element t writeonly_prop
 end
 
 and element = object
@@ -4961,7 +4961,7 @@ let showPopover ?source (el : #element t) =
   | None -> el##showPopover
   | Some s ->
       let opts : showPopover_options t = Js.Unsafe.obj [||] in
-      opts##.source := s;
+      opts##.source := (s :> element t);
       el##showPopover_options opts
 
 let hidePopover (el : #element t) = el##hidePopover
@@ -4973,7 +4973,7 @@ let togglePopover ?force ?source (el : #element t) =
   | _, _ ->
       let opts : togglePopover_options t = Js.Unsafe.obj [||] in
       Option.iter (fun f -> opts##.force := f) force;
-      Option.iter (fun s -> opts##.source := s) source;
+      Option.iter (fun s -> opts##.source := (s :> element t)) source;
       el##togglePopover_options opts
 
 let postMessage ?transfer ?targetOrigin (w : window t) message =

--- a/lib/js_of_ocaml/dom_html.ml
+++ b/lib/js_of_ocaml/dom_html.ml
@@ -1472,17 +1472,6 @@ and clientRectList = object
   method item : int -> clientRect t opt meth
 end
 
-let showPopover_options ?source () : showPopover_options t =
-  let init = Js.Unsafe.obj [||] in
-  Option.iter (fun s -> init##.source := s) source;
-  init
-
-let togglePopover_options ?force ?source () : togglePopover_options t =
-  let init = Js.Unsafe.obj [||] in
-  Option.iter (fun f -> init##.force := Js.bool f) force;
-  Option.iter (fun s -> init##.source := s) source;
-  init
-
 let no_handler : ('a, 'b) event_listener = Dom.no_handler
 
 let handler = Dom.handler
@@ -4966,6 +4955,26 @@ let focus ?preventScroll (el : #element t) =
       let opts : focusOptions t = Js.Unsafe.obj [||] in
       opts##.preventScroll := v;
       el##focus_options opts
+
+let showPopover ?source (el : #element t) =
+  match source with
+  | None -> el##showPopover
+  | Some s ->
+      let opts : showPopover_options t = Js.Unsafe.obj [||] in
+      opts##.source := s;
+      el##showPopover_options opts
+
+let hidePopover (el : #element t) = el##hidePopover
+
+let togglePopover ?force ?source (el : #element t) =
+  match force, source with
+  | None, None -> el##togglePopover
+  | Some f, None -> el##togglePopover_force f
+  | _, _ ->
+      let opts : togglePopover_options t = Js.Unsafe.obj [||] in
+      Option.iter (fun f -> opts##.force := f) force;
+      Option.iter (fun s -> opts##.source := s) source;
+      el##togglePopover_options opts
 
 let postMessage ?transfer ?targetOrigin (w : window t) message =
   let opts : windowPostMessageOptions t = Js.Unsafe.obj [||] in

--- a/lib/js_of_ocaml/dom_html.ml
+++ b/lib/js_of_ocaml/dom_html.ml
@@ -1303,13 +1303,13 @@ and focusOptions = object
 end
 
 and showPopover_options = object
-  method source : element t writeonly_prop
+  method source : #element t writeonly_prop
 end
 
 and togglePopover_options = object
   method force : bool t writeonly_prop
 
-  method source : element t writeonly_prop
+  method source : #element t writeonly_prop
 end
 
 and element = object

--- a/lib/js_of_ocaml/dom_html.ml
+++ b/lib/js_of_ocaml/dom_html.ml
@@ -2075,7 +2075,7 @@ class type inputElement = object ('self)
 
   method setCustomValidity : js_string t -> unit meth
 
-  method popoverTarget : element t opt prop
+  method popoverTargetElement : element t opt prop
 
   method popoverTargetAction : js_string t prop
 
@@ -2197,7 +2197,7 @@ class type buttonElement = object
 
   method value : js_string t prop
 
-  method popoverTarget : element t opt prop
+  method popoverTargetElement : element t opt prop
 
   method popoverTargetAction : js_string t prop
 

--- a/lib/js_of_ocaml/dom_html.mli
+++ b/lib/js_of_ocaml/dom_html.mli
@@ -1478,6 +1478,8 @@ and element = object
   method togglePopover : bool t meth
 
   method togglePopover_force : bool t -> bool t meth
+  (** [togglePopover(force)] — [force=true] forces the popover open, [false]
+      forces it closed; the no-arg form toggles. Returns the new open state. *)
 
   method togglePopover_options : togglePopover_options t -> bool t meth
 
@@ -1504,11 +1506,6 @@ and clientRectList = object
 
   method item : int -> clientRect t opt meth
 end
-
-val showPopover_options : ?source:element t -> unit -> showPopover_options t
-
-val togglePopover_options :
-  ?force:bool -> ?source:element t -> unit -> togglePopover_options t
 
 class type ['node] collection = ['node] Dom.collection
 (** Collection of HTML elements. Alias for {!Dom.collection}. *)
@@ -4390,6 +4387,16 @@ val scrollIntoView :
 
 val focus : ?preventScroll:bool t -> #element t -> unit
 (** Wrapper for [HTMLElement.focus(options)] taking labeled arguments. *)
+
+val showPopover : ?source:element t -> #element t -> unit
+(** Wrapper for [Element.showPopover(options)] taking labeled arguments. *)
+
+val hidePopover : #element t -> unit
+(** Wrapper for [Element.hidePopover()]. *)
+
+val togglePopover : ?force:bool t -> ?source:element t -> #element t -> bool t
+(** Wrapper for [Element.togglePopover(options)] taking labeled arguments.
+    Returns the new open state. *)
 
 val postMessage :
   ?transfer:Unsafe.any js_array t -> ?targetOrigin:js_string t -> window t -> 'a -> unit

--- a/lib/js_of_ocaml/dom_html.mli
+++ b/lib/js_of_ocaml/dom_html.mli
@@ -4388,13 +4388,13 @@ val scrollIntoView :
 val focus : ?preventScroll:bool t -> #element t -> unit
 (** Wrapper for [HTMLElement.focus(options)] taking labeled arguments. *)
 
-val showPopover : ?source:element t -> #element t -> unit
+val showPopover : ?source:#element t -> #element t -> unit
 (** Wrapper for [Element.showPopover(options)] taking labeled arguments. *)
 
 val hidePopover : #element t -> unit
 (** Wrapper for [Element.hidePopover()]. *)
 
-val togglePopover : ?force:bool t -> ?source:element t -> #element t -> bool t
+val togglePopover : ?force:bool t -> ?source:#element t -> #element t -> bool t
 (** Wrapper for [Element.togglePopover(options)] taking labeled arguments.
     Returns the new open state. *)
 

--- a/lib/js_of_ocaml/dom_html.mli
+++ b/lib/js_of_ocaml/dom_html.mli
@@ -1876,7 +1876,7 @@ class type inputElement = object ('self)
 
   method setCustomValidity : js_string t -> unit meth
 
-  method popoverTarget : element t opt prop
+  method popoverTargetElement : element t opt prop
 
   method popoverTargetAction : js_string t prop
 
@@ -1998,7 +1998,7 @@ class type buttonElement = object
 
   method value : js_string t prop
 
-  method popoverTarget : element t opt prop
+  method popoverTargetElement : element t opt prop
 
   method popoverTargetAction : js_string t prop
 

--- a/lib/js_of_ocaml/dom_html.mli
+++ b/lib/js_of_ocaml/dom_html.mli
@@ -800,6 +800,8 @@ and toggleEvent = object
   method newState : js_string t readonly_prop
 
   method oldState : js_string t readonly_prop
+
+  method source : element t opt readonly_prop
 end
 
 and mediaQueryListEvent = object
@@ -909,6 +911,10 @@ and eventTarget = object ('self)
   method onpointerover : ('self t, pointerEvent t) event_listener writeonly_prop
 
   method onpointerup : ('self t, pointerEvent t) event_listener writeonly_prop
+
+  method onbeforetoggle : ('self t, toggleEvent t) event_listener writeonly_prop
+
+  method ontoggle : ('self t, toggleEvent t) event_listener writeonly_prop
 
   method dispatchEvent : event t -> bool t meth
 end
@@ -1322,6 +1328,16 @@ and focusOptions = object
   method preventScroll : bool t writeonly_prop
 end
 
+and showPopover_options = object
+  method source : element t writeonly_prop
+end
+
+and togglePopover_options = object
+  method force : bool t writeonly_prop
+
+  method source : element t writeonly_prop
+end
+
 (** Properties common to all HTML elements *)
 and element = object
   inherit Dom.element
@@ -1414,6 +1430,8 @@ and element = object
 
   method scrollHeight : int readonly_prop
 
+  method popover : js_string t opt prop
+
   method getClientRects : clientRectList t meth
 
   method getBoundingClientRect : clientRect t meth
@@ -1451,6 +1469,18 @@ and element = object
 
   method getAnimations : animation t js_array t meth
 
+  method hidePopover : unit meth
+
+  method showPopover : unit meth
+
+  method showPopover_options : showPopover_options t -> unit meth
+
+  method togglePopover : bool t meth
+
+  method togglePopover_force : bool t -> bool t meth
+
+  method togglePopover_options : togglePopover_options t -> bool t meth
+
   inherit eventTarget
 end
 
@@ -1474,6 +1504,11 @@ and clientRectList = object
 
   method item : int -> clientRect t opt meth
 end
+
+val showPopover_options : ?source:element t -> unit -> showPopover_options t
+
+val togglePopover_options :
+  ?force:bool -> ?source:element t -> unit -> togglePopover_options t
 
 class type ['node] collection = ['node] Dom.collection
 (** Collection of HTML elements. Alias for {!Dom.collection}. *)
@@ -1841,6 +1876,10 @@ class type inputElement = object ('self)
 
   method setCustomValidity : js_string t -> unit meth
 
+  method popoverTarget : element t opt prop
+
+  method popoverTargetAction : js_string t prop
+
   method onselect : ('self t, event t) event_listener prop
 
   method onchange : ('self t, event t) event_listener prop
@@ -1958,6 +1997,10 @@ class type buttonElement = object
   method _type : js_string t readonly_prop
 
   method value : js_string t prop
+
+  method popoverTarget : element t opt prop
+
+  method popoverTargetAction : js_string t prop
 
   method labels : labelElement Dom.nodeList t readonly_prop
 
@@ -2238,8 +2281,6 @@ class type detailsElement = object ('self)
   method open_ : bool t prop
 
   method name : js_string t prop
-
-  method ontoggle : ('self t, toggleEvent t) event_listener prop
 end
 
 class type imageElement = object ('self)
@@ -3776,6 +3817,8 @@ module Event : sig
   val volumechange : mediaEvent t typ
 
   val waiting : mediaEvent t typ
+
+  val beforetoggle : toggleEvent t typ
 
   val toggle : toggleEvent t typ
 


### PR DESCRIPTION
## Summary
- Add `Dom_html` bindings for the [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API):
  - `element##.popover` attribute, and the `showPopover` / `hidePopover` / `togglePopover` methods, with `showPopover ?source`, `hidePopover`, and `togglePopover ?force ?source` wrapper functions taking labeled arguments.
  - `popoverTargetElement` / `popoverTargetAction` on `inputElement` and `buttonElement`.
  - `beforetoggle` / `toggle` events (`Event.beforetoggle`, `Event.toggle`), `onbeforetoggle` / `ontoggle` handlers on `eventTarget`, and `ToggleEvent.source`.
- Update `API-STATUS.md` (new Popover API row) and `CHANGES.md`.

Replaces #1734, rebased onto current `master` with the merge conflicts resolved. Original work by @SylvainBoilard.

### Note
`ontoggle` was previously declared on `detailsElement` as a read/write `prop`; it is now inherited from `eventTarget` as a `writeonly_prop` (consistent with the other `on*` handlers). Code that *read* the handler back will need to adjust; setting it is unchanged.

## Test plan
- [x] `dune build lib ppx examples toplevel` (the `Dom_html` library and its in-repo consumers)
- [x] `make tests`
