### PR TITLE
Runtime: key ephemeron data WeakMaps on the key object

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -76,6 +76,9 @@
   counts 41 to 47; the sign bits did not reach the low limb (#2270)
 * Runtime: comparison of float16 bigarrays now handles nan like the
   other float kinds; a nan element used to compare equal to anything
+* Runtime: ephemeron data is now weakly keyed on the key object itself
+  rather than on its WeakRef wrapper, so key <-> data cycles can be
+  garbage collected (#2274)
 * Runtime: the `#` flag no longer adds a base prefix to zero;
   `Printf.printf "%#x" 0` printed `0x0` where native prints `0`
 * Runtime: the fake filesystem no longer ignores `Open_append`; writes

--- a/compiler/tests-jsoo/dune
+++ b/compiler/tests-jsoo/dune
@@ -129,6 +129,7 @@
    test_lwt_promise
    test_unix_perms
    test_str
+   test_weak_gc
    calc_parser
    calc_lexer))
  (libraries unix compiler-libs.common js_of_ocaml-compiler)
@@ -190,6 +191,22 @@
  (wasm_of_ocaml
   (javascript_files custom.js custom.wat))
  (modes js wasm))
+
+; Forces a major GC through node's v8/vm modules to observe ephemeron
+; liveness, so it only runs in js mode under node.
+
+(test
+ (name test_weak_gc)
+ (modules test_weak_gc)
+ (enabled_if
+  (and
+   (<> %{profile} wasi)
+   (<> %{profile} wasi-with-native-effects)
+   (<> %{profile} quickjs)))
+ (libraries js_of_ocaml)
+ (modes js)
+ (preprocess
+  (pps ppx_js_internal)))
 
 (test
  (name test_promise)

--- a/compiler/tests-jsoo/test_weak_gc.expected
+++ b/compiler/tests-jsoo/test_weak_gc.expected
@@ -1,2 +1,2 @@
-key alive: true
-data alive: true
+key alive: false
+data alive: false

--- a/compiler/tests-jsoo/test_weak_gc.expected
+++ b/compiler/tests-jsoo/test_weak_gc.expected
@@ -1,0 +1,2 @@
+key alive: true
+data alive: true

--- a/compiler/tests-jsoo/test_weak_gc.ml
+++ b/compiler/tests-jsoo/test_weak_gc.ml
@@ -1,0 +1,55 @@
+(* Js_of_ocaml tests
+ * http://www.ocsigen.org/js_of_ocaml/
+ * Copyright (C) 2026 Hugo Heuzard
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+
+(* Ephemeron liveness: data referencing its own key (a key <-> data
+   cycle) must not keep the key alive once nothing else references it. *)
+
+open Js_of_ocaml
+
+let force_gc : unit -> unit =
+  let f =
+    Js.Unsafe.js_expr
+      {|(function () {
+        var v8 = require("node:v8");
+        var vm = require("node:vm");
+        v8.setFlagsFromString("--expose-gc");
+        var g = vm.runInNewContext("gc");
+        v8.setFlagsFromString("--no-expose-gc");
+        return g;
+      })()|}
+  in
+  fun () -> ignore (Js.Unsafe.fun_call f [||])
+
+let e = Obj.Ephemeron.create 1
+
+let () =
+  let key = ref 42 in
+  Obj.Ephemeron.set_key e 0 (Obj.repr key);
+  (* the data holds the only other reference to the key *)
+  Obj.Ephemeron.set_data e (Obj.repr (key, "payload"))
+
+let () =
+  let check () =
+    force_gc ();
+    Printf.printf "key alive: %b\n%!" (Obj.Ephemeron.check_key e 0);
+    Printf.printf "data alive: %b\n%!" (Obj.Ephemeron.check_data e)
+  in
+  (* WeakRef targets are kept alive until the end of the turn in which
+     they were created or dereferenced; observe from a later turn *)
+  ignore (Js.Unsafe.global##setTimeout (Js.wrap_callback check) 0)

--- a/runtime/js/weak.js
+++ b/runtime/js/weak.js
@@ -174,7 +174,7 @@ function caml_ephe_get_data(x) {
         return 0;
       }
       if (globalThis.WeakMap) {
-        data = data.get(k);
+        data = data.get(d);
         if (data === undefined) {
           x[caml_ephe_data_offset] = caml_ephe_none;
           return 0;
@@ -209,7 +209,11 @@ function caml_ephe_set_data(x, data) {
         continue;
       }
       if (globalThis.WeakMap) {
-        data = new globalThis.WeakMap().set(k, data);
+        // Key the map on the key object itself (not the WeakRef
+        // wrapper, which the ephemeron strongly holds): the data must
+        // be reachable only while the key is, so that key <-> data
+        // cycles can be collected.
+        data = new globalThis.WeakMap().set(d, data);
       }
     }
   }


### PR DESCRIPTION
The ephemeron data WeakMap chain was keyed on the WeakRef *wrapper* stored in the key slot. The ephemeron itself strongly holds that wrapper, so the WeakMap entry was never collectable while the ephemeron was alive: the data stayed strongly reachable through `x[2]`, and data referencing its own key (a key ↔ data cycle) kept the key alive forever — defeating the ephemeron liveness model that the WeakMap chain exists to implement. The chain is now keyed on the dereferenced key object, making the data reachable only while every key is alive. The Wasm runtime already does this correctly (`weak.wat` derefs before `map_set`), so this also restores js↔wasm parity.

Functionally invisible while keys are alive (all existing `test_weak.ml` tests pass unchanged) — the bug is purely a liveness property, so the regression test forces a real major GC: `test_weak_gc.ml` is a small js-only `(test)` program that obtains `gc()` through node's `v8.setFlagsFromString` + `vm.runInNewContext` (no CLI flag required), builds an ephemeron whose data holds the only other reference to its key, and observes from a later event-loop turn (after the `WeakRef` KeptObjects list is cleared, making the result deterministic). Skipped under the quickjs/wasi profiles.

One of the findings from the JS runtime review (follow-up to #2263).

The first commit records the buggy behavior (`key alive: true` after a full GC); the second commit fixes the runtime and flips the expected output to `false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)