### PR TITLE
Runtime: zero-extend bigarray hash tail elements (JS and Wasm)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -233,6 +233,10 @@
   translation; this fixes `ba_to_ba` (where the read position was
   translated but the write position was not) as well as `string_to_ba`,
   `bytes_to_ba` and `ba_to_bytes` for fortran_layout bigarrays
+* Runtime: bigarray hashing now zero-extends tail elements as the C
+  runtime does; signed 8/16-bit bigarrays whose size is not a multiple
+  of the hashed word size hashed differently from native (and the byte
+  case trapped under WASI on the Wasm runtime)
 * Runtime: the `#` flag no longer adds a base prefix to zero;
   `Printf.printf "%#x" 0` printed `0x0` where native prints `0`
 * Runtime: the fake filesystem no longer ignores `Open_append`; writes

--- a/compiler/tests-jsoo/dune
+++ b/compiler/tests-jsoo/dune
@@ -201,6 +201,7 @@
   (pps ppx_expect)))
 
 ; test_bigarray uses the float16 kind, which requires OCaml 5.2.
+
 (library
  (name jsoo_testsuite_bigarray)
  (modules test_bigarray)

--- a/compiler/tests-jsoo/dune
+++ b/compiler/tests-jsoo/dune
@@ -192,7 +192,23 @@
  (libraries unix compiler-libs.common js_of_ocaml-compiler)
  (foreign_stubs
   (language c)
-  (names bigarray_stubs jsoo_runtime_stubs))
+  (names jsoo_runtime_stubs))
+ (inline_tests
+  (deps
+   (sandbox preserve_file_kind))
+  (modes js wasm best))
+ (preprocess
+  (pps ppx_expect)))
+
+; test_bigarray uses the float16 kind, which requires OCaml 5.2.
+(library
+ (name jsoo_testsuite_bigarray)
+ (modules test_bigarray)
+ (enabled_if
+  (>= %{ocaml_version} 5.2))
+ (foreign_stubs
+  (language c)
+  (names bigarray_stubs))
  (inline_tests
   (deps
    (sandbox preserve_file_kind))
@@ -232,7 +248,7 @@
  (name test_float16)
  (build_if
   (>= %{ocaml_version} 5.2))
- (modules test_float16 test_bigarray)
+ (modules test_float16)
  (modes js wasm native))
 
 (test

--- a/compiler/tests-jsoo/test_bigarray.ml
+++ b/compiler/tests-jsoo/test_bigarray.ml
@@ -396,15 +396,15 @@ let%expect_test "hash with tail elements" =
   test_hash "int16_unsigned" int16_unsigned Fun.id 5;
   [%expect
     {|
-    3219615e int8_signed 5
+    032d048f int8_signed 5
     032d048f int8_unsigned 5
     032d048f char 5
-    3219615e int8_signed 6
+    3c24ece4 int8_signed 6
     3c24ece4 int8_unsigned 6
     3c24ece4 char 6
-    3219615e int8_signed 7
+    292ac2a1 int8_signed 7
     292ac2a1 int8_unsigned 7
     292ac2a1 char 7
-    0f00e0d4 int16_signed 5
+    30682b2c int16_signed 5
     30682b2c int16_unsigned 5
     |}]

--- a/compiler/tests-jsoo/test_bigarray.ml
+++ b/compiler/tests-jsoo/test_bigarray.ml
@@ -372,3 +372,39 @@ let%expect_test "bigstring blit positions are raw offsets" =
   blit_ba_to_bytes src 1 buf 0 3;
   print_endline (Bytes.to_string buf);
   [%expect {| bcd--- |}]
+
+let%expect_test "hash with tail elements" =
+  (* Sizes that are not multiples of the hashed word size exercise the
+     tail handling, which must zero-extend the elements as the C
+     runtime does (hash.c reads bytes as unsigned char and 16-bit
+     elements as uint16). High values at tail positions catch
+     sign-extension. *)
+  let test_hash nm kind conv sz =
+    let a = Array1.create kind c_layout sz in
+    for i = 0 to sz - 1 do
+      a.{i} <- conv (i - 10)
+    done;
+    Printf.printf "%08x %s %d\n" (Hashtbl.hash a) nm sz
+  in
+  List.iter
+    ~f:(fun sz ->
+      test_hash "int8_signed" int8_signed Fun.id sz;
+      test_hash "int8_unsigned" int8_unsigned Fun.id sz;
+      test_hash "char" char (fun i -> Char.chr (i land 0xff)) sz)
+    [ 5; 6; 7 ];
+  test_hash "int16_signed" int16_signed Fun.id 5;
+  test_hash "int16_unsigned" int16_unsigned Fun.id 5;
+  [%expect
+    {|
+    3219615e int8_signed 5
+    032d048f int8_unsigned 5
+    032d048f char 5
+    3219615e int8_signed 6
+    3c24ece4 int8_unsigned 6
+    3c24ece4 char 6
+    3219615e int8_signed 7
+    292ac2a1 int8_unsigned 7
+    292ac2a1 char 7
+    0f00e0d4 int16_signed 5
+    30682b2c int16_unsigned 5
+    |}]

--- a/runtime/js/bigarray.js
+++ b/runtime/js/bigarray.js
@@ -1013,14 +1013,14 @@ function caml_ba_hash(ba) {
       switch (num_elts & 3) {
         // biome-ignore lint/suspicious/noFallthroughSwitchClause: falls through
         case 3:
-          w = ba.data[i + 2] << 16;
+          w = (ba.data[i + 2] & 0xff) << 16;
         // falls through
         // biome-ignore lint/suspicious/noFallthroughSwitchClause: falls through
         case 2:
-          w |= ba.data[i + 1] << 8;
+          w |= (ba.data[i + 1] & 0xff) << 8;
         // falls through
         case 1:
-          w |= ba.data[i + 0];
+          w |= ba.data[i + 0] & 0xff;
           h = caml_hash_mix_int(h, w);
       }
       break;
@@ -1033,7 +1033,7 @@ function caml_ba_hash(ba) {
         w = (ba.data[i + 0] & 0xffff) | (ba.data[i + 1] << 16);
         h = caml_hash_mix_int(h, w);
       }
-      if ((num_elts & 1) !== 0) h = caml_hash_mix_int(h, ba.data[i]);
+      if ((num_elts & 1) !== 0) h = caml_hash_mix_int(h, ba.data[i] & 0xffff);
       break;
     case 6: // Int32Array (int32)
       if (num_elts > 64) num_elts = 64;

--- a/runtime/wasm/bigarray.wat
+++ b/runtime/wasm/bigarray.wat
@@ -875,7 +875,7 @@
                    (local.set $h
                       (call $caml_hash_mix_int
                          (local.get $h)
-                         (call $dv_get_i32
+                         (call $dv_get_i32_unaligned
                             (local.get $view) (local.get $i) (i32.const 1))))
                    (local.set $i (i32.add (local.get $i) (i32.const 4)))
                    (br $loop))))
@@ -897,7 +897,7 @@
                                (i32.const 8)))))
              (local.set $w
                 (i32.or (local.get $w)
-                   (call $dv_get_i8 (local.get $view) (local.get $i))))
+                   (call $dv_get_ui8 (local.get $view) (local.get $i))))
              (local.set $h
                 (call $caml_hash_mix_int (local.get $h) (local.get $w))))
           (return (local.get $h)))


