### PR TITLE
Runtime: hash float arrays and skip abstract blocks like native

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -111,6 +111,11 @@
 * Runtime (wasm): `Weak.get_copy` and `Ephemeron.get_data_copy` now
   copy float arrays, matching the native and JavaScript runtimes
   (#2270)
+* Runtime: `Hashtbl.hash` now hashes float arrays like native (a
+  dedicated tag-254 case mixing the elements); the JS runtime hashed
+  them as generic blocks and the Wasm runtime ignored them entirely,
+  so all three runtimes disagreed. Abstract-tag blocks are now skipped
+  like in the C runtime (#2263, #2270)
 * Runtime: the Str engine's SIMPLEOPT/SIMPLESTAR/SIMPLEPLUS opcodes
   no longer read past the end of the string; matching a negated
   character class at the end of the input could loop forever (#2270)

--- a/compiler/tests-jsoo/test_floats.ml
+++ b/compiler/tests-jsoo/test_floats.ml
@@ -229,3 +229,25 @@ let%expect_test "Array.make negative length" =
      Printf.printf "len=%d\n" (Array.length a)
    with Invalid_argument m -> print_endline m);
   [%expect {| Array.make |}]
+
+(* hash.c has a dedicated Double_array_tag case (elements mixed
+   directly, no header word) and skips Abstract_tag blocks. *)
+let%expect_test "Hashtbl.hash of float arrays" =
+  let p (x : Obj.t) = Printf.printf "%08x\n" (Hashtbl.hash x) in
+  p (Obj.repr [| 1.5 |]);
+  p (Obj.repr [| 1.5; 2.5 |]);
+  p (Obj.repr (Array.init 20 float_of_int));
+  p (Obj.repr [| nan |]);
+  p (Obj.repr [| -0. |]);
+  p (Obj.repr (1, [| 1.5 |], 2));
+  p (Obj.new_block 251 3);
+  [%expect
+    {|
+    3e121f87
+    165fed5c
+    162489c5
+    2baaf13f
+    1c14f790
+    3f7de68b
+    35565b7c
+    |}]

--- a/compiler/tests-jsoo/test_floats.ml
+++ b/compiler/tests-jsoo/test_floats.ml
@@ -236,18 +236,28 @@ let%expect_test "Hashtbl.hash of float arrays" =
   let p (x : Obj.t) = Printf.printf "%08x\n" (Hashtbl.hash x) in
   p (Obj.repr [| 1.5 |]);
   p (Obj.repr [| 1.5; 2.5 |]);
-  p (Obj.repr (Array.init 20 float_of_int));
+  (* A long float array exercises the per-element budget (only the first
+     elements are mixed before [num] runs out). Build it with
+     [create_float] so the runtime representation is a flat float array
+     (Double_array_tag) on every OCaml version: [Array.init]'s result is
+     only unboxed by some stdlib versions, leaving the array generic and
+     the hash version-dependent. *)
+  let long = Array.create_float 20 in
+  for i = 0 to Array.length long - 1 do
+    long.(i) <- float_of_int i
+  done;
+  p (Obj.repr long);
   p (Obj.repr [| nan |]);
   p (Obj.repr [| -0. |]);
   p (Obj.repr (1, [| 1.5 |], 2));
   p (Obj.new_block 251 3);
   [%expect
     {|
-    3e121f87
-    165fed5c
-    162489c5
-    2baaf13f
-    1c14f790
-    3f7de68b
-    35565b7c
+    30d3d2e3
+    07e28e3a
+    1ab69813
+    3228858d
+    0f478b8c
+    3498f980
+    00000000
     |}]

--- a/runtime/js/hash.js
+++ b/runtime/js/hash.js
@@ -184,6 +184,17 @@ function caml_hash(count, limit, seed, obj) {
           // Forward
           queue[--rd] = v[1];
           break;
+        case 251:
+          // Abstract: block contents unknown, do nothing
+          break;
+        case 254:
+          // Double_array_tag: mix the elements directly, no header
+          for (i = 1, len = v.length; i < len; i++) {
+            h = caml_hash_mix_float(h, v[i]);
+            num--;
+            if (num <= 0) break;
+          }
+          break;
         default:
           if (caml_is_continuation_tag(v[0])) {
             /* All continuations hash to the same value,

--- a/runtime/wasm/hash.wat
+++ b/runtime/wasm/hash.wat
@@ -18,6 +18,7 @@
 (module
    (import "obj" "object_tag" (global $object_tag i32))
    (import "obj" "forward_tag" (global $forward_tag i32))
+   (import "obj" "abstract_tag" (global $abstract_tag i32))
    (import "jsstring" "jsstring_test"
       (func $jsstring_test (param anyref) (result i32)))
    (import "jsstring" "jsstring_hash"
@@ -174,6 +175,8 @@
    (global $caml_hash_queue (ref $block)
       (array.new $block (ref.i31 (i32.const 0)) (global.get $HASH_QUEUE_SIZE)))
 
+   (type $float_array (array (mut f64)))
+
    (func (export "caml_hash") (export "caml_hash_exn")
       (param $count (ref eq)) (param $limit (ref eq)) (param $seed (ref eq))
       (param $obj (ref eq)) (result (ref eq))
@@ -181,6 +184,7 @@
       (local $rd i32) (local $wr i32)
       (local $v (ref eq))
       (local $b (ref $block))
+      (local $fa (ref $float_array))
       (local $i i32)
       (local $len i32)
       (local $tag i32)
@@ -266,6 +270,9 @@
                                        (array.get $block
                                           (local.get $b) (i32.const 2))))))
                            (br $loop)))
+                     ;; abstract tag: block contents unknown, do nothing
+                     (br_if $loop
+                        (i32.eq (local.get $tag) (global.get $abstract_tag)))
                      (local.set $len (array.len (local.get $b)))
                      (local.set $h
                         (call $caml_hash_mix_int (local.get $h)
@@ -290,6 +297,27 @@
                               (br_on_cast_fail $not_float (ref eq) (ref $float)
                                  (local.get $v)))))
                      (local.set $num (i32.sub (local.get $num) (i32.const 1)))
+                     (br $loop)))
+                  (drop (block $not_float_array (result (ref eq))
+                     (local.set $fa
+                        (br_on_cast_fail $not_float_array (ref eq)
+                           (ref $float_array) (local.get $v)))
+                     ;; mix the elements directly, no header
+                     (local.set $len (array.len (local.get $fa)))
+                     (local.set $i (i32.const 0))
+                     (loop $fa_iter
+                        (if (i32.lt_u (local.get $i) (local.get $len))
+                           (then
+                              (local.set $h
+                                 (call $caml_hash_mix_double (local.get $h)
+                                    (array.get $float_array (local.get $fa)
+                                       (local.get $i))))
+                              (local.set $num
+                                 (i32.sub (local.get $num) (i32.const 1)))
+                              (local.set $i
+                                 (i32.add (local.get $i) (i32.const 1)))
+                              (br_if $fa_iter
+                                 (i32.gt_s (local.get $num) (i32.const 0))))))
                      (br $loop)))
                   (drop (block $not_custom (result (ref eq))
                      (local.set $h


### PR DESCRIPTION
`hash.c` has a dedicated `Double_array_tag` case — elements mixed directly with `caml_hash_mix_double`, no header word, per-element budget decrement — and skips `Abstract_tag` contents entirely. Neither jsoo runtime implemented it, each in its own way:

- **JS** hashed float arrays as generic blocks (header word mixed, elements queued under the size budget): `Hashtbl.hash [|1.5|]` gave `0x3e121f87` where native gives `0x30d3d2e3`.
- **Wasm** never tested for `$float_array` in the dispatch chain, so float arrays fell through to the "ignored" branch and contributed *nothing*: all float-array keys collided (the #2263 item).

All three runtimes disagreed; both now implement the C semantics exactly (loop ported from hash.c, including the `num <= 0` break placement), and the `Abstract_tag` skip is added to both as well.

Fixes the `hash.js:176-199` item of #2270 and the "caml_hash ignores float arrays" item of #2263.

The regression test covers single/multiple elements, budget exhaustion (20 elements vs the count of 10), nan and -0. normalization, a float array nested in a tuple, and an abstract block. Buggy JS values recorded first; flipped to native-verified values (`30d3d2e3` for `[|1.5|]`, matching the value #2270 quotes from `hfun.expected`) — js and native agree at the tip, wasm validated through the binaryen build and runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)