### PR TITLE
Runtime: marshal float arrays as CODE_DOUBLE_ARRAY

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,10 @@
 * Lib: add Intl.RelativeTimeFormat (#2070)
 
 ## Bug fixes
+* Runtime: float arrays are marshalled as a `CODE_DOUBLE_ARRAY` block
+  like the native runtime, instead of a generic tag-254 block with
+  per-element double codes; jsoo-marshalled float arrays can now be
+  read by the native and Wasm runtimes (#2270)
 * Runtime: the Str engine no longer masks instruction arguments to 8
   bits; regexps with more than 256 constant-pool entries (large
   alternations) indexed the wrong pool slot and mismatched (#2270)

--- a/compiler/tests-jsoo/test_marshal.ml
+++ b/compiler/tests-jsoo/test_marshal.ml
@@ -246,3 +246,16 @@ let%expect_test "shared reference after a big-endian double array" =
   let (a, d, b) : string * float array * string = Marshal.from_string buf 0 in
   Printf.printf "%s %g %b\n" a d.(0) (a == b);
   [%expect {| hi 1.5 true |}]
+
+let%expect_test "float array marshalling is interoperable" =
+  let hex s = String.iter (fun c -> Printf.printf "%02x" (Char.code c)) s; print_newline () in
+  (* the marshalled bytes must match the native format (a
+     CODE_DOUBLE_ARRAY block) so other runtimes can read them *)
+  hex (Marshal.to_string [| 1.5; 2.5; 3.5 |] []);
+  (* round-trip within jsoo still works *)
+  let a : float array = Marshal.from_string (Marshal.to_string [| 1.5; 2.5; 3.5 |] []) 0 in
+  Printf.printf "%g %g %g\n" a.(0) a.(1) a.(2);
+  [%expect {|
+    8495a6be00000020000000040000000d0000000a0800000cfe0c000000000000f83f0c00000000000004400c0000000000000c40
+    1.5 2.5 3.5
+    |}]

--- a/compiler/tests-jsoo/test_marshal.ml
+++ b/compiler/tests-jsoo/test_marshal.ml
@@ -256,6 +256,6 @@ let%expect_test "float array marshalling is interoperable" =
   let a : float array = Marshal.from_string (Marshal.to_string [| 1.5; 2.5; 3.5 |] []) 0 in
   Printf.printf "%g %g %g\n" a.(0) a.(1) a.(2);
   [%expect {|
-    8495a6be00000020000000040000000d0000000a0800000cfe0c000000000000f83f0c00000000000004400c0000000000000c40
+    8495a6be0000001a0000000100000007000000040e03000000000000f83f00000000000004400000000000000c40
     1.5 2.5 3.5
     |}]

--- a/runtime/js/marshal.js
+++ b/runtime/js/marshal.js
@@ -726,6 +726,26 @@ var caml_output_val = (function () {
         }
         writer.size_32 += 2 + ((sz_32_64[0] + 3) >> 2);
         writer.size_64 += 2 + ((sz_32_64[1] + 7) >> 3);
+      } else if (Array.isArray(v) && v[0] === 254) {
+        // float array (Double_array_tag): emit a CODE_DOUBLE_ARRAY
+        // block (raw doubles) like the native runtime, so other
+        // runtimes can read it
+        if (memo(v)) return;
+        var nfloats = v.length - 1;
+        if (nfloats < 0x100)
+          writer.write_code(8, 0x0e /*cst.CODE_DOUBLE_ARRAY8_LITTLE*/, nfloats);
+        else
+          writer.write_code(
+            32,
+            0x07 /*cst.CODE_DOUBLE_ARRAY32_LITTLE*/,
+            nfloats,
+          );
+        for (var i = 1; i <= nfloats; i++) {
+          var t = caml_int64_to_bytes(caml_int64_bits_of_float(v[i]));
+          for (var j = 0; j < 8; j++) writer.write(8, t[7 - j]);
+        }
+        writer.size_32 += 1 + nfloats * 2;
+        writer.size_64 += 1 + nfloats;
       } else if (Array.isArray(v) && v[0] === (v[0] | 0)) {
         if (v[0] === 251) {
           caml_failwith("output_value: abstract value (Abstract)");


### PR DESCRIPTION
`extern_rec` (`marshal.js:727-747`) serialized a float array (tag 254) as a generic block (`CODE_BLOCK32` with tag 254) followed by a per-element `CODE_DOUBLE`. But the native runtime reads a tag-254 block header as a *flat double array* (the doubles follow inline), so jsoo-marshalled float arrays were unreadable by the native and Wasm runtimes — even though the jsoo *reader* understands the proper `CODE_DOUBLE_ARRAY*` opcodes.

The writer now emits a `CODE_DOUBLE_ARRAY8_LITTLE` / `CODE_DOUBLE_ARRAY32_LITTLE` block of raw little-endian doubles, with the `size_32 += 1 + 2·n` / `size_64 += 1 + n` accounting from `extern.c`. The marshalled bytes now match native byte-for-byte:

```
8495a6be 0000001a 00000001 00000007 00000004  0e 03  <1.5> <2.5> <3.5>
```

(The other half of float marshalling — a lone `float` written as `CODE_DOUBLE` — is documented as non-interoperable because jsoo can't tell a float-typed integer from an int; that is unchanged. This array half is independently fixable because tag 254 is unambiguous.)

Test-first; the buggy generic-block bytes are recorded, then flipped to the native-verified `CODE_DOUBLE_ARRAY` bytes. The in-jsoo round-trip still works (the reader registers the array, see #2276). js + native green; wasm runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)