### PR TITLE
Runtime: Open_append must imply write access

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -51,6 +51,9 @@
   `Printf.printf "%#x" 0` printed `0x0` where native prints `0`
 * Runtime: the fake filesystem no longer ignores `Open_append`; writes
   on an append-mode channel used to overwrite the file from the start
+* Runtime: `Open_append` now implies write access, as in the C runtime
+  (`O_WRONLY | O_APPEND`); `open_out_gen [Open_append; Open_creat]`
+  used to produce a channel that fails on write
 * Runtime/wasm: fix Int64.of_string (#2223)
 * Compiler: don't rewrite `x = e + x` into `x += e` for the `Plus`
   operator; JavaScript `+` is not commutative for strings, which made

--- a/lib/tests/test_sys.ml
+++ b/lib/tests/test_sys.ml
@@ -126,3 +126,17 @@ let%expect_test "open_out_gen Open_append" =
   Printf.printf "[%s]" (In_channel.input_all c);
   close_in c;
   [%expect {| [hello world] |}]
+
+(* [Open_append] implies write permission: the C runtime maps it to
+   O_WRONLY | O_APPEND. *)
+let%expect_test "Open_append implies write access" =
+  let name = "/static/append_wronly.txt" in
+  (try
+     let c = open_out_gen [ Open_append; Open_creat; Open_binary ] 0o666 name in
+     output_string c "hello";
+     close_out c;
+     let c = open_in_bin name in
+     Printf.printf "[%s]" (In_channel.input_all c);
+     close_in c
+   with Sys_error msg -> print_endline ("Sys_error: " ^ msg));
+  [%expect {| Sys_error: EBADF: bad file descriptor, write |}]

--- a/lib/tests/test_sys.ml
+++ b/lib/tests/test_sys.ml
@@ -139,4 +139,4 @@ let%expect_test "Open_append implies write access" =
      Printf.printf "[%s]" (In_channel.input_all c);
      close_in c
    with Sys_error msg -> print_endline ("Sys_error: " ^ msg));
-  [%expect {| Sys_error: EBADF: bad file descriptor, write |}]
+  [%expect {| [hello] |}]

--- a/runtime/js/io.js
+++ b/runtime/js/io.js
@@ -70,8 +70,10 @@ function caml_sys_open(name, flags, perms) {
         f.wronly = 1;
         break;
       case 2:
+        // Open_append implies write access (O_WRONLY | O_APPEND in the
+        // C runtime)
         f.append = 1;
-        f.writeonly = 1;
+        f.wronly = 1;
         break;
       case 3:
         f.create = 1;


### PR DESCRIPTION
`caml_sys_open` set `f.writeonly` for `Open_append` — a typo for `f.wronly` that nothing reads. In the C runtime `Open_append` maps to `O_WRONLY | O_APPEND`, so `open_out_gen [Open_append; Open_creat]` (without an explicit `Open_wronly`) must grant write access. Without it:

- the fake device rejected writes with `EBADF` (its write path checks `flags.wronly || flags.rdwr`);
- the node and quickjs backends OR'd only `O_APPEND` into the open flags, leaving the fd with an `O_RDONLY` access mode, so writes failed at the OS level.

Adding `wronly` ORs in `O_WRONLY` exactly as the C runtime does; the append+wronly combination doesn't change behavior for callers that already passed `Open_wronly` explicitly.

Found during a correctness review of the JS runtime (follow-up to the Wasm runtime review in #2263).

The first commit adds the regression test with the buggy behavior recorded (`Sys_error: EBADF: bad file descriptor, write` on flush); the second commit fixes the runtime and flips the expectation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)