### PR TITLE
Runtime: only install the uncaughtException handler for standalone programs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,6 +50,11 @@
   whole-program builds emit reversed `Filename.concat` operands and
   silently broke `Filename.temp_file`
 * Runtime/wasm: fix string conversion from JS to OCaml (#2230)
+* Runtime: only install the process-wide "uncaughtException" handler when
+  the program is run directly (`node a.js`), not when it is loaded as a
+  library (`require("./a.js")`) or in the Node REPL, where it used to
+  override the host's error handling and abort the process on unrelated
+  errors (#1277)
 * Lib: fix several `Dom_html` bindings (#2221)
 * Lib: defer `Intl.{Collator,DateTimeFormat,...}` member lookups so the
   `Intl` module no longer throws at load time on hosts where

--- a/compiler/tests-compiler/error.ml
+++ b/compiler/tests-compiler/error.ml
@@ -120,3 +120,29 @@ let _ = null 1 2
   (try ignore (Str.search_forward (Str.regexp "TypeError: Cannot read") s 0)
    with Not_found -> print_endline s);
   [%expect {||}]
+
+let%expect_test "uncaught handler is not installed when loaded as a library (#1277)" =
+  (* When jsoo output is loaded with [require] (e.g. in the Node REPL or as a
+     library) rather than run directly, it must not register a process-wide
+     "uncaughtException" handler: doing so used to override the host's error
+     handling and abort the whole process on unrelated errors. *)
+  with_temp_dir ~f:(fun () ->
+      let _js_file =
+        {| let () = ignore (Sys.opaque_identity 0) |}
+        |> Filetype.ocaml_text_of_string
+        |> Filetype.write_ocaml ~name:"test.ml"
+        |> compile_ocaml_to_bc
+        |> compile_bc_to_javascript
+      in
+      let driver =
+        {|
+require("./test.js");
+console.log(
+  "uncaughtException listeners: " +
+    process.listenerCount("uncaughtException"));
+|}
+        |> Filetype.js_text_of_string
+        |> Filetype.write_js ~name:"driver.js"
+      in
+      print_string (run_javascript driver));
+  [%expect {| uncaughtException listeners: 0 |}]

--- a/runtime/js/sys.js
+++ b/runtime/js/sys.js
@@ -514,6 +514,18 @@ function caml_sys_const_standard_library_default(_unit) {
 function caml_setup_uncaught_exception_handler() {
   var process = globalThis.process;
   if (process?.on) {
+    // Only emulate OCaml's fatal-error behaviour (report the exception and
+    // exit with code 2) when the program is run directly, e.g. `node a.js`.
+    // When the generated code is loaded as a library (`require("./a.js")`) or
+    // in the Node REPL, registering a process-wide "uncaughtException" handler
+    // that calls process.exit would override the host's error handling and
+    // make unrelated errors abort the whole process. See ocsigen/js_of_ocaml#1277.
+    if (
+      typeof module !== "undefined" &&
+      typeof require !== "undefined" &&
+      require.main !== module
+    )
+      return;
     process.on("uncaughtException", function (err, origin) {
       caml_fatal_uncaught_exception(err);
       process.exit(2);
@@ -525,5 +537,10 @@ function caml_setup_uncaught_exception_handler() {
       }
     });
   }
+  // On QuickJS there is nothing to do: it exposes neither `process.on` nor
+  // `addEventListener`, so we install no global handler. The engine prints
+  // uncaught exceptions and exits itself, and loading the output as a library
+  // never overrides the host's error handling -- so no standalone guard like
+  // the one above (or `import.meta.main`) is needed here.
 }
 caml_setup_uncaught_exception_handler();

--- a/runtime/wasm/runtime.js
+++ b/runtime/wasm/runtime.js
@@ -796,9 +796,20 @@
   start_fiber = make_promising(caml_start_fiber);
   var _initialize = make_promising(_initialize);
   if (globalThis.process?.on) {
-    globalThis.process.on("uncaughtException", (err, _origin) =>
-      caml_handle_uncaught_exception(err),
-    );
+    // Only install the handler when run directly (`node a.js`), not when
+    // loaded as a library or in the REPL, where hijacking "uncaughtException"
+    // would override the host's error handling. See ocsigen/js_of_ocaml#1277.
+    if (
+      !(
+        typeof module !== "undefined" &&
+        typeof require !== "undefined" &&
+        require.main !== module
+      )
+    ) {
+      globalThis.process.on("uncaughtException", (err, _origin) =>
+        caml_handle_uncaught_exception(err),
+      );
+    }
   } else if (globalThis.addEventListener) {
     globalThis.addEventListener(
       "error",


### PR DESCRIPTION
Fixes #1277.

## Problem

The runtime registers a process-wide `uncaughtException` handler at module-load time (`runtime/js/sys.js`):

```js
process.on("uncaughtException", function (err, origin) {
  caml_fatal_uncaught_exception(err);
  process.exit(2);
});
```

This is meant to emulate native OCaml's fatal-error behaviour (print `Fatal error: exception …`, exit with code 2). But it runs unconditionally, even when the generated code is loaded as a library. As reported in #1277, requiring jsoo output in the Node REPL then overrides the host's error handling: an error completely unrelated to the OCaml code (e.g. a typo at the prompt) trips the handler and aborts the whole process via `process.exit(2)` instead of letting the REPL recover.

## Fix

Only install the handler when the program is run directly (`require.main === module`, e.g. `node a.js`), not when it is loaded via `require("./a.js")` or in the REPL. `module`/`require` are already in scope inside the runtime (the runtime uses `require("node:fs")` directly), so the check works through the IIFE wrapper. When the discriminator is unavailable (no CommonJS `module`, e.g. ESM/browser), the previous behaviour is preserved.

This matches the direction suggested on the issue: keep the fatal-error logic for standalone programs only.

The same guard is applied to the wasm_of_ocaml runtime (`runtime/wasm/runtime.js`).

## Behaviour after the fix

- `node a.js` — handler installed; an async uncaught exception still prints `Fatal error: exception …` and exits 2 (unchanged).
- `require("./a.js")` (library / REPL) — handler not installed; the host's own error handling applies, so unrelated errors no longer abort the process and the REPL recovers normally.

## Tests

Added a regression test in `compiler/tests-compiler/error.ml` that compiles a module, loads it from a driver via `require`, and asserts `process.listenerCount("uncaughtException") === 0`.