### PR TITLE
Runtime: fix floatarray op result tags and Array.make message

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -67,6 +67,10 @@
   escaping `spawn` and leaving the domain id and termination mutex in
   a broken state; the Wasm runtime additionally now sets the spawned
   domain's id (#2263, #2270)
+* Runtime: `Float.Array.sub`/`append`/`concat` return a proper
+  tag-254 float array (their result had tag 0); `Array.make` of an
+  invalid length raises `Invalid_argument "Array.make"` instead of
+  `"index out of bounds"` (#2270)
 * Compiler: fix reference unboxing (#2210)
 * Compiler/wasm: fix int division return type to Unnormalized (#2197)
 * Compiler/wasm: preserve physical identity of empty closures (#2207)

--- a/compiler/tests-jsoo/test_floats.ml
+++ b/compiler/tests-jsoo/test_floats.ml
@@ -217,9 +217,9 @@ let%expect_test "floatarray ops keep tag 254" =
   p "concat" (Float.Array.concat [ a; a ]);
   [%expect {|
     make=254
-    sub=0
-    append=0
-    concat=0
+    sub=254
+    append=254
+    concat=254
     |}]
 
 let%expect_test "Array.make negative length" =
@@ -228,4 +228,4 @@ let%expect_test "Array.make negative length" =
      let a = Array.make n 0 in
      Printf.printf "len=%d\n" (Array.length a)
    with Invalid_argument m -> print_endline m);
-  [%expect {| index out of bounds |}]
+  [%expect {| Array.make |}]

--- a/compiler/tests-jsoo/test_floats.ml
+++ b/compiler/tests-jsoo/test_floats.ml
@@ -207,3 +207,25 @@ let%expect_test "of_string" =
   let x = "3.14 " in
   print' (fun () -> float_of_string x);
   [%expect {| Failure("float_of_string") |}]
+
+let%expect_test "floatarray ops keep tag 254" =
+  let a = Float.Array.make 3 1.5 in
+  let p label fa = Printf.printf "%s=%d\n" label (Obj.tag (Obj.repr fa)) in
+  p "make" a;
+  p "sub" (Float.Array.sub a 0 2);
+  p "append" (Float.Array.append a a);
+  p "concat" (Float.Array.concat [ a; a ]);
+  [%expect {|
+    make=254
+    sub=0
+    append=0
+    concat=0
+    |}]
+
+let%expect_test "Array.make negative length" =
+  let n = Sys.opaque_identity (-1) in
+  (try
+     let a = Array.make n 0 in
+     Printf.printf "len=%d\n" (Array.length a)
+   with Invalid_argument m -> print_endline m);
+  [%expect {| index out of bounds |}]

--- a/compiler/tests-jsoo/test_marshal.ml
+++ b/compiler/tests-jsoo/test_marshal.ml
@@ -248,14 +248,20 @@ let%expect_test "shared reference after a big-endian double array" =
   [%expect {| hi 1.5 true |}]
 
 let%expect_test "float array marshalling is interoperable" =
-  let hex s = String.iter (fun c -> Printf.printf "%02x" (Char.code c)) s; print_newline () in
+  let hex s =
+    String.iter (fun c -> Printf.printf "%02x" (Char.code c)) s;
+    print_newline ()
+  in
   (* the marshalled bytes must match the native format (a
      CODE_DOUBLE_ARRAY block) so other runtimes can read them *)
   hex (Marshal.to_string [| 1.5; 2.5; 3.5 |] []);
   (* round-trip within jsoo still works *)
-  let a : float array = Marshal.from_string (Marshal.to_string [| 1.5; 2.5; 3.5 |] []) 0 in
+  let a : float array =
+    Marshal.from_string (Marshal.to_string [| 1.5; 2.5; 3.5 |] []) 0
+  in
   Printf.printf "%g %g %g\n" a.(0) a.(1) a.(2);
-  [%expect {|
+  [%expect
+    {|
     8495a6be0000001a0000000100000007000000040e03000000000000f83f00000000000004400000000000000c40
     1.5 2.5 3.5
     |}]

--- a/runtime/js/array.js
+++ b/runtime/js/array.js
@@ -32,7 +32,9 @@ function caml_array_sub(a, i, len) {
 //Requires: caml_array_sub
 //Version: >= 5.3
 function caml_floatarray_sub(a, i, len) {
-  return caml_array_sub(a, i, len);
+  var r = caml_array_sub(a, i, len);
+  r[0] = 254;
+  return r;
 }
 
 //Provides: caml_uniform_array_sub mutable
@@ -61,7 +63,9 @@ function caml_array_append(a1, a2) {
 //Requires: caml_array_append
 //Version: >= 5.3
 function caml_floatarray_append(a1, a2) {
-  return caml_array_append(a1, a2);
+  var r = caml_array_append(a1, a2);
+  r[0] = 254;
+  return r;
 }
 
 //Provides: caml_uniform_array_append mutable
@@ -84,15 +88,12 @@ function caml_array_concat(l) {
 }
 
 //Provides: caml_floatarray_concat mutable
+//Requires: caml_array_concat
 //Version: >= 5.4
 function caml_floatarray_concat(l) {
-  var a = [0];
-  while (l !== 0) {
-    var b = l[1];
-    for (var i = 1; i < b.length; i++) a.push(b[i]);
-    l = l[2];
-  }
-  return a;
+  var r = caml_array_concat(l);
+  r[0] = 254;
+  return r;
 }
 
 //Provides: caml_uniform_array_concat mutable
@@ -191,9 +192,9 @@ function caml_check_bound(array, index) {
 }
 
 //Provides: caml_array_make const (const, mutable)
-//Requires: caml_array_bound_error
+//Requires: caml_invalid_argument
 function caml_array_make(len, init) {
-  if (len >>> 0 >= ((0x7fffffff / 4) | 0)) caml_array_bound_error();
+  if (len >>> 0 >= ((0x7fffffff / 4) | 0)) caml_invalid_argument("Array.make");
   var len = (len + 1) | 0;
   var b = new Array(len);
   b[0] = 0;


### PR DESCRIPTION
Two `array.js` items from #2270:

- **`caml_floatarray_sub`/`_append`/`_concat`** (`array.js:31-43,60-72,86-96`) delegated to the generic array helpers and returned tag-0 blocks, while float arrays everywhere else (`caml_floatarray_make`) are tag 254. So `Obj.tag (Float.Array.sub a i n) = 0` but `Obj.tag (Float.Array.make ...) = 254`, and — now that float arrays hash with a dedicated case (#2283) — structurally equal float arrays hashed differently depending on how they were produced. The `array.wat` ops keep the `$float_array` representation, so this was js-only. Fixed by setting tag 254 on the result.
- **`caml_array_make`** (`array.js:193-208`) raised `Invalid_argument "index out of bounds"` for a negative/oversized length, where the C runtime and `array.wat` raise `Invalid_argument "Array.make"`.

Test-first; buggy tags (0/0/0) and message recorded, flipped to native-verified (254/254/254, `"Array.make"`). js + native green. The `Array.make` test uses `Sys.opaque_identity` and consumes the result, since `caml_array_make` is flagged pure and an ignored call is otherwise dead-code-eliminated before it can raise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)