### PR TITLE
Runtime: bound-check the Str simple opcodes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,6 +47,9 @@
 * Runtime: fix caml_oo_cache_id (#2224)
 * Runtime: `Ephemeron.blit_key` no longer overwrites the destination's
   data with the source's data (#2263)
+* Runtime: the Str engine's SIMPLEOPT/SIMPLESTAR/SIMPLEPLUS opcodes
+  no longer read past the end of the string; matching a negated
+  character class at the end of the input could loop forever (#2270)
 * Runtime: the `#` flag no longer adds a base prefix to zero;
   `Printf.printf "%#x" 0` printed `0x0` where native prints `0`
 * Runtime: the fake filesystem no longer ignores `Open_append`; writes

--- a/compiler/tests-jsoo/dune
+++ b/compiler/tests-jsoo/dune
@@ -128,6 +128,7 @@
    test_promise
    test_lwt_promise
    test_unix_perms
+   test_str
    calc_parser
    calc_lexer))
  (libraries unix compiler-libs.common js_of_ocaml-compiler)
@@ -151,6 +152,17 @@
   (<> %{profile} quickjs))
  (modules test_unix)
  (libraries unix compiler-libs.common js_of_ocaml-compiler)
+ (inline_tests
+  (deps
+   (sandbox preserve_file_kind))
+  (modes js wasm best))
+ (preprocess
+  (pps ppx_expect)))
+
+(library
+ (name jsoo_testsuite_str)
+ (modules test_str)
+ (libraries str)
  (inline_tests
   (deps
    (sandbox preserve_file_kind))

--- a/compiler/tests-jsoo/test_str.ml
+++ b/compiler/tests-jsoo/test_str.ml
@@ -1,0 +1,31 @@
+(* Js_of_ocaml tests
+ * http://www.ocsigen.org/js_of_ocaml/
+ * Copyright (C) 2026 Hugo Heuzard
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+
+(* The SIMPLEOPT/SIMPLESTAR/SIMPLEPLUS opcodes of the Str engine must
+   not read past the end of the string: an out-of-bounds read tests
+   the membership of '\000' in the character class, which negated
+   classes contain. *)
+
+let%expect_test "negated class at end of string" =
+  let b = Str.string_partial_match (Str.regexp "[^;]?;") "" 0 in
+  Printf.printf "%b\n" b;
+  [%expect {| false |}];
+  let b = Str.string_partial_match (Str.regexp "a[^;]?;") "a" 0 in
+  Printf.printf "%b\n" b;
+  [%expect {| false |}]

--- a/compiler/tests-jsoo/test_str.ml
+++ b/compiler/tests-jsoo/test_str.ml
@@ -25,7 +25,23 @@
 let%expect_test "negated class at end of string" =
   let b = Str.string_partial_match (Str.regexp "[^;]?;") "" 0 in
   Printf.printf "%b\n" b;
-  [%expect {| false |}];
+  [%expect {| true |}];
   let b = Str.string_partial_match (Str.regexp "a[^;]?;") "a" 0 in
   Printf.printf "%b\n" b;
-  [%expect {| false |}]
+  [%expect {| true |}]
+
+(* These used to loop forever: the negated class kept matching the
+   out-of-bounds read at the end of the string. *)
+let%expect_test "simple star and plus at end of string" =
+  let b = Str.string_match (Str.regexp "[^;]*;") "no semicolon" 0 in
+  Printf.printf "%b\n" b;
+  [%expect {| false |}];
+  let b = Str.string_match (Str.regexp "[^;]+;") "no semicolon" 0 in
+  Printf.printf "%b\n" b;
+  [%expect {| false |}];
+  let b = Str.string_match (Str.regexp "[^;]*;") "stop; go" 0 in
+  Printf.printf "%b %s\n" b (Str.matched_string "stop; go");
+  [%expect {| true stop; |}];
+  let b = Str.string_match (Str.regexp "x[^;]+") "xabc" 0 in
+  Printf.printf "%b %s\n" b (Str.matched_string "xabc");
+  [%expect {| true xabc |}]

--- a/runtime/js/str.js
+++ b/runtime/js/str.js
@@ -247,10 +247,10 @@ var re_match = (function () {
           }
           break;
         case opcodes.SIMPLEOPT:
-          if (in_bitset(cpool[uarg], c)) pos++;
+          if (pos < s.length && in_bitset(cpool[uarg], c)) pos++;
           break;
         case opcodes.SIMPLESTAR:
-          while (in_bitset(cpool[uarg], c)) c = s[++pos];
+          while (pos < s.length && in_bitset(cpool[uarg], c)) c = s[++pos];
           break;
         case opcodes.SIMPLEPLUS:
           if (pos === s.length) {
@@ -260,7 +260,7 @@ var re_match = (function () {
           if (in_bitset(cpool[uarg], c)) {
             do {
               c = s[++pos];
-            } while (in_bitset(cpool[uarg], c));
+            } while (pos < s.length && in_bitset(cpool[uarg], c));
           } else backtrack();
           break;
         case opcodes.ACCEPT:


### PR DESCRIPTION
The Str engine's SIMPLEOPT/SIMPLESTAR/SIMPLEPLUS opcodes read `s[pos]` without checking `pos` against the string length. The out-of-bounds read yields `undefined`, and `in_bitset(set, undefined)` tests bit 0 of byte 0 — i.e. whether `'\000'` is in the character class. Negated classes contain `'\000'`, and `str.ml` compiles bare `[^x]*` / `[^x]+` / `[^x]?` to the simple opcodes whenever the class is disjoint from what follows, so:

- `Str.string_match (Str.regexp "[^;]*;") "no semicolon" 0` **looped forever** (SIMPLESTAR; same for `+` via SIMPLEPLUS);
- SIMPLEOPT advanced `pos` past the end of the string, making `Str.string_partial_match (Str.regexp "[^;]?;") "" 0` return `false` where native returns `true`.

The C engine guards every iteration with `txt < end`, and `str.wat` with `pos <u len`; the JS opcodes now do the same.

Str item from #2270. Adds a `test_str.ml` module to tests-jsoo (linking `str`), since none existed.

Commit structure note: the test-first commit only records the SIMPLEOPT symptom — the SIMPLESTAR/SIMPLEPLUS symptom is an infinite loop, which cannot be recorded as an expectation without hanging the runner. Those cases are added together with the fix. The partial-match expectations were validated against native (`true`/`true`) before recording the buggy JS output (`false`/`false`); everything passes identically under js and native at the tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)