### PR TITLE
Runtime: sign-extend the high limb in Int64.shift_right

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -57,6 +57,8 @@
   (CODE_DOUBLE_ARRAY32_BIG) in the object table like its sibling
   codes; shared references read after one resolved to the wrong
   object (#2270)
+* Runtime: fix `Int64.shift_right` for negative values and shift
+  counts 41 to 47; the sign bits did not reach the low limb (#2270)
 * Runtime: the `#` flag no longer adds a base prefix to zero;
   `Printf.printf "%#x" 0` printed `0x0` where native prints `0`
 * Runtime: the fake filesystem no longer ignores `Open_append`; writes

--- a/compiler/tests-jsoo/test_ints.ml
+++ b/compiler/tests-jsoo/test_ints.ml
@@ -81,6 +81,27 @@ let%expect_test _ =
   check_fail "-9223372036854775809";
   [%expect {| overflow |}]
 
+(* Arithmetic shifts must sign-extend into the low 24-bit limb for
+   shift counts 41..47. *)
+let%expect_test "Int64.shift_right, shifts 40..48" =
+  List.iter
+    (fun s ->
+      Printf.printf
+        "%d: %Lx %Lx %Lx\n"
+        s
+        (Int64.shift_right (-1L) s)
+        (Int64.shift_right Int64.min_int s)
+        (Int64.shift_right 0x123456789abcdef0L s))
+    [ 40; 41; 44; 47; 48 ];
+  [%expect
+    {|
+    40: ffffffffffffffff ffffffffff800000 123456
+    41: ffffffffff7fffff ffffffffff400000 91a2b
+    44: ffffffffff0fffff ffffffffff080000 12345
+    47: ffffffffff01ffff ffffffffff010000 2468
+    48: ffffffffffffffff ffffffffffff8000 1234
+    |}]
+
 (* The '#' (alternate) flag must not add a base prefix to zero: native
    prints "0" for %#x / %#X / %#o of 0, like C printf. *)
 let%expect_test "alternate flag with zero" =

--- a/compiler/tests-jsoo/test_ints.ml
+++ b/compiler/tests-jsoo/test_ints.ml
@@ -96,9 +96,9 @@ let%expect_test "Int64.shift_right, shifts 40..48" =
   [%expect
     {|
     40: ffffffffffffffff ffffffffff800000 123456
-    41: ffffffffff7fffff ffffffffff400000 91a2b
-    44: ffffffffff0fffff ffffffffff080000 12345
-    47: ffffffffff01ffff ffffffffff010000 2468
+    41: ffffffffffffffff ffffffffffc00000 91a2b
+    44: ffffffffffffffff fffffffffff80000 12345
+    47: ffffffffffffffff ffffffffffff0000 2468
     48: ffffffffffffffff ffffffffffff8000 1234
     |}]
 

--- a/runtime/js/int64.js
+++ b/runtime/js/int64.js
@@ -162,7 +162,9 @@ class MlInt64 {
     var sign = (this.hi << 16) >> 31;
     if (s < 48)
       return new MlInt64(
-        (this.mi >> (s - 24)) | (this.hi << (48 - s)),
+        // [h] is sign-extended: for s > 40 the sign bits reach
+        // into the low limb
+        (this.mi >> (s - 24)) | (h << (48 - s)),
         ((this.hi << 16) >> (s - 24)) >> 16,
         sign & 0xffff,
       );


### PR DESCRIPTION
In the `24 <= s < 48` branch of `MlInt64.shift_right`, the low limb was computed as `(mi >> (s-24)) | (hi << (48-s))` with the raw *unsigned* 16-bit high limb. For shift counts above 40, `hi`'s 16 significant bits end below bit 23, so the top `s - 40` bits of the 24-bit low limb stayed zero instead of being sign bits: `Int64.shift_right (-1L) 44` returned `0xffffffffff0fffff` instead of `-1L`. Shifts 40 and 48 (the branch boundaries) and all positive values were unaffected, which is how it hid.

The fix uses the sign-extended `h = (hi << 16) >> 16` already computed for the other limbs; for `s ≤ 40` the additional sign bits fall outside the 24-bit limb and are masked off by the constructor, so behavior there is unchanged.

`int64.js` item from #2270 (found by its 200k-case BigInt differential test, all failures on `asr` 41–47).

The regression test covers shifts 40/41/44/47/48 on `-1L`, `Int64.min_int`, and a positive value; the first commit records the buggy JS values, the second commit fixes the runtime and flips them to the native-verified values — identical under js and native at the tip (wasm uses native i64 shifts and was never affected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)