### PR TITLE
Runtime: handle a raising body in Domain.spawn (js and wasm)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,11 @@
   >= 5.1 (it threw a `TypeError` because the filename landed in the
   removed parameter) and returns the index of the library slot it
   filled rather than one past it (#2270)
+* Runtime: `Domain.spawn` with a body that raises now succeeds and
+  `Domain.join` re-raises the exception, instead of the exception
+  escaping `spawn` and leaving the domain id and termination mutex in
+  a broken state; the Wasm runtime additionally now sets the spawned
+  domain's id (#2263, #2270)
 * Compiler: fix reference unboxing (#2210)
 * Compiler/wasm: fix int division return type to Unnormalized (#2197)
 * Compiler/wasm: preserve physical identity of empty closures (#2207)

--- a/compiler/tests-jsoo/lib-effects/test_domain.ml
+++ b/compiler/tests-jsoo/lib-effects/test_domain.ml
@@ -58,6 +58,6 @@ let%expect_test "domain body raising" =
   Printf.printf "result: %d\n" (Domain.join d);
   [%expect {|
     Not_found
-    self id: 3
+    self id: 0
     result: 7
     |}]

--- a/compiler/tests-jsoo/lib-effects/test_domain.ml
+++ b/compiler/tests-jsoo/lib-effects/test_domain.ml
@@ -42,3 +42,22 @@ let%expect_test _ =
   handle (fun () ->
       if Random.int 2 < 1 then print_int (1 + f ()) else print_int (f () + 1));
   [%expect {| 43 |}]
+
+let%expect_test "domain body raising" =
+  (match
+     let d = Domain.spawn (fun () -> raise Not_found) in
+     Domain.join d
+   with
+  | (_ : int) -> print_endline "no exn"
+  | exception Not_found -> print_endline "Not_found"
+  | exception e -> print_endline ("other: " ^ Printexc.to_string e));
+  (* the main domain id must be restored after a raising body *)
+  Printf.printf "self id: %d\n" (Domain.self () :> int);
+  (* spawning still works afterwards *)
+  let d = Domain.spawn (fun () -> 7) in
+  Printf.printf "result: %d\n" (Domain.join d);
+  [%expect {|
+    Not_found
+    self id: 3
+    result: 7
+    |}]

--- a/runtime/js/domain.js
+++ b/runtime/js/domain.js
@@ -211,17 +211,25 @@ var caml_domain_id = 0;
 //Requires: caml_ml_mutex_unlock
 //Requires: caml_domain_id
 //Requires: caml_callback
+//Requires: caml_wrap_exception, caml_get_exception_raw_backtrace
 //Version: >= 5.2
 var caml_domain_latest_idx = 1;
 function caml_domain_spawn(f, term_sync) {
   var id = caml_domain_latest_idx++;
   var old = caml_domain_id;
   caml_domain_id = id;
-  var res = caml_callback(f, [0]);
+  var result;
+  try {
+    // term_sync.state = Finished (Ok res)
+    result = [0, [0, caml_callback(f, [0])]];
+  } catch (e) {
+    // term_sync.state = Finished (Error (exn, backtrace))
+    var exn = caml_wrap_exception(e);
+    result = [0, [1, [0, exn, caml_get_exception_raw_backtrace(0)]]];
+  }
   caml_domain_id = old;
   caml_ml_mutex_unlock(term_sync[2]);
-  //TODO: fix exn case
-  term_sync[1] = [0, [0, res]];
+  term_sync[1] = result;
   return id;
 }
 
@@ -235,9 +243,12 @@ function caml_domain_spawn(f, mutex) {
   var id = caml_domain_latest_idx++;
   var old = caml_domain_id;
   caml_domain_id = id;
-  var _res = caml_callback(f, [0]);
-  caml_domain_id = old;
-  caml_ml_mutex_unlock(mutex);
+  try {
+    caml_callback(f, [0]);
+  } finally {
+    caml_domain_id = old;
+    caml_ml_mutex_unlock(mutex);
+  }
   return id;
 }
 

--- a/runtime/wasm/domain.wat
+++ b/runtime/wasm/domain.wat
@@ -19,6 +19,7 @@
    (import "obj" "caml_callback_1"
       (func $caml_callback_1
          (param (ref eq)) (param (ref eq)) (result (ref eq))))
+   (import "fail" "ocaml_exception" (tag $ocaml_exception (param (ref eq))))
    (import "sync" "caml_ml_mutex_unlock"
       (func $caml_ml_mutex_unlock (param (ref eq)) (result (ref eq))))
 
@@ -246,37 +247,55 @@
 (@then
    (func (export "caml_domain_spawn")
       (param $f (ref eq)) (param $term_sync_v (ref eq)) (result (ref eq))
-      (local $id i32) (local $old i32) (local $ts (ref $block)) (local $res (ref eq))
+      (local $id i32) (local $old i32) (local $ts (ref $block))
+      (local $result (ref null eq)) (local $exn (ref eq))
       (local.set $id (global.get $caml_domain_latest_id))
       (global.set $caml_domain_latest_id
          (i32.add (local.get $id) (i32.const 1)))
       (local.set $old (global.get $caml_domain_id))
-      (local.set $res
-         (call $caml_callback_1 (local.get $f) (ref.i31 (i32.const 0))))
-      (global.set $caml_domain_id (local.get $old))
+      (global.set $caml_domain_id (local.get $id))
       (local.set $ts (ref.cast (ref $block) (local.get $term_sync_v)))
+      (try
+         (do
+            ;; state = Finished (Ok res)
+            (local.set $result
+               (array.new_fixed $block 2 (ref.i31 (i32.const 0))
+                  (array.new_fixed $block 2 (ref.i31 (i32.const 0))
+                     (call $caml_callback_1
+                        (local.get $f) (ref.i31 (i32.const 0)))))))
+         (catch $ocaml_exception
+            (local.set $exn (pop (ref eq)))
+            ;; state = Finished (Error (exn, backtrace))
+            (local.set $result
+               (array.new_fixed $block 2 (ref.i31 (i32.const 0))
+                  (array.new_fixed $block 2 (ref.i31 (i32.const 1))
+                     (array.new_fixed $block 3 (ref.i31 (i32.const 0))
+                        (local.get $exn)
+                        (array.new_fixed $block 1 (ref.i31 (i32.const 0)))))))))
+      (global.set $caml_domain_id (local.get $old))
       (drop (call $caml_ml_mutex_unlock (array.get $block (local.get $ts) (i32.const 2))))
-      ;; TODO: fix exn case
-      (array.set
-         $block
-         (local.get $ts)
-         (i32.const 1)
-         (array.new_fixed
-            $block
-            2
-            (ref.i31 (i32.const 0))
-            (array.new_fixed $block 2 (ref.i31 (i32.const 0)) (local.get $res))))
+      (array.set $block (local.get $ts) (i32.const 1)
+         (ref.as_non_null (local.get $result)))
       (ref.i31 (local.get $id)))
 )
 (@else
    (func (export "caml_domain_spawn")
       (param $f (ref eq)) (param $mutex (ref eq)) (result (ref eq))
-      (local $id i32) (local $old i32)
+      (local $id i32) (local $old i32) (local $exn (ref eq))
       (local.set $id (global.get $caml_domain_latest_id))
       (global.set $caml_domain_latest_id
          (i32.add (local.get $id) (i32.const 1)))
       (local.set $old (global.get $caml_domain_id))
-      (drop (call $caml_callback_1 (local.get $f) (ref.i31 (i32.const 0))))
+      (global.set $caml_domain_id (local.get $id))
+      (try
+         (do
+            (drop (call $caml_callback_1
+               (local.get $f) (ref.i31 (i32.const 0)))))
+         (catch $ocaml_exception
+            (local.set $exn (pop (ref eq)))
+            (global.set $caml_domain_id (local.get $old))
+            (drop (call $caml_ml_mutex_unlock (local.get $mutex)))
+            (throw $ocaml_exception (local.get $exn))))
       (global.set $caml_domain_id (local.get $old))
       (drop (call $caml_ml_mutex_unlock (local.get $mutex)))
       (ref.i31 (local.get $id)))


### PR DESCRIPTION
`caml_domain_spawn` ran the domain body without catching exceptions. Per `stdlib/domain.ml`, `spawn` should always return the domain handle and the body's exception should be stored as `Finished (Error (exn, bt))` for `join` to re-raise. Instead:

- the exception escaped `spawn` itself (so `let d = Domain.spawn (fun () -> raise e)` raised);
- `caml_domain_id` was left pointing at the dead domain, so `Domain.self ()`/DLS were wrong for the rest of the program;
- the termination mutex stayed locked and `state` stayed `Running`.

Both runtimes now wrap the callback and store `Finished (Ok res)` / `Finished (Error (exn, backtrace))`, restoring the id and unlocking the mutex on both paths.

The **Wasm** runtime additionally never set the spawned domain's id at all — it saved/restored `caml_domain_id` but never assigned it `id`, so `Domain.self ()` inside the body returned the parent's id (the `caml_domain_spawn` item from #2263). Fixed here too (the `>= 5.2` and `>= 5.0, < 5.2` variants).

Test in `lib-effects/test_domain.ml` (js+wasm+native): `Domain.join (Domain.spawn (fun () -> raise Not_found))` re-raises `Not_found`, `Domain.self ()` is back to 0 afterwards, and a subsequent spawn still works. Buggy js recorded first (`self id: 3`), flipped to native-verified output; js + native green, wasm runtime validated through the binaryen build.

Fixes `domain.js:216-226` (#2270) and the `caml_domain_spawn` id bug (#2263).

🤖 Generated with [Claude Code](https://claude.com/claude-code)