### PR TITLE
Runtime: honor Open_append on the fake filesystem

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,6 +49,8 @@
   data with the source's data (#2263)
 * Runtime: the `#` flag no longer adds a base prefix to zero;
   `Printf.printf "%#x" 0` printed `0x0` where native prints `0`
+* Runtime: the fake filesystem no longer ignores `Open_append`; writes
+  on an append-mode channel used to overwrite the file from the start
 * Runtime/wasm: fix Int64.of_string (#2223)
 * Compiler: don't rewrite `x = e + x` into `x += e` for the `Plus`
   operator; JavaScript `+` is not commutative for strings, which made

--- a/lib/tests/test_sys.ml
+++ b/lib/tests/test_sys.ml
@@ -125,4 +125,4 @@ let%expect_test "open_out_gen Open_append" =
   let c = open_in_bin name in
   Printf.printf "[%s]" (In_channel.input_all c);
   close_in c;
-  [%expect {| [ world] |}]
+  [%expect {| [hello world] |}]

--- a/lib/tests/test_sys.ml
+++ b/lib/tests/test_sys.ml
@@ -111,3 +111,18 @@ let%expect_test _ =
   let content' = Sys_js.read_file ~name:"/static/temp0" in
   assert (content' = content);
   [%expect {||}]
+
+(* Opening a file with [Open_append] must position writes at the end of
+   the existing content, not overwrite it from the start. *)
+let%expect_test "open_out_gen Open_append" =
+  let name = "/static/append.txt" in
+  let c = open_out_bin name in
+  output_string c "hello";
+  close_out c;
+  let c = open_out_gen [ Open_wronly; Open_append; Open_binary ] 0o666 name in
+  output_string c " world";
+  close_out c;
+  let c = open_in_bin name in
+  Printf.printf "[%s]" (In_channel.input_all c);
+  close_in c;
+  [%expect {| [ world] |}]

--- a/runtime/js/fs_fake.js
+++ b/runtime/js/fs_fake.js
@@ -481,7 +481,7 @@ class MlFakeFd {
     this.file = file;
     this.name = name;
     this.flags = flags;
-    this.offset = 0;
+    this.offset = flags.append ? file.length() : 0;
     this.seeked = false;
   }
 


### PR DESCRIPTION
`MlFakeFd` ignored `flags.append` and always started writing at offset 0, so a channel opened with `Open_append` on the fake filesystem overwrote the existing content instead of appending. The fd offset is now initialized to the file size when the append flag is set, matching the node backend (`MlNodeFd`).

Found during a correctness review of the JS runtime (follow-up to the Wasm runtime review in #2263).

The first commit adds the regression test with the buggy output recorded; the second commit fixes the runtime and flips the expectation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)