### PR TITLE
Compiler: fix dead require() guard in share_constant

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,10 @@
 * Runtime: the Str engine no longer masks instruction arguments to 8
   bits; regexps with more than 256 constant-pool entries (large
   alternations) indexed the wrong pool slot and mismatched (#2270)
+* Compiler: fix the dead require() guard in the share_constant pass: it
+  matched the identifier "requires" instead of "require", so string
+  literals passed to require could be replaced by a shared variable,
+  confusing bundlers (#2284)
 * Compiler: bound the statement-nesting depth of generated functions by
   emitting a flat dispatch loop instead of a deep tower of nested labelled
   blocks when a block has many sibling merge-node branch targets. Deep

--- a/compiler/lib/js_traverse.ml
+++ b/compiler/lib/js_traverse.ml
@@ -913,7 +913,7 @@ let share_constant js =
         (* Some js bundler get confused when the argument
          of 'require' is not a literal *)
         | ECall
-            ( EVar (S { var = None; name = Utf8 "requires"; _ })
+            ( EVar (S { var = None; name = Utf8 "require"; _ })
             , (ANormal | ANullish)
             , [ Arg (EStr _) ]
             , _ ) -> ()
@@ -978,7 +978,7 @@ let share_constant js =
           (* Some js bundler get confused when the argument
                    of 'require' is not a literal *)
           | ECall
-              ( EVar (S { var = None; name = Utf8 "requires"; _ })
+              ( EVar (S { var = None; name = Utf8 "require"; _ })
               , (ANormal | ANullish)
               , [ Arg (EStr _) ]
               , _ ) -> e


### PR DESCRIPTION
The `share_constant` pass (driver, on by default via the `share` flag) deliberately keeps string literals passed to `require()` inline, because bundlers statically analyze `require` calls:

```ocaml
(* Some js bundler get confused when the argument
   of 'require' is not a literal *)
```

However both the counting and the rewriting guards matched the identifier `"requires"` instead of `"require"`, so the protection never fired. The linked runtime contains `require("node:fs")` three times (plus other `node:*` modules), so a node-target program could end up with `var str_node_fs = "node:fs"; ... require(str_node_fs)` — exactly the shape the guard was written to prevent.

Found during the `compiler/lib` correctness review (sibling of #2270/#2282).

https://claude.ai/code/session_01NngidtdtKPQVt54xVNgGG2

---
_Generated by [Claude Code](https://claude.ai/code/session_01NngidtdtKPQVt54xVNgGG2)_