### PR TITLE
Runtime: handle nan in float16 bigarray comparison

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -74,6 +74,8 @@
   object (#2270)
 * Runtime: fix `Int64.shift_right` for negative values and shift
   counts 41 to 47; the sign bits did not reach the low limb (#2270)
+* Runtime: comparison of float16 bigarrays now handles nan like the
+  other float kinds; a nan element used to compare equal to anything
 * Runtime: the `#` flag no longer adds a base prefix to zero;
   `Printf.printf "%#x" 0` printed `0x0` where native prints `0`
 * Runtime: the fake filesystem no longer ignores `Open_append`; writes

--- a/compiler/tests-jsoo/test_bigarray.ml
+++ b/compiler/tests-jsoo/test_bigarray.ml
@@ -116,9 +116,9 @@ let%expect_test "compare elt" =
   test float16 Float.to_string nan nan;
   [%expect {| nan = nan: Bigarray compare the same |}];
   test float16 Float.to_string nan 1.0;
-  [%expect {| nan < 1. vs nan = 1.: Bigarray compare differently |}];
+  [%expect {| nan < 1.: Bigarray compare the same |}];
   test float16 Float.to_string 1.0 nan;
-  [%expect {| 1. > nan vs 1. = nan: Bigarray compare differently |}];
+  [%expect {| 1. > nan: Bigarray compare the same |}];
   test int8_signed Int.to_string (-1) 1;
   [%expect {| -1 < 1: Bigarray compare the same |}];
   test int8_unsigned Int.to_string (-1) 1;
@@ -334,4 +334,4 @@ let%expect_test "float16 equality with nan" =
      the total order where nan equals nan. *)
   let a = from_list float16 [ nan ] in
   Printf.printf "%b %b\n" (a = a) (compare a a = 0);
-  [%expect {| true true |}]
+  [%expect {| false true |}]

--- a/compiler/tests-jsoo/test_bigarray.ml
+++ b/compiler/tests-jsoo/test_bigarray.ml
@@ -111,6 +111,14 @@ let%expect_test "compare elt" =
   [%expect {| 0. < 1.: Bigarray compare the same |}];
   test float64 Float.to_string nan nan;
   [%expect {| nan = nan: Bigarray compare the same |}];
+  test float16 Float.to_string 1.0 2.0;
+  [%expect {| 1. < 2.: Bigarray compare the same |}];
+  test float16 Float.to_string nan nan;
+  [%expect {| nan = nan: Bigarray compare the same |}];
+  test float16 Float.to_string nan 1.0;
+  [%expect {| nan < 1. vs nan = 1.: Bigarray compare differently |}];
+  test float16 Float.to_string 1.0 nan;
+  [%expect {| 1. > nan vs 1. = nan: Bigarray compare differently |}];
   test int8_signed Int.to_string (-1) 1;
   [%expect {| -1 < 1: Bigarray compare the same |}];
   test int8_unsigned Int.to_string (-1) 1;
@@ -319,3 +327,11 @@ let%expect_test "hash" =
     1c259f64 int64 300
     1e14ef2b nativeint 20
     314148ee nativeint 300 |}]
+
+let%expect_test "float16 equality with nan" =
+  (* nan <> nan, so structural equality on a bigarray containing a nan
+     must be false (the comparison is unordered), while [compare] uses
+     the total order where nan equals nan. *)
+  let a = from_list float16 [ nan ] in
+  Printf.printf "%b %b\n" (a = a) (compare a a = 0);
+  [%expect {| true true |}]

--- a/runtime/js/bigarray.js
+++ b/runtime/js/bigarray.js
@@ -410,6 +410,11 @@ class Ml_Bigarray {
           var bb = caml_double_of_float16(b.data[i]);
           if (aa < bb) return -1;
           if (aa > bb) return 1;
+          if (aa !== bb) {
+            if (!total) return Number.NaN;
+            if (!Number.isNaN(aa)) return 1;
+            if (!Number.isNaN(bb)) return -1;
+          }
         }
         break;
       case 2:


### PR DESCRIPTION
`Ml_Bigarray.compare`'s float16 case (kind 13) only tested `<` and `>`, so a nan element fell through both and compared **equal to anything**: `compare [|nan|] [|1.0|]` returned 0 instead of -1, and structural equality on a bigarray containing nan returned true instead of false. The float32/float64 branch directly above has the correct logic (unordered when not total, nan-first in the total order), and the Wasm runtime's float16 compare already gets this right — only the JS runtime was missing it.

One of the bigarray findings from the JS runtime review (follow-up to #2263).

Stacked on #2271 (based on `fix-bigarray-hash-sign`), because the regression tests live in `test_bigarray.ml`, which only compiles and runs again with the test-revival commit from that PR. GitHub should retarget this to master automatically once #2271 merges.

The first commit adds float16 compare cases (nan vs number, both-nan, plain ordering) and a structural-equality-with-nan test, with the buggy JS behavior recorded; the second commit fixes the runtime and flips the expectations — verified identical under js and native.

🤖 Generated with [Claude Code](https://claude.com/claude-code)