### PR TITLE
Compiler: bound statement-nesting depth with a flat dispatch loop (#2122)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,11 @@
 * Wasm_of_ocaml: alternative effect implementation based on the Stack Switching proposal (#2189)
 
 ## Bug fixes
+* Compiler: bound the statement-nesting depth of generated functions by
+  emitting a flat dispatch loop instead of a deep tower of nested labelled
+  blocks when a block has many sibling merge-node branch targets. Deep
+  nesting could overflow some JavaScript engine parsers (e.g. SpiderMonkey,
+  "too much recursion" at load time) (#2122)
 * Compiler: fix UGEINT bytecode lowering (returned wrong result on
   equal operands)
 * Compiler: fix reference unboxing (#2210)

--- a/compiler/lib/config.ml
+++ b/compiler/lib/config.ml
@@ -191,7 +191,7 @@ module Param = struct
       ~desc:
         "set the maximum number of nested labelled blocks before switching to a flat \
          dispatch loop"
-      (int 50)
+      (int 10)
 
   type tc =
     | TcNone

--- a/compiler/lib/config.ml
+++ b/compiler/lib/config.ml
@@ -181,6 +181,18 @@ module Param = struct
       ~desc:"set the maximum depth of generated literal JavaScript values"
       (int 10)
 
+  let merge_node_max =
+    (* Above this many sibling merge-node branch targets, emit a flat
+       selector-driven dispatch loop instead of a tower of nested labelled
+       blocks, to bound the statement-nesting depth of generated functions
+       (deep nesting overflows some JS engine parsers, e.g. SpiderMonkey). *)
+    p
+      ~name:"merge_node_max"
+      ~desc:
+        "set the maximum number of nested labelled blocks before switching to a flat \
+         dispatch loop"
+      (int 50)
+
   type tc =
     | TcNone
     | TcTrampoline

--- a/compiler/lib/config.mli
+++ b/compiler/lib/config.mli
@@ -101,6 +101,8 @@ module Param : sig
 
   val constant_max_depth : unit -> int
 
+  val merge_node_max : unit -> int
+
   type tc =
     | TcNone
     | TcTrampoline

--- a/compiler/lib/generate.ml
+++ b/compiler/lib/generate.ml
@@ -350,6 +350,9 @@ type edge_kind =
   | Exit_loop of bool ref
   | Exit_switch of bool ref
   | Forward
+  (* Branch target reached through a flat dispatch loop: assign the
+     selector variable the given case index and [continue] the loop. *)
+  | Dispatch of Code.Var.t * int
 
 let var x = J.EVar (J.V x)
 
@@ -2068,7 +2071,56 @@ and compile_block_no_loop st loc queue (pc : Addr.t) ~fall_through scope_stack =
         | true -> never, [ J.Labelled_statement (l, (J.Block inner, J.N)), J.N ] @ code
         | false -> never, inner @ code)
   in
-  let never_after, after = loop ~scope_stack ~fall_through new_scopes in
+  let never_after, after =
+    if List.length new_scopes > Config.Param.merge_node_max ()
+    then
+      (* Too many sibling merge-node targets: a tower of nested labelled
+         blocks would nest as deep as [new_scopes], which overflows some JS
+         engine parsers (#2122). Emit a flat selector-driven dispatch loop
+         instead, whose statement-nesting depth is constant. Each branch to a
+         target [x_i] becomes [sel = i; continue L]; branches to the join
+         become [break L]. *)
+      let sel = Code.Var.fresh () in
+      let l = J.Label.fresh () in
+      let used = ref false in
+      (* case 0 is the dispatch itself, the targets are cases 1..n *)
+      let indexed = List.mapi new_scopes ~f:(fun i x -> succ i, x) in
+      let scope_stack =
+        List.fold_left indexed ~init:scope_stack ~f:(fun ss (c, x) ->
+            (x, (l, used, Dispatch (sel, c))) :: ss)
+      in
+      let scope_stack =
+        match fall_through with
+        | Block fpc -> (fpc, (l, used, Exit_loop (ref false))) :: scope_stack
+        | Return -> scope_stack
+      in
+      (* Branches are routed through the selector, so the bodies must never
+         rely on falling through to the join; compile them with a [Return]
+         fall-through so every exit is explicit. *)
+      let dispatch_never, dispatch_code =
+        compile_conditional st queue ~fall_through:Return loc block.branch scope_stack
+      in
+      let close never code =
+        if never then code else code @ [ J.Break_statement None, J.N ]
+      in
+      let cases =
+        (int 0, close dispatch_never dispatch_code)
+        :: List.map indexed ~f:(fun (c, x) ->
+            let never, code =
+              compile_block st loc Q.empty x scope_stack ~fall_through:Return
+            in
+            int c, close never code)
+      in
+      let switch = J.Switch_statement (var sel, cases, None, []), loc in
+      let body = Js_simpl.block [ switch; J.Break_statement (Some l), J.N ] in
+      let for_loop = J.For_statement (J.Left None, None, None, body), loc in
+      let for_loop =
+        if !used then J.Labelled_statement (l, for_loop), J.N else for_loop
+      in
+      let decl = J.variable_declaration [ J.V sel, (int 0, J.N) ], J.N in
+      false, [ decl; for_loop ]
+    else loop ~scope_stack ~fall_through new_scopes
+  in
   never_after, seq @ after
 
 and compile_decision_tree kind st scope_stack loc_before cx loc_after dtree ~fall_through
@@ -2340,7 +2392,7 @@ and compile_branch st loc queue ((pc, _) as cont) scope_stack ~fall_through : bo
               match scope_stack with
               | [] -> assert false
               | (_, (_, _, (Forward | Exit_switch _))) :: rem -> can_skip_label rem
-              | (pc', (l', _, (Loop | Exit_loop _))) :: rem ->
+              | (pc', (l', _, (Loop | Exit_loop _ | Dispatch _))) :: rem ->
                   J.Label.equal l' l && (pc = pc' || can_skip_label rem)
             in
             let label =
@@ -2365,8 +2417,8 @@ and compile_branch st loc queue ((pc, _) as cont) scope_stack ~fall_through : bo
               match scope_stack with
               | [] -> assert false
               | (_, (_, _, Forward)) :: rem -> can_skip_label rem
-              | (pc', (l', _, (Loop | Exit_loop _ | Exit_switch _))) :: rem ->
-                  J.Label.equal l' l && (pc = pc' || can_skip_label rem)
+              | (pc', (l', _, (Loop | Exit_loop _ | Exit_switch _ | Dispatch _))) :: rem
+                -> J.Label.equal l' l && (pc = pc' || can_skip_label rem)
             in
             let label =
               if can_skip_label scope_stack
@@ -2386,6 +2438,18 @@ and compile_branch st loc queue ((pc, _) as cont) scope_stack ~fall_through : bo
             if debug () then Format.eprintf "(br %d)@;" pc;
             used := true;
             true, Q.flush_all queue loc [ J.Break_statement (Some l), J.N ]
+        | Some (l, used, Dispatch (sel, k)) ->
+            (* Reach the target through the enclosing dispatch loop: select the
+               corresponding case and loop back. The label is mandatory. *)
+            if debug () then Format.eprintf "(dispatch %d -> %d)@;" pc k;
+            used := true;
+            ( true
+            , Q.flush_all
+                queue
+                loc
+                [ J.Expression_statement (J.EBin (J.Eq, var sel, int k)), loc
+                ; J.Continue_statement (Some l), J.N
+                ] )
         | None -> compile_block st loc queue pc scope_stack ~fall_through)
 
 and compile_closure ctx (pc, args) (cloc : Parse_info.t option) =

--- a/compiler/lib/generate.ml
+++ b/compiler/lib/generate.ml
@@ -2077,9 +2077,16 @@ and compile_block_no_loop st loc queue (pc : Addr.t) ~fall_through scope_stack =
       (* Too many sibling merge-node targets: a tower of nested labelled
          blocks would nest as deep as [new_scopes], which overflows some JS
          engine parsers (#2122). Emit a flat selector-driven dispatch loop
-         instead, whose statement-nesting depth is constant. Each branch to a
-         target [x_i] becomes [sel = i; continue L]; branches to the join
-         become [break L]. *)
+         instead, whose statement-nesting depth is constant. A branch to a
+         target [x_i] becomes [sel = i; continue L]; a branch to the join
+         becomes [break L].
+
+         The cases are laid out in the same textual order as the nested
+         scheme (the dispatch, then the targets in reverse), and each is
+         compiled with the textually-next case as its fall-through. A branch
+         to that next case is then elided and falls through in the [switch]
+         instead of routing through the loop, exactly as it would fall through
+         in the nested scheme. *)
       let sel = Code.Var.fresh () in
       let l = J.Label.fresh () in
       let used = ref false in
@@ -2094,24 +2101,40 @@ and compile_block_no_loop st loc queue (pc : Addr.t) ~fall_through scope_stack =
         | Block fpc -> (fpc, (l, used, Exit_loop (ref false))) :: scope_stack
         | Return -> scope_stack
       in
-      (* Branches are routed through the selector, so the bodies must never
-         rely on falling through to the join; compile them with a [Return]
-         fall-through so every exit is explicit. *)
-      let dispatch_never, dispatch_code =
-        compile_conditional st queue ~fall_through:Return loc block.branch scope_stack
+      (* Targets are emitted in reverse so that each one falls through to the
+         previous target, and the first target ([x_1]) falls through to the
+         join. *)
+      let ordered = List.rev indexed in
+      let dispatch_fall_through =
+        match ordered with
+        | (_, x) :: _ -> Block x
+        | [] -> fall_through
       in
-      let close never code =
-        if never then code else code @ [ J.Break_statement None, J.N ]
+      let _dispatch_never, dispatch_code =
+        compile_conditional
+          st
+          queue
+          ~fall_through:dispatch_fall_through
+          loc
+          block.branch
+          scope_stack
       in
-      let cases =
-        (int 0, close dispatch_never dispatch_code)
-        :: List.map indexed ~f:(fun (c, x) ->
-            let never, code =
-              compile_block st loc Q.empty x scope_stack ~fall_through:Return
+      let rec scope_cases = function
+        | [] -> []
+        | (c, x) :: rest ->
+            let fall_through =
+              match rest with
+              | (_, x') :: _ -> Block x'
+              | [] -> fall_through
             in
-            int c, close never code)
+            let _never, code = compile_block st loc Q.empty x scope_stack ~fall_through in
+            (int c, code) :: scope_cases rest
       in
+      let cases = (int 0, dispatch_code) :: scope_cases ordered in
       let switch = J.Switch_statement (var sel, cases, None, []), loc in
+      (* A target that falls off its case lands on the next case; the dispatch
+         and the join exit the loop. The trailing [break L] catches a case
+         that falls through to the join. *)
       let body = Js_simpl.block [ switch; J.Break_statement (Some l), J.N ] in
       let for_loop = J.For_statement (J.Left None, None, None, body), loc in
       let for_loop =

--- a/compiler/lib/generate.ml
+++ b/compiler/lib/generate.ml
@@ -354,6 +354,32 @@ type edge_kind =
      selector variable the given case index and [continue] the loop. *)
   | Dispatch of Code.Var.t * int
 
