### PR TITLE
Runtime: fix Sys.command exit code, Sys.getenv, Sys.isatty

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -91,6 +91,11 @@
   silently ignored); `Blake2.create` truncates an over-long key instead
   of discarding the truncation; and `OCAMLRUNPARAM` backtrace parsing is
   left-to-right last-wins (`b,b=0` now disables backtraces)
+* Runtime: `Sys.command` returns the child's exit status instead of
+  `1` for any failure; `Sys.getenv` raises `Not_found` for names
+  inherited from `Object.prototype` (e.g. `"toString"`); and
+  `Sys.isatty` consults the channel's file instead of always
+  returning false (#2270)
 * Compiler: fix reference unboxing (#2210)
 * Compiler/wasm: fix int division return type to Unnormalized (#2197)
 * Compiler/wasm: preserve physical identity of empty closures (#2207)

--- a/compiler/tests-jsoo/test_unix.ml
+++ b/compiler/tests-jsoo/test_unix.ml
@@ -141,7 +141,7 @@ let%expect_test "Sys.command exit code" =
   Printf.printf "%d\n" (Sys.command "exit 0");
   [%expect
     {|
-    1
+    42
     0
     |}]
 
@@ -155,6 +155,6 @@ let%expect_test "Sys.getenv prototype" =
   (try get "hasOwnProperty" with _ -> print_endline "exn");
   [%expect
     {|
-    found true
-    exn
+    Not_found
+    Not_found
     |}]

--- a/compiler/tests-jsoo/test_unix.ml
+++ b/compiler/tests-jsoo/test_unix.ml
@@ -135,3 +135,26 @@ let%expect_test "Unix.symlink to_dir" =
 let%expect_test "Unix.getenv" =
   Printf.printf "%s\n" (Sys.getenv "FOO");
   [%expect {| bar |}]
+
+let%expect_test "Sys.command exit code" =
+  Printf.printf "%d\n" (Sys.command "exit 42");
+  Printf.printf "%d\n" (Sys.command "exit 0");
+  [%expect
+    {|
+    1
+    0
+    |}]
+
+let%expect_test "Sys.getenv prototype" =
+  let get n =
+    match Sys.getenv n with
+    | v -> Printf.printf "found %b\n" (String.length v >= 0)
+    | exception Not_found -> print_endline "Not_found"
+  in
+  (try get "toString" with _ -> print_endline "exn");
+  (try get "hasOwnProperty" with _ -> print_endline "exn");
+  [%expect
+    {|
+    found true
+    exn
+    |}]

--- a/compiler/tests-ocaml/lib-unix/isatty/dune
+++ b/compiler/tests-ocaml/lib-unix/isatty/dune
@@ -9,7 +9,9 @@
   (and
    (<> %{profile} wasi)
    (<> %{profile} wasi-with-native-effects)
-   (not %{env:CI=false})))
+   (not %{env:CI=false})
+   ; In_channel.isatty / Out_channel.isatty are OCaml 4.14+
+   (>= %{ocaml_version} 4.14)))
  ; WASI has no notion of tty
  ; isatty_tty does not work on the CI since we are not running in a tty there
  (libraries ocaml_testing unix)

--- a/compiler/tests-ocaml/lib-unix/isatty/isatty_tty.expected
+++ b/compiler/tests-ocaml/lib-unix/isatty/isatty_tty.expected
@@ -1,1 +1,3 @@
 /dev/tty = true
+In_channel.isatty = true
+Out_channel.isatty = true

--- a/compiler/tests-ocaml/lib-unix/isatty/isatty_tty.ml
+++ b/compiler/tests-ocaml/lib-unix/isatty/isatty_tty.ml
@@ -14,4 +14,10 @@ let console =
   with _ ->
     Unix.(openfile "CONIN$" [O_RDWR] 0)
 in
-Printf.printf "/dev/tty = %b\n" (Unix.isatty console)
+Printf.printf "/dev/tty = %b\n" (Unix.isatty console);
+(* In_channel.isatty / Out_channel.isatty exercise caml_sys_isatty,
+   a different primitive from Unix.isatty (caml_unix_isatty). *)
+Printf.printf "In_channel.isatty = %b\n"
+  (In_channel.isatty (Unix.in_channel_of_descr console));
+Printf.printf "Out_channel.isatty = %b\n"
+  (Out_channel.isatty (Unix.out_channel_of_descr console))

--- a/runtime/js/sys.js
+++ b/runtime/js/sys.js
@@ -117,10 +117,10 @@ function caml_set_static_env(k, v) {
 //Provides: jsoo_sys_getenv (const)
 //Requires: jsoo_static_env
 function jsoo_sys_getenv(n) {
-  if (jsoo_static_env[n]) return jsoo_static_env[n];
+  if (Object.hasOwn(jsoo_static_env, n)) return jsoo_static_env[n];
   var process = globalThis.process;
   //nodejs env
-  if (process && process.env && process.env[n] !== undefined)
+  if (process && process.env && Object.hasOwn(process.env, n))
     return process.env[n];
   //QuickJS: no `process`, but the host environment is reachable via `std`.
   var std = globalThis.std;
@@ -241,7 +241,11 @@ function caml_sys_system_command(cmd) {
         child_process.execSync(cmd, { stdio: "inherit" });
         return 0;
       } catch (e) {
-        return 1;
+        // execSync throws on non-zero exit; e.status is the exit code,
+        // or e.signal is set when the child was killed by a signal
+        if (typeof e.status === "number") return e.status;
+        if (e.signal) return 1;
+        return 127;
       }
   }
   // QuickJS: spawn `sh -c <cmd>` via os.exec. With block:true the
@@ -349,7 +353,11 @@ function caml_sys_get_config() {
 }
 
 //Provides: caml_sys_isatty
-function caml_sys_isatty(_chan) {
+//Requires: caml_ml_channel_get
+function caml_sys_isatty(chan) {
+  var info = caml_ml_channel_get(chan);
+  if (info?.file && typeof info.file.isatty === "function")
+    return info.file.isatty();
   return 0;
 }
 


### PR DESCRIPTION
Three `sys.js` items from #2270:

- **`caml_sys_system_command`** (`sys.js:244`): returned `1` for every failing command on node instead of the child's exit status. `execSync` throws on non-zero exit with `e.status` set to the exit code (`e.signal` when killed by a signal); `Sys.command "exit 42"` now returns 42 like native and the QuickJS branch.
- **`jsoo_sys_getenv`** (`sys.js:119-124`): used truthiness/`!== undefined` membership tests, so `Sys.getenv "toString"` returned a stringified `Object.prototype` function (which then crashes downstream) instead of raising `Not_found`, and a static var set to `""` was skipped. Now uses `Object.hasOwn` on both the static env and `process.env`.
- **`caml_sys_isatty`** (`sys.js:352-354`): was hardcoded to `0` while the wasm runtime implements it and the channel's file already has a working `isatty()`. Now consults `caml_ml_channel_get(chan).file.isatty()`.

Test-first; the buggy `Sys.command "exit 42"` → 1 and `Sys.getenv "toString"` → downstream crash are recorded, then flipped to native-verified output. js + native suites green at the tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)