### PR DESCRIPTION
The C runtime (`caml_ba_hash` in hash.c) reads tail bytes as `unsigned char` and 16-bit tail elements as `uint16`. Both jsoo runtimes got this wrong, in different ways:

- **JS** read tail elements through the typed array, sign-extending for the int8/int16 kinds. The sign-extended last byte ORs over the other tail bytes, so `int8_signed` bigarrays of sizes 5, 6 and 7 (same leading bytes, high tail bytes) all hash to the same value — and none of them match native.
- **Wasm** sign-extended the last tail byte (`dv_get_i8`) for every byte kind (int8/uint8/char). Additionally, its byte-kind word loop used the aligned `dv_get_i32`, which under WASI casts the backing array to `$i32_array` and traps — byte-kind bigarrays are backed by `$i8_array`. It now uses `dv_get_i32_unaligned` (identical behavior on the JS-bindings path, byte-wise reads under WASI).

These are the bigarray-hash items from #2263 and the follow-up JS runtime review.

Commits:
1. **Revive the test_bigarray expect tests** — `test_bigarray.ml` was sitting in the `test_float16` `(test)` stanza, which has no ppx_expect preprocessing and no inline-test runner: the module didn't compile (`Uninterpreted extension 'expect_test'`) and its tests never ran. It now has its own inline-tests library (gated on OCaml ≥ 5.2 for the float16 kind), taking `bigarray_stubs.c` with it. This is also why the bug survived: the pre-existing hash test only used sizes 20 and 300, which never leave a tail.
2. **Regression test** with tail-exercising sizes and high tail values, expectations recording the buggy JS values (including the size-5/6/7 collision).
3. **The fix** in both runtimes, expectations flipped to the native ground truth — the test passes identically under js and native (`best`); native passing confirms the values, and the unsigned kinds (which were already correct in JS) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)