### PR TITLE
Runtime: order immediate before custom block in compare

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -124,6 +124,10 @@
   corner, so they no longer sit half a pixel up and to the left of
   native; and line caps and joins are round, matching the X11 backend's
   thick lines
+* Runtime: comparing an immediate against a custom block (e.g.
+  `compare (Obj.repr 1) (Obj.repr 1L)`) no longer throws a `TypeError`
+  and orders the immediate before the block, like the native runtime
+  (#2270)
 * Compiler: fix reference unboxing (#2210)
 * Compiler/wasm: fix int division return type to Unnormalized (#2197)
 * Compiler/wasm: preserve physical identity of empty closures (#2207)

--- a/compiler/tests-jsoo/test_ints.ml
+++ b/compiler/tests-jsoo/test_ints.ml
@@ -122,3 +122,25 @@ let%expect_test "alternate flag with zero" =
   [%expect {| [0xff] |}];
   Printf.printf "[%#o]\n" 8;
   [%expect {| [010] |}]
+
+(* Comparing an immediate against a custom block (e.g. an int64) must
+   not call the custom's compare op with a raw number: native treats
+   the immediate as strictly less than the block. *)
+let%expect_test "compare immediate vs custom" =
+  let a : Obj.t = Obj.repr 1 in
+  let b : Obj.t = Obj.repr 1L in
+  let p label f = match f () with
+    | v -> Printf.printf "%s = %d\n" label v
+    | exception e -> Printf.printf "%s raised %s\n" label (Printexc.to_string e)
+  in
+  p "cmp 1 1L" (fun () -> compare a b);
+  p "cmp 1L 1" (fun () -> compare b a);
+  p "cmp 2 1L" (fun () -> compare (Obj.repr 2) b);
+  p "eq 1 1L" (fun () -> if a = b then 1 else 0);
+  [%expect
+    {|
+    cmp 1 1L raised Failure("TypeError: x.compare is not a function")
+    cmp 1L 1 = 1
+    cmp 2 1L raised Failure("TypeError: x.compare is not a function")
+    eq 1 1L = 0
+    |}]

--- a/compiler/tests-jsoo/test_ints.ml
+++ b/compiler/tests-jsoo/test_ints.ml
@@ -139,8 +139,8 @@ let%expect_test "compare immediate vs custom" =
   p "eq 1 1L" (fun () -> if a = b then 1 else 0);
   [%expect
     {|
-    cmp 1 1L raised Failure("TypeError: x.compare is not a function")
+    cmp 1 1L = -1
     cmp 1L 1 = 1
-    cmp 2 1L raised Failure("TypeError: x.compare is not a function")
+    cmp 2 1L = -1
     eq 1 1L = 0
     |}]

--- a/runtime/js/compare.js
+++ b/runtime/js/compare.js
@@ -55,23 +55,9 @@ function caml_compare_val_get_custom(a) {
   );
 }
 
-//Provides: caml_compare_val_number_custom
-//Requires: caml_compare_val_get_custom
-function caml_compare_val_number_custom(num, custom, swap, total) {
-  var comp = caml_compare_val_get_custom(custom);
-  if (comp) {
-    var x = swap > 0 ? comp(custom, num, total) : comp(num, custom, total);
-    if (total && Number.isNaN(x)) return swap; // total && nan
-    if (Number.isNaN(+x)) return +x; // nan
-    if ((x | 0) !== 0) return x | 0; // !nan
-  }
-  return swap;
-}
-
 //Provides: caml_compare_val (const, const, const)
 //Requires: caml_int_compare, caml_string_compare, caml_bytes_compare
 //Requires: caml_invalid_argument, caml_compare_val_get_custom, caml_compare_val_tag
-//Requires: caml_compare_val_number_custom
 //Requires: caml_jsbytes_of_string
 //Requires: caml_is_continuation_tag
 function caml_compare_val(a, b, total) {
@@ -102,17 +88,13 @@ function caml_compare_val(a, b, total) {
           return 1;
         }
         if (tag_a === 1000) {
-          if (tag_b === 1255) {
-            //immediate can compare against custom
-            return caml_compare_val_number_custom(a, b, -1, total);
-          }
+          // An immediate is less than any block, including a custom block
+          // (e.g. int32/int64/nativeint/bigarray): the built-in custom
+          // blocks define no [compare_ext], so the C runtime orders the
+          // immediate strictly before the block regardless of values.
           return -1;
         }
         if (tag_b === 1000) {
-          if (tag_a === 1255) {
-            //immediate can compare against custom
-            return caml_compare_val_number_custom(b, a, 1, total);
-          }
           return 1;
         }
         return tag_a < tag_b ? -1 : 1;


### PR DESCRIPTION
`caml_compare_val_number_custom` (`compare.js:60-69`, `107`, `114`) compared an immediate against a custom block by calling the custom's `compare` op with a raw number — `caml_int64_compare(1, 1L)` does `(1).compare(...)`, throwing `TypeError: x.compare is not a function`. It also ignored an "equal" result, falling through to `return swap`.

Verified against native (5.5.0~beta1): `compare (Obj.repr 1) (Obj.repr 1L) = -1`, `compare (Obj.repr 1L) (Obj.repr 1) = 1`, `compare (Obj.repr 2) (Obj.repr 1L) = -1` — i.e. an immediate is **strictly less than** a custom block regardless of values, because the built-in numeric customs define no `compare_ext`. (Note: #2270 claimed native raises `Invalid_argument`; it does not — it returns -1.) The wasm runtime already does this: `compare.wat` reads the `compare_ext` field, which is null for these customs, and falls through to "v1 long < v2 block". The fix returns `swap`.

The third `compare.js` item from #2270 (218-228, non-antisymmetric total comparison of distinct unorderable JS values) is **deliberately left out**: `lib/tests/test_poly_compare.ml` has explicit tests asserting `compare s1 s2 = 1` *and* `compare s2 s1 = 1` for Symbols and objects, so the current js behavior is intentional and locked by tests (the js and wasm runtimes diverge here by design). Changing it is a maintainer call.

Test-first; the TypeError and false-equality are recorded, then flipped to the native-verified ordering. js + native green at the tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)