### PR TITLE
Runtime: the '#' flag must not add a base prefix to zero

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,6 +47,8 @@
 * Runtime: fix caml_oo_cache_id (#2224)
 * Runtime: `Ephemeron.blit_key` no longer overwrites the destination's
   data with the source's data (#2263)
+* Runtime: the `#` flag no longer adds a base prefix to zero;
+  `Printf.printf "%#x" 0` printed `0x0` where native prints `0`
 * Runtime/wasm: fix Int64.of_string (#2223)
 * Compiler: don't rewrite `x = e + x` into `x += e` for the `Plus`
   operator; JavaScript `+` is not commutative for strings, which made

--- a/compiler/tests-jsoo/test_ints.ml
+++ b/compiler/tests-jsoo/test_ints.ml
@@ -80,3 +80,24 @@ let%expect_test _ =
   [%expect {| overflow |}];
   check_fail "-9223372036854775809";
   [%expect {| overflow |}]
+
+(* The '#' (alternate) flag must not add a base prefix to zero: native
+   prints "0" for %#x / %#X / %#o of 0, like C printf. *)
+let%expect_test "alternate flag with zero" =
+  Printf.printf "[%#x]\n" 0;
+  [%expect {| [0x0] |}];
+  Printf.printf "[%#X]\n" 0;
+  [%expect {| [0X0] |}];
+  Printf.printf "[%#o]\n" 0;
+  [%expect {| [00] |}];
+  Printf.printf "[%#6x]\n" 0;
+  [%expect {| [   0x0] |}];
+  Printf.printf "[%#lx]\n" 0l;
+  [%expect {| [0x0] |}];
+  Printf.printf "[%#Lx]\n" 0L;
+  [%expect {| [0x0] |}];
+  (* non-zero values keep the prefix *)
+  Printf.printf "[%#x]\n" 255;
+  [%expect {| [0xff] |}];
+  Printf.printf "[%#o]\n" 8;
+  [%expect {| [010] |}]

--- a/compiler/tests-jsoo/test_ints.ml
+++ b/compiler/tests-jsoo/test_ints.ml
@@ -85,17 +85,17 @@ let%expect_test _ =
    prints "0" for %#x / %#X / %#o of 0, like C printf. *)
 let%expect_test "alternate flag with zero" =
   Printf.printf "[%#x]\n" 0;
-  [%expect {| [0x0] |}];
+  [%expect {| [0] |}];
   Printf.printf "[%#X]\n" 0;
-  [%expect {| [0X0] |}];
+  [%expect {| [0] |}];
   Printf.printf "[%#o]\n" 0;
-  [%expect {| [00] |}];
+  [%expect {| [0] |}];
   Printf.printf "[%#6x]\n" 0;
-  [%expect {| [   0x0] |}];
+  [%expect {| [     0] |}];
   Printf.printf "[%#lx]\n" 0l;
-  [%expect {| [0x0] |}];
+  [%expect {| [0] |}];
   Printf.printf "[%#Lx]\n" 0L;
-  [%expect {| [0x0] |}];
+  [%expect {| [0] |}];
   (* non-zero values keep the prefix *)
   Printf.printf "[%#x]\n" 255;
   [%expect {| [0xff] |}];

--- a/runtime/js/format.js
+++ b/runtime/js/format.js
@@ -120,7 +120,9 @@ function caml_finish_formatting(f, rawbuffer) {
   var len = rawbuffer.length;
   /* Adjust len to reflect additional chars (sign, etc) */
   if (f.signedconv && (f.sign < 0 || f.signstyle !== "-")) len++;
-  if (f.alternate) {
+  // Like C printf, the alternate flag only prefixes non-zero values
+  var alternate = f.alternate && rawbuffer !== "0";
+  if (alternate) {
     if (f.base === 8) len += 1;
     if (f.base === 16) len += 2;
   }
@@ -132,8 +134,8 @@ function caml_finish_formatting(f, rawbuffer) {
     if (f.sign < 0) buffer += "-";
     else if (f.signstyle !== "-") buffer += f.signstyle;
   }
-  if (f.alternate && f.base === 8) buffer += "0";
-  if (f.alternate && f.base === 16) buffer += f.uppercase ? "0X" : "0x";
+  if (alternate && f.base === 8) buffer += "0";
+  if (alternate && f.base === 16) buffer += f.uppercase ? "0X" : "0x";
   if (f.justify === "+" && f.filler === "0")
     for (var i = len; i < f.width; i++) buffer += "0";
   buffer += rawbuffer;


### PR DESCRIPTION
`caml_finish_formatting` added `0x`/`0X`/`0` whenever the alternate flag was set, but C printf (and hence native `caml_format_int`, and the Wasm runtime) only prefixes non-zero values: `Printf.printf "%#x" 0` printed `0x0` where native prints `0` (and `%#o` printed `00`). The value itself is not available in `caml_finish_formatting`, but for integer conversions zero always yields the raw digit string `"0"`, so the prefix is now skipped in that case. This covers the int, int32, nativeint, and int64 formatting paths in one place; float conversions never set `base` and are unaffected.

The Wasm runtime already guards its prefix on a non-zero value, so no counterpart change is needed there.

Found during a correctness review of the JS runtime (follow-up to the Wasm runtime review in #2263).

The first commit adds the regression test with the buggy output recorded (covering `%#x`, `%#X`, `%#o`, width, `%#lx`, `%#Lx`, and non-zero sanity cases); the second commit fixes the runtime and flips the expectations — the native (`best`) test mode passing confirms the corrected expectations match real OCaml output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)