### PR TITLE
Runtime: fix caml_dynlink_open_lib signature and return index

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,10 @@
   "too much recursion" at load time) (#2122)
 * Compiler: fix UGEINT bytecode lowering (returned wrong result on
   equal operands)
+* Runtime: `caml_dynlink_open_lib` drops the `mode` argument on OCaml
+  >= 5.1 (it threw a `TypeError` because the filename landed in the
+  removed parameter) and returns the index of the library slot it
+  filled rather than one past it (#2270)
 * Compiler: fix reference unboxing (#2210)
 * Compiler/wasm: fix int division return type to Unnormalized (#2197)
 * Compiler/wasm: preserve physical identity of empty closures (#2207)

--- a/runtime/js/dynlink.js
+++ b/runtime/js/dynlink.js
@@ -23,16 +23,28 @@ function get_current_libs() {
   return current_libs;
 }
 
-//Provides: caml_dynlink_open_lib
-//Requires: get_current_libs, caml_failwith
-//Requires: caml_jsstring_of_string
-function caml_dynlink_open_lib(_mode, file) {
-  var name = caml_jsstring_of_string(file);
-  console.log("Dynlink: try to open ", name);
-  //caml_failwith("file not found: "+name)
+//Provides: caml_dynlink_open_lib_impl
+//Requires: get_current_libs
+function caml_dynlink_open_lib_impl(_file) {
   var current_libs = get_current_libs();
   current_libs.push({});
-  return current_libs.length;
+  // return the index of the slot just filled, used directly by
+  // lookup_symbol/close_lib
+  return current_libs.length - 1;
+}
+
+//Provides: caml_dynlink_open_lib
+//Requires: caml_dynlink_open_lib_impl
+//Version: < 5.1
+function caml_dynlink_open_lib(_mode, file) {
+  return caml_dynlink_open_lib_impl(file);
+}
+
+//Provides: caml_dynlink_open_lib
+//Requires: caml_dynlink_open_lib_impl
+//Version: >= 5.1
+function caml_dynlink_open_lib(file) {
+  return caml_dynlink_open_lib_impl(file);
 }
 
 //Provides: caml_dynlink_close_lib


### PR DESCRIPTION
Two `dynlink.js` items from #2270:

- **`caml_dynlink_open_lib` had the pre-5.1 two-argument signature** (`dynlink.js:29`). OCaml 5.1 dropped the `mode` argument (`dynlink.wat` versions this with `@if (>= ocaml_version (5 1 0))`); on >= 5.1 the filename landed in `_mode`, `file` was `undefined`, and `caml_jsstring_of_string(undefined)` threw a raw `TypeError`. Now version-split into `< 5.1` (`mode, file`) and `>= 5.1` (`file`) wrappers over a shared impl.
- **It returned `current_libs.length` after the push** (`dynlink.js:35`) — one past the slot it just filled. Handles are used directly as indices by `lookup_symbol`/`close_lib`, so lookups always missed and `close_lib` nulled the next library's slot. Now returns `length - 1`.

Fix-only (no test): these are dynlink/toplevel stubs not exercised by the test suite. Verified through `make lint-js` and a full tests-jsoo js build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)