### PR TITLE
Runtime: register big-endian double arrays when unmarshalling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,10 @@
 * Runtime: unmarshalling now decodes BLOCK32 sizes with an unsigned
   shift; blocks with 2^21 or more fields were silently read as having
   a single field, corrupting the stream (#2270)
+* Runtime: unmarshalling registers big-endian double arrays
+  (CODE_DOUBLE_ARRAY32_BIG) in the object table like its sibling
+  codes; shared references read after one resolved to the wrong
+  object (#2270)
 * Runtime: the `#` flag no longer adds a base prefix to zero;
   `Printf.printf "%#x" 0` printed `0x0` where native prints `0`
 * Runtime: the fake filesystem no longer ignores `Open_append`; writes

--- a/compiler/tests-jsoo/test_marshal.ml
+++ b/compiler/tests-jsoo/test_marshal.ml
@@ -224,3 +224,25 @@ let%expect_test "block with 2^21 fields" =
      Printf.printf "%d %d %d\n" (Array.length a') a'.(0) a'.(Array.length a' - 1)
    with e -> print_endline (Printexc.to_string e));
   [%expect {| 2097152 1 2 |}]
+
+let%expect_test "shared reference after a big-endian double array" =
+  (* Hand-crafted stream (the jsoo writer only emits little-endian
+     codes; native writers on big-endian platforms emit
+     CODE_DOUBLE_ARRAY32_BIG): the value is (s, [| 1.5 |], s) with the
+     second occurrence of s shared. The double array must be registered
+     in the object table for the back-reference to resolve. *)
+  let buf =
+    "\x84\x95\xa6\xbe" (* magic *)
+    ^ "\x00\x00\x00\x13" (* data length: 19 *)
+    ^ "\x00\x00\x00\x03" (* number of shared objects *)
+    ^ "\x00\x00\x00\x09" (* size_32 *)
+    ^ "\x00\x00\x00\x08" (* size_64 *)
+    ^ "\xb0" (* small block, tag 0, size 3 *)
+    ^ "\x22hi" (* small string "hi" *)
+    ^ "\x0f\x00\x00\x00\x01" (* DOUBLE_ARRAY32_BIG, 1 element *)
+    ^ "\x3f\xf8\x00\x00\x00\x00\x00\x00" (* 1.5, big-endian *)
+    ^ "\x04\x02" (* SHARED8, offset 2 *)
+  in
+  let (a, d, b) : string * float array * string = Marshal.from_string buf 0 in
+  Printf.printf "%s %g %b\n" a d.(0) (a == b);
+  [%expect {| hi 1.5 false |}]

--- a/compiler/tests-jsoo/test_marshal.ml
+++ b/compiler/tests-jsoo/test_marshal.ml
@@ -245,4 +245,4 @@ let%expect_test "shared reference after a big-endian double array" =
   in
   let (a, d, b) : string * float array * string = Marshal.from_string buf 0 in
   Printf.printf "%s %g %b\n" a d.(0) (a == b);
-  [%expect {| hi 1.5 false |}]
+  [%expect {| hi 1.5 true |}]

--- a/runtime/js/marshal.js
+++ b/runtime/js/marshal.js
@@ -450,6 +450,7 @@ function caml_input_value_from_reader(reader) {
             var len = reader.read32u();
             var v = new Array(len + 1);
             v[0] = 254;
+            if (intern_obj_table) intern_obj_table[obj_counter++] = v;
             var t = new Array(8);
             for (var i = 1; i <= len; i++) {
               for (var j = 0; j < 8; j++) t[j] = reader.read8u();


### PR DESCRIPTION
The `CODE_DOUBLE_ARRAY32_BIG` branch (0x0f) was the only one of the four double-array codes missing the `if (intern_obj_table) intern_obj_table[obj_counter++] = v;` registration, so every shared back-reference read after such an array resolved one slot off. Reachable when reading data marshalled on a big-endian platform (the jsoo writer itself only emits little-endian codes).

`marshal.js` item from #2270.

The regression test uses a hand-crafted stream — `(s, [| 1.5 |], s)` with the second occurrence of `s` shared after a `CODE_DOUBLE_ARRAY32_BIG` array — byte-exact including the header sizes, validated by running it through native, which reads `hi 1.5 true`. The buggy JS reader resolved the back-reference to the outer block instead of the string (`a == b` was false). First commit records the buggy behavior; second commit adds the registration and flips the expectation, verified under js and native.

Stacked on #2275 (`fix-marshal-block32-size`) since both append tests to `test_marshal.ml`; GitHub should retarget to master when it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)