### PR TITLE
Benchmarks: measure compilation memory with %M, not %R

### DIFF
--- a/benchmarks/benchmark-fiat-crypto/Makefile
+++ b/benchmarks/benchmark-fiat-crypto/Makefile
@@ -11,7 +11,7 @@ bench:
 	@date -u +"%FT%TZ - $(NAME): done"
 
 perform: bedrock2_fiat_crypto.byte
-	/usr/bin/time -f "%E %R" $(COMPILER) --debug times --source-map $(EXTRA_ARGS) $< -o out.js 2>&1 | \
+	/usr/bin/time -f "%E %M" $(COMPILER) --debug times --source-map $(EXTRA_ARGS) $< -o out.js 2>&1 | \
 	ocaml -I +str str.cma ../utils/compilation_metrics.ml $(COMPILER) $(NAME) out.js | \
 	sh ../utils/aggregate.sh $(KIND)
 

--- a/benchmarks/benchmark-ocamlc/Makefile
+++ b/benchmarks/benchmark-ocamlc/Makefile
@@ -14,7 +14,7 @@ bench:
 ARGS=ml/*.ml ml/*.ml ml/*.ml ml/*.ml ml/*.ml ml/*.ml ml/*.ml ml/*.ml
 
 perform:
-	/usr/bin/time -f "%E %R" $(COMPILER) --debug times --opt 2 --pretty `which ocamlc.byte` -o $(SCRIPT) 2>&1 | \
+	/usr/bin/time -f "%E %M" $(COMPILER) --debug times --opt 2 --pretty `which ocamlc.byte` -o $(SCRIPT) 2>&1 | \
 	ocaml -I +str str.cma ../utils/compilation_metrics.ml $(COMPILER) $(NAME) $(SCRIPT) | \
 	sh ../utils/aggregate.sh $(KIND)
 	/usr/bin/time -f '{"compiler": "$(COMPILER)", "time":"%E"}' node $(SCRIPT) -c $(ARGS) 2>&1 | \

--- a/benchmarks/benchmark-partial-render-table/Makefile
+++ b/benchmarks/benchmark-partial-render-table/Makefile
@@ -14,7 +14,7 @@ bench:
 	@date -u +"%FT%TZ - $(NAME): done"
 
 perform:
-	/usr/bin/time -f "%E %R" $(COMPILER) --debug times --opt 2 --pretty main.bc-for-jsoo -o out.js 2>&1 | \
+	/usr/bin/time -f "%E %M" $(COMPILER) --debug times --opt 2 --pretty main.bc-for-jsoo -o out.js 2>&1 | \
 	tee /dev/stderr | \
 	ocaml -I +str str.cma ../utils/compilation_metrics.ml $(COMPILER) "$(NAME)" out.js | \
 	sh ../utils/aggregate.sh $(KIND)


### PR DESCRIPTION
The compilation benchmarks reported /usr/bin/time's %R (minor page faults) under the "Compilation memory usage" / KiB label. %R is a fault count, not memory. Use %M (maximum resident set size, in KiB), which matches what compilation_metrics.ml already expects.