### PR TITLE
Runtime: fix Ephemeron.blit_key clobbering the destination's data

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,8 @@
 * Compiler: fix missing conditional simplification (#2217)
 * Compiler: fix Js_assign.simpl (#2218)
 * Runtime: fix caml_oo_cache_id (#2224)
+* Runtime: `Ephemeron.blit_key` no longer overwrites the destination's
+  data with the source's data (#2263)
 * Runtime/wasm: fix Int64.of_string (#2223)
 * Compiler: don't rewrite `x = e + x` into `x += e` for the `Plus`
   operator; JavaScript `+` is not commutative for strings, which made

--- a/compiler/tests-jsoo/test_weak.ml
+++ b/compiler/tests-jsoo/test_weak.ml
@@ -152,3 +152,34 @@ let%expect_test _ =
   E.unset_data e;
   bool (E.check_data e);
   [%expect {| false |}]
+
+(* Regression test for https://github.com/ocsigen/js_of_ocaml/issues/2263:
+   [blit_key] must only copy keys; it must not modify the destination's
+   data. *)
+let%expect_test "blit_key does not touch data" =
+  let module E = Obj.Ephemeron in
+  let print_data e =
+    match E.get_data e with
+    | None -> print_endline "no data"
+    | Some d -> print_endline (Obj.obj d : string)
+  in
+  let k1 = Some 1 and k2 = Some 2 and k3 = Some 3 and k4 = Some 4 in
+  let src = E.create 2 in
+  let dst = E.create 2 in
+  E.set_key src 0 (Obj.repr k1);
+  E.set_key src 1 (Obj.repr k2);
+  E.set_key dst 0 (Obj.repr k3);
+  E.set_key dst 1 (Obj.repr k4);
+  E.set_data src (Obj.repr "src data");
+  E.set_data dst (Obj.repr "dst data");
+  E.blit_key src 0 dst 0 2;
+  print_data dst;
+  [%expect {| src data |}];
+  (* blitting from a source without data must not clear the destination's
+     data either *)
+  E.unset_data src;
+  E.set_data dst (Obj.repr "dst data");
+  E.blit_key src 0 dst 0 2;
+  print_data dst;
+  [%expect {| no data |}];
+  ignore (Sys.opaque_identity (k1, k2, k3, k4))

--- a/compiler/tests-jsoo/test_weak.ml
+++ b/compiler/tests-jsoo/test_weak.ml
@@ -174,12 +174,12 @@ let%expect_test "blit_key does not touch data" =
   E.set_data dst (Obj.repr "dst data");
   E.blit_key src 0 dst 0 2;
   print_data dst;
-  [%expect {| src data |}];
+  [%expect {| dst data |}];
   (* blitting from a source without data must not clear the destination's
      data either *)
   E.unset_data src;
   E.set_data dst (Obj.repr "dst data");
   E.blit_key src 0 dst 0 2;
   print_data dst;
-  [%expect {| no data |}];
+  [%expect {| dst data |}];
   ignore (Sys.opaque_identity (k1, k2, k3, k4))

--- a/runtime/js/weak.js
+++ b/runtime/js/weak.js
@@ -134,7 +134,10 @@ function caml_ephe_check_key(x, i) {
 //Requires: caml_ephe_set_data_opt
 //Alias: caml_weak_blit
 function caml_ephe_blit_key(a1, i1, a2, i2, len) {
-  var old = caml_ephe_get_data(a1);
+  // The data is stored wrapped in WeakMaps keyed on the (live) keys, so
+  // fetch the destination's data before changing its keys and store it
+  // back afterwards.
+  var old = caml_ephe_get_data(a2);
   // minus one because caml_array_blit works on ocaml array
   caml_array_blit(
     a1,


### PR DESCRIPTION
`caml_ephe_blit_key` in the JS runtime re-fetched the *source's* data and stored it into the destination, so blitting keys leaked the source's data into the destination — or cleared the destination's data when the source had none. Native (and the Wasm runtime) blit keys only.

The `get_data`/`set_data_opt` dance around the key blit is only there to re-key the WeakMap-wrapped data after the key array changes, so it must operate on the destination's own data.

Found while reviewing the Wasm runtime against the JS runtime; one item of #2263.

The first commit adds the regression test with the buggy output recorded (red on native/wasm, green on js); the second commit fixes the runtime and flips the expectations to the correct output (green everywhere).

🤖 Generated with [Claude Code](https://claude.com/claude-code)