### PR TITLE
Runtime: copy bytes and float arrays in Weak.get_copy / Ephemeron.get_data_copy

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -87,6 +87,9 @@
 * Runtime: `Weak.get_copy` and `Ephemeron.get_data_copy` now copy
   bytes values too; they used to return the weakly held value itself
   (#2270)
+* Runtime (wasm): `Weak.get_copy` and `Ephemeron.get_data_copy` now
+  copy float arrays, matching the native and JavaScript runtimes
+  (#2270)
 * Runtime: the Str engine's SIMPLEOPT/SIMPLESTAR/SIMPLEPLUS opcodes
   no longer read past the end of the string; matching a negated
   character class at the end of the input could loop forever (#2270)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -84,6 +84,9 @@
 * Runtime: fix caml_oo_cache_id (#2224)
 * Runtime: `Ephemeron.blit_key` no longer overwrites the destination's
   data with the source's data (#2263)
+* Runtime: `Weak.get_copy` and `Ephemeron.get_data_copy` now copy
+  bytes values too; they used to return the weakly held value itself
+  (#2270)
 * Runtime: the Str engine's SIMPLEOPT/SIMPLESTAR/SIMPLEPLUS opcodes
   no longer read past the end of the string; matching a negated
   character class at the end of the input could loop forever (#2270)

--- a/compiler/tests-jsoo/test_weak.ml
+++ b/compiler/tests-jsoo/test_weak.ml
@@ -201,3 +201,22 @@ let%expect_test "get_copy copies bytes" =
   | Some d -> Printf.printf "%b\n" (d == Obj.repr b)
   | None -> print_endline "none");
   [%expect {| false |}]
+
+(* Custom blocks (Int64, bigarrays, ...) are deliberately NOT copied:
+   the native runtime returns the value itself rather than risk an
+   unsafe raw copy (finalizers, the bigarray data proxy, ...). *)
+let%expect_test "get_copy does not copy custom blocks" =
+  let n = Int64.add 1L 2L in
+  let w = Weak.create 1 in
+  Weak.set w 0 (Some n);
+  (match Weak.get_copy w 0 with
+  | Some n' -> Printf.printf "%b %b\n" (n' == n) (Int64.equal n' n)
+  | None -> print_endline "none");
+  [%expect {| true true |}];
+  let a = Bigarray.Array1.create Bigarray.int Bigarray.c_layout 1 in
+  let w = Weak.create 1 in
+  Weak.set w 0 (Some a);
+  (match Weak.get_copy w 0 with
+  | Some a' -> Printf.printf "%b\n" (a' == a)
+  | None -> print_endline "none");
+  [%expect {| true |}]

--- a/compiler/tests-jsoo/test_weak.ml
+++ b/compiler/tests-jsoo/test_weak.ml
@@ -183,3 +183,21 @@ let%expect_test "blit_key does not touch data" =
   print_data dst;
   [%expect {| dst data |}];
   ignore (Sys.opaque_identity (k1, k2, k3, k4))
+
+(* [Weak.get_copy] / [Ephemeron.get_data_copy] must copy bytes too:
+   returning the value itself both lets mutations reach the weakly
+   held original and creates a strong reference to it. *)
+let%expect_test "get_copy copies bytes" =
+  let b = Bytes.of_string "hello" in
+  let w = Weak.create 1 in
+  Weak.set w 0 (Some b);
+  (match Weak.get_copy w 0 with
+  | Some b' -> Printf.printf "%b %b\n" (b' == b) (Bytes.equal b' b)
+  | None -> print_endline "none");
+  [%expect {| true true |}];
+  let e = Obj.Ephemeron.create 1 in
+  Obj.Ephemeron.set_data e (Obj.repr b);
+  (match Obj.Ephemeron.get_data_copy e with
+  | Some d -> Printf.printf "%b\n" (d == Obj.repr b)
+  | None -> print_endline "none");
+  [%expect {| true |}]

--- a/compiler/tests-jsoo/test_weak.ml
+++ b/compiler/tests-jsoo/test_weak.ml
@@ -202,6 +202,20 @@ let%expect_test "get_copy copies bytes" =
   | None -> print_endline "none");
   [%expect {| false |}]
 
+(* A float array is a mutable no-scan block, so like ordinary blocks
+   and bytes it must be copied. In the Wasm runtime it is its own type
+   (not an ordinary block), so it needs its own case. *)
+let%expect_test "get_copy copies float arrays" =
+  let fa = [| 1.0; 2.0; 3.0 |] in
+  let w = Weak.create 1 in
+  Weak.set w 0 (Some fa);
+  (match Weak.get_copy w 0 with
+  | Some fa' ->
+      fa'.(0) <- 99.0;
+      Printf.printf "shares=%b orig_mutated=%b\n" (fa' == fa) (fa.(0) = 99.0)
+  | None -> print_endline "none");
+  [%expect {| shares=false orig_mutated=false |}]
+
 (* Custom blocks (Int64, bigarrays, ...) are deliberately NOT copied:
    the native runtime returns the value itself rather than risk an
    unsafe raw copy (finalizers, the bigarray data proxy, ...). *)

--- a/compiler/tests-jsoo/test_weak.ml
+++ b/compiler/tests-jsoo/test_weak.ml
@@ -194,10 +194,10 @@ let%expect_test "get_copy copies bytes" =
   (match Weak.get_copy w 0 with
   | Some b' -> Printf.printf "%b %b\n" (b' == b) (Bytes.equal b' b)
   | None -> print_endline "none");
-  [%expect {| true true |}];
+  [%expect {| false true |}];
   let e = Obj.Ephemeron.create 1 in
   Obj.Ephemeron.set_data e (Obj.repr b);
   (match Obj.Ephemeron.get_data_copy e with
   | Some d -> Printf.printf "%b\n" (d == Obj.repr b)
   | None -> print_endline "none");
-  [%expect {| true |}]
+  [%expect {| false |}]

--- a/runtime/js/weak.js
+++ b/runtime/js/weak.js
@@ -99,13 +99,13 @@ function caml_ephe_get_key(x, i) {
 }
 //Provides: caml_ephe_get_key_copy
 //Requires: caml_ephe_get_key,caml_ephe_key_offset
-//Requires: caml_obj_dup
+//Requires: caml_obj_dup, caml_is_ml_bytes
 //Alias: caml_weak_get_copy
 function caml_ephe_get_key_copy(x, i) {
   var y = caml_ephe_get_key(x, i);
   if (y === 0) return y;
   var z = y[1];
-  if (Array.isArray(z)) return [0, caml_obj_dup(z)];
+  if (Array.isArray(z) || caml_is_ml_bytes(z)) return [0, caml_obj_dup(z)];
   return y;
 }
 
@@ -187,12 +187,12 @@ function caml_ephe_get_data(x) {
 
 //Provides: caml_ephe_get_data_copy
 //Requires: caml_ephe_get_data
-//Requires: caml_obj_dup
+//Requires: caml_obj_dup, caml_is_ml_bytes
 function caml_ephe_get_data_copy(x) {
   var r = caml_ephe_get_data(x);
   if (r === 0) return 0;
   var z = r[1];
-  if (Array.isArray(z)) return [0, caml_obj_dup(z)];
+  if (Array.isArray(z) || caml_is_ml_bytes(z)) return [0, caml_obj_dup(z)];
   return r;
 }
 

--- a/runtime/wasm/weak.wat
+++ b/runtime/wasm/weak.wat
@@ -109,17 +109,21 @@
 
    (func (export "caml_ephe_get_data_copy")
       (param $x (ref eq)) (result (ref eq))
-      (local $r (ref eq))
+      (local $r (ref eq)) (local $v (ref eq))
       (local.set $r (call $caml_ephe_get_data (local.get $x)))
       (drop (block $no_copy (result (ref eq))
-         (return
-            (array.new_fixed $block 2 (ref.i31 (i32.const 0))
-               (call $caml_obj_dup
-                  (br_on_cast_fail $no_copy (ref eq) (ref $block)
-                     (array.get $block
-                        (br_on_cast_fail $no_copy (ref eq) (ref $block)
-                           (local.get $r))
-                        (i32.const 1))))))))
+         (local.set $v
+            (array.get $block
+               (br_on_cast_fail $no_copy (ref eq) (ref $block) (local.get $r))
+               (i32.const 1)))
+         ;; copy blocks and bytes (caml_obj_dup handles both)
+         (if (i32.or (ref.test (ref $block) (local.get $v))
+                (ref.test (ref $bytes) (local.get $v)))
+            (then
+               (return
+                  (array.new_fixed $block 2 (ref.i31 (i32.const 0))
+                     (call $caml_obj_dup (local.get $v))))))
+         (ref.i31 (i32.const 0))))
       (local.get $r))
 
    (func $caml_ephe_set_data (export "caml_ephe_set_data")
@@ -215,17 +219,21 @@
    (export "caml_weak_get_copy" (func $caml_ephe_get_key_copy))
    (func $caml_ephe_get_key_copy (export "caml_ephe_get_key_copy")
       (param $x (ref eq)) (param $i (ref eq)) (result (ref eq))
-      (local $r (ref eq))
+      (local $r (ref eq)) (local $v (ref eq))
       (local.set $r (call $caml_ephe_get_key (local.get $x) (local.get $i)))
       (drop (block $no_copy (result (ref eq))
-         (return
-            (array.new_fixed $block 2 (ref.i31 (i32.const 0))
-               (call $caml_obj_dup
-                  (br_on_cast_fail $no_copy (ref eq) (ref $block)
-                     (array.get $block
-                        (br_on_cast_fail $no_copy (ref eq) (ref $block)
-                           (local.get $r))
-                        (i32.const 1))))))))
+         (local.set $v
+            (array.get $block
+               (br_on_cast_fail $no_copy (ref eq) (ref $block) (local.get $r))
+               (i32.const 1)))
+         ;; copy blocks and bytes (caml_obj_dup handles both)
+         (if (i32.or (ref.test (ref $block) (local.get $v))
+                (ref.test (ref $bytes) (local.get $v)))
+            (then
+               (return
+                  (array.new_fixed $block 2 (ref.i31 (i32.const 0))
+                     (call $caml_obj_dup (local.get $v))))))
+         (ref.i31 (i32.const 0))))
       (local.get $r))
 
    (export "caml_weak_check" (func $caml_ephe_check_key))

--- a/runtime/wasm/weak.wat
+++ b/runtime/wasm/weak.wat
@@ -49,6 +49,7 @@
 
    (type $block (array (mut (ref eq))))
    (type $bytes (array (mut i8)))
+   (type $float_array (array (mut f64)))
    (type $js (struct (field anyref)))
 
    ;; A weak array is a an abstract value composed of possibly some
@@ -116,9 +117,14 @@
             (array.get $block
                (br_on_cast_fail $no_copy (ref eq) (ref $block) (local.get $r))
                (i32.const 1)))
-         ;; copy blocks and bytes (caml_obj_dup handles both)
-         (if (i32.or (ref.test (ref $block) (local.get $v))
-                (ref.test (ref $bytes) (local.get $v)))
+         ;; Copy the mutable heap blocks that can alias the original:
+         ;; ordinary blocks, bytes and float arrays. Float arrays are
+         ;; their own Wasm type, so they need an explicit test. Custom
+         ;; blocks are returned as is, like the native runtime.
+         (if (i32.or
+                (i32.or (ref.test (ref $block) (local.get $v))
+                   (ref.test (ref $bytes) (local.get $v)))
+                (ref.test (ref $float_array) (local.get $v)))
             (then
                (return
                   (array.new_fixed $block 2 (ref.i31 (i32.const 0))
@@ -226,9 +232,14 @@
             (array.get $block
                (br_on_cast_fail $no_copy (ref eq) (ref $block) (local.get $r))
                (i32.const 1)))
-         ;; copy blocks and bytes (caml_obj_dup handles both)
-         (if (i32.or (ref.test (ref $block) (local.get $v))
-                (ref.test (ref $bytes) (local.get $v)))
+         ;; Copy the mutable heap blocks that can alias the original:
+         ;; ordinary blocks, bytes and float arrays. Float arrays are
+         ;; their own Wasm type, so they need an explicit test. Custom
+         ;; blocks are returned as is, like the native runtime.
+         (if (i32.or
+                (i32.or (ref.test (ref $block) (local.get $v))
+                   (ref.test (ref $bytes) (local.get $v)))
+                (ref.test (ref $float_array) (local.get $v)))
             (then
                (return
                   (array.new_fixed $block 2 (ref.i31 (i32.const 0))


### PR DESCRIPTION
`Weak.get_copy` / `caml_weak_get_copy` and `Ephemeron.get_data_copy` / `get_key_copy` are meant to return a **copy** of the weakly held value: mutations through the copy must not reach the original, and the result must not be a strong reference to the original (which would defeat the point of `get_copy` — reading the value out without strongly retaining the weak target).

Both runtimes only copied a subset of values; for the rest the weakly held value was returned **as is**, breaking the contract twice over (aliased mutation + strong retention). This PR aligns both runtimes with the native runtime, whose rule is: copy every *mutable, non-custom* heap block, and return custom blocks unchanged.

### Fixes

- **Bytes (js + wasm).** Both runtimes only copied ordinary blocks (JS array / wasm `$block`); a bytes value was returned uncopied. `caml_obj_dup` already copies bytes, so the type test is widened — `caml_is_ml_bytes` on the JS side, `ref.test (ref $bytes)` on the wasm side (`weak.js:108,195` per #2270).
- **Float arrays (wasm).** A float array is its own Wasm type (`$float_array`), not an ordinary `$block`, so it slipped through and was returned uncopied — mutations through the "copy" reached the original. The JS runtime already copies them (they are plain arrays). Widen the wasm test to also cover `$float_array`; `caml_obj_dup` already knows how to copy it.

### Deliberately *not* changed

Custom blocks (`Int64`, `Nat`, bigarrays, …) are returned **as is**, exactly like the native runtime — verified directly. Duplicating a custom block with a raw copy is unsafe (finalizers, the bigarray data proxy / refcount, …); native even *shares* a bigarray's data buffer on `Obj.dup`. A regression test pins this behaviour down so it is not "generalized" away by mistake.

Boxed floats are immutable and unobservable through `==`, and the JS runtime does not copy them either, so they are left uncopied (no behavioural change).

### Tests

`compiler/tests-jsoo/test_weak.ml`, run under js / wasm / native:
- `get_copy` / `get_data_copy` copy bytes (recorded buggy `true` first, then flipped to the native-verified `false` + content-equal).
- `get_copy` copies float arrays (the wasm fix; verified non-aliasing across all three backends).
- `get_copy` does **not** copy custom blocks (`Int64`, bigarray) — matches native.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
