### PR TITLE
Runtime: flush on a closed channel must do nothing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -56,6 +56,8 @@
   used to produce a channel that fails on write
 * Runtime: renaming a file to itself on the fake filesystem no longer
   deletes it
+* Runtime: `flush` on a closed out_channel no longer raises; the manual
+  specifies it does nothing in that case
 * Runtime/wasm: fix Int64.of_string (#2223)
 * Compiler: don't rewrite `x = e + x` into `x += e` for the `Plus`
   operator; JavaScript `+` is not commutative for strings, which made

--- a/lib/tests/test_sys.ml
+++ b/lib/tests/test_sys.ml
@@ -156,3 +156,18 @@ let%expect_test "Sys.rename to itself" =
     close_in c)
   else print_endline "gone";
   [%expect {| [hello] |}]
+
+(* From the manual (close_out): "Output functions raise a Sys_error
+   exception when they are applied to a closed output channel, except
+   close_out and flush, which do nothing when applied to an already
+   closed channel." *)
+let%expect_test "flush on closed channel" =
+  let name = "/static/flush_closed.txt" in
+  let c = open_out_bin name in
+  output_string c "hello";
+  close_out c;
+  (try
+     flush c;
+     print_endline "ok"
+   with Sys_error msg -> print_endline ("Sys_error: " ^ msg));
+  [%expect {| Sys_error: Cannot flush a closed channel |}]

--- a/lib/tests/test_sys.ml
+++ b/lib/tests/test_sys.ml
@@ -170,4 +170,4 @@ let%expect_test "flush on closed channel" =
      flush c;
      print_endline "ok"
    with Sys_error msg -> print_endline ("Sys_error: " ^ msg));
-  [%expect {| Sys_error: Cannot flush a closed channel |}]
+  [%expect {| ok |}]

--- a/runtime/js/io.js
+++ b/runtime/js/io.js
@@ -563,11 +563,11 @@ function caml_ml_input_scan_line(chanid) {
 }
 
 //Provides: caml_ml_flush
-//Requires: caml_raise_sys_error, caml_ml_channel_get
+//Requires: caml_ml_channel_get
 //Requires: caml_sub_uint8_array_to_jsbytes
 function caml_ml_flush(chanid) {
   var chan = caml_ml_channel_get(chanid);
-  if (!chan.opened) caml_raise_sys_error("Cannot flush a closed channel");
+  if (!chan.opened) return 0;
   if (!chan.buffer || chan.buffer_curr === 0) return 0;
   if (chan.output) {
     chan.output(


### PR DESCRIPTION
`caml_ml_flush` raised `Sys_error "Cannot flush a closed channel"`, but the manual is explicit (doc of `close_out`): "Output functions raise a Sys_error exception when they are applied to a closed output channel, except `close_out` and `flush`, which do nothing when applied to an already closed channel." The native runtime complies; the JS runtime now returns silently.

Found during a correctness review of the JS runtime (follow-up to the Wasm runtime review in #2263).

The first commit adds the regression test with the buggy behavior recorded; the second commit fixes the runtime and flips the expectation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)