### PR TITLE
Runtime: fix Gc.finalise_last under effects and Gc.counters representation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -101,6 +101,10 @@
 * Runtime: ephemeron data is now weakly keyed on the key object itself
   rather than on its WeakRef wrapper, so key <-> data cycles can be
   garbage collected (#2274)
+* Runtime: `Gc.finalise_last` callbacks are invoked through
+  caml_callback; with `--effects=cps` they silently never ran, and
+  `Gc.counters` now returns an ordinary tuple instead of a float-array
+  block (#2279)
 * Runtime: the `#` flag no longer adds a base prefix to zero;
   `Printf.printf "%#x" 0` printed `0x0` where native prints `0`
 * Runtime: the fake filesystem no longer ignores `Open_append`; writes

--- a/compiler/tests-jsoo/lib-effects/dune
+++ b/compiler/tests-jsoo/lib-effects/dune
@@ -27,7 +27,8 @@
    assume_no_perform_unhandled
    assume_no_perform_nested_handler
    deep_state
-   effects))
+   effects
+   test_finalise))
  (preprocess
   (pps ppx_expect)))
 
@@ -67,3 +68,21 @@
  (wasm_of_ocaml
   (compilation_mode whole_program))
  (modes js wasm))
+
+; Forces a major GC through node's v8/vm modules to observe
+; Gc.finalise_last under the CPS calling convention.
+
+(test
+ (name test_finalise)
+ (build_if
+  (>= %{ocaml_version} 5))
+ (enabled_if
+  (and
+   (<> %{profile} wasi)
+   (<> %{profile} wasi-with-native-effects)
+   (<> %{profile} quickjs)))
+ (modules test_finalise)
+ (libraries js_of_ocaml)
+ (modes js)
+ (preprocess
+  (pps ppx_js_internal)))

--- a/compiler/tests-jsoo/lib-effects/test_finalise.expected
+++ b/compiler/tests-jsoo/lib-effects/test_finalise.expected
@@ -1,3 +1,4 @@
 finalised
 js probe fired
+finalised
 done

--- a/compiler/tests-jsoo/lib-effects/test_finalise.expected
+++ b/compiler/tests-jsoo/lib-effects/test_finalise.expected
@@ -1,4 +1,3 @@
 finalised
 js probe fired
-finalised
 done

--- a/compiler/tests-jsoo/lib-effects/test_finalise.expected
+++ b/compiler/tests-jsoo/lib-effects/test_finalise.expected
@@ -1,0 +1,3 @@
+finalised
+js probe fired
+done

