### PR TITLE
Runtime: use raw offsets in the caml_bigstring_blit_* primitives

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -185,10 +185,12 @@
   caml_callback; with `--effects=cps` they silently never ran, and
   `Gc.counters` now returns an ordinary tuple instead of a float-array
   block (#2279)
-* Runtime: `caml_bigstring_blit_ba_to_ba` now treats positions as raw
-  offsets on both sides, like the C and Wasm implementations; the read
-  position went through the layout-aware index translation while the
-  write position did not
+* Runtime: the `caml_bigstring_blit_*` primitives now treat bigarray
+  positions as raw offsets, like base_bigstring's native stubs and the
+  Wasm runtime, instead of running them through the layout-aware index
+  translation; this fixes `ba_to_ba` (where the read position was
+  translated but the write position was not) as well as `string_to_ba`,
+  `bytes_to_ba` and `ba_to_bytes` for fortran_layout bigarrays
 * Runtime: the `#` flag no longer adds a base prefix to zero;
   `Printf.printf "%#x" 0` printed `0x0` where native prints `0`
 * Runtime: the fake filesystem no longer ignores `Open_append`; writes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -185,6 +185,10 @@
   caml_callback; with `--effects=cps` they silently never ran, and
   `Gc.counters` now returns an ordinary tuple instead of a float-array
   block (#2279)
+* Runtime: `caml_bigstring_blit_ba_to_ba` now treats positions as raw
+  offsets on both sides, like the C and Wasm implementations; the read
+  position went through the layout-aware index translation while the
+  write position did not
 * Runtime: the `#` flag no longer adds a base prefix to zero;
   `Printf.printf "%#x" 0` printed `0x0` where native prints `0`
 * Runtime: the fake filesystem no longer ignores `Open_append`; writes

--- a/compiler/tests-jsoo/test_bigarray.ml
+++ b/compiler/tests-jsoo/test_bigarray.ml
@@ -350,10 +350,10 @@ let%expect_test "bigstring blit positions are raw offsets" =
   let dst = mk "------" in
   blit_ba_to_ba src 1 dst 2 3;
   print_endline (to_string dst);
-  [%expect {| --abc- |}];
+  [%expect {| --bcd- |}];
   let dst = mk "------" in
   (try
      blit_ba_to_ba src 0 dst 0 2;
      print_endline (to_string dst)
    with Invalid_argument msg -> print_endline ("Invalid_argument: " ^ msg));
-  [%expect {| Invalid_argument: index out of bounds |}]
+  [%expect {| ab---- |}]

--- a/compiler/tests-jsoo/test_bigarray.ml
+++ b/compiler/tests-jsoo/test_bigarray.ml
@@ -337,9 +337,10 @@ let%expect_test "float16 equality with nan" =
   [%expect {| false true |}]
 
 let%expect_test "bigstring blit positions are raw offsets" =
-  (* The reference C implementation of caml_bigstring_blit_ba_to_ba is
-     layout-blind: positions are offsets from the start of the data,
-     even for fortran_layout bigarrays. *)
+  (* These primitives back base_bigstring's bigstring_blit_* stubs,
+     whose C code is layout-blind: positions are offsets from the start
+     of the data, even for fortran_layout bigarrays. The bigarray_stubs.c
+     in this directory mirrors that for the native build of this test. *)
   let mk l =
     let a = Array1.create char fortran_layout (String.length l) in
     String.iteri ~f:(fun i c -> a.{i + 1} <- c) l;
@@ -356,4 +357,18 @@ let%expect_test "bigstring blit positions are raw offsets" =
      blit_ba_to_ba src 0 dst 0 2;
      print_endline (to_string dst)
    with Invalid_argument msg -> print_endline ("Invalid_argument: " ^ msg));
-  [%expect {| ab---- |}]
+  [%expect {| ab---- |}];
+  (* The string/bytes variants are layout-blind in the same way: a
+     fortran_layout destination is still indexed from raw offset 0. *)
+  let dst = mk "------" in
+  blit_string_to_ba "XY" 0 dst 2 2;
+  print_endline (to_string dst);
+  [%expect {| --XY-- |}];
+  let dst = mk "------" in
+  blit_bytes_to_ba (Bytes.of_string "XY") 0 dst 2 2;
+  print_endline (to_string dst);
+  [%expect {| --XY-- |}];
+  let buf = Bytes.make 6 '-' in
+  blit_ba_to_bytes src 1 buf 0 3;
+  print_endline (Bytes.to_string buf);
+  [%expect {| bcd--- |}]

--- a/compiler/tests-jsoo/test_bigarray.ml
+++ b/compiler/tests-jsoo/test_bigarray.ml
@@ -335,3 +335,25 @@ let%expect_test "float16 equality with nan" =
   let a = from_list float16 [ nan ] in
   Printf.printf "%b %b\n" (a = a) (compare a a = 0);
   [%expect {| false true |}]
+
+let%expect_test "bigstring blit positions are raw offsets" =
+  (* The reference C implementation of caml_bigstring_blit_ba_to_ba is
+     layout-blind: positions are offsets from the start of the data,
+     even for fortran_layout bigarrays. *)
+  let mk l =
+    let a = Array1.create char fortran_layout (String.length l) in
+    String.iteri ~f:(fun i c -> a.{i + 1} <- c) l;
+    a
+  in
+  let to_string a = String.init (Array1.dim a) ~f:(fun i -> a.{i + 1}) in
+  let src = mk "abcdef" in
+  let dst = mk "------" in
+  blit_ba_to_ba src 1 dst 2 3;
+  print_endline (to_string dst);
+  [%expect {| --abc- |}];
+  let dst = mk "------" in
+  (try
+     blit_ba_to_ba src 0 dst 0 2;
+     print_endline (to_string dst)
+   with Invalid_argument msg -> print_endline ("Invalid_argument: " ^ msg));
+  [%expect {| Invalid_argument: index out of bounds |}]

--- a/runtime/js/bigstring.js
+++ b/runtime/js/bigstring.js
@@ -54,15 +54,15 @@ function caml_bigstring_blit_ba_to_ba(ba1, pos1, ba2, pos2, len) {
   if (12 !== ba2.kind)
     caml_invalid_argument("caml_bigstring_blit_ba_to_ba: kind mismatch");
   if (len === 0) return 0;
-  var ofs1 = ba1.offset(pos1);
-  var ofs2 = ba2.offset(pos2);
-  if (ofs1 + len > ba1.data.length) {
+  // Positions are raw offsets from the start of the data, ignoring the
+  // layout, as in the reference C implementation (and the Wasm runtime)
+  if (pos1 < 0 || pos1 + len > ba1.data.length) {
     caml_array_bound_error();
   }
-  if (ofs2 + len > ba2.data.length) {
+  if (pos2 < 0 || pos2 + len > ba2.data.length) {
     caml_array_bound_error();
   }
-  var slice = ba1.data.subarray(ofs1, ofs1 + len);
+  var slice = ba1.data.subarray(pos1, pos1 + len);
   ba2.data.set(slice, pos2);
   return 0;
 }

--- a/runtime/js/bigstring.js
+++ b/runtime/js/bigstring.js
@@ -55,7 +55,9 @@ function caml_bigstring_blit_ba_to_ba(ba1, pos1, ba2, pos2, len) {
     caml_invalid_argument("caml_bigstring_blit_ba_to_ba: kind mismatch");
   if (len === 0) return 0;
   // Positions are raw offsets from the start of the data, ignoring the
-  // layout, as in the reference C implementation (and the Wasm runtime)
+  // layout: these primitives back base_bigstring's bigstring_blit_*
+  // stubs, whose C code indexes from `data + pos` (and so does the Wasm
+  // runtime here)
   if (pos1 < 0 || pos1 + len > ba1.data.length) {
     caml_array_bound_error();
   }
@@ -74,15 +76,18 @@ function caml_bigstring_blit_string_to_ba(str1, pos1, ba2, pos2, len) {
   if (12 !== ba2.kind)
     caml_invalid_argument("caml_bigstring_blit_string_to_ba: kind mismatch");
   if (len === 0) return 0;
-  var ofs2 = ba2.offset(pos2);
-  if (pos1 + len > caml_ml_string_length(str1)) {
+  // Positions are raw offsets from the start of the data, ignoring the
+  // layout: these primitives back base_bigstring's bigstring_blit_*
+  // stubs, whose C code indexes from `data + pos` (and so does the Wasm
+  // runtime here)
+  if (pos1 < 0 || pos1 + len > caml_ml_string_length(str1)) {
     caml_array_bound_error();
   }
-  if (ofs2 + len > ba2.data.length) {
+  if (pos2 < 0 || pos2 + len > ba2.data.length) {
     caml_array_bound_error();
   }
   var slice = caml_uint8_array_of_string(str1).subarray(pos1, pos1 + len);
-  ba2.data.set(slice, ofs2);
+  ba2.data.set(slice, pos2);
   return 0;
 }
 
@@ -91,17 +96,20 @@ function caml_bigstring_blit_string_to_ba(str1, pos1, ba2, pos2, len) {
 //Requires: caml_ml_bytes_length
 function caml_bigstring_blit_bytes_to_ba(str1, pos1, ba2, pos2, len) {
   if (12 !== ba2.kind)
-    caml_invalid_argument("caml_bigstring_blit_string_to_ba: kind mismatch");
+    caml_invalid_argument("caml_bigstring_blit_bytes_to_ba: kind mismatch");
   if (len === 0) return 0;
-  var ofs2 = ba2.offset(pos2);
-  if (pos1 + len > caml_ml_bytes_length(str1)) {
+  // Positions are raw offsets from the start of the data, ignoring the
+  // layout: these primitives back base_bigstring's bigstring_blit_*
+  // stubs, whose C code indexes from `data + pos` (and so does the Wasm
+  // runtime here)
+  if (pos1 < 0 || pos1 + len > caml_ml_bytes_length(str1)) {
     caml_array_bound_error();
   }
-  if (ofs2 + len > ba2.data.length) {
+  if (pos2 < 0 || pos2 + len > ba2.data.length) {
     caml_array_bound_error();
   }
   var slice = caml_uint8_array_of_bytes(str1).subarray(pos1, pos1 + len);
-  ba2.data.set(slice, ofs2);
+  ba2.data.set(slice, pos2);
   return 0;
 }
 
@@ -111,16 +119,19 @@ function caml_bigstring_blit_bytes_to_ba(str1, pos1, ba2, pos2, len) {
 //Requires: caml_ml_bytes_length
 function caml_bigstring_blit_ba_to_bytes(ba1, pos1, bytes2, pos2, len) {
   if (12 !== ba1.kind)
-    caml_invalid_argument("caml_bigstring_blit_string_to_ba: kind mismatch");
+    caml_invalid_argument("caml_bigstring_blit_ba_to_bytes: kind mismatch");
   if (len === 0) return 0;
-  var ofs1 = ba1.offset(pos1);
-  if (ofs1 + len > ba1.data.length) {
+  // Positions are raw offsets from the start of the data, ignoring the
+  // layout: these primitives back base_bigstring's bigstring_blit_*
+  // stubs, whose C code indexes from `data + pos` (and so does the Wasm
+  // runtime here)
+  if (pos1 < 0 || pos1 + len > ba1.data.length) {
     caml_array_bound_error();
   }
-  if (pos2 + len > caml_ml_bytes_length(bytes2)) {
+  if (pos2 < 0 || pos2 + len > caml_ml_bytes_length(bytes2)) {
     caml_array_bound_error();
   }
-  var slice = ba1.data.subarray(ofs1, ofs1 + len);
+  var slice = ba1.data.subarray(pos1, pos1 + len);
   caml_blit_bytes(caml_bytes_of_uint8_array(slice), 0, bytes2, pos2, len);
   return 0;
 }


### PR DESCRIPTION
The `caml_bigstring_blit_*` primitives back base_bigstring's `bigstring_blit_*` stubs (base_bigstring's own `runtime.js` forwards to them, and `bin_prot`/`cstruct` rely on them too). The native stubs in `base_bigstring_stubs.c` are layout-blind — they index from `data + pos` and `memmove`/`memcpy`, ignoring the bigarray layout — and the Wasm runtime here does the same. The JS runtime did not.

### `ba_to_ba`

`caml_bigstring_blit_ba_to_ba` read through the layout-aware, bounds-checked `Ml_Bigarray.offset` translation but wrote at the raw position (`ba2.data.set(slice, pos2)`, with the bound check done on `ofs2`). For the real consumers this is latent — bigstrings are c_layout `Array1`, where `offset(pos) === pos` — but the function was internally inconsistent: with a fortran_layout array the copied region was shifted by one, raw position 0 was rejected with a spurious bound error, and a write at the last position could pass the check yet overflow in `TypedArray.set`. It now uses raw positions on both sides, with explicit bound checks.

### `string_to_ba`, `bytes_to_ba`, `ba_to_bytes`

These three still ran the bigarray position through `Ml_Bigarray.offset`, so they diverged from both the native stubs and the Wasm runtime for fortran_layout bigarrays (off-by-one copy, spurious bound error at position 0). They now use the raw position too, matching `ba_to_ba`. This commit also fixes three copy-pasted `kind mismatch` error labels.

### Tests

The first commit records the buggy JS behavior with fortran_layout arrays; the rest fix the runtime. The expectations pass identically under js, wasm and native, where native runs C stubs that mirror base_bigstring's layout-blind semantics and is the ground truth.

Last of the bigarray findings from the JS runtime review (follow-up to #2263).

🤖 Generated with [Claude Code](https://claude.com/claude-code)