+(* The label for an unlabelled [break]/[continue] reaching [(pc, l)]: [None]
+   when it can be omitted, otherwise [Some l] -- in which case [used] is set,
+   so the target construct is emitted carrying its label.
+
+   An unlabelled jump lands on the innermost enclosing construct that captures
+   it, so the label can be omitted exactly when that construct is the target
+   itself -- i.e. nothing capturing lies in between. [continue] is captured
+   only by loops ([Loop], [Exit_loop], [Dispatch]); [break] also by switches
+   ([Exit_switch]). Labelled blocks ([Forward]) capture neither. *)
+let branch_label kind pc l used scope_stack =
+  let rec can_skip = function
+    | [] -> assert false
+    | (_, (_, _, Forward)) :: rem -> can_skip rem
+    | (_, (_, _, Exit_switch _)) :: rem
+      when match kind with
+           | `Continue -> true
+           | `Break -> false -> can_skip rem
+    | (pc', (l', _, (Loop | Exit_loop _ | Exit_switch _ | Dispatch _))) :: rem ->
+        J.Label.equal l' l && (pc = pc' || can_skip rem)
+  in
+  if can_skip scope_stack
+  then None
+  else (
+    used := true;
+    Some l)
+
 let var x = J.EVar (J.V x)
 
 let int n = J.ENum (J.Num.of_targetint (Targetint.of_int_exn n))
@@ -2413,20 +2439,7 @@ and compile_branch st loc queue ((pc, _) as cont) scope_stack ~fall_through : bo
         | Some (l, used, Loop) ->
             (* Loop back to the beginning of the loop using continue.
                We can skip the label if we're not inside a nested loop. *)
-            let rec can_skip_label scope_stack =
-              match scope_stack with
-              | [] -> assert false
-              | (_, (_, _, (Forward | Exit_switch _))) :: rem -> can_skip_label rem
-              | (pc', (l', _, (Loop | Exit_loop _ | Dispatch _))) :: rem ->
-                  J.Label.equal l' l && (pc = pc' || can_skip_label rem)
-            in
-            let label =
-              if can_skip_label scope_stack
-              then None
-              else (
-                used := true;
-                Some l)
-            in
+            let label = branch_label `Continue pc l used scope_stack in
             if debug ()
             then
               if Option.is_none label
@@ -2438,20 +2451,7 @@ and compile_branch st loc queue ((pc, _) as cont) scope_stack ~fall_through : bo
                We can skip the label if we're not inside a nested loop or switch.
             *)
             branch_used := true;
-            let rec can_skip_label scope_stack =
-              match scope_stack with
-              | [] -> assert false
-              | (_, (_, _, Forward)) :: rem -> can_skip_label rem
-              | (pc', (l', _, (Loop | Exit_loop _ | Exit_switch _ | Dispatch _))) :: rem
-                -> J.Label.equal l' l && (pc = pc' || can_skip_label rem)
-            in
-            let label =
-              if can_skip_label scope_stack
-              then None
-              else (
-                used := true;
-                Some l)
-            in
+            let label = branch_label `Break pc l used scope_stack in
             if debug ()
             then
               if Option.is_none label