--- a/compiler/tests-jsoo/lib-effects/test_finalise.ml
+++ b/compiler/tests-jsoo/lib-effects/test_finalise.ml
@@ -1,0 +1,93 @@
+(* Js_of_ocaml tests
+ * http://www.ocsigen.org/js_of_ocaml/
+ * Copyright (C) 2026 Hugo Heuzard
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+
+(* [Gc.finalise_last] callbacks run inside the FinalizationRegistry
+   host callback; they must be invoked through caml_callback so that
+   the CPS calling convention (--effects cps, used to compile this
+   directory) is respected. *)
+
+open Js_of_ocaml
+
+let force_gc : unit -> unit =
+  let f =
+    Js.Unsafe.js_expr
+      {|(function () {
+        var v8 = require("node:v8");
+        var vm = require("node:vm");
+        v8.setFlagsFromString("--expose-gc");
+        var g = vm.runInNewContext("gc");
+        v8.setFlagsFromString("--no-expose-gc");
+        return g;
+      })()|}
+  in
+  fun () -> ignore (Js.Unsafe.fun_call f [||])
+
+let () =
+  ignore
+    (Js.Unsafe.js_expr
+       {|process.on("uncaughtException", function (e) {
+           console.log("uncaught exception");
+         })|})
+
+let set_timeout (f : unit -> unit) =
+  ignore (Js.Unsafe.global##setTimeout (Js.wrap_callback f) 0)
+
+(* The JS FinalizationRegistry probe and the OCaml finalizer both fire on
+   the same collection, but the host does not guarantee an order between
+   them, so we buffer the messages and print them sorted once everything
+   has run. *)
+let lines = ref []
+
+let record s = lines := s :: !lines
+
+let js_probe : 'a -> unit =
+  let f =
+    Js.Unsafe.js_expr
+      {|(function (o, cb) {
+        var r = new FinalizationRegistry(function () {
+          cb();
+        });
+        r.register(o, 0);
+        globalThis.__probe_keep = r;
+      })|}
+  in
+  fun v ->
+    ignore
+      (Js.Unsafe.fun_call
+         f
+         [| Js.Unsafe.inject v
+          ; Js.Unsafe.inject (Js.wrap_callback (fun () -> record "js probe fired"))
+         |])
+
+let[@inline never] make () =
+  let v = Array.make 16 0 in
+  js_probe v;
+  Gc.finalise_last (fun () -> record "finalised") v
+
+let () = make ()
+
+let rec wait n =
+  force_gc ();
+  if n = 0
+  then (
+    List.iter (fun s -> Printf.printf "%s\n" s) (List.sort compare !lines);
+    Printf.printf "done\n%!")
+  else set_timeout (fun () -> wait (n - 1))
+
+let () = set_timeout (fun () -> wait 3)

--- a/compiler/tests-jsoo/test_gc_repr.ml
+++ b/compiler/tests-jsoo/test_gc_repr.ml
@@ -1,0 +1,24 @@
+(* Js_of_ocaml tests
+ * http://www.ocsigen.org/js_of_ocaml/
+ * Copyright (C) 2026 Hugo Heuzard
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+
+let%expect_test "Gc.counters returns an ordinary tuple" =
+  let c = Gc.counters () in
+  let mi, pr, ma = c in
+  Printf.printf "%d %g %g %g\n" (Obj.tag (Obj.repr c)) mi pr ma;
+  [%expect {| 254 0 0 0 |}]

--- a/compiler/tests-jsoo/test_gc_repr.ml
+++ b/compiler/tests-jsoo/test_gc_repr.ml
@@ -18,7 +18,9 @@
  *)
 
 let%expect_test "Gc.counters returns an ordinary tuple" =
+  (* the counter values themselves are nondeterministic on native;
+     only check the representation *)
   let c = Gc.counters () in
-  let mi, pr, ma = c in
-  Printf.printf "%d %g %g %g\n" (Obj.tag (Obj.repr c)) mi pr ma;
-  [%expect {| 254 0 0 0 |}]
+  let r = Obj.repr c in
+  Printf.printf "%d %d\n" (Obj.tag r) (Obj.size r);
+  [%expect {| 0 3 |}]

--- a/runtime/js/gc.js
+++ b/runtime/js/gc.js
@@ -22,7 +22,7 @@ function caml_gc_compaction(_unit) {
 }
 //Provides: caml_gc_counters
 function caml_gc_counters(_unit) {
-  return [254, 0, 0, 0];
+  return [0, 0, 0, 0];
 }
 //Provides: caml_gc_quick_stat
 //Version: < 5.5
@@ -58,12 +58,15 @@ function caml_final_register(_f, _x) {
 }
 
 //Provides: caml_final_register_called_without_value
+//Requires: caml_callback
 var all_finalizers = new globalThis.Set();
 function caml_final_register_called_without_value(cb, a) {
   if (globalThis.FinalizationRegistry && a instanceof Object) {
     var x = new globalThis.FinalizationRegistry(function (x) {
       all_finalizers.delete(x);
-      cb(0);
+      // Go through caml_callback so that the CPS calling convention
+      // is respected and exceptions are handled
+      caml_callback(cb, [0]);
       return;
     });
     x.register(a, x);


### PR DESCRIPTION
Two `gc.js` items from #2270:

**`Gc.finalise_last` never ran under `--effects=cps`.** `caml_final_register_called_without_value` invoked the finaliser as a bare `cb(0)`. Under the CPS calling convention the closure expects a continuation argument — but rather than throwing as the issue predicted, the body returns a trampoline bounce object that the `FinalizationRegistry` cleanup callback silently discards, so the finaliser does nothing at all (with an exhausted stack budget it would instead throw inside the host callback). The fix invokes it through `caml_callback`, which handles the calling convention and exception wrapping in every effects mode.

The regression test lives in `lib-effects` (compiled with `--effects cps`): it forces a major GC via node's `v8`/`vm` modules (same technique as `test_weak_gc.ml`), and registers a parallel plain-JS `FinalizationRegistry` on the same value as a guard — its firing proves the value was actually collected, so a missing `finalised` line can only mean the OCaml finaliser was dropped. Buggy recorded output: probe fires, no `finalised`; fixed: both.

**`Gc.counters` returned a tag-254 float-array block** (`[254, 0, 0, 0]`) where native and `gc.wat` return an ordinary tag-0 tuple; `Obj.tag`, comparison and marshalling observed the wrong representation. Now `[0, 0, 0, 0]`. The test checks tag and size only — the counter values themselves are nondeterministic on native.

🤖 Generated with [Claude Code](https://claude.com/claude-code)