### PR TITLE
Runtime: small fixes from the runtime review (runtime_events, effect, blake2, backtrace)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -75,6 +75,13 @@
   tag-254 float array (their result had tag 0); `Array.make` of an
   invalid length raises `Invalid_argument "Array.make"` instead of
   `"index out of bounds"` (#2270)
+* Runtime: several small fixes from the runtime review (#2270): the
+  `Runtime_events` cursor primitives are named `caml_ml_runtime_events_*`
+  (they were dead code under the wrong name); `jsoo_effect_not_supported`
+  is provided only when effects are disabled (the `//!If:` annotation was
+  silently ignored); `Blake2.create` truncates an over-long key instead
+  of discarding the truncation; and `OCAMLRUNPARAM` backtrace parsing is
+  left-to-right last-wins (`b,b=0` now disables backtraces)
 * Compiler: fix reference unboxing (#2210)
 * Compiler/wasm: fix int division return type to Unnormalized (#2197)
 * Compiler/wasm: preserve physical identity of empty closures (#2207)

--- a/compiler/tests-ocaml/lib-digest/blake2_long_key.ml
+++ b/compiler/tests-ocaml/lib-digest/blake2_long_key.ml
@@ -1,0 +1,36 @@
+(* Regression test for the js/wasm BLAKE2 runtime: a key longer than 64
+   bytes must be accepted and truncated to its first 64 bytes.
+
+   The [caml_blake2_create] primitive used to compute [key.subarray(0, 64)]
+   but discard the result, so the over-long key reached the BLAKE2b
+   initialisation unchanged and the JS runtime threw "Illegal key" instead
+   of producing a digest.
+
+   BLAKE2b keys are at most 64 bytes; the underlying state only copies the
+   first 64. The jsoo runtime truncates the key to that prefix, so hashing
+   with a long key is equivalent to hashing with its 64-byte prefix. (This
+   equivalence is jsoo-specific: the native runtime keeps the original key
+   length in the parameter block, hence [modes js wasm] only.) *)
+
+type state
+
+external create_gen : int -> string -> state = "caml_blake2_create"
+external update : state -> bytes -> int -> int -> unit = "caml_blake2_update"
+external final : state -> int -> string = "caml_blake2_final"
+
+let digest_keyed key msg =
+  let st = create_gen 64 key in
+  let b = Bytes.of_string msg in
+  update st b 0 (Bytes.length b);
+  final st 64
+
+let () =
+  let key100 = String.init 100 (fun i -> Char.chr (i land 0xff)) in
+  let key64 = String.sub key100 0 64 in
+  let msg = "the quick brown fox" in
+  (* Used to raise "Illegal key" in the JS runtime before the fix. *)
+  let h_long = digest_keyed key100 msg in
+  let h_trunc = digest_keyed key64 msg in
+  assert (String.length h_long = 64);
+  assert (String.equal h_long h_trunc);
+  print_string "ok\n"

--- a/compiler/tests-ocaml/lib-digest/dune
+++ b/compiler/tests-ocaml/lib-digest/dune
@@ -14,3 +14,11 @@
    (<> %{profile} wasi-with-native-effects)))
  (modules digests)
  (modes js wasm))
+
+(tests
+ (names blake2_long_key)
+ (libraries)
+ (build_if
+  (>= %{ocaml_version} 5.2))
+ (modules blake2_long_key)
+ (modes js wasm))

--- a/runtime/js/backtrace.js
+++ b/runtime/js/backtrace.js
@@ -25,8 +25,8 @@ var caml_record_backtrace_env_flag = FLAG("with-js-error");
     var l = r.split(",");
     for (var i = 0; i < l.length; i++) {
       if (l[i] === "b") {
+        // left-to-right, last wins: do not stop at the first bare "b"
         caml_record_backtrace_env_flag = 1;
-        break;
       } else if (l[i].startsWith("b=")) {
         caml_record_backtrace_env_flag = +l[i].slice(2);
       } else continue;

--- a/runtime/js/blake2.js
+++ b/runtime/js/blake2.js
@@ -309,7 +309,7 @@ var blake2b = (function () {
 function caml_blake2_create(hashlen, key) {
   key = caml_uint8_array_of_string(key);
   if (key.length > 64) {
-    key.subarray(0, 64);
+    key = key.subarray(0, 64);
   }
   return blake2b.Init(hashlen, key);
 }

--- a/runtime/js/effect.js
+++ b/runtime/js/effect.js
@@ -311,7 +311,7 @@ function caml_ml_condition_signal(_t) {
 
 //Provides: jsoo_effect_not_supported
 //Requires: caml_failwith
-//!If: effects
+//If: !effects
 //Version: >= 5.0
 function jsoo_effect_not_supported() {
   caml_failwith("Effect handlers are not supported");

--- a/runtime/js/runtime_events.js
+++ b/runtime/js/runtime_events.js
@@ -64,21 +64,21 @@ function caml_ml_runtime_events_resume() {
   return 0;
 }
 
-//Provides: caml_runtime_events_create_cursor
+//Provides: caml_ml_runtime_events_create_cursor
 //Version: >= 5.0
-function caml_runtime_events_create_cursor(_target) {
+function caml_ml_runtime_events_create_cursor(_target) {
   return {};
 }
 
-//Provides: caml_runtime_events_free_cursor
+//Provides: caml_ml_runtime_events_free_cursor
 //Version: >= 5.0
-function caml_runtime_events_free_cursor(_cursor) {
+function caml_ml_runtime_events_free_cursor(_cursor) {
   return 0;
 }
 
-//Provides: caml_runtime_events_read_poll
+//Provides: caml_ml_runtime_events_read_poll
 //Version: >= 5.0
-function caml_runtime_events_read_poll(_cursor, _callbacks, _num) {
+function caml_ml_runtime_events_read_poll(_cursor, _callbacks, _num) {
   return 0;
 }
 


### PR DESCRIPTION
Four small, independent `#2270` items grouped together:

- **`runtime_events.js:67-83`** — the cursor primitives were named `caml_runtime_events_create_cursor` / `_free_cursor` / `_read_poll`, but every OCaml 5 release declares them with `ml_` (`caml_ml_runtime_events_*`, as `runtime_events.wat` uses). So the JS stubs were dead code and `Runtime_events.create_cursor` hit a missing-primitive failure. Renamed to add `ml_`.
- **`effect.js:314`** — `//!If: effects` is not valid annotation syntax (the grammar is `//If: !effects`); `parse_annot` swallowed it, so `jsoo_effect_not_supported` was provided unconditionally instead of only when effects are disabled. Fixed to `//If: !effects` (matching the many other uses in the file).
- **`blake2.js:311-313`** — `caml_blake2_create` did `key.subarray(0, 64);` and discarded the result, so an over-long key reached `blake2bInit` and threw `"Illegal key"` instead of being truncated. Now `key = key.subarray(0, 64)`. (Unreachable from `Digest.BLAKE*`, which is keyless.)
- **`backtrace.js:26-33`** — `OCAMLRUNPARAM` parsing `break`ed on the first bare `b`, so `b,b=0` left backtraces enabled where native's left-to-right last-wins parse disables them. Removed the `break`.

## Test

Added a regression test for the BLAKE2 fix, `compiler/tests-ocaml/lib-digest/blake2_long_key.ml` (js+wasm). It declares the keyed `caml_blake2_create`/`update`/`final` externals directly (the keyed API isn't reachable through `Digest.BLAKE*`) and checks that a 100-byte key is accepted, yields a 64-byte digest, and matches the digest of its 64-byte prefix. With the bug reintroduced the test throws `"Illegal key"` (exit 7); with the fix it prints `ok`. It runs on js+wasm only — the equivalence with the 64-byte prefix is jsoo-specific, since the native runtime keeps the original key length in the BLAKE2 parameter block.

The other three items remain fix-only (stubs / annotation / startup-parsing fixes not exercised by the suite). Verified through `make lint-js` and a full tests-jsoo js build; the renames match the wasm runtime and OCaml's expected primitive names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
