### PR TITLE
Runtime: decode BLOCK32 sizes with an unsigned shift

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,6 +50,9 @@
 * Runtime: the Str engine's SIMPLEOPT/SIMPLESTAR/SIMPLEPLUS opcodes
   no longer read past the end of the string; matching a negated
   character class at the end of the input could loop forever (#2270)
+* Runtime: unmarshalling now decodes BLOCK32 sizes with an unsigned
+  shift; blocks with 2^21 or more fields were silently read as having
+  a single field, corrupting the stream (#2270)
 * Runtime: the `#` flag no longer adds a base prefix to zero;
   `Printf.printf "%#x" 0` printed `0x0` where native prints `0`
 * Runtime: the fake filesystem no longer ignores `Open_append`; writes

--- a/compiler/tests-jsoo/test_marshal.ml
+++ b/compiler/tests-jsoo/test_marshal.ml
@@ -223,4 +223,4 @@ let%expect_test "block with 2^21 fields" =
      let a' : int array = Marshal.from_string (Marshal.to_string a []) 0 in
      Printf.printf "%d %d %d\n" (Array.length a') a'.(0) a'.(Array.length a' - 1)
    with e -> print_endline (Printexc.to_string e));
-  [%expect {| 1 1 1 |}]
+  [%expect {| 2097152 1 2 |}]

--- a/compiler/tests-jsoo/test_marshal.ml
+++ b/compiler/tests-jsoo/test_marshal.ml
@@ -210,3 +210,17 @@ let%expect_test "test input with offset" =
   in
   Printf.printf "%f" (Marshal.from_bytes b (String.length prefix));
   [%expect {| 3.140000 |}]
+
+let%expect_test "block with 2^21 fields" =
+  (* Blocks with 2^21..2^22-1 fields have bit 31 of their BLOCK32
+     header set; the reader must extract the size with an unsigned
+     shift. *)
+  let n = 1 lsl 21 in
+  let a = Array.make n 0 in
+  a.(0) <- 1;
+  a.(n - 1) <- 2;
+  (try
+     let a' : int array = Marshal.from_string (Marshal.to_string a []) 0 in
+     Printf.printf "%d %d %d\n" (Array.length a') a'.(0) a'.(Array.length a' - 1)
+   with e -> print_endline (Printexc.to_string e));
+  [%expect {| 1 1 1 |}]

--- a/runtime/js/marshal.js
+++ b/runtime/js/marshal.js
@@ -380,7 +380,8 @@ function caml_input_value_from_reader(reader) {
           case 0x08: //cst.CODE_BLOCK32:
             var header = reader.read32u();
             var tag = header & 0xff;
-            var size = header >> 10;
+            // unsigned: bit 31 of the header is set for sizes >= 2^21
+            var size = header >>> 10;
             var v = [tag];
             if (size === 0) return v;
             if (intern_obj_table) intern_obj_table[obj_counter++] = v;


### PR DESCRIPTION
The BLOCK32 header packs the size in bits 10–31, so bit 31 is set for blocks with 2²¹ or more fields, and the signed `header >> 10` in the unmarshaller went negative: the block was silently read as having a single field and the rest of the stream desynchronized. jsoo's own writer→reader round-trip of a 2²¹-field array failed (it came back as `[|1|]`). The C runtime reads the size with `Wosize_hd` (unsigned) and `marshal.wat` uses `i32.shr_u`; the JS reader now uses `>>> 10`.

BLOCK32 reader item from #2270 (distinct from the ≥2²² *writer* truncation already listed in #2263).

The first commit adds the round-trip regression test with the buggy output recorded (`1 1 1`); the second commit fixes the runtime and flips the expectation to `2097152 1 2`, verified under js and native.

🤖 Generated with [Claude Code](https://claude.com/claude-code)