### PR TITLE
Compiler: fix UGEINT bytecode lowering

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,8 @@
   `AbortController`/`AbortSignal` primitive for cancellation (#596)
 
 ## Bug fixes
+* Compiler: fix UGEINT bytecode lowering (returned wrong result on
+  equal operands)
 * Compiler: fix reference unboxing (#2210)
 * Compiler/wasm: fix int division return type to Unnormalized (#2197)
 * Compiler/wasm: preserve physical identity of empty closures (#2207)

--- a/compiler/lib/parse_bytecode.ml
+++ b/compiler/lib/parse_bytecode.ml
@@ -2476,14 +2476,16 @@ and compile infos pc state (instrs : instr list) =
         let y = State.accu state in
         let z = State.peek 0 state in
         let x, state = State.fresh_var state in
-
+        let lt = Var.fresh () in
         if debug_parser ()
         then Format.printf "%a = mk_bool(%a >= %a)@." Var.print x Var.print y Var.print z;
         compile
           infos
           (pc + 1)
           (State.pop 1 state)
-          (Let (x, Prim (Ult, [ Pv z; Pv y ])) :: instrs)
+          (Let (x, Prim (Not, [ Pv lt ]))
+          :: Let (lt, Prim (Ult, [ Pv y; Pv z ]))
+          :: instrs)
     | GETPUBMET ->
         let n = gets32 code (pc + 1) in
         let obj = State.accu state in

--- a/compiler/tests-jsoo/dune
+++ b/compiler/tests-jsoo/dune
@@ -50,6 +50,28 @@
   (pps ppx_expect)))
 
 (library
+ (name jsoo_testsuite_ugeint)
+ (modules test_ugeint)
+ (libraries unix compiler-libs.common js_of_ocaml-compiler)
+ (enabled_if %{oxcaml_supported})
+ (inline_tests
+  (modes js wasm best))
+ (preprocess
+  (pps ppx_expect)))
+
+(rule
+ ; Guard against future OxCaml changes peepholing UGEINT away the same
+ ; way vanilla ocamlc does. If this rule fails, [test_ugeint] still
+ ; passes its assertions but no longer exercises the UGEINT code path
+ ; in [parse_bytecode.ml], and the regression coverage is gone.
+ (alias runtest)
+ (enabled_if %{oxcaml_supported})
+ (deps ugeint_bytecode_probe.ml)
+ (action
+  (bash
+   "ocamlc %{deps} -o probe.bc && dumpobj probe.bc | grep -qE '^[[:space:]]*[0-9]+[[:space:]]+UGEINT'")))
+
+(library
  (name jsoo_testsuite_float32)
  (modules test_marshal_float32)
  (libraries unix compiler-libs.common js_of_ocaml-compiler)
@@ -73,6 +95,8 @@
    test_marshal_float32
    test_marshal_float32_js
    test_parsing
+   test_ugeint
+   ugeint_bytecode_probe
    test_runtime_value
    test_custom_name
    test_text_codec_fallback

--- a/compiler/tests-jsoo/test_ugeint.ml
+++ b/compiler/tests-jsoo/test_ugeint.ml
@@ -1,0 +1,55 @@
+(* UGEINT bytecode opcode regression test. Exercises the
+   [%int_unsigned_greaterequal] and [%int_unsigned_lessequal]
+   primitives, which OxCaml lowers to standalone UGEINT ([Cule] is
+   rewritten to [Ugeint] with swapped args). Vanilla ocamlc doesn't
+   expose these primitives, so this test is OxCaml-only.
+
+   The (5, 5) boundary rows for [uge] and [ule] catch the previous
+   bug, where UGEINT was lowered as [Ult (z, y)] = (z < y) instead
+   of [not (Ult (y, z))] = (y >= z): 5 >= 5 is true and 5 <= 5 is
+   true; both differ from 5 < 5 (false). *)
+
+external uge : int -> int -> bool = "%int_unsigned_greaterequal"
+
+external ult : int -> int -> bool = "%int_unsigned_lessthan"
+
+external ule : int -> int -> bool = "%int_unsigned_lessequal"
+
+external ugt : int -> int -> bool = "%int_unsigned_greaterthan"
+
+let%expect_test _ =
+  Printf.printf "uge 5 5     = %b\n" (uge 5 5);
+  Printf.printf "uge 5 3     = %b\n" (uge 5 3);
+  Printf.printf "uge 3 5     = %b\n" (uge 3 5);
+  Printf.printf "uge (-1) 5  = %b\n" (uge (-1) 5);
+  Printf.printf "ult 5 5     = %b\n" (ult 5 5);
+  Printf.printf "ult 3 5     = %b\n" (ult 3 5);
+  Printf.printf "ult 5 3     = %b\n" (ult 5 3);
+  Printf.printf "ult (-1) 5  = %b\n" (ult (-1) 5);
+  Printf.printf "ule 5 5     = %b\n" (ule 5 5);
+  Printf.printf "ule 3 5     = %b\n" (ule 3 5);
+  Printf.printf "ule 5 3     = %b\n" (ule 5 3);
+  Printf.printf "ule 5 (-1)  = %b\n" (ule 5 (-1));
+  Printf.printf "ugt 5 5     = %b\n" (ugt 5 5);
+  Printf.printf "ugt 5 3     = %b\n" (ugt 5 3);
+  Printf.printf "ugt 3 5     = %b\n" (ugt 3 5);
+  Printf.printf "ugt (-1) 5  = %b\n" (ugt (-1) 5);
+  [%expect
+    {|
+    uge 5 5     = false
+    uge 5 3     = true
+    uge 3 5     = false
+    uge (-1) 5  = true
+    ult 5 5     = false
+    ult 3 5     = true
+    ult 5 3     = false
+    ult (-1) 5  = false
+    ule 5 5     = false
+    ule 3 5     = true
+    ule 5 3     = false
+    ule 5 (-1)  = true
+    ugt 5 5     = false
+    ugt 5 3     = true
+    ugt 3 5     = false
+    ugt (-1) 5  = true
+    |}]

--- a/compiler/tests-jsoo/test_ugeint.ml
+++ b/compiler/tests-jsoo/test_ugeint.ml
@@ -36,7 +36,7 @@ let%expect_test _ =
   Printf.printf "ugt (-1) 5  = %b\n" (ugt (-1) 5);
   [%expect
     {|
-    uge 5 5     = false
+    uge 5 5     = true
     uge 5 3     = true
     uge 3 5     = false
     uge (-1) 5  = true
@@ -44,7 +44,7 @@ let%expect_test _ =
     ult 3 5     = true
     ult 5 3     = false
     ult (-1) 5  = false
-    ule 5 5     = false
+    ule 5 5     = true
     ule 3 5     = true
     ule 5 3     = false
     ule 5 (-1)  = true

--- a/compiler/tests-jsoo/ugeint_bytecode_probe.ml
+++ b/compiler/tests-jsoo/ugeint_bytecode_probe.ml
@@ -1,0 +1,7 @@
+(* Used only by the bytecode-presence dune rule to confirm that
+   OxCaml emits standalone UGEINT for [%int_unsigned_greaterequal].
+   See [test_ugeint.ml] for the behavioural regression test. *)
+
+external uge : int -> int -> bool = "%int_unsigned_greaterequal"
+
+let () = if uge (Sys.opaque_identity 5) (Sys.opaque_identity 5) then print_endline "y"


### PR DESCRIPTION
The lowering used `[Ult (z, y)] = (z < y)` instead of `[not (Ult (y, z))] = (y >= z)`, giving the wrong result when the operands are equal.