@@ -2465,15 +2465,20 @@ and compile_branch st loc queue ((pc, _) as cont) scope_stack ~fall_through : bo
             true, Q.flush_all queue loc [ J.Break_statement (Some l), J.N ]
         | Some (l, used, Dispatch (sel, k)) ->
             (* Reach the target through the enclosing dispatch loop: select the
-               corresponding case and loop back. The label is mandatory. *)
-            if debug () then Format.eprintf "(dispatch %d -> %d)@;" pc k;
-            used := true;
+               corresponding case and loop back. As for [Loop], the label can be
+               skipped when the dispatch loop is the innermost enclosing loop. *)
+            let label = branch_label `Continue pc l used scope_stack in
+            if debug ()
+            then
+              if Option.is_none label
+              then Format.eprintf "(dispatch %d -> %d) continue;@," pc k
+              else Format.eprintf "(dispatch %d -> %d) continue (%d);@," pc k pc;
             ( true
             , Q.flush_all
                 queue
                 loc
                 [ J.Expression_statement (J.EBin (J.Eq, var sel, int k)), loc
-                ; J.Continue_statement (Some l), J.N
+                ; J.Continue_statement label, J.N
                 ] )
         | None -> compile_block st loc queue pc scope_stack ~fall_through)
 

--- a/compiler/lib/generate.ml
+++ b/compiler/lib/generate.ml
@@ -2116,6 +2116,8 @@ and compile_block_no_loop st loc queue (pc : Addr.t) ~fall_through scope_stack =
       let sel = Code.Var.fresh () in
       let l = J.Label.fresh () in
       let used = ref false in
+      (* Set when some case breaks to the join, i.e. exits the loop. *)
+      let exit_branch_used = ref false in
       (* case 0 is the dispatch itself, the targets are cases 1..n *)
       let indexed = List.mapi new_scopes ~f:(fun i x -> succ i, x) in
       let scope_stack =
@@ -2124,7 +2126,7 @@ and compile_block_no_loop st loc queue (pc : Addr.t) ~fall_through scope_stack =
       in
       let scope_stack =
         match fall_through with
-        | Block fpc -> (fpc, (l, used, Exit_loop (ref false))) :: scope_stack
+        | Block fpc -> (fpc, (l, used, Exit_loop exit_branch_used)) :: scope_stack
         | Return -> scope_stack
       in
       (* Targets are emitted in reverse so that each one falls through to the
@@ -2145,31 +2147,50 @@ and compile_block_no_loop st loc queue (pc : Addr.t) ~fall_through scope_stack =
           block.branch
           scope_stack
       in
+      (* Returns the cases together with the [never] of the last case ([x_1]),
+         whose fall-through is the join: it is [false] exactly when control can
+         fall off the bottom of the [switch]. *)
       let rec scope_cases = function
-        | [] -> []
-        | (c, x) :: rest ->
+        | [] -> [], true
+        | (c, x) :: rest -> (
             let fall_through =
               match rest with
               | (_, x') :: _ -> Block x'
               | [] -> fall_through
             in
-            let _never, code = compile_block st loc Q.empty x scope_stack ~fall_through in
-            (int c, code) :: scope_cases rest
+            let never, code = compile_block st loc Q.empty x scope_stack ~fall_through in
+            let cases, last_never = scope_cases rest in
+            ( (int c, code) :: cases
+            , match rest with
+              | [] -> never
+              | _ :: _ -> last_never ))
       in
-      let cases = (int 0, dispatch_code) :: scope_cases ordered in
+      let scope_cases, last_case_never = scope_cases ordered in
+      let cases = (int 0, dispatch_code) :: scope_cases in
       let switch = J.Switch_statement (var sel, cases, None, []), loc in
+      (* The construct only falls through to the join in two ways: a case falls
+         off the bottom of the [switch] (governed by [last_case_never]), or a
+         case breaks out ([exit_branch_used]). *)
+      let never_after = (not !exit_branch_used) && last_case_never in
       (* A target that falls off its case lands on the next case; the dispatch
          and the join exit the loop. The trailing [break] (unlabelled: it sits
          in the loop body, after the [switch]) catches a case that falls through
-         to the join. It must not be labelled with [l], as [l] is only emitted
-         when a branch actually routes through the loop ([!used]). *)
-      let body = Js_simpl.block [ switch; J.Break_statement None, J.N ] in
+         to the join, and is also the loop exit reached by an unlabelled break
+         out of the [switch]. It is unreachable -- and nothing relies on it --
+         exactly when [never_after] holds, so it can then be dropped. It must
+         not be labelled with [l], as [l] is only emitted when a branch actually
+         routes through the loop ([!used]). *)
+      let body =
+        if never_after
+        then Js_simpl.block [ switch ]
+        else Js_simpl.block [ switch; J.Break_statement None, J.N ]
+      in
       let for_loop = J.For_statement (J.Left None, None, None, body), loc in
       let for_loop =
         if !used then J.Labelled_statement (l, for_loop), J.N else for_loop
       in
       let decl = J.variable_declaration [ J.V sel, (int 0, J.N) ], J.N in
-      false, [ decl; for_loop ]
+      never_after, [ decl; for_loop ]
     else loop ~scope_stack ~fall_through new_scopes
   in
   never_after, seq @ after

--- a/compiler/lib/generate.ml
+++ b/compiler/lib/generate.ml
@@ -2133,9 +2133,11 @@ and compile_block_no_loop st loc queue (pc : Addr.t) ~fall_through scope_stack =
       let cases = (int 0, dispatch_code) :: scope_cases ordered in
       let switch = J.Switch_statement (var sel, cases, None, []), loc in
       (* A target that falls off its case lands on the next case; the dispatch
-         and the join exit the loop. The trailing [break L] catches a case
-         that falls through to the join. *)
-      let body = Js_simpl.block [ switch; J.Break_statement (Some l), J.N ] in
+         and the join exit the loop. The trailing [break] (unlabelled: it sits
+         in the loop body, after the [switch]) catches a case that falls through
+         to the join. It must not be labelled with [l], as [l] is only emitted
+         when a branch actually routes through the loop ([!used]). *)
+      let body = Js_simpl.block [ switch; J.Break_statement None, J.N ] in
       let for_loop = J.For_statement (J.Left None, None, None, body), loc in
       let for_loop =
         if !used then J.Labelled_statement (l, for_loop), J.N else for_loop

--- a/compiler/tests-compiler/dune.inc
+++ b/compiler/tests-compiler/dune.inc
@@ -453,6 +453,19 @@
   (pps ppx_expect)))
 
 (library
+ ;; compiler/tests-compiler/gh2122.ml
+ (name gh2122_15)
+ (modules gh2122)
+ (libraries js_of_ocaml_compiler unix str jsoo_compiler_expect_tests_helper)
+ (inline_tests
+  (deps
+   (file %{project_root}/compiler/bin-js_of_ocaml/js_of_ocaml.exe)
+   (file %{project_root}/compiler/bin-jsoo_minify/jsoo_minify.exe)))
+ (flags (:standard -open Jsoo_compiler_expect_tests_helper))
+ (preprocess
+  (pps ppx_expect)))
+
+(library
  ;; compiler/tests-compiler/gh2156.ml
  (name gh2156_15)
  (modules gh2156)

--- a/compiler/tests-compiler/gh2122.ml
+++ b/compiler/tests-compiler/gh2122.ml
@@ -57,7 +57,8 @@ let%expect_test "match with many shared continuations is a flat dispatch loop" =
   [%expect {| if=1 in=2 match=3 module=4 open=5 while=0 then=1 function=3 |}];
   let program = compile_and_parse ~flags prog in
   print_fun_decl program (Some "kind");
-  [%expect {|
+  [%expect
+    {|
     function kind(param){
      var _c_ = runtime.caml_string_compare(param, cst_let), _b_ = 0;
      a:
@@ -102,3 +103,91 @@ let%expect_test "match with many shared continuations is a flat dispatch loop" =
 let%expect_test "the default (nested) scheme computes the same result" =
   compile_and_run prog;
   [%expect {| if=1 in=2 match=3 module=4 open=5 while=0 then=1 function=3 |}]
+
+(* Non-independent scopes: here the match result is used downstream, so the
+   per-value scopes are not self-contained -- each one assigns the result and
+   then flows into the shared join scope that computes [n * 100 + length].
+
+   In the flat dispatch loop this currently shows up as a round-trip through
+   the loop: every result case ends with [n = <v>; sel = <join>; continue],
+   then the join case does the actual computation. Because the result cases and
+   the join are not independent, a fall-through optimisation could lay them out
+   adjacently and let control fall through instead of re-entering the loop --
+   this test pins the current (un-optimised) output so that change is visible. *)
+let score_prog =
+  {|
+let score s =
+  let n =
+    match s with
+    | "if" | "then" | "else" -> 1
+    | "let" | "in" -> 2
+    | "fun" | "function" | "match" -> 3
+    | "type" | "module" -> 4
+    | "open" | "include" -> 5
+    | _ -> 0
+  in
+  n * 100 + String.length s
+
+let () =
+  List.iter
+    (fun s -> Printf.printf "%d " (score s))
+    [ "if"; "in"; "match"; "module"; "open"; "while" ];
+  print_newline ()
+|}
+
+let%expect_test "non-independent scopes route through the dispatch loop" =
+  let flags = [ "--set=merge_node_max=2" ] in
+  compile_and_run ~flags score_prog;
+  [%expect {| 102 202 305 406 504 5 |}];
+  let program = compile_and_parse ~flags score_prog in
+  print_fun_decl program (Some "score");
+  [%expect
+    {|
+    function score(s){
+     var _c_ = runtime.caml_string_compare(s, cst_let), _b_ = 0;
+     a:
+     for(;;){
+      switch(_b_){
+        case 0:
+         if(0 > _c_){
+          if(! caml_string_notequal(s, cst_else)){_b_ = 5; continue a;}
+          if(! caml_string_notequal(s, cst_fun)){_b_ = 6; continue a;}
+          if(! caml_string_notequal(s, cst_function)){_b_ = 6; continue a;}
+          if(! caml_string_notequal(s, cst_if)){_b_ = 5; continue a;}
+          if(! caml_string_notequal(s, cst_in)){_b_ = 4; continue a;}
+          if(caml_string_notequal(s, cst_include)){_b_ = 2; continue a;}
+          _b_ = 3;
+          continue a;
+         }
+         if(0 >= _c_){_b_ = 4; continue a;}
+         if(! caml_string_notequal(s, cst_match)){_b_ = 6; continue a;}
+         if(caml_string_notequal(s, cst_module)){
+          if(! caml_string_notequal(s, cst_open)){_b_ = 3; continue a;}
+          if(! caml_string_notequal(s, cst_then)){_b_ = 5; continue a;}
+          if(caml_string_notequal(s, cst_type)){_b_ = 2; continue a;}
+         }
+         var n = 4;
+         _b_ = 1;
+         continue a;
+        case 1:
+         return (n * 100 | 0) + runtime.caml_ml_string_length(s) | 0;
+        case 2:
+         n = 0; _b_ = 1; continue a;
+        case 3:
+         n = 5; _b_ = 1; continue a;
+        case 4:
+         n = 2; _b_ = 1; continue a;
+        case 5:
+         n = 1; _b_ = 1; continue a;
+        case 6:
+         n = 3; _b_ = 1; continue a;
+      }
+      break a;
+     }
+    }
+    //end
+    |}]
+
+let%expect_test "non-independent scopes: both schemes compute the same result" =
+  compile_and_run score_prog;
+  [%expect {| 102 202 305 406 504 5 |}]

--- a/compiler/tests-compiler/gh2122.ml
+++ b/compiler/tests-compiler/gh2122.ml
@@ -65,34 +65,39 @@ let%expect_test "match with many shared continuations is a flat dispatch loop" =
      for(;;){
       switch(_b_){
         case 0:
-         if(0 > _c_){
+         if(0 <= _c_){
+          if(0 >= _c_){_b_ = 3; continue a;}
+          if(caml_string_notequal(param, cst_match)){
+           if(caml_string_notequal(param, cst_module)){
+            if(! caml_string_notequal(param, cst_open)){_b_ = 2; continue a;}
+            if(! caml_string_notequal(param, cst_then)){_b_ = 4; continue a;}
+            if(caml_string_notequal(param, cst_type)){_b_ = 1; continue a;}
+           }
+           return 4;
+          }
+         }
+         else{
           if(! caml_string_notequal(param, cst_else)){_b_ = 4; continue a;}
-          if(! caml_string_notequal(param, cst_fun)){_b_ = 5; continue a;}
-          if(! caml_string_notequal(param, cst_function)){_b_ = 5; continue a;}
-          if(! caml_string_notequal(param, cst_if)){_b_ = 4; continue a;}
-          if(! caml_string_notequal(param, cst_in)){_b_ = 3; continue a;}
-          if(caml_string_notequal(param, cst_include)){_b_ = 1; continue a;}
-          _b_ = 2;
-          continue a;
+          if
+           (caml_string_notequal(param, cst_fun)
+            && caml_string_notequal(param, cst_function)){
+           if(! caml_string_notequal(param, cst_if)){_b_ = 4; continue a;}
+           if(! caml_string_notequal(param, cst_in)){_b_ = 3; continue a;}
+           if(caml_string_notequal(param, cst_include)){_b_ = 1; continue a;}
+           _b_ = 2;
+           continue a;
+          }
          }
-         if(0 >= _c_){_b_ = 3; continue a;}
-         if(! caml_string_notequal(param, cst_match)){_b_ = 5; continue a;}
-         if(caml_string_notequal(param, cst_module)){
-          if(! caml_string_notequal(param, cst_open)){_b_ = 2; continue a;}
-          if(! caml_string_notequal(param, cst_then)){_b_ = 4; continue a;}
-          if(caml_string_notequal(param, cst_type)){_b_ = 1; continue a;}
-         }
-         return 4;
-        case 1:
-         return 0;
-        case 2:
-         return 5;
-        case 3:
-         return 2;
-        case 4:
-         return 1;
         case 5:
          return 3;
+        case 4:
+         return 1;
+        case 3:
+         return 2;
+        case 2:
+         return 5;
+        case 1:
+         return 0;
       }
       break a;
      }
@@ -104,16 +109,15 @@ let%expect_test "the default (nested) scheme computes the same result" =
   compile_and_run prog;
   [%expect {| if=1 in=2 match=3 module=4 open=5 while=0 then=1 function=3 |}]
 
-(* Non-independent scopes: here the match result is used downstream, so the
+(* Non-independent scopes: the match result is used downstream, so the
    per-value scopes are not self-contained -- each one assigns the result and
    then flows into the shared join scope that computes [n * 100 + length].
 
-   In the flat dispatch loop this currently shows up as a round-trip through
-   the loop: every result case ends with [n = <v>; sel = <join>; continue],
-   then the join case does the actual computation. Because the result cases and
-   the join are not independent, a fall-through optimisation could lay them out
-   adjacently and let control fall through instead of re-entering the loop --
-   this test pins the current (un-optimised) output so that change is visible. *)
+   The cases are laid out so that the join sits right after the last result
+   scope, which therefore falls through into it ([case 2: n = 0;] below)
+   instead of re-entering the loop. The other result scopes are not adjacent to
+   the join, so they still route through it ([n = <v>; sel = <join>; continue]),
+   just as they would all [break] to the join in the nested scheme. *)
 let score_prog =
   {|
 let score s =
@@ -135,7 +139,7 @@ let () =
   print_newline ()
 |}
 
-let%expect_test "non-independent scopes route through the dispatch loop" =
+let%expect_test "non-independent scopes fall through to the join where adjacent" =
   let flags = [ "--set=merge_node_max=2" ] in
   compile_and_run ~flags score_prog;
   [%expect {| 102 202 305 406 504 5 |}];
@@ -149,38 +153,42 @@ let%expect_test "non-independent scopes route through the dispatch loop" =
      for(;;){
       switch(_b_){
         case 0:
-         if(0 > _c_){
+         if(0 <= _c_){
+          if(0 >= _c_){_b_ = 4; continue a;}
+          if(caml_string_notequal(s, cst_match)){
+           if(caml_string_notequal(s, cst_module)){
+            if(! caml_string_notequal(s, cst_open)){_b_ = 3; continue a;}
+            if(! caml_string_notequal(s, cst_then)){_b_ = 5; continue a;}
+            if(caml_string_notequal(s, cst_type)){_b_ = 2; continue a;}
+           }
+           var n = 4;
+           _b_ = 1;
+           continue a;
+          }
+         }
+         else{
           if(! caml_string_notequal(s, cst_else)){_b_ = 5; continue a;}
-          if(! caml_string_notequal(s, cst_fun)){_b_ = 6; continue a;}
-          if(! caml_string_notequal(s, cst_function)){_b_ = 6; continue a;}
-          if(! caml_string_notequal(s, cst_if)){_b_ = 5; continue a;}
-          if(! caml_string_notequal(s, cst_in)){_b_ = 4; continue a;}
-          if(caml_string_notequal(s, cst_include)){_b_ = 2; continue a;}
-          _b_ = 3;
-          continue a;
+          if
+           (caml_string_notequal(s, cst_fun)
+            && caml_string_notequal(s, cst_function)){
+           if(! caml_string_notequal(s, cst_if)){_b_ = 5; continue a;}
+           if(! caml_string_notequal(s, cst_in)){_b_ = 4; continue a;}
+           if(caml_string_notequal(s, cst_include)){_b_ = 2; continue a;}
+           _b_ = 3;
+           continue a;
+          }
          }
-         if(0 >= _c_){_b_ = 4; continue a;}
-         if(! caml_string_notequal(s, cst_match)){_b_ = 6; continue a;}
-         if(caml_string_notequal(s, cst_module)){
-          if(! caml_string_notequal(s, cst_open)){_b_ = 3; continue a;}
-          if(! caml_string_notequal(s, cst_then)){_b_ = 5; continue a;}
-          if(caml_string_notequal(s, cst_type)){_b_ = 2; continue a;}
-         }
-         var n = 4;
-         _b_ = 1;
-         continue a;
-        case 1:
-         return (n * 100 | 0) + runtime.caml_ml_string_length(s) | 0;
-        case 2:
-         n = 0; _b_ = 1; continue a;
-        case 3:
-         n = 5; _b_ = 1; continue a;
-        case 4:
-         n = 2; _b_ = 1; continue a;
-        case 5:
-         n = 1; _b_ = 1; continue a;
         case 6:
          n = 3; _b_ = 1; continue a;
+        case 5:
+         n = 1; _b_ = 1; continue a;
+        case 4:
+         n = 2; _b_ = 1; continue a;
+        case 3:
+         n = 5; _b_ = 1; continue a;
+        case 2: n = 0;
+        case 1:
+         return (n * 100 | 0) + runtime.caml_ml_string_length(s) | 0;
       }
       break a;
      }

--- a/compiler/tests-compiler/gh2122.ml
+++ b/compiler/tests-compiler/gh2122.ml
@@ -61,7 +61,7 @@ let%expect_test "match with many shared continuations is a flat dispatch loop" =
     {|
     function kind(param){
      var _c_ = runtime.caml_string_compare(param, cst_let), _b_ = 0;
-     for(;;){
+     for(;;)
       switch(_b_){
         case 0:
          if(0 <= _c_){
@@ -98,8 +98,6 @@ let%expect_test "match with many shared continuations is a flat dispatch loop" =
         case 1:
          return 0;
       }
-      break;
-     }
     }
     //end
     |}]
@@ -148,7 +146,7 @@ let%expect_test "non-independent scopes fall through to the join where adjacent"
     {|
     function score(s){
      var _c_ = runtime.caml_string_compare(s, cst_let), _b_ = 0;
-     for(;;){
+     for(;;)
       switch(_b_){
         case 0:
          if(0 <= _c_){
@@ -188,8 +186,6 @@ let%expect_test "non-independent scopes fall through to the join where adjacent"
         case 1:
          return (n * 100 | 0) + runtime.caml_ml_string_length(s) | 0;
       }
-      break;
-     }
     }
     //end
     |}]

--- a/compiler/tests-compiler/gh2122.ml
+++ b/compiler/tests-compiler/gh2122.ml
@@ -1,0 +1,99 @@
+(* Js_of_ocaml tests
+ * http://www.ocsigen.org/js_of_ocaml/
+ * Copyright (C) 2024 Hugo Heuzard
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+
+(* A match with many branches sharing continuations (here, or-patterns over
+   strings, as in a menhir/ocamllex-generated lexer) produces many sibling
+   merge-node targets dominated by a single block. These are compiled as a
+   tower of nested labelled blocks, one level per target, so the
+   statement-nesting depth grows with the number of distinct continuations.
+   For a large lexer this nests hundreds of levels deep, which overflows the
+   recursive-descent parser of some JavaScript engines (e.g. Firefox /
+   SpiderMonkey: "too much recursion" at load time, before any code runs).
+   See #2122. *)
+
+open Util
+
+let prog =
+  {|
+let kind = function
+  | "if" | "then" | "else" -> 1
+  | "let" | "in" -> 2
+  | "fun" | "function" | "match" -> 3
+  | "type" | "module" -> 4
+  | "open" | "include" -> 5
+  | _ -> 0
+
+let () =
+  List.iter
+    (fun s -> Printf.printf "%s=%d " s (kind s))
+    [ "if"; "in"; "match"; "module"; "open"; "while"; "then"; "function" ];
+  print_newline ()
+|}
+
+let%expect_test "match with many shared continuations" =
+  compile_and_run prog;
+  [%expect {| if=1 in=2 match=3 module=4 open=5 while=0 then=1 function=3 |}];
+  let program = compile_and_parse prog in
+  print_fun_decl program (Some "kind");
+  [%expect
+    {|
+    function kind(param){
+     var _b_ = runtime.caml_string_compare(param, cst_let);
+     a:
+     {
+      b:
+      {
+       c:
+       {
+        d:
+        {
+         if(0 <= _b_){
+          if(0 >= _b_) break c;
+          if(caml_string_notequal(param, cst_match)){
+           if(caml_string_notequal(param, cst_module)){
+            if(! caml_string_notequal(param, cst_open)) break b;
+            if(! caml_string_notequal(param, cst_then)) break d;
+            if(caml_string_notequal(param, cst_type)) break a;
+           }
+           return 4;
+          }
+         }
+         else{
+          if(! caml_string_notequal(param, cst_else)) break d;
+          if
+           (caml_string_notequal(param, cst_fun)
+            && caml_string_notequal(param, cst_function)){
+           if(! caml_string_notequal(param, cst_if)) break d;
+           if(! caml_string_notequal(param, cst_in)) break c;
+           if(caml_string_notequal(param, cst_include)) break a;
+           break b;
+          }
+         }
+         return 3;
+        }
+        return 1;
+       }
+       return 2;
+      }
+      return 5;
+     }
+     return 0;
+    }
+    //end
+    |}]

--- a/compiler/tests-compiler/gh2122.ml
+++ b/compiler/tests-compiler/gh2122.ml
@@ -19,13 +19,17 @@
 
 (* A match with many branches sharing continuations (here, or-patterns over
    strings, as in a menhir/ocamllex-generated lexer) produces many sibling
-   merge-node targets dominated by a single block. These are compiled as a
-   tower of nested labelled blocks, one level per target, so the
+   merge-node targets dominated by a single block. By default these are
+   compiled as a tower of nested labelled blocks, one level per target, so the
    statement-nesting depth grows with the number of distinct continuations.
    For a large lexer this nests hundreds of levels deep, which overflows the
    recursive-descent parser of some JavaScript engines (e.g. Firefox /
    SpiderMonkey: "too much recursion" at load time, before any code runs).
-   See #2122. *)
+   See #2122.
+
+   With [merge_node_max] lowered, the same block is instead compiled as a flat
+   dispatch loop ([for(;;)] around a [switch]) whose statement-nesting depth is
+   constant. *)
 
 open Util
 
@@ -46,54 +50,55 @@ let () =
   print_newline ()
 |}
 
-let%expect_test "match with many shared continuations" =
-  compile_and_run prog;
+let%expect_test "match with many shared continuations is a flat dispatch loop" =
+  (* Force the flat dispatch loop on the [kind] match. *)
+  let flags = [ "--set=merge_node_max=2" ] in
+  compile_and_run ~flags prog;
   [%expect {| if=1 in=2 match=3 module=4 open=5 while=0 then=1 function=3 |}];
-  let program = compile_and_parse prog in
+  let program = compile_and_parse ~flags prog in
   print_fun_decl program (Some "kind");
-  [%expect
-    {|
+  [%expect {|
     function kind(param){
-     var _b_ = runtime.caml_string_compare(param, cst_let);
+     var _c_ = runtime.caml_string_compare(param, cst_let), _b_ = 0;
      a:
-     {
-      b:
-      {
-       c:
-       {
-        d:
-        {
-         if(0 <= _b_){
-          if(0 >= _b_) break c;
-          if(caml_string_notequal(param, cst_match)){
-           if(caml_string_notequal(param, cst_module)){
-            if(! caml_string_notequal(param, cst_open)) break b;
-            if(! caml_string_notequal(param, cst_then)) break d;
-            if(caml_string_notequal(param, cst_type)) break a;
-           }
-           return 4;
-          }
+     for(;;){
+      switch(_b_){
+        case 0:
+         if(0 > _c_){
+          if(! caml_string_notequal(param, cst_else)){_b_ = 4; continue a;}
+          if(! caml_string_notequal(param, cst_fun)){_b_ = 5; continue a;}
+          if(! caml_string_notequal(param, cst_function)){_b_ = 5; continue a;}
+          if(! caml_string_notequal(param, cst_if)){_b_ = 4; continue a;}
+          if(! caml_string_notequal(param, cst_in)){_b_ = 3; continue a;}
+          if(caml_string_notequal(param, cst_include)){_b_ = 1; continue a;}
+          _b_ = 2;
+          continue a;
          }
-         else{
-          if(! caml_string_notequal(param, cst_else)) break d;
-          if
-           (caml_string_notequal(param, cst_fun)
-            && caml_string_notequal(param, cst_function)){
-           if(! caml_string_notequal(param, cst_if)) break d;
-           if(! caml_string_notequal(param, cst_in)) break c;
-           if(caml_string_notequal(param, cst_include)) break a;
-           break b;
-          }
+         if(0 >= _c_){_b_ = 3; continue a;}
+         if(! caml_string_notequal(param, cst_match)){_b_ = 5; continue a;}
+         if(caml_string_notequal(param, cst_module)){
+          if(! caml_string_notequal(param, cst_open)){_b_ = 2; continue a;}
+          if(! caml_string_notequal(param, cst_then)){_b_ = 4; continue a;}
+          if(caml_string_notequal(param, cst_type)){_b_ = 1; continue a;}
          }
+         return 4;
+        case 1:
+         return 0;
+        case 2:
+         return 5;
+        case 3:
+         return 2;
+        case 4:
+         return 1;
+        case 5:
          return 3;
-        }
-        return 1;
-       }
-       return 2;
       }
-      return 5;
+      break a;
      }
-     return 0;
     }
     //end
     |}]
+
+let%expect_test "the default (nested) scheme computes the same result" =
+  compile_and_run prog;
+  [%expect {| if=1 in=2 match=3 module=4 open=5 while=0 then=1 function=3 |}]

--- a/compiler/tests-compiler/gh2122.ml
+++ b/compiler/tests-compiler/gh2122.ml
@@ -61,31 +61,30 @@ let%expect_test "match with many shared continuations is a flat dispatch loop" =
     {|
     function kind(param){
      var _c_ = runtime.caml_string_compare(param, cst_let), _b_ = 0;
-     a:
      for(;;){
       switch(_b_){
         case 0:
          if(0 <= _c_){
-          if(0 >= _c_){_b_ = 3; continue a;}
+          if(0 >= _c_){_b_ = 3; continue;}
           if(caml_string_notequal(param, cst_match)){
            if(caml_string_notequal(param, cst_module)){
-            if(! caml_string_notequal(param, cst_open)){_b_ = 2; continue a;}
-            if(! caml_string_notequal(param, cst_then)){_b_ = 4; continue a;}
-            if(caml_string_notequal(param, cst_type)){_b_ = 1; continue a;}
+            if(! caml_string_notequal(param, cst_open)){_b_ = 2; continue;}
+            if(! caml_string_notequal(param, cst_then)){_b_ = 4; continue;}
+            if(caml_string_notequal(param, cst_type)){_b_ = 1; continue;}
            }
            return 4;
           }
          }
          else{
-          if(! caml_string_notequal(param, cst_else)){_b_ = 4; continue a;}
+          if(! caml_string_notequal(param, cst_else)){_b_ = 4; continue;}
           if
            (caml_string_notequal(param, cst_fun)
             && caml_string_notequal(param, cst_function)){
-           if(! caml_string_notequal(param, cst_if)){_b_ = 4; continue a;}
-           if(! caml_string_notequal(param, cst_in)){_b_ = 3; continue a;}
-           if(caml_string_notequal(param, cst_include)){_b_ = 1; continue a;}
+           if(! caml_string_notequal(param, cst_if)){_b_ = 4; continue;}
+           if(! caml_string_notequal(param, cst_in)){_b_ = 3; continue;}
+           if(caml_string_notequal(param, cst_include)){_b_ = 1; continue;}
            _b_ = 2;
-           continue a;
+           continue;
           }
          }
         case 5:
@@ -149,43 +148,42 @@ let%expect_test "non-independent scopes fall through to the join where adjacent"
     {|
     function score(s){
      var _c_ = runtime.caml_string_compare(s, cst_let), _b_ = 0;
-     a:
      for(;;){
       switch(_b_){
         case 0:
          if(0 <= _c_){
-          if(0 >= _c_){_b_ = 4; continue a;}
+          if(0 >= _c_){_b_ = 4; continue;}
           if(caml_string_notequal(s, cst_match)){
            if(caml_string_notequal(s, cst_module)){
-            if(! caml_string_notequal(s, cst_open)){_b_ = 3; continue a;}
-            if(! caml_string_notequal(s, cst_then)){_b_ = 5; continue a;}
-            if(caml_string_notequal(s, cst_type)){_b_ = 2; continue a;}
+            if(! caml_string_notequal(s, cst_open)){_b_ = 3; continue;}
+            if(! caml_string_notequal(s, cst_then)){_b_ = 5; continue;}
+            if(caml_string_notequal(s, cst_type)){_b_ = 2; continue;}
            }
            var n = 4;
            _b_ = 1;
-           continue a;
+           continue;
           }
          }
          else{
-          if(! caml_string_notequal(s, cst_else)){_b_ = 5; continue a;}
+          if(! caml_string_notequal(s, cst_else)){_b_ = 5; continue;}
           if
            (caml_string_notequal(s, cst_fun)
             && caml_string_notequal(s, cst_function)){
-           if(! caml_string_notequal(s, cst_if)){_b_ = 5; continue a;}
-           if(! caml_string_notequal(s, cst_in)){_b_ = 4; continue a;}
-           if(caml_string_notequal(s, cst_include)){_b_ = 2; continue a;}
+           if(! caml_string_notequal(s, cst_if)){_b_ = 5; continue;}
+           if(! caml_string_notequal(s, cst_in)){_b_ = 4; continue;}
+           if(caml_string_notequal(s, cst_include)){_b_ = 2; continue;}
            _b_ = 3;
-           continue a;
+           continue;
           }
          }
         case 6:
-         n = 3; _b_ = 1; continue a;
+         n = 3; _b_ = 1; continue;
         case 5:
-         n = 1; _b_ = 1; continue a;
+         n = 1; _b_ = 1; continue;
         case 4:
-         n = 2; _b_ = 1; continue a;
+         n = 2; _b_ = 1; continue;
         case 3:
-         n = 5; _b_ = 1; continue a;
+         n = 5; _b_ = 1; continue;
         case 2: n = 0;
         case 1:
          return (n * 100 | 0) + runtime.caml_ml_string_length(s) | 0;

--- a/compiler/tests-compiler/gh2122.ml
+++ b/compiler/tests-compiler/gh2122.ml
@@ -99,7 +99,7 @@ let%expect_test "match with many shared continuations is a flat dispatch loop" =
         case 1:
          return 0;
       }
-      break a;
+      break;
      }
     }
     //end
@@ -190,7 +190,7 @@ let%expect_test "non-independent scopes fall through to the join where adjacent"
         case 1:
          return (n * 100 | 0) + runtime.caml_ml_string_length(s) | 0;
       }
-      break a;
+      break;
      }
     }
     //end

--- a/compiler/tests-full/stdlib.cma.expected.js
+++ b/compiler/tests-full/stdlib.cma.expected.js
@@ -17774,253 +17774,229 @@
    }
    var _w_ =  /*<<?>>*/ [0, _a_, 1558, 4];
    function make_printf$0(counter, k$2, acc$4, fmt$2){
+    var _ag_ = 0;
     a:
-    {
-     b:
-     {
-      c:
-      {
-       d:
-       {
-        e:
-        {
-         f:
-         {
-          g:
-          {
-           h:
-           {
-            i:
-            {
-             j:
-             {
-              var
-               k =  /*<<camlinternalFormat.ml:1518:17>>*/ k$2,
-               acc = acc$4,
-               fmt = fmt$2;
-              k:
-              for(;;){
-               if(typeof fmt === "number")
-                 /*<<camlinternalFormat.ml:1605:4>>*/ return caml_call1
-                        (k, acc) /*<<camlinternalFormat.ml:1605:9>>*/ ;
-                /*<<camlinternalFormat.ml:1518:17>>*/ switch(fmt[0]){
-                 case 0:
-                  break a;
-                 case 1:
-                  break b;
-                 case 2:
-                  break c;
-                 case 3:
-                  var rest$2 = fmt[2], pad$0 = fmt[1];
-                   /*<<camlinternalFormat.ml:1530:4>>*/ return make_padding
-                          (k, acc, rest$2, pad$0, string_to_caml_string) /*<<camlinternalFormat.ml:1605:9>>*/ ;
-                 case 4:
-                  var
-                   rest$3 =  /*<<camlinternalFormat.ml:1518:17>>*/ fmt[4],
-                   prec = fmt[3],
-                   pad$1 = fmt[2],
-                   iconv = fmt[1];
-                   /*<<camlinternalFormat.ml:1532:4>>*/ return make_int_padding_precision
-                          (k, acc, rest$3, pad$1, prec, convert_int, iconv) /*<<camlinternalFormat.ml:1605:9>>*/ ;
-                 case 5:
-                  var
-                   rest$4 =  /*<<camlinternalFormat.ml:1518:17>>*/ fmt[4],
-                   prec$0 = fmt[3],
-                   pad$2 = fmt[2],
-                   iconv$0 = fmt[1];
-                   /*<<camlinternalFormat.ml:1534:4>>*/ return make_int_padding_precision
-                          (k, acc, rest$4, pad$2, prec$0, convert_int32, iconv$0) /*<<camlinternalFormat.ml:1605:9>>*/ ;
-                 case 6:
-                  var
-                   rest$5 =  /*<<camlinternalFormat.ml:1518:17>>*/ fmt[4],
-                   prec$1 = fmt[3],
-                   pad$3 = fmt[2],
-                   iconv$1 = fmt[1];
-                   /*<<camlinternalFormat.ml:1536:4>>*/ return make_int_padding_precision
-                          (k, acc, rest$5, pad$3, prec$1, convert_nativeint, iconv$1) /*<<camlinternalFormat.ml:1605:9>>*/ ;
-                 case 7:
-                  var
-                   rest$6 =  /*<<camlinternalFormat.ml:1518:17>>*/ fmt[4],
-                   prec$2 = fmt[3],
-                   pad$4 = fmt[2],
-                   iconv$2 = fmt[1];
-                   /*<<camlinternalFormat.ml:1538:4>>*/ return make_int_padding_precision
-                          (k, acc, rest$6, pad$4, prec$2, convert_int64, iconv$2) /*<<camlinternalFormat.ml:1605:9>>*/ ;
-                 case 8:
-                  break d;
-                 case 9:
-                  var
-                   rest$8 =  /*<<camlinternalFormat.ml:1518:17>>*/ fmt[2],
-                   pad$6 = fmt[1];
-                   /*<<camlinternalFormat.ml:1542:4>>*/ return make_padding
-                          (k, acc, rest$8, pad$6, Stdlib[30]) /*<<camlinternalFormat.ml:1605:9>>*/ ;
-                 case 10:
-                  var
-                   rest$9 =  /*<<camlinternalFormat.ml:1518:17>>*/ fmt[1],
-                   acc$0 =  /*<<camlinternalFormat.ml:1560:4>>*/ [7, acc];
-                  acc = acc$0;
-                  fmt = rest$9;
-                  break;
-                 case 11:
-                  var
-                   rest$10 =  /*<<camlinternalFormat.ml:1518:17>>*/ fmt[2],
-                   str = fmt[1],
-                   acc$1 =  /*<<camlinternalFormat.ml:1563:4>>*/ [2, acc, str];
-                  acc = acc$1;
-                  fmt = rest$10;
-                  break;
-                 case 12:
-                  var
-                   rest$11 =  /*<<camlinternalFormat.ml:1518:17>>*/ fmt[2],
-                   chr = fmt[1],
-                   acc$2 =  /*<<camlinternalFormat.ml:1565:4>>*/ [3, acc, chr];
-                  acc = acc$2;
-                  fmt = rest$11;
-                  break;
-                 case 13:
-                  break e;
-                 case 14:
-                  break f;
-                 case 15:
-                  break g;
-                 case 16:
-                  break h;
-                 case 17:
-                  var
-                   rest$16 =  /*<<camlinternalFormat.ml:1518:17>>*/ fmt[2],
-                   fmting_lit = fmt[1],
-                   acc$3 =
-                      /*<<camlinternalFormat.ml:1594:4>>*/ [0, acc, fmting_lit];
-                  acc = acc$3;
-                  fmt = rest$16;
-                  break;
-                 case 18:
-                  var _ag_ =  /*<<camlinternalFormat.ml:1518:17>>*/ fmt[1];
-                  if(0 === _ag_[0]){
-                   var rest$17 = fmt[2], fmt$0 = _ag_[1][1];
-                   let
-                    acc$0 =  /*<<camlinternalFormat.ml:1596:4>>*/ acc,
-                    k$1 = k,
-                    rest = rest$17;
-                   var
-                    k$0 =
-                      function(kacc){
-                        /*<<camlinternalFormat.ml:1597:6>>*/ return make_printf
-                               (k$1, [1, acc$0, [0, kacc]], rest) /*<<camlinternalFormat.ml:1597:70>>*/ ;
-                      };
-                    /*<<camlinternalFormat.ml:1598:4>>*/ k = k$0;
-                   acc = 0;
-                   fmt = fmt$0;
-                  }
-                  else{
-                   var
-                    rest$18 =  /*<<camlinternalFormat.ml:1518:17>>*/ fmt[2],
-                    fmt$1 = _ag_[1][1];
-                   let
-                    acc$0 =  /*<<camlinternalFormat.ml:1600:4>>*/ acc,
-                    k$0 = k,
-                    rest = rest$18;
-                   var
-                    k$1 =
-                      function(kacc){
-                        /*<<camlinternalFormat.ml:1601:6>>*/ return make_printf
-                               (k$0, [1, acc$0, [1, kacc]], rest) /*<<camlinternalFormat.ml:1601:70>>*/ ;
-                      };
-                    /*<<camlinternalFormat.ml:1602:4>>*/ k = k$1;
-                   acc = 0;
-                   fmt = fmt$1;
-                  }
-                  break;
-                 case 19:
-                   /*<<camlinternalFormat.ml:1558:4>>*/ throw caml_maybe_attach_backtrace
-                         ([0, Assert_failure, _w_], 1);
-                 case 20:
-                  break i;
-                 case 21:
-                  break j;
-                 case 22:
-                  break k;
-                 case 23:
-                  var
-                   rest$22 =  /*<<camlinternalFormat.ml:1518:17>>*/ fmt[2],
-                   ign = fmt[1];
-                   /*<<camlinternalFormat.ml:1591:4>>*/ return counter < 50
-                          ? make_ignored_param$0
-                            (counter + 1 | 0, k, acc, ign, rest$22)
-                          : caml_trampoline_return
-                            (make_ignored_param$0, [0, k, acc, ign, rest$22]) /*<<camlinternalFormat.ml:1605:9>>*/ ;
-                 default:
-                  var
-                   rest$23 =  /*<<camlinternalFormat.ml:1518:17>>*/ fmt[3],
-                   f = fmt[2],
-                   arity = fmt[1],
-                   _ag_ =
-                      /*<<camlinternalFormat.ml:1548:33>>*/ caml_call1(f, 0);
-                   /*<<camlinternalFormat.ml:1548:39>>*/ return counter < 50
-                          ? make_custom$0
-                            (counter + 1 | 0, k, acc, rest$23, arity, _ag_)
-                          : caml_trampoline_return
-                            (make_custom$0, [0, k, acc, rest$23, arity, _ag_]) /*<<camlinternalFormat.ml:1605:9>>*/ ;
-               }
-              }
-              var rest$21 =  /*<<camlinternalFormat.ml:1518:17>>*/ fmt[1];
-               /*<<camlinternalFormat.ml:1587:4>>*/ return function(c){
-               var
-                new_acc =  /*<<camlinternalFormat.ml:1588:6>>*/ [5, acc, c];
-                /*<<camlinternalFormat.ml:1589:6>>*/ return make_printf
-                       (k, new_acc, rest$21) /*<<camlinternalFormat.ml:1589:32>>*/ ;} /*<<camlinternalFormat.ml:1587:4>>*/ ;
-             }
-             var rest$20 =  /*<<camlinternalFormat.ml:1518:17>>*/ fmt[2];
-              /*<<camlinternalFormat.ml:1583:4>>*/ return function(n){
-              var
-               new_acc =
-                  /*<<camlinternalFormat.ml:1584:42>>*/ [4,
-                  acc,
-                  caml_format_int(cst_u, n)];
-               /*<<camlinternalFormat.ml:1585:6>>*/ return make_printf
-                      (k, new_acc, rest$20) /*<<camlinternalFormat.ml:1585:32>>*/ ;} /*<<camlinternalFormat.ml:1583:4>>*/ ;
-            }
+     /*<<camlinternalFormat.ml:1518:17>>*/ for(;;){
+     switch(_ag_){
+       case 0:
+        var k = k$2, acc = acc$4, fmt = fmt$2;
+        b:
+        for(;;){
+         if(typeof fmt === "number")
+           /*<<camlinternalFormat.ml:1605:4>>*/ return caml_call1(k, acc) /*<<camlinternalFormat.ml:1605:9>>*/ ;
+          /*<<camlinternalFormat.ml:1518:17>>*/ switch(fmt[0]){
+           case 0:
+            _ag_ = 1; continue a;
+           case 1:
+            _ag_ = 2; continue a;
+           case 2:
+            _ag_ = 3; continue a;
+           case 3:
+            var rest$2 = fmt[2], pad$0 = fmt[1];
+             /*<<camlinternalFormat.ml:1530:4>>*/ return make_padding
+                    (k, acc, rest$2, pad$0, string_to_caml_string) /*<<camlinternalFormat.ml:1605:9>>*/ ;
+           case 4:
             var
-             rest$19 =  /*<<camlinternalFormat.ml:1518:17>>*/ fmt[3],
-             new_acc =
-                /*<<camlinternalFormat.ml:1577:4>>*/ [8,
-                acc,
-                "Printf: bad conversion %["];
-             /*<<camlinternalFormat.ml:1578:4>>*/ return function(param){
-              /*<<camlinternalFormat.ml:1578:13>>*/ return make_printf
-                     (k, new_acc, rest$19) /*<<camlinternalFormat.ml:1578:39>>*/ ;} /*<<camlinternalFormat.ml:1578:4>>*/ ;
-           }
-           var rest$15 =  /*<<camlinternalFormat.ml:1518:17>>*/ fmt[1];
-            /*<<camlinternalFormat.ml:1546:4>>*/ return function(f){
-             /*<<camlinternalFormat.ml:1546:13>>*/ return make_printf
-                    (k, [6, acc, f], rest$15) /*<<camlinternalFormat.ml:1546:52>>*/ ;} /*<<camlinternalFormat.ml:1546:4>>*/ ;
-          }
-          var rest$14 =  /*<<camlinternalFormat.ml:1518:17>>*/ fmt[1];
-           /*<<camlinternalFormat.ml:1544:4>>*/ return function(f, x){
-            /*<<camlinternalFormat.ml:1544:15>>*/ return make_printf
-                   (k,
-                    [6,
-                     acc,
-                     function(o){
-                       /*<<camlinternalFormat.ml:1544:55>>*/ return caml_call2
-                              (f, o, x) /*<<camlinternalFormat.ml:1544:60>>*/ ;
-                     }],
-                    rest$14) /*<<camlinternalFormat.ml:1544:67>>*/ ;} /*<<camlinternalFormat.ml:1544:4>>*/ ;
+             rest$3 =  /*<<camlinternalFormat.ml:1518:17>>*/ fmt[4],
+             prec = fmt[3],
+             pad$1 = fmt[2],
+             iconv = fmt[1];
+             /*<<camlinternalFormat.ml:1532:4>>*/ return make_int_padding_precision
+                    (k, acc, rest$3, pad$1, prec, convert_int, iconv) /*<<camlinternalFormat.ml:1605:9>>*/ ;
+           case 5:
+            var
+             rest$4 =  /*<<camlinternalFormat.ml:1518:17>>*/ fmt[4],
+             prec$0 = fmt[3],
+             pad$2 = fmt[2],
+             iconv$0 = fmt[1];
+             /*<<camlinternalFormat.ml:1534:4>>*/ return make_int_padding_precision
+                    (k, acc, rest$4, pad$2, prec$0, convert_int32, iconv$0) /*<<camlinternalFormat.ml:1605:9>>*/ ;
+           case 6:
+            var
+             rest$5 =  /*<<camlinternalFormat.ml:1518:17>>*/ fmt[4],
+             prec$1 = fmt[3],
+             pad$3 = fmt[2],
+             iconv$1 = fmt[1];
+             /*<<camlinternalFormat.ml:1536:4>>*/ return make_int_padding_precision
+                    (k, acc, rest$5, pad$3, prec$1, convert_nativeint, iconv$1) /*<<camlinternalFormat.ml:1605:9>>*/ ;
+           case 7:
+            var
+             rest$6 =  /*<<camlinternalFormat.ml:1518:17>>*/ fmt[4],
+             prec$2 = fmt[3],
+             pad$4 = fmt[2],
+             iconv$2 = fmt[1];
+             /*<<camlinternalFormat.ml:1538:4>>*/ return make_int_padding_precision
+                    (k, acc, rest$6, pad$4, prec$2, convert_int64, iconv$2) /*<<camlinternalFormat.ml:1605:9>>*/ ;
+           case 8:
+             /*<<camlinternalFormat.ml:1518:17>>*/ _ag_ = 4; continue a;
+           case 9:
+            var rest$8 = fmt[2], pad$6 = fmt[1];
+             /*<<camlinternalFormat.ml:1542:4>>*/ return make_padding
+                    (k, acc, rest$8, pad$6, Stdlib[30]) /*<<camlinternalFormat.ml:1605:9>>*/ ;
+           case 10:
+            var
+             rest$9 =  /*<<camlinternalFormat.ml:1518:17>>*/ fmt[1],
+             acc$0 =  /*<<camlinternalFormat.ml:1560:4>>*/ [7, acc];
+            acc = acc$0;
+            fmt = rest$9;
+            break;
+           case 11:
+            var
+             rest$10 =  /*<<camlinternalFormat.ml:1518:17>>*/ fmt[2],
+             str = fmt[1],
+             acc$1 =  /*<<camlinternalFormat.ml:1563:4>>*/ [2, acc, str];
+            acc = acc$1;
+            fmt = rest$10;
+            break;
+           case 12:
+            var
+             rest$11 =  /*<<camlinternalFormat.ml:1518:17>>*/ fmt[2],
+             chr = fmt[1],
+             acc$2 =  /*<<camlinternalFormat.ml:1565:4>>*/ [3, acc, chr];
+            acc = acc$2;
+            fmt = rest$11;
+            break;
+           case 13:
+             /*<<camlinternalFormat.ml:1518:17>>*/ _ag_ = 5; continue a;
+           case 14:
+            _ag_ = 6; continue a;
+           case 15:
+            _ag_ = 7; continue a;
+           case 16:
+            _ag_ = 8; continue a;
+           case 17:
+            var
+             rest$16 = fmt[2],
+             fmting_lit = fmt[1],
+             acc$3 =
+                /*<<camlinternalFormat.ml:1594:4>>*/ [0, acc, fmting_lit];
+            acc = acc$3;
+            fmt = rest$16;
+            break;
+           case 18:
+             /*<<camlinternalFormat.ml:1518:17>>*/ _ag_ = fmt[1];
+            if(0 === _ag_[0]){
+             var rest$17 = fmt[2], fmt$0 = _ag_[1][1];
+             let
+              acc$0 =  /*<<camlinternalFormat.ml:1596:4>>*/ acc,
+              k$1 = k,
+              rest = rest$17;
+             var
+              k$0 =
+                function(kacc){
+                  /*<<camlinternalFormat.ml:1597:6>>*/ return make_printf
+                         (k$1, [1, acc$0, [0, kacc]], rest) /*<<camlinternalFormat.ml:1597:70>>*/ ;
+                };
+              /*<<camlinternalFormat.ml:1598:4>>*/ k = k$0;
+             acc = 0;
+             fmt = fmt$0;
+            }
+            else{
+             var
+              rest$18 =  /*<<camlinternalFormat.ml:1518:17>>*/ fmt[2],
+              fmt$1 = _ag_[1][1];
+             let
+              acc$0 =  /*<<camlinternalFormat.ml:1600:4>>*/ acc,
+              k$0 = k,
+              rest = rest$18;
+             var
+              k$1 =
+                function(kacc){
+                  /*<<camlinternalFormat.ml:1601:6>>*/ return make_printf
+                         (k$0, [1, acc$0, [1, kacc]], rest) /*<<camlinternalFormat.ml:1601:70>>*/ ;
+                };
+              /*<<camlinternalFormat.ml:1602:4>>*/ k = k$1;
+             acc = 0;
+             fmt = fmt$1;
+            }
+            break;
+           case 19:
+             /*<<camlinternalFormat.ml:1558:4>>*/ throw caml_maybe_attach_backtrace
+                   ([0, Assert_failure, _w_], 1);
+           case 20:
+             /*<<camlinternalFormat.ml:1518:17>>*/ _ag_ = 9; continue a;
+           case 21:
+            _ag_ = 10; continue a;
+           case 22:
+            break b;
+           case 23:
+            var rest$22 = fmt[2], ign = fmt[1];
+             /*<<camlinternalFormat.ml:1591:4>>*/ return counter < 50
+                    ? make_ignored_param$0
+                      (counter + 1 | 0, k, acc, ign, rest$22)
+                    : caml_trampoline_return
+                      (make_ignored_param$0, [0, k, acc, ign, rest$22]) /*<<camlinternalFormat.ml:1605:9>>*/ ;
+           default:
+            var
+             rest$23 =  /*<<camlinternalFormat.ml:1518:17>>*/ fmt[3],
+             f = fmt[2],
+             arity = fmt[1],
+             _ag_ =  /*<<camlinternalFormat.ml:1548:33>>*/ caml_call1(f, 0);
+             /*<<camlinternalFormat.ml:1548:39>>*/ return counter < 50
+                    ? make_custom$0
+                      (counter + 1 | 0, k, acc, rest$23, arity, _ag_)
+                    : caml_trampoline_return
+                      (make_custom$0, [0, k, acc, rest$23, arity, _ag_]) /*<<camlinternalFormat.ml:1605:9>>*/ ;
          }
-         var
-          rest$13 =  /*<<camlinternalFormat.ml:1518:17>>*/ fmt[3],
-          fmtty = fmt[2];
-          /*<<camlinternalFormat.ml:1573:4>>*/ return function(_ag_){
-          var
-           fmt = _ag_[1],
-           _ag_ =  /*<<camlinternalFormat.ml:1574:18>>*/ recast(fmt, fmtty);
-           /*<<camlinternalFormat.ml:1574:6>>*/ return  /*<<camlinternalFormat.ml:1574:42>>*/ make_printf
-                  (k,
-                   acc,
-                    /*<<camlinternalFormat.ml:1574:6>>*/ CamlinternalFormatBasics
-                     [3].call
-                    (null, _ag_, rest$13)) /*<<camlinternalFormat.ml:1574:42>>*/ ;} /*<<camlinternalFormat.ml:1573:4>>*/ ;
         }
+       case 11:
+        var rest$21 =  /*<<camlinternalFormat.ml:1518:17>>*/ fmt[1];
+         /*<<camlinternalFormat.ml:1587:4>>*/ return function(c){
+         var new_acc =  /*<<camlinternalFormat.ml:1588:6>>*/ [5, acc, c];
+          /*<<camlinternalFormat.ml:1589:6>>*/ return make_printf
+                 (k, new_acc, rest$21) /*<<camlinternalFormat.ml:1589:32>>*/ ;} /*<<camlinternalFormat.ml:1587:4>>*/ ;
+       case 10:
+        var rest$20 =  /*<<camlinternalFormat.ml:1518:17>>*/ fmt[2];
+         /*<<camlinternalFormat.ml:1583:4>>*/ return function(n){
+         var
+          new_acc =
+             /*<<camlinternalFormat.ml:1584:42>>*/ [4,
+             acc,
+             caml_format_int(cst_u, n)];
+          /*<<camlinternalFormat.ml:1585:6>>*/ return make_printf
+                 (k, new_acc, rest$20) /*<<camlinternalFormat.ml:1585:32>>*/ ;} /*<<camlinternalFormat.ml:1583:4>>*/ ;
+       case 9:
+        var
+         rest$19 =  /*<<camlinternalFormat.ml:1518:17>>*/ fmt[3],
+         new_acc =
+            /*<<camlinternalFormat.ml:1577:4>>*/ [8,
+            acc,
+            "Printf: bad conversion %["];
+         /*<<camlinternalFormat.ml:1578:4>>*/ return function(param){
+          /*<<camlinternalFormat.ml:1578:13>>*/ return make_printf
+                 (k, new_acc, rest$19) /*<<camlinternalFormat.ml:1578:39>>*/ ;} /*<<camlinternalFormat.ml:1578:4>>*/ ;
+       case 8:
+        var rest$15 =  /*<<camlinternalFormat.ml:1518:17>>*/ fmt[1];
+         /*<<camlinternalFormat.ml:1546:4>>*/ return function(f){
+          /*<<camlinternalFormat.ml:1546:13>>*/ return make_printf
+                 (k, [6, acc, f], rest$15) /*<<camlinternalFormat.ml:1546:52>>*/ ;} /*<<camlinternalFormat.ml:1546:4>>*/ ;
+       case 7:
+        var rest$14 =  /*<<camlinternalFormat.ml:1518:17>>*/ fmt[1];
+         /*<<camlinternalFormat.ml:1544:4>>*/ return function(f, x){
+          /*<<camlinternalFormat.ml:1544:15>>*/ return make_printf
+                 (k,
+                  [6,
+                   acc,
+                   function(o){
+                     /*<<camlinternalFormat.ml:1544:55>>*/ return caml_call2
+                            (f, o, x) /*<<camlinternalFormat.ml:1544:60>>*/ ;
+                   }],
+                  rest$14) /*<<camlinternalFormat.ml:1544:67>>*/ ;} /*<<camlinternalFormat.ml:1544:4>>*/ ;
+       case 6:
+        var
+         rest$13 =  /*<<camlinternalFormat.ml:1518:17>>*/ fmt[3],
+         fmtty = fmt[2];
+         /*<<camlinternalFormat.ml:1573:4>>*/ return function(_ag_){
+         var
+          fmt = _ag_[1],
+          _ag_ =  /*<<camlinternalFormat.ml:1574:18>>*/ recast(fmt, fmtty);
+          /*<<camlinternalFormat.ml:1574:6>>*/ return  /*<<camlinternalFormat.ml:1574:42>>*/ make_printf
+                 (k,
+                  acc,
+                   /*<<camlinternalFormat.ml:1574:6>>*/ CamlinternalFormatBasics
+                    [3].call
+                   (null, _ag_, rest$13)) /*<<camlinternalFormat.ml:1574:42>>*/ ;} /*<<camlinternalFormat.ml:1573:4>>*/ ;
+       case 5:
         var
          rest$12 =  /*<<camlinternalFormat.ml:1518:17>>*/ fmt[3],
          sub_fmtty = fmt[2],
@@ -18029,165 +18005,169 @@
          /*<<camlinternalFormat.ml:1569:4>>*/ return function(str){
           /*<<camlinternalFormat.ml:1571:6>>*/ return make_printf
                  (k, [4, acc, ty], rest$12) /*<<camlinternalFormat.ml:1571:52>>*/ ;} /*<<camlinternalFormat.ml:1569:4>>*/ ;
-       }
-       var
-        rest$7 =  /*<<camlinternalFormat.ml:1518:17>>*/ fmt[4],
-        prec$3 = fmt[3],
-        pad$5 = fmt[2],
-        fconv = fmt[1];
-        /*<<camlinternalFormat.ml:1735:34>>*/ if(typeof pad$5 === "number"){
+       case 4:
+        var
+         rest$7 =  /*<<camlinternalFormat.ml:1518:17>>*/ fmt[4],
+         prec$3 = fmt[3],
+         pad$5 = fmt[2],
+         fconv = fmt[1];
+         /*<<camlinternalFormat.ml:1735:34>>*/ if(typeof pad$5 === "number"){
+         if(typeof prec$3 === "number")
+          return prec$3
+                  ? function
+                   (p, x){
+                    var
+                     str =
+                        /*<<camlinternalFormat.ml:1746:16>>*/ convert_float
+                        (fconv, p, x);
+                     /*<<camlinternalFormat.ml:1747:6>>*/ return make_printf
+                            (k, [4, acc, str], rest$7) /*<<camlinternalFormat.ml:1747:52>>*/ ;
+                   }
+                  : function
+                   (x){
+                    var
+                     str =
+                        /*<<camlinternalFormat.ml:1738:36>>*/  /*<<camlinternalFormat.ml:1738:16>>*/ convert_float
+                        (fconv,
+                          /*<<camlinternalFormat.ml:1738:36>>*/ default_float_precision
+                          (fconv),
+                         x);
+                     /*<<camlinternalFormat.ml:1739:6>>*/ return make_printf
+                            (k, [4, acc, str], rest$7) /*<<camlinternalFormat.ml:1739:52>>*/ ;
+                   } /*<<camlinternalFormat.ml:1605:9>>*/ ;
+         var p =  /*<<camlinternalFormat.ml:1735:34>>*/ prec$3[1];
+          /*<<camlinternalFormat.ml:1741:4>>*/ return function(x){
+          var
+           str =
+              /*<<camlinternalFormat.ml:1742:16>>*/ convert_float(fconv, p, x);
+           /*<<camlinternalFormat.ml:1743:6>>*/ return make_printf
+                  (k, [4, acc, str], rest$7) /*<<camlinternalFormat.ml:1743:52>>*/ ;} /*<<camlinternalFormat.ml:1741:4>>*/ ;
+        }
+         /*<<camlinternalFormat.ml:1735:34>>*/ if(0 === pad$5[0]){
+         var w = pad$5[2], padty = pad$5[1];
+         if(typeof prec$3 === "number")
+          return prec$3
+                  ? function
+                   (p, x){
+                    var
+                     str =
+                        /*<<camlinternalFormat.ml:1759:36>>*/  /*<<camlinternalFormat.ml:1759:16>>*/ fix_padding
+                        (padty,
+                         w,
+                          /*<<camlinternalFormat.ml:1759:36>>*/ convert_float
+                          (fconv, p, x));
+                     /*<<camlinternalFormat.ml:1760:6>>*/ return make_printf
+                            (k, [4, acc, str], rest$7) /*<<camlinternalFormat.ml:1760:52>>*/ ;
+                   }
+                  : function
+                   (x){
+                    var
+                     str =
+                        /*<<camlinternalFormat.ml:1750:36>>*/  /*<<camlinternalFormat.ml:1750:16>>*/ convert_float
+                        (fconv,
+                          /*<<camlinternalFormat.ml:1750:36>>*/ default_float_precision
+                          (fconv),
+                         x),
+                     str$0 =
+                        /*<<camlinternalFormat.ml:1751:17>>*/ fix_padding
+                        (padty, w, str);
+                     /*<<camlinternalFormat.ml:1752:6>>*/ return make_printf
+                            (k, [4, acc, str$0], rest$7) /*<<camlinternalFormat.ml:1752:53>>*/ ;
+                   } /*<<camlinternalFormat.ml:1605:9>>*/ ;
+         var p$0 =  /*<<camlinternalFormat.ml:1735:34>>*/ prec$3[1];
+          /*<<camlinternalFormat.ml:1754:4>>*/ return function(x){
+          var
+           str =
+              /*<<camlinternalFormat.ml:1755:36>>*/  /*<<camlinternalFormat.ml:1755:16>>*/ fix_padding
+              (padty,
+               w,
+                /*<<camlinternalFormat.ml:1755:36>>*/ convert_float
+                (fconv, p$0, x));
+           /*<<camlinternalFormat.ml:1756:6>>*/ return make_printf
+                  (k, [4, acc, str], rest$7) /*<<camlinternalFormat.ml:1756:52>>*/ ;} /*<<camlinternalFormat.ml:1754:4>>*/ ;
+        }
+        var padty$0 =  /*<<camlinternalFormat.ml:1735:34>>*/ pad$5[1];
         if(typeof prec$3 === "number")
          return prec$3
                  ? function
-                  (p, x){
+                  (w, p, x){
                    var
                     str =
-                       /*<<camlinternalFormat.ml:1746:16>>*/ convert_float
-                       (fconv, p, x);
-                    /*<<camlinternalFormat.ml:1747:6>>*/ return make_printf
-                           (k, [4, acc, str], rest$7) /*<<camlinternalFormat.ml:1747:52>>*/ ;
-                  }
-                 : function
-                  (x){
-                   var
-                    str =
-                       /*<<camlinternalFormat.ml:1738:36>>*/  /*<<camlinternalFormat.ml:1738:16>>*/ convert_float
-                       (fconv,
-                         /*<<camlinternalFormat.ml:1738:36>>*/ default_float_precision
-                         (fconv),
-                        x);
-                    /*<<camlinternalFormat.ml:1739:6>>*/ return make_printf
-                           (k, [4, acc, str], rest$7) /*<<camlinternalFormat.ml:1739:52>>*/ ;
-                  } /*<<camlinternalFormat.ml:1605:9>>*/ ;
-        var p =  /*<<camlinternalFormat.ml:1735:34>>*/ prec$3[1];
-         /*<<camlinternalFormat.ml:1741:4>>*/ return function(x){
-         var
-          str =
-             /*<<camlinternalFormat.ml:1742:16>>*/ convert_float(fconv, p, x);
-          /*<<camlinternalFormat.ml:1743:6>>*/ return make_printf
-                 (k, [4, acc, str], rest$7) /*<<camlinternalFormat.ml:1743:52>>*/ ;} /*<<camlinternalFormat.ml:1741:4>>*/ ;
-       }
-        /*<<camlinternalFormat.ml:1735:34>>*/ if(0 === pad$5[0]){
-        var w = pad$5[2], padty = pad$5[1];
-        if(typeof prec$3 === "number")
-         return prec$3
-                 ? function
-                  (p, x){
-                   var
-                    str =
-                       /*<<camlinternalFormat.ml:1759:36>>*/  /*<<camlinternalFormat.ml:1759:16>>*/ fix_padding
-                       (padty,
+                       /*<<camlinternalFormat.ml:1772:36>>*/  /*<<camlinternalFormat.ml:1772:16>>*/ fix_padding
+                       (padty$0,
                         w,
-                         /*<<camlinternalFormat.ml:1759:36>>*/ convert_float
+                         /*<<camlinternalFormat.ml:1772:36>>*/ convert_float
                          (fconv, p, x));
-                    /*<<camlinternalFormat.ml:1760:6>>*/ return make_printf
-                           (k, [4, acc, str], rest$7) /*<<camlinternalFormat.ml:1760:52>>*/ ;
+                    /*<<camlinternalFormat.ml:1773:6>>*/ return make_printf
+                           (k, [4, acc, str], rest$7) /*<<camlinternalFormat.ml:1773:52>>*/ ;
                   }
                  : function
-                  (x){
+                  (w, x){
                    var
                     str =
-                       /*<<camlinternalFormat.ml:1750:36>>*/  /*<<camlinternalFormat.ml:1750:16>>*/ convert_float
+                       /*<<camlinternalFormat.ml:1763:36>>*/  /*<<camlinternalFormat.ml:1763:16>>*/ convert_float
                        (fconv,
-                         /*<<camlinternalFormat.ml:1750:36>>*/ default_float_precision
+                         /*<<camlinternalFormat.ml:1763:36>>*/ default_float_precision
                          (fconv),
                         x),
                     str$0 =
-                       /*<<camlinternalFormat.ml:1751:17>>*/ fix_padding
-                       (padty, w, str);
-                    /*<<camlinternalFormat.ml:1752:6>>*/ return make_printf
-                           (k, [4, acc, str$0], rest$7) /*<<camlinternalFormat.ml:1752:53>>*/ ;
+                       /*<<camlinternalFormat.ml:1764:17>>*/ fix_padding
+                       (padty$0, w, str);
+                    /*<<camlinternalFormat.ml:1765:6>>*/ return make_printf
+                           (k, [4, acc, str$0], rest$7) /*<<camlinternalFormat.ml:1765:53>>*/ ;
                   } /*<<camlinternalFormat.ml:1605:9>>*/ ;
-        var p$0 =  /*<<camlinternalFormat.ml:1735:34>>*/ prec$3[1];
-         /*<<camlinternalFormat.ml:1754:4>>*/ return function(x){
+        var p$1 =  /*<<camlinternalFormat.ml:1735:34>>*/ prec$3[1];
+         /*<<camlinternalFormat.ml:1767:4>>*/ return function(w, x){
          var
           str =
-             /*<<camlinternalFormat.ml:1755:36>>*/  /*<<camlinternalFormat.ml:1755:16>>*/ fix_padding
-             (padty,
+             /*<<camlinternalFormat.ml:1768:36>>*/  /*<<camlinternalFormat.ml:1768:16>>*/ fix_padding
+             (padty$0,
               w,
-               /*<<camlinternalFormat.ml:1755:36>>*/ convert_float
-               (fconv, p$0, x));
-          /*<<camlinternalFormat.ml:1756:6>>*/ return make_printf
-                 (k, [4, acc, str], rest$7) /*<<camlinternalFormat.ml:1756:52>>*/ ;} /*<<camlinternalFormat.ml:1754:4>>*/ ;
-       }
-       var padty$0 =  /*<<camlinternalFormat.ml:1735:34>>*/ pad$5[1];
-       if(typeof prec$3 === "number")
-        return prec$3
-                ? function
-                 (w, p, x){
-                  var
-                   str =
-                      /*<<camlinternalFormat.ml:1772:36>>*/  /*<<camlinternalFormat.ml:1772:16>>*/ fix_padding
-                      (padty$0,
-                       w,
-                        /*<<camlinternalFormat.ml:1772:36>>*/ convert_float
-                        (fconv, p, x));
-                   /*<<camlinternalFormat.ml:1773:6>>*/ return make_printf
-                          (k, [4, acc, str], rest$7) /*<<camlinternalFormat.ml:1773:52>>*/ ;
-                 }
-                : function
-                 (w, x){
-                  var
-                   str =
-                      /*<<camlinternalFormat.ml:1763:36>>*/  /*<<camlinternalFormat.ml:1763:16>>*/ convert_float
-                      (fconv,
-                        /*<<camlinternalFormat.ml:1763:36>>*/ default_float_precision
-                        (fconv),
-                       x),
-                   str$0 =
-                      /*<<camlinternalFormat.ml:1764:17>>*/ fix_padding
-                      (padty$0, w, str);
-                   /*<<camlinternalFormat.ml:1765:6>>*/ return make_printf
-                          (k, [4, acc, str$0], rest$7) /*<<camlinternalFormat.ml:1765:53>>*/ ;
-                 } /*<<camlinternalFormat.ml:1605:9>>*/ ;
-       var p$1 =  /*<<camlinternalFormat.ml:1735:34>>*/ prec$3[1];
-        /*<<camlinternalFormat.ml:1767:4>>*/ return function(w, x){
+               /*<<camlinternalFormat.ml:1768:36>>*/ convert_float
+               (fconv, p$1, x));
+          /*<<camlinternalFormat.ml:1769:6>>*/ return make_printf
+                 (k, [4, acc, str], rest$7) /*<<camlinternalFormat.ml:1769:52>>*/ ;} /*<<camlinternalFormat.ml:1767:4>>*/ ;
+       case 3:
         var
-         str =
-            /*<<camlinternalFormat.ml:1768:36>>*/  /*<<camlinternalFormat.ml:1768:16>>*/ fix_padding
-            (padty$0,
-             w,
-              /*<<camlinternalFormat.ml:1768:36>>*/ convert_float
-              (fconv, p$1, x));
-         /*<<camlinternalFormat.ml:1769:6>>*/ return make_printf
-                (k, [4, acc, str], rest$7) /*<<camlinternalFormat.ml:1769:52>>*/ ;} /*<<camlinternalFormat.ml:1767:4>>*/ ;
-      }
-      var
-       rest$1 =  /*<<camlinternalFormat.ml:1518:17>>*/ fmt[2],
-       pad = fmt[1];
-       /*<<camlinternalFormat.ml:1528:4>>*/ return make_padding
-              (k,
-               acc,
-               rest$1,
-               pad,
-               function(str){
-                 /*<<camlinternalFormat.ml:1528:44>>*/ return str;
-                /*<<camlinternalFormat.ml:1528:47>>*/ }) /*<<camlinternalFormat.ml:1605:9>>*/ ;
+         rest$1 =  /*<<camlinternalFormat.ml:1518:17>>*/ fmt[2],
+         pad = fmt[1];
+         /*<<camlinternalFormat.ml:1528:4>>*/ return make_padding
+                (k,
+                 acc,
+                 rest$1,
+                 pad,
+                 function(str){
+                   /*<<camlinternalFormat.ml:1528:44>>*/ return str;
+                  /*<<camlinternalFormat.ml:1528:47>>*/ }) /*<<camlinternalFormat.ml:1605:9>>*/ ;
+       case 2:
+        var rest$0 =  /*<<camlinternalFormat.ml:1518:17>>*/ fmt[1];
+         /*<<camlinternalFormat.ml:1524:4>>*/ return function(c){
+         var
+          str =
+             /*<<camlinternalFormat.ml:1493:12>>*/ Stdlib_Char[2].call
+             (null, c),
+          l =  /*<<camlinternalFormat.ml:1494:2>>*/ caml_ml_string_length(str),
+          res =
+             /*<<camlinternalFormat.ml:1495:12>>*/ Stdlib_Bytes[1].call
+             (null, l + 2 | 0, 39);
+          /*<<camlinternalFormat.ml:1496:2>>*/ caml_blit_string
+          (str, 0, res, 1, l);
+         var
+          new_acc =
+             /*<<camlinternalFormat.ml:1496:34>>*/ [4,
+             acc,
+             Stdlib_Bytes[44].call(null, res)];
+          /*<<camlinternalFormat.ml:1526:6>>*/ return make_printf
+                 (k, new_acc, rest$0) /*<<camlinternalFormat.ml:1526:32>>*/ ;} /*<<camlinternalFormat.ml:1524:4>>*/ ;
+       case 1:
+        var rest =  /*<<camlinternalFormat.ml:1518:17>>*/ fmt[1];
+         /*<<camlinternalFormat.ml:1520:4>>*/ return function(c){
+         var new_acc =  /*<<camlinternalFormat.ml:1521:6>>*/ [5, acc, c];
+          /*<<camlinternalFormat.ml:1522:6>>*/ return make_printf
+                 (k, new_acc, rest) /*<<camlinternalFormat.ml:1522:32>>*/ ;} /*<<camlinternalFormat.ml:1520:4>>*/ ;
      }
-     var rest$0 =  /*<<camlinternalFormat.ml:1518:17>>*/ fmt[1];
-      /*<<camlinternalFormat.ml:1524:4>>*/ return function(c){
-      var
-       str =
-          /*<<camlinternalFormat.ml:1493:12>>*/ Stdlib_Char[2].call(null, c),
-       l =  /*<<camlinternalFormat.ml:1494:2>>*/ caml_ml_string_length(str),
-       res =
-          /*<<camlinternalFormat.ml:1495:12>>*/ Stdlib_Bytes[1].call
-          (null, l + 2 | 0, 39);
-       /*<<camlinternalFormat.ml:1496:2>>*/ caml_blit_string
-       (str, 0, res, 1, l);
-      var
-       new_acc =
-          /*<<camlinternalFormat.ml:1496:34>>*/ [4,
-          acc,
-          Stdlib_Bytes[44].call(null, res)];
-       /*<<camlinternalFormat.ml:1526:6>>*/ return make_printf
-              (k, new_acc, rest$0) /*<<camlinternalFormat.ml:1526:32>>*/ ;} /*<<camlinternalFormat.ml:1524:4>>*/ ;
+     break;
     }
-    var rest =  /*<<camlinternalFormat.ml:1518:17>>*/ fmt[1];
-     /*<<camlinternalFormat.ml:1520:4>>*/ return function(c){
-     var new_acc =  /*<<camlinternalFormat.ml:1521:6>>*/ [5, acc, c];
-      /*<<camlinternalFormat.ml:1522:6>>*/ return make_printf
-             (k, new_acc, rest) /*<<camlinternalFormat.ml:1522:32>>*/ ;} /*<<camlinternalFormat.ml:1520:4>>*/ ;
     /*<<camlinternalFormat.ml:1605:9>>*/ }
    function make_printf(k, acc, fmt){
      /*<<camlinternalFormat.ml:1518:17>>*/ return  /*<<?>>*/ caml_trampoline

--- a/compiler/tests-full/stdlib.cma.expected.js
+++ b/compiler/tests-full/stdlib.cma.expected.js
@@ -17776,7 +17776,7 @@
    function make_printf$0(counter, k$2, acc$4, fmt$2){
     var _ag_ = 0;
     a:
-     /*<<camlinternalFormat.ml:1518:17>>*/ for(;;){
+     /*<<camlinternalFormat.ml:1518:17>>*/ for(;;)
      switch(_ag_){
        case 0:
         var k = k$2, acc = acc$4, fmt = fmt$2;
@@ -18166,8 +18166,6 @@
           /*<<camlinternalFormat.ml:1522:6>>*/ return make_printf
                  (k, new_acc, rest) /*<<camlinternalFormat.ml:1522:32>>*/ ;} /*<<camlinternalFormat.ml:1520:4>>*/ ;
      }
-     break;
-    }
     /*<<camlinternalFormat.ml:1605:9>>*/ }
    function make_printf(k, acc, fmt){
      /*<<camlinternalFormat.ml:1518:17>>*/ return  /*<<?>>*/ caml_trampoline


### PR DESCRIPTION
## Problem

A match with many branches sharing continuations — e.g. or-patterns over strings, as in a menhir/ocamllex-generated lexer like herd's `AArch64Lexer.mll`, or the format-string interpreters in `camlinternalFormat` — produces many sibling merge-node targets dominated by a single block. These are compiled as a *tower of nested labelled blocks*, one level per target:

```js
a:{b:{c:{ d:{ ... } code_d } code_c } code_b } code_a
```

The nesting depth grows with the number of distinct shared continuations. This can overflow the **parser** of some JavaScript engines — Firefox/SpiderMonkey reports `InternalError: too much recursion` *at page load*, before any code runs. See #2122.

## Fix

When a block has more than `merge_node_max` (default **10**) sibling merge-node targets, emit a flat selector-driven dispatch loop — a `for(;;)` around a `switch` — whose statement-nesting depth is **constant** regardless of the number of targets:

```js
var sel = 0;
L: for(;;){
  switch(sel){
    case 0: /* dispatch */ … if(…){ sel = 3; continue L; } …
    case 3: n = 5; sel = 1; continue L;
    case 2: n = 0;                 // adjacent to the join → falls through, no round-trip
    case 1: return n * 100 + len;  // the join
  }
  break;                           // a case that reaches the join leaves the loop here
}
```

The cases are laid out in the same textual order as the nested scheme (the dispatch, then the targets in reverse), and each is compiled with the textually-next case as its fall-through. So:

- A branch to the **next** case is elided and **falls through** in the `switch`, exactly as it would fall through in the nested scheme (no round-trip).
- A branch to any **other** target becomes `sel = i; continue L`.
- A branch to the **join** breaks out of the `switch` (unlabelled `break`) and the trailing `break` leaves the loop — or a labelled `break L` when it occurs inside a nested loop/switch in a case body.

The label `L` is only emitted when something actually routes through the loop. The threshold is exposed as `--set merge_node_max=N`, so the behaviour is tunable (and `merge_node_max=∞` restores the nested scheme).

## Validation

- On a 50-keyword string match, max brace-nesting depth drops from **56 → 12** with identical runtime output.
- Differential testing of control-flow-heavy programs (nested loops, exceptions, shared-continuation matches, `Printf`/`Format`) across `merge_node_max ∈ {0,1,2,5,…,∞}` × effects `{disabled, cps, double-translation}`: all outputs match native OCaml.
- `@compiler/tests-full/runtest` and `@compiler/tests-jsoo/runtest` pass; the generated stdlib is syntactically valid (`node --check`).
- At the default of 10, the only stdlib functions reshaped are the deeply nested (~10-level) format interpreters in `camlinternalFormat` (linked into every program that uses `Printf`/`Format`); they now compile to a flat dispatch loop and the output is marginally smaller. The `stdlib.cma.expected.js` snapshot is updated accordingly.
- `compiler/tests-compiler/gh2122.ml` pins the behaviour: the nested tower (before), the flat loop (after), and a non-independent-scope example showing where cases fall through to a shared join vs. route through the loop.

## Commits

1. Regression test capturing the nested-tower output.
2. The flat dispatch loop.
3. A non-independent-scope example (cases that feed a shared join).
4. Fall-through optimisation (adjacent cases fall through instead of routing).
5. Fix a latent "Break without loop" crash (`merge_node_max=0`): the loop-exit uses an unlabelled `break`.
6. Lower the `merge_node_max` default to 10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
