### PR TITLE
Runtime: Sys.rename to the same path must not delete the file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -54,6 +54,8 @@
 * Runtime: `Open_append` now implies write access, as in the C runtime
   (`O_WRONLY | O_APPEND`); `open_out_gen [Open_append; Open_creat]`
   used to produce a channel that fails on write
+* Runtime: renaming a file to itself on the fake filesystem no longer
+  deletes it
 * Runtime/wasm: fix Int64.of_string (#2223)
 * Compiler: don't rewrite `x = e + x` into `x += e` for the `Plus`
   operator; JavaScript `+` is not commutative for strings, which made

--- a/lib/tests/test_sys.ml
+++ b/lib/tests/test_sys.ml
@@ -155,4 +155,4 @@ let%expect_test "Sys.rename to itself" =
     Printf.printf "[%s]" (In_channel.input_all c);
     close_in c)
   else print_endline "gone";
-  [%expect {| gone |}]
+  [%expect {| [hello] |}]

--- a/lib/tests/test_sys.ml
+++ b/lib/tests/test_sys.ml
@@ -140,3 +140,19 @@ let%expect_test "Open_append implies write access" =
      close_in c
    with Sys_error msg -> print_endline ("Sys_error: " ^ msg));
   [%expect {| [hello] |}]
+
+(* Renaming a file to itself must succeed and leave the file intact
+   (POSIX rename is a no-op in that case). *)
+let%expect_test "Sys.rename to itself" =
+  let name = "/static/rename_self.txt" in
+  let c = open_out_bin name in
+  output_string c "hello";
+  close_out c;
+  Sys.rename name name;
+  if Sys.file_exists name
+  then (
+    let c = open_in_bin name in
+    Printf.printf "[%s]" (In_channel.input_all c);
+    close_in c)
+  else print_endline "gone";
+  [%expect {| gone |}]

--- a/runtime/js/fs_fake.js
+++ b/runtime/js/fs_fake.js
@@ -112,8 +112,10 @@ class MlFakeDevice {
           this.nm(newname) + " : file already exists and is a directory",
         );
       }
-      this.content[newname] = this.content[oldname];
-      delete this.content[oldname];
+      if (newname !== oldname) {
+        this.content[newname] = this.content[oldname];
+        delete this.content[oldname];
+      }
     }
   }
 


### PR DESCRIPTION
The fake device's `rename` copied the directory entry onto itself and then deleted it, so renaming a file to its own path removed the file. POSIX `rename` succeeds and does nothing when both paths name the same file, and the native runtime complies.

Found during a correctness review of the JS runtime (follow-up to the Wasm runtime review in #2263).

The first commit adds the regression test with the buggy behavior recorded (the file is gone after `Sys.rename name name`); the second commit fixes the runtime and flips the expectation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)