### PR TITLE
Runtime: fix Graphics and align it with the native X11 backend (+ tests)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -104,8 +104,23 @@
   bottom-left-origin pixel row `height - 1 - y` so they agree with
   `fill_rect`/`draw_image`/text; `draw_arc` no longer renders the
   wrong quadrant for a nonzero start angle (the canvas y-flip negates
-  the angle); and the first `draw_image` of an image is synchronous
-  (it drew through an asynchronous `Image`/data-URL round trip)
+  the angle); the first `draw_image` of an image is synchronous
+  (it drew through an asynchronous `Image`/data-URL round trip); and
+  `fill_rect` now paints `(w+1)x(h+1)` pixels (including the far edge
+  column `x+w` and row `y+h`) to match the native X11 backend; the
+  `lineto`, `draw_rect`, `draw_arc`, `fill_arc` and `fill_poly` use the
+  same `height - 1 - y` row as `plot`/`fill_rect` instead of `height - y`,
+  so they are no longer shifted one pixel down relative to the other
+  primitives and to native; `fill_arc` closes a partial arc through the
+  centre, filling
+  a pie slice like native instead of the circular segment a bare path
+  fill produced; stroked lines, rectangles and arcs are centred on the
+  pixel grid (a half-pixel offset) so a 1px stroke stays crisp like the
+  native backend instead of blurring across two rows; filled arcs,
+  circles and ellipses are centred on the pixel rather than the pixel
+  corner, so they no longer sit half a pixel up and to the left of
+  native; and line caps and joins are round, matching the X11 backend's
+  thick lines
 * Compiler: fix reference unboxing (#2210)
 * Compiler/wasm: fix int division return type to Unnormalized (#2197)
 * Compiler/wasm: preserve physical identity of empty closures (#2207)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -100,6 +100,12 @@
   inherited from `Object.prototype` (e.g. `"toString"`); and
   `Sys.isatty` consults the channel's file instead of always
   returning false (#2270)
+* Runtime: Graphics fixes (#2270): `plot`/`point_color` use the
+  bottom-left-origin pixel row `height - 1 - y` so they agree with
+  `fill_rect`/`draw_image`/text; `draw_arc` no longer renders the
+  wrong quadrant for a nonzero start angle (the canvas y-flip negates
+  the angle); and the first `draw_image` of an image is synchronous
+  (it drew through an asynchronous `Image`/data-URL round trip)
 * Compiler: fix reference unboxing (#2210)
 * Compiler/wasm: fix int division return type to Unnormalized (#2197)
 * Compiler/wasm: preserve physical identity of empty closures (#2207)

--- a/compiler/tests-check-prim/main.4.14.output
+++ b/compiler/tests-check-prim/main.4.14.output
@@ -91,6 +91,9 @@ caml_gr_synchronize
 caml_gr_text_size
 caml_gr_wait_event
 caml_gr_window_id
+caml_gr_xc
+caml_gr_y
+caml_gr_yc
 
 From +hash.js:
 caml_hash_mix_int64

--- a/compiler/tests-check-prim/main.5.2+ox.output
+++ b/compiler/tests-check-prim/main.5.2+ox.output
@@ -318,6 +318,9 @@ caml_gr_synchronize
 caml_gr_text_size
 caml_gr_wait_event
 caml_gr_window_id
+caml_gr_xc
+caml_gr_y
+caml_gr_yc
 
 From +hash.js:
 caml_hash_mix_int64

--- a/compiler/tests-check-prim/main.5.4.output
+++ b/compiler/tests-check-prim/main.5.4.output
@@ -85,6 +85,9 @@ caml_gr_synchronize
 caml_gr_text_size
 caml_gr_wait_event
 caml_gr_window_id
+caml_gr_xc
+caml_gr_y
+caml_gr_yc
 
 From +hash.js:
 caml_hash_mix_int64

--- a/compiler/tests-check-prim/unix-Unix.4.14.output
+++ b/compiler/tests-check-prim/unix-Unix.4.14.output
@@ -167,6 +167,9 @@ caml_gr_synchronize
 caml_gr_text_size
 caml_gr_wait_event
 caml_gr_window_id
+caml_gr_xc
+caml_gr_y
+caml_gr_yc
 
 From +hash.js:
 caml_hash_mix_int64

--- a/compiler/tests-check-prim/unix-Unix.5.2+ox.output
+++ b/compiler/tests-check-prim/unix-Unix.5.2+ox.output
@@ -394,6 +394,9 @@ caml_gr_synchronize
 caml_gr_text_size
 caml_gr_wait_event
 caml_gr_window_id
+caml_gr_xc
+caml_gr_y
+caml_gr_yc
 
 From +hash.js:
 caml_hash_mix_int64

--- a/compiler/tests-check-prim/unix-Unix.5.4.output
+++ b/compiler/tests-check-prim/unix-Unix.5.4.output
@@ -162,6 +162,9 @@ caml_gr_synchronize
 caml_gr_text_size
 caml_gr_wait_event
 caml_gr_window_id
+caml_gr_xc
+caml_gr_y
+caml_gr_yc
 
 From +hash.js:
 caml_hash_mix_int64

--- a/compiler/tests-check-prim/unix-Win32.4.14.output
+++ b/compiler/tests-check-prim/unix-Win32.4.14.output
@@ -139,6 +139,9 @@ caml_gr_synchronize
 caml_gr_text_size
 caml_gr_wait_event
 caml_gr_window_id
+caml_gr_xc
+caml_gr_y
+caml_gr_yc
 
 From +hash.js:
 caml_hash_mix_int64

--- a/compiler/tests-check-prim/unix-Win32.5.4.output
+++ b/compiler/tests-check-prim/unix-Win32.5.4.output
@@ -134,6 +134,9 @@ caml_gr_synchronize
 caml_gr_text_size
 caml_gr_wait_event
 caml_gr_window_id
+caml_gr_xc
+caml_gr_y
+caml_gr_yc
 
 From +hash.js:
 caml_hash_mix_int64

--- a/compiler/tests-graphics/README.md
+++ b/compiler/tests-graphics/README.md
@@ -1,0 +1,74 @@
+# Graphics_js tests
+
+Tests for the `js_of_ocaml-lwt.graphics` runtime (`runtime/js/graphics.js`).
+
+These are **not** run by `make tests`. They need a real `<canvas>` —
+specifically `getImageData`, to read back rendered pixels — which Node does
+not provide. So they are driven manually in a browser. `dune build @all` keeps
+them compiling, but nothing here is attached to the `runtest` aliases.
+
+## `test.ml` — self-checks
+
+About 50 assertions covering the full `Graphics_js` API: `plot`/`point_color`
+origin, `fill_rect` placement and extent, `fill_poly`/`fill_arc`/`fill_circle`/
+`fill_ellipse`, strokes (`lineto`/`draw_rect`/`draw_*`), `curveto`, images
+(`make_image`/`dump_image`/`draw_image`/`blit_image`/`get_image`, transparency),
+text metrics, context management, and that the unimplemented primitives raise.
+
+Build and run:
+
+```sh
+dune build compiler/tests-graphics/test.bc.js
+# serve the build dir and open index.html in a browser:
+(cd _build/default/compiler/tests-graphics && python3 -m http.server 8000)
+# browse http://localhost:8000/  -> results in <pre id="results"> and the console
+```
+
+Headless (Chromium), extracting the result block:
+
+```sh
+cd _build/default/compiler/tests-graphics
+python3 -m http.server 8000 &
+chromium --headless --no-sandbox --virtual-time-budget=10000 \
+  --dump-dom http://localhost:8000/index.html | grep -A100 'id="results"'
+```
+
+The last line is `SUMMARY: N passed, M failed`.
+
+## `compare/` — pixel comparison against native X11 Graphics
+
+Renders one shared scene (`gscene/scene.ml`) two ways and diffs the rasters:
+
+- `native.exe` draws it with the real `graphics` library (X11) and dumps a
+  binary PPM.
+- `web.bc.js` draws it on a DOM canvas and dumps the raster as hex into a
+  `<pre id="dump">`.
+- `diff.py` compares them.
+
+The scene is split into two bands (see `gscene/scene.ml`):
+
+- **Exact zone** (`y < 99`): axis-aligned `fill_rect`/`fill_poly`, `plot`s and
+  images. The native backend does no anti-aliasing, so these must match the
+  canvas output **pixel-for-pixel** — `diff.py` requires 0 differences here.
+- **AA zone** (`y >= 99`): curves, strokes and filled curves, whose edges are
+  anti-aliased by the browser but hard-edged by X11. Per-pixel differences
+  there are expected and tolerated.
+
+Text is included in the AA zone purely for illustration; native and browser
+fonts are different engines (X11 bitmap vs browser outline, points vs pixels),
+so glyphs are never pixel-comparable — only the geometric primitives are.
+
+Run (needs an X display for the native side and a browser for the web side):
+
+```sh
+dune build compiler/tests-graphics/compare/native.exe \
+            compiler/tests-graphics/compare/web.bc.js
+# native -> PPM
+_build/default/compiler/tests-graphics/compare/native.exe native.ppm
+# web -> hex (serve web.bc.js with an index.html that loads it, dump #dump)
+# then:
+python3 compiler/tests-graphics/compare/diff.py native.ppm web.hex
+```
+
+`diff.py` prints the exact-zone diff count (must be 0), the AA-zone diff count,
+and exits non-zero if the exact zone differs.

--- a/compiler/tests-graphics/compare/diff.py
+++ b/compiler/tests-graphics/compare/diff.py
@@ -1,0 +1,76 @@
+import sys
+
+W = H = 200
+
+# Boundary between the two scene bands (see gscene/scene.ml).
+# OCaml y < 99 (the EXACT zone) maps to screen rows >= 101; everything at
+# screen row <= 100 is the AA zone (curved/stroked primitives, tolerated).
+EXACT_FIRST_ROW = 101
+
+
+def read_ppm(path):
+    with open(path, "rb") as f:
+        data = f.read()
+    # parse P6 header: "P6\n200 200\n255\n"
+    parts = []
+    i = 2
+    while len(parts) < 3:
+        while data[i] in b" \t\n\r":
+            i += 1
+        j = i
+        while data[j] not in b" \t\n\r":
+            j += 1
+        parts.append(data[i:j]); i = j
+    i += 1  # single whitespace after maxval
+    body = data[i:]
+    return [(body[3 * k], body[3 * k + 1], body[3 * k + 2]) for k in range(W * H)]
+
+
+def read_hex(path):
+    with open(path) as f:
+        s = f.read().strip()
+    px = []
+    for k in range(W * H):
+        o = k * 6
+        px.append((int(s[o:o + 2], 16), int(s[o + 2:o + 4], 16), int(s[o + 4:o + 6], 16)))
+    return px
+
+
+native = read_ppm(sys.argv[1])
+web = read_hex(sys.argv[2])
+
+exact_diff = 0          # diffs in the exact zone -> must be 0
+aa_diff = 0             # diffs in the AA zone -> tolerated
+aa_near = 0             # of those, AA fringe (<=32 per channel)
+examples = []           # exact-zone mismatches (the ones that matter)
+
+for k in range(W * H):
+    c = k % W
+    r = k // W
+    n = native[k]
+    we = web[k]
+    if n == we:
+        continue
+    if r >= EXACT_FIRST_ROW:
+        exact_diff += 1
+        if len(examples) < 16:
+            examples.append((c, r, n, we))
+    else:
+        aa_diff += 1
+        d = max(abs(n[0] - we[0]), abs(n[1] - we[1]), abs(n[2] - we[2]))
+        if d <= 32:
+            aa_near += 1
+
+print(f"image: {W}x{H} = {W * H} px")
+print(f"EXACT zone (rows >= {EXACT_FIRST_ROW}) diffs : {exact_diff}   (MUST be 0)")
+print(f"AA zone    (rows <= {EXACT_FIRST_ROW - 1}) diffs : {aa_diff}   "
+      f"({aa_near} near-match <=32/chan, rest hard AA edges)")
+if examples:
+    print("EXACT-zone mismatches (col,row  native vs web):")
+    for c, r, n, we in examples:
+        print(f"   ({c:3d},{r:3d}) {n} vs {we}")
+if exact_diff == 0:
+    print("RESULT: PASS  (every solid fill / poly / plot / image matches native)")
+else:
+    print(f"RESULT: FAIL  ({exact_diff} exact-zone pixels differ from native)")
+sys.exit(1 if exact_diff else 0)

--- a/compiler/tests-graphics/compare/dune
+++ b/compiler/tests-graphics/compare/dune
@@ -1,0 +1,20 @@
+; Pixel comparison of Graphics_js against the native X11 Graphics backend.
+; Manual / diagnostic only (needs X11 for the native renderer and a browser
+; for the web one); not attached to the runtest aliases. See ../README.md.
+
+(executable
+ (name native)
+ (modules native)
+ (libraries graphics gscene))
+
+(executable
+ (name web)
+ (modes js)
+ (modules web)
+ (libraries js_of_ocaml-lwt.graphics gscene)
+ (preprocess
+  (pps js_of_ocaml-ppx)))
+
+(alias
+ (name default)
+ (deps web.bc.js))

--- a/compiler/tests-graphics/compare/gscene/dune
+++ b/compiler/tests-graphics/compare/gscene/dune
@@ -1,0 +1,3 @@
+(library
+ (name gscene)
+ (libraries graphics))

--- a/compiler/tests-graphics/compare/gscene/scene.ml
+++ b/compiler/tests-graphics/compare/gscene/scene.ml
@@ -1,0 +1,125 @@
+(* Shared drawing, used identically by the native and the jsoo executables.
+   Uses only plain Graphics primitives (Graphics_js re-exports the same ones,
+   and the jsoo runtime implements the same caml_gr_* externals).
+
+   The canvas is split into two horizontal bands (see compare/diff.py):
+
+   - EXACT zone, OCaml y < 99 (screen rows >= 101): axis-aligned fill_rect
+     and fill_poly, single-pixel plots and images. The native X11 backend
+     does no anti-aliasing, so these must match the jsoo canvas output
+     pixel-for-pixel -- any difference here is a real placement/colour bug.
+
+   - AA zone, OCaml y >= 99 (screen rows <= 100): curved and stroked
+     primitives (arcs, circles, ellipses, lines, polylines, segments,
+     Bezier) plus the filled curves (fill_arc, fill_circle, fill_ellipse).
+     Their curved edges are anti-aliased by the browser but hard-edged by
+     X11, so per-pixel differences along them are expected and tolerated.
+
+   Text (draw_string) is included in the AA zone, but native and browser
+   font rasterizers are entirely different, so the glyphs themselves are
+   never pixel-comparable -- only the baseline placement is meaningful. The
+   per-glyph differences are expected and tolerated. *)
+
+let make_img () =
+  let open Graphics in
+  let m = Array.make_matrix 12 12 (rgb 0 0 0) in
+  for r = 0 to 11 do
+    for c = 0 to 11 do
+      m.(r).(c) <- rgb (r * 20) (c * 20) 160
+    done
+  done;
+  m
+
+(* an 8x8 tile, opaque yellow with a transparent 4x4 hole in the middle *)
+let make_hole () =
+  let open Graphics in
+  let m = Array.make_matrix 8 8 (rgb 255 255 0) in
+  for i = 2 to 5 do
+    for j = 2 to 5 do
+      m.(i).(j) <- transp
+    done
+  done;
+  m
+
+let draw () =
+  let open Graphics in
+  (* background *)
+  set_color (rgb 255 255 255);
+  fill_rect 0 0 200 200;
+
+  (* ===================== EXACT zone (OCaml y < 99) ===================== *)
+  (* solid rectangles, including origin- and edge-touching ones; these
+     exercise fill_rect placement and the (w+1)x(h+1) far-edge extent *)
+  set_color (rgb 255 0 0);
+  fill_rect 8 8 30 20;
+  set_color (rgb 0 0 255);
+  fill_rect 70 55 40 30;
+  set_color (rgb 0 160 0);
+  fill_rect 150 8 30 25;
+  (* the origin pixel and a low-y block (origin-sensitive, #2296) *)
+  set_color (rgb 0 0 0);
+  fill_rect 0 0 5 5;
+
+  (* axis-aligned fill_poly (an L/staircase: every edge horizontal or
+     vertical, so no diagonal AA -- matches native exactly) *)
+  set_color (rgb 200 0 200);
+  fill_poly [| 45, 40; 65, 40; 65, 60; 55, 60; 55, 90; 45, 90 |];
+
+  (* single-pixel plots: origin, bottom edge, bottom-right corner, and a
+     diagonal cluster via plots *)
+  set_color (rgb 0 0 0);
+  plot 0 0;
+  plot 6 0;
+  plot 0 6;
+  plot 199 0;
+  plots [| 120, 50; 121, 51; 122, 52; 123, 53; 124, 54 |];
+
+  (* a drawn image (origin + draw_image sync sensitive) *)
+  draw_image (make_image (make_img ())) 160 55;
+
+  (* draw_image with a transparent hole over a coloured patch: the hole
+     must show the patch colour through (transp compositing) *)
+  set_color (rgb 0 200 200);
+  fill_rect 120 8 24 24;
+  draw_image (make_image (make_hole ())) 124 12;
+
+  (* ====================== AA zone (OCaml y >= 99) ======================
+     Everything here is tolerated, so primitives may overlap freely; the
+     only constraint is that nothing dips below y ~= 102 (so anti-aliasing
+     never bleeds into the exact zone). *)
+  (* filled curves (interiors match native; only the curved edge is AA) *)
+  set_color (rgb 0 0 200);
+  fill_circle 100 120 14;
+  set_color (rgb 0 160 0);
+  fill_ellipse 140 118 24 12;
+  set_color (rgb 200 120 0);
+  fill_arc 178 120 16 16 0 270;
+  (* outlined curves *)
+  set_color (rgb 0 0 0);
+  set_line_width 1;
+  draw_arc 30 165 22 22 90 180;
+  draw_circle 95 165 18;
+  draw_ellipse 150 168 28 12;
+  (* straight strokes: a horizontal then a vertical segment via lineto *)
+  moveto 12 145;
+  lineto 32 145;
+  lineto 32 160;
+  (* a rectangle outline *)
+  draw_rect 188 150 8 30;
+  (* an open polyline and a pair of crossing segments *)
+  draw_poly_line [| 60, 145; 85, 145; 85, 160; 62, 160 |];
+  draw_segments [| 108, 145, 135, 162; 108, 162, 135, 145 |];
+  (* a thick line (set_line_width) *)
+  set_line_width 4;
+  moveto 10 192;
+  lineto 90 192;
+  set_line_width 1;
+  (* a cubic Bezier *)
+  moveto 105 184;
+  curveto (130, 199) (165, 199) (192, 186);
+  (* text: glyphs differ between X11 and the browser, but the baseline is
+     at the current point in both *)
+  set_font "courier";
+  set_text_size 18;
+  moveto 6 106;
+  draw_string "Abg123"

--- a/compiler/tests-graphics/compare/native.ml
+++ b/compiler/tests-graphics/compare/native.ml
@@ -1,0 +1,22 @@
+(* Native renderer: draw the shared scene with the real X11 Graphics lib,
+   dump the framebuffer (row 0 = top) as a binary PPM to argv.(1). *)
+let () =
+  Graphics.open_graph " 200x200";
+  Gscene.Scene.draw ();
+  let w = Graphics.size_x () and h = Graphics.size_y () in
+  let m = Graphics.dump_image (Graphics.get_image 0 0 w h) in
+  let buf = Buffer.create ((w * h * 3) + 32) in
+  Buffer.add_string buf (Printf.sprintf "P6\n%d %d\n255\n" w h);
+  for r = 0 to h - 1 do
+    for c = 0 to w - 1 do
+      let col = m.(r).(c) in
+      let col = if col < 0 then 0xffffff else col in
+      Buffer.add_char buf (Char.chr ((col lsr 16) land 0xff));
+      Buffer.add_char buf (Char.chr ((col lsr 8) land 0xff));
+      Buffer.add_char buf (Char.chr (col land 0xff))
+    done
+  done;
+  let oc = open_out_bin Sys.argv.(1) in
+  Buffer.output_buffer oc buf;
+  close_out oc;
+  Graphics.close_graph ()

--- a/compiler/tests-graphics/compare/web.ml
+++ b/compiler/tests-graphics/compare/web.ml
@@ -1,0 +1,35 @@
+(* jsoo renderer: draw the shared scene onto a DOM canvas, then emit the raw
+   canvas raster (row 0 = top, hex rrggbb per pixel) into <pre id="dump">. *)
+open Js_of_ocaml
+module Html = Dom_html
+
+let () =
+  let w = 200 and h = 200 in
+  let canvas = Html.createCanvas Html.document in
+  canvas##.width := w;
+  canvas##.height := h;
+  Dom.appendChild Html.document##.body canvas;
+  Graphics_js.open_canvas canvas;
+  Gscene.Scene.draw ();
+  let ctx = canvas##getContext Html._2d_ in
+  let n = Js.number_of_float in
+  let img = ctx##getImageData (n 0.) (n 0.) (n (float w)) (n (float h)) in
+  let d = img##.data in
+  let buf = Buffer.create (w * h * 6) in
+  let hx = "0123456789abcdef" in
+  let put v =
+    Buffer.add_char buf hx.[(v lsr 4) land 0xf];
+    Buffer.add_char buf hx.[v land 0xf]
+  in
+  for r = 0 to h - 1 do
+    for c = 0 to w - 1 do
+      let idx = ((r * w) + c) * 4 in
+      put (Html.pixel_get d idx);
+      put (Html.pixel_get d (idx + 1));
+      put (Html.pixel_get d (idx + 2))
+    done
+  done;
+  let pre = Html.createPre Html.document in
+  pre##.id := Js.string "dump";
+  pre##.textContent := Js.some (Js.string (Buffer.contents buf));
+  Dom.appendChild Html.document##.body pre

--- a/compiler/tests-graphics/dune
+++ b/compiler/tests-graphics/dune
@@ -1,0 +1,16 @@
+; Graphics_js tests. These are NOT run by `make tests`: they need a real
+; canvas (getImageData), which Node does not provide, so they are driven
+; manually in a browser. See README.md. The executables still build under
+; `dune build @all` (so they are kept compiling), but nothing here is
+; attached to the runtest aliases.
+
+(executable
+ (name test)
+ (modes js)
+ (libraries js_of_ocaml-lwt.graphics)
+ (preprocess
+  (pps js_of_ocaml-ppx)))
+
+(alias
+ (name default)
+ (deps test.bc.js index.html))

--- a/compiler/tests-graphics/index.html
+++ b/compiler/tests-graphics/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head><meta charset="utf-8"><title>Graphics_js self-test</title></head>
   <body>
     <script src="test.bc.js"></script>

--- a/compiler/tests-graphics/index.html
+++ b/compiler/tests-graphics/index.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+  <head><meta charset="utf-8"><title>Graphics_js self-test</title></head>
+  <body>
+    <script src="test.bc.js"></script>
+  </body>
+</html>

--- a/compiler/tests-graphics/test.ml
+++ b/compiler/tests-graphics/test.ml
@@ -1,0 +1,682 @@
+open Js_of_ocaml
+open Graphics_js
+module Html = Dom_html
+
+let w = 200
+
+let h = 200
+
+(* Independent raw pixel reader: read canvas pixel at *canvas* coords
+   (cx, cy) -> (r, g, b), bypassing the Graphics coordinate primitives. *)
+let raw_ctx = ref None
+
+let n = Js.number_of_float
+
+(* read a pixel from an arbitrary 2d context *)
+let read_ctx ctx cx cy =
+  let img = ctx##getImageData (n (float cx)) (n (float cy)) (n 1.) (n 1.) in
+  let d = img##.data in
+  Html.pixel_get d 0, Html.pixel_get d 1, Html.pixel_get d 2
+
+let raw_read cx cy =
+  let ctx =
+    match !raw_ctx with
+    | Some c -> c
+    | None -> assert false
+  in
+  read_ctx ctx cx cy
+
+(* Convert OCaml (bottom-left origin) coords to the canonical canvas row. *)
+let canvas_row oy = h - 1 - oy
+
+let results = Buffer.create 256
+
+let pass = ref 0
+
+let fail = ref 0
+
+let check name ok detail =
+  if ok then incr pass else incr fail;
+  Buffer.add_string
+    results
+    (Printf.sprintf "[%s] %s : %s\n" (if ok then "PASS" else "FAIL") name detail)
+
+let hex (r, g, b) = Printf.sprintf "#%02x%02x%02x" r g b
+
+let is_white (r, g, b) = r = 255 && g = 255 && b = 255
+
+(* Did anything get drawn (a non-white pixel appear) in the canvas-space
+   rectangle [cx0, cx0+ww) x [cy0, cy0+hh) ? Used for anti-aliased
+   primitives (strokes, arcs, text) where exact colours are unreliable. *)
+let scan_non_white cx0 cy0 ww hh =
+  let found = ref false in
+  for yy = cy0 to cy0 + hh - 1 do
+    for xx = cx0 to cx0 + ww - 1 do
+      if not (is_white (raw_read xx yy)) then found := true
+    done
+  done;
+  !found
+
+(* any ink within +/-3 px of canvas point (cx, cy)? (for anti-aliased
+   curves, where the exact pixel is unreliable) *)
+let drew_at cx cy = scan_non_white (cx - 3) (cy - 3) 7 7
+
+let raises f =
+  try
+    f ();
+    false
+  with _ -> true
+
+let white () =
+  set_color (rgb 255 255 255);
+  fill_rect 0 0 w h
+
+let () =
+  let canvas = Html.createCanvas Html.document in
+  canvas##.width := w;
+  canvas##.height := h;
+  Dom.appendChild Html.document##.body canvas;
+  open_canvas canvas;
+  raw_ctx := Some (canvas##getContext Html._2d_);
+  let main_ctx = get_context () in
+
+  (* --- Test 1: fill_rect placement + point_color agreement (off-by-one) --- *)
+  white ();
+  set_color (rgb 255 0 0);
+  fill_rect 5 5 1 1;
+  let fr = raw_read 5 (canvas_row 5) in
+  check
+    "fill_rect places at height-1-y"
+    (fr = (255, 0, 0))
+    (Printf.sprintf "raw(5,%d)=%s" (canvas_row 5) (hex fr));
+  let pc = point_color 5 5 in
+  check
+    "point_color reads back fill_rect color"
+    (pc = 0xFF0000)
+    (Printf.sprintf "point_color 5 5 = 0x%06x (want 0xff0000)" pc);
+
+  (* --- Test 2: plot placement uses height-1-y --- *)
+  white ();
+  set_color (rgb 0 0 255);
+  plot 10 20;
+  let pr = raw_read 10 (canvas_row 20) in
+  check
+    "plot places at height-1-y"
+    (pr = (0, 0, 255))
+    (Printf.sprintf "raw(10,%d)=%s" (canvas_row 20) (hex pr));
+  (* old buggy row height-y would land one row lower (off intended pixel) *)
+  let pr_old = raw_read 10 (h - 20) in
+  check
+    "plot does NOT place at buggy height-y"
+    (pr_old = (255, 255, 255))
+    (Printf.sprintf "raw(10,%d)=%s (should be white)" (h - 20) (hex pr_old));
+
+  (* --- Test 3: plot at y=0 is on-canvas (visible) and round-trips --- *)
+  white ();
+  set_color (rgb 0 255 0);
+  plot 15 0;
+  let p0 = raw_read 15 (canvas_row 0) in
+  check
+    "plot x 0 is visible (bottom row)"
+    (p0 = (0, 255, 0))
+    (Printf.sprintf "raw(15,%d)=%s" (canvas_row 0) (hex p0));
+  let pc0 = point_color 15 0 in
+  check
+    "point_color x 0 reads it back"
+    (pc0 = 0x00FF00)
+    (Printf.sprintf "point_color 15 0 = 0x%06x" pc0);
+
+  (* --- Test 4: draw_arc 90->180 renders the top-left quadrant --- *)
+  white ();
+  set_color (rgb 0 0 0);
+  let cx = 100 and cy = 100 and r = 60 in
+  draw_arc cx cy r r 90 180;
+  (* scan the whole canvas once, classify colored pixels by OCaml quadrant *)
+  let img =
+    (match !raw_ctx with
+      | Some c -> c
+      | None -> assert false)##getImageData
+      (n 0.)
+      (n 0.)
+      (n (float w))
+      (n (float h))
+  in
+  let d = img##.data in
+  let tl = ref 0 and tr = ref 0 and bl = ref 0 and br = ref 0 in
+  for cyi = 0 to h - 1 do
+    for cxi = 0 to w - 1 do
+      let idx = ((cyi * w) + cxi) * 4 in
+      let rr = Html.pixel_get d idx in
+      let gg = Html.pixel_get d (idx + 1) in
+      let bb = Html.pixel_get d (idx + 2) in
+      if rr < 128 && gg < 128 && bb < 128
+      then begin
+        let ox = cxi and oy = h - 1 - cyi in
+        if ox < cx && oy > cy
+        then incr tl
+        else if ox > cx && oy > cy
+        then incr tr
+        else if ox < cx && oy < cy
+        then incr bl
+        else if ox > cx && oy < cy
+        then incr br
+      end
+    done
+  done;
+  check
+    "draw_arc 90->180 is in top-left quadrant"
+    (!tl > 10 && !br = 0)
+    (Printf.sprintf "counts tl=%d tr=%d bl=%d br=%d" !tl !tr !bl !br);
+
+  (* --- Test 5: first draw_image is synchronous --- *)
+  white ();
+  let red = rgb 255 0 0 in
+  let img5 = make_image (Array.make_matrix 4 4 red) in
+  draw_image img5 50 50;
+  (* immediately (synchronously) read a pixel inside the drawn image.
+     image top-left canvas coords = (50, h - 4 - 50); fill a pixel inside. *)
+  let ix = 51 and iy = h - 4 - 50 + 1 in
+  let di = raw_read ix iy in
+  check
+    "first draw_image is synchronous"
+    (di = (255, 0, 0))
+    (Printf.sprintf "raw(%d,%d)=%s immediately after draw_image" ix iy (hex di));
+
+  (* ===================================================================== *)
+  (* The remaining tests exercise the rest of the Graphics_js API surface.  *)
+  (* ===================================================================== *)
+
+  (* --- Test 6: window geometry (size_x / size_y) --- *)
+  check
+    "size_x/size_y report the canvas size"
+    (size_x () = w && size_y () = h)
+    (Printf.sprintf "size_x=%d size_y=%d" (size_x ()) (size_y ()));
+
+  (* --- Test 7: moveto / current_x / current_y / current_point --- *)
+  moveto 12 34;
+  let curp = current_point () in
+  check
+    "moveto sets current_x/current_y/current_point"
+    (current_x () = 12 && current_y () = 34 && curp = (12, 34))
+    (Printf.sprintf
+       "current=(%d,%d) current_point=(%d,%d)"
+       (current_x ())
+       (current_y ())
+       (fst curp)
+       (snd curp));
+
+  (* --- Test 8: rmoveto is relative to the current point --- *)
+  moveto 10 10;
+  rmoveto 5 7;
+  check
+    "rmoveto moves relative to current point"
+    (current_point () = (15, 17))
+    (Printf.sprintf "current_point=(%d,%d)" (current_x ()) (current_y ()));
+
+  (* --- Test 9: set_window_title is a harmless no-op (must not raise) --- *)
+  check
+    "set_window_title does not raise"
+    (not (raises (fun () -> set_window_title "gr2296")))
+    "set_window_title \"gr2296\"";
+
+  (* --- Test 10: plots draws every point of the array --- *)
+  white ();
+  set_color (rgb 0 0 0);
+  plots [| 30, 30; 31, 31; 32, 32 |];
+  check
+    "plots draws each point"
+    (raw_read 30 (canvas_row 30) = (0, 0, 0)
+    && raw_read 31 (canvas_row 31) = (0, 0, 0)
+    && raw_read 32 (canvas_row 32) = (0, 0, 0))
+    "three plotted pixels are black";
+
+  (* --- Test 11: fill_poly fills a triangle's interior --- *)
+  (* fill_poly fills the triangle interior only: the centroid and a point
+     near the base are coloured, but the upper corners of the bounding box
+     -- outside the sloped edges -- stay white (a filled rectangle would
+     colour them). *)
+  white ();
+  let tcol = rgb 10 20 200 in
+  set_color tcol;
+  fill_poly [| 60, 60; 90, 60; 75, 90 |];
+  let fp_centroid = point_color 75 70 = tcol in
+  let fp_base = point_color 75 62 = tcol in
+  let fp_out_l = point_color 62 85 = 0xFFFFFF in
+  let fp_out_r = point_color 88 85 = 0xFFFFFF in
+  check
+    "fill_poly fills the triangle interior only (corners stay white)"
+    (fp_centroid && fp_base && fp_out_l && fp_out_r)
+    (Printf.sprintf
+       "centroid=0x%06x base=0x%06x outL(62,85)=0x%06x outR(88,85)=0x%06x"
+       (point_color 75 70)
+       (point_color 75 62)
+       (point_color 62 85)
+       (point_color 88 85));
+
+  (* --- Test 12: fill_circle / fill_ellipse / fill_arc fill the centre --- *)
+  (* fill_circle fills a round disc: points within the radius are
+     coloured, but the bounding-box corner (distance r*sqrt2 > r) and a
+     point just past the radius stay white -- a square fill would colour
+     both. *)
+  white ();
+  let ccol = rgb 200 30 30 in
+  set_color ccol;
+  fill_circle 100 100 20;
+  let c_centre = point_color 100 100 = ccol in
+  let c_in = point_color 115 100 = ccol && point_color 100 115 = ccol in
+  let c_out_edge = point_color 125 100 = 0xFFFFFF in
+  let c_out_corner = point_color 116 116 = 0xFFFFFF in
+  check
+    "fill_circle fills a round disc (bbox corner stays white)"
+    (c_centre && c_in && c_out_edge && c_out_corner)
+    (Printf.sprintf
+       "centre=0x%06x (115,100)=0x%06x (125,100)=0x%06x corner(116,116)=0x%06x"
+       (point_color 100 100)
+       (point_color 115 100)
+       (point_color 125 100)
+       (point_color 116 116));
+  (* fill_ellipse must honour distinct radii (rx<>ry): a wide, short
+     ellipse (rx=40, ry=15) covers (cx+30,cy) but leaves (cx,cy+30)
+     white -- a circle of radius 40 would colour both. *)
+  white ();
+  let ecol = rgb 30 200 30 in
+  set_color ecol;
+  fill_ellipse 100 100 40 15;
+  let e_centre = point_color 100 100 = ecol in
+  let e_in_h = point_color 130 100 = ecol in
+  let e_in_v = point_color 100 108 = ecol in
+  let e_out_v = point_color 100 130 = 0xFFFFFF in
+  check
+    "fill_ellipse honours rx<>ry (wide and short)"
+    (e_centre && e_in_h && e_in_v && e_out_v)
+    (Printf.sprintf
+       "centre=0x%06x (130,100)=0x%06x (100,108)=0x%06x (100,130)=0x%06x"
+       (point_color 100 100)
+       (point_color 130 100)
+       (point_color 100 108)
+       (point_color 100 130));
+  white ();
+  let acol = rgb 30 30 200 in
+  set_color acol;
+  fill_arc 100 100 25 25 0 360;
+  check
+    "fill_arc (full disk) fills the centre"
+    (point_color 100 100 = acol)
+    (Printf.sprintf "centre = 0x%06x" (point_color 100 100));
+
+  (* --- Test 13: lineto / rlineto draw a stroke --- *)
+  white ();
+  set_color (rgb 0 0 0);
+  moveto 20 100;
+  lineto 180 100;
+  (* lineto strokes at canvas row h-y; scan a band around it *)
+  check
+    "lineto draws a horizontal stroke"
+    (scan_non_white 21 (h - 100 - 2) 158 5)
+    "non-white pixels found along the line";
+  white ();
+  set_color (rgb 0 0 0);
+  moveto 10 30;
+  rlineto 60 0;
+  check
+    "rlineto draws relative to current point"
+    (scan_non_white 11 (h - 30 - 2) 58 5)
+    "non-white pixels found along the relative line";
+
+  (* --- Test 14: draw_rect draws a rectangle outline --- *)
+  white ();
+  set_color (rgb 0 0 0);
+  draw_rect 40 40 50 30;
+  check
+    "draw_rect strokes a rectangle outline"
+    (scan_non_white 38 (h - 70 - 2) 56 36)
+    "non-white pixels found on the rectangle border";
+
+  (* --- Test 15: draw_poly_line / draw_poly / draw_segments --- *)
+  white ();
+  set_color (rgb 0 0 0);
+  draw_poly_line [| 10, 10; 50, 10; 50, 50 |];
+  check
+    "draw_poly_line strokes an open path"
+    (scan_non_white 8 (h - 50 - 2) 46 46)
+    "non-white pixels found on the poly line";
+  white ();
+  set_color (rgb 0 0 0);
+  draw_poly [| 120, 120; 160, 120; 140, 160 |];
+  check
+    "draw_poly strokes a closed path"
+    (scan_non_white 118 (h - 160 - 2) 46 46)
+    "non-white pixels found on the closed poly";
+  white ();
+  set_color (rgb 0 0 0);
+  draw_segments [| 5, 5, 60, 60; 60, 5, 5, 60 |];
+  check
+    "draw_segments strokes the given segments"
+    (scan_non_white 4 (h - 60 - 2) 60 60)
+    "non-white pixels found on the segments";
+
+  (* --- Test 16: draw_arc full circle / draw_circle / draw_ellipse --- *)
+  (* draw_circle strokes a round outline: ink at all four vertices but
+     none at the bounding-box corner (cx+r, cy+r) *)
+  white ();
+  set_color (rgb 0 0 0);
+  draw_circle 100 100 40;
+  let dc_right = drew_at 140 (h - 100) in
+  let dc_left = drew_at 60 (h - 100) in
+  let dc_top = drew_at 100 (h - 140) in
+  let dc_bottom = drew_at 100 (h - 60) in
+  let dc_corner_clear = not (drew_at 140 (h - 140)) in
+  check
+    "draw_circle strokes a round outline (bbox corner is clear)"
+    (dc_right && dc_left && dc_top && dc_bottom && dc_corner_clear)
+    (Printf.sprintf
+       "right=%b left=%b top=%b bottom=%b corner-clear=%b"
+       dc_right
+       dc_left
+       dc_top
+       dc_bottom
+       dc_corner_clear);
+  (* draw_ellipse honours distinct radii (rx=45, ry=20): ink at the right
+     vertex (cx+rx,cy) and top vertex (cx,cy+ry), but none where a circle
+     of radius rx would be (cx, cy+rx) *)
+  white ();
+  set_color (rgb 0 0 0);
+  draw_ellipse 100 100 45 20;
+  let de_right = drew_at 145 (h - 100) in
+  let de_top = drew_at 100 (h - 120) in
+  let de_not_circle = not (drew_at 100 (h - 145)) in
+  check
+    "draw_ellipse honours rx<>ry (no ink at a circle's radius)"
+    (de_right && de_top && de_not_circle)
+    (Printf.sprintf
+       "right=%b top=%b no-ink-at-(100,145)=%b"
+       de_right
+       de_top
+       de_not_circle);
+
+  (* --- curveto strokes a cubic Bezier and leaves the current point at
+     its endpoint (it draws the spline via draw_poly_line then moveto). --- *)
+  white ();
+  set_color (rgb 0 0 0);
+  moveto 20 100;
+  curveto (60, 160) (140, 160) (180, 100);
+  let cv_end = current_point () = (180, 100) in
+  let cv_start_ink = drew_at 20 (h - 100) in
+  let cv_end_ink = drew_at 180 (h - 100) in
+  let cv_path_ink = scan_non_white 20 (h - 160) 161 70 in
+  check
+    "curveto strokes a cubic Bezier ending at the last point"
+    (cv_end && cv_start_ink && cv_end_ink && cv_path_ink)
+    (Printf.sprintf
+       "end=(%d,%d) start_ink=%b end_ink=%b path_ink=%b"
+       (current_x ())
+       (current_y ())
+       cv_start_ink
+       cv_end_ink
+       cv_path_ink);
+
+  (* --- Test 17: set_line_width thickens strokes --- *)
+  white ();
+  set_color (rgb 0 0 0);
+  set_line_width 5;
+  moveto 20 50;
+  lineto 180 50;
+  (* the line is centred on canvas row h-1-50; a 5px width inks a band of
+     about 5 rows there, vs ~2 for a 1px line *)
+  let cy = h - 1 - 50 in
+  let band = ref 0 in
+  for r = cy - 4 to cy + 4 do
+    if not (is_white (raw_read 100 r)) then incr band
+  done;
+  check
+    "set_line_width 5 produces a thick line (>= 4 px band)"
+    (!band >= 4)
+    (Printf.sprintf "non-white rows in column 100 around y=%d: %d" cy !band);
+  set_line_width 1;
+
+  (* --- Test 18: set_font / set_text_size / text_size --- *)
+  set_font "sans-serif";
+  set_text_size 20;
+  let tw, th = text_size "Hi" in
+  check
+    "text_size reports the configured text height"
+    (th = 20 && tw > 0)
+    (Printf.sprintf "text_size \"Hi\" = (%d,%d)" tw th);
+
+  (* --- Test 19: draw_string / draw_char render glyphs and advance x --- *)
+  white ();
+  set_color (rgb 0 0 0);
+  set_text_size 26;
+  moveto 20 100;
+  draw_string "Hello";
+  check
+    "draw_string renders glyphs"
+    (scan_non_white 20 (h - 100 - 26) 110 28)
+    "non-white pixels found where the string was drawn";
+  check
+    "draw_string advances current_x"
+    (current_x () > 20)
+    (Printf.sprintf "current_x = %d (was 20)" (current_x ()));
+  white ();
+  set_color (rgb 0 0 0);
+  moveto 20 100;
+  draw_char 'A';
+  check
+    "draw_char renders a glyph"
+    (scan_non_white 20 (h - 100 - 26) 30 28)
+    "non-white pixels found where the char was drawn";
+
+  (* --- Test 20: make_image / dump_image round-trips a colour matrix --- *)
+  let m =
+    Array.init 3 (fun i -> Array.init 3 (fun j -> rgb (i * 10) (j * 10) (i + j + 1)))
+  in
+  let dumped = dump_image (make_image m) in
+  let matrix_eq = ref true in
+  Array.iteri
+    (fun i row ->
+      Array.iteri (fun j c -> if dumped.(i).(j) <> c then matrix_eq := false) row)
+    m;
+  check
+    "make_image/dump_image round-trip a colour matrix"
+    !matrix_eq
+    "dump_image reproduces the source matrix";
+
+  (* --- Test 21: create_image + blit_image capture the canvas --- *)
+  white ();
+  let bcol = rgb 7 8 9 in
+  set_color bcol;
+  fill_rect 50 50 4 4;
+  let cap = create_image 4 4 in
+  blit_image cap 50 50;
+  let cdump = dump_image cap in
+  let blit_ok = ref true in
+  Array.iter
+    (fun row -> Array.iter (fun c -> if c <> bcol then blit_ok := false) row)
+    cdump;
+  check
+    "create_image + blit_image capture canvas pixels"
+    !blit_ok
+    (Printf.sprintf "all blitted pixels = 0x%06x" bcol);
+
+  (* --- Test 22: get_image returns the captured region --- *)
+  white ();
+  let gcol = rgb 11 22 33 in
+  set_color gcol;
+  fill_rect 80 80 5 5;
+  let gi = get_image 80 80 5 5 in
+  let gdump = dump_image gi in
+  let get_ok = ref true in
+  Array.iter
+    (fun row -> Array.iter (fun c -> if c <> gcol then get_ok := false) row)
+    gdump;
+  check
+    "get_image captures the requested region"
+    !get_ok
+    (Printf.sprintf "all captured pixels = 0x%06x" gcol);
+
+  (* --- Test 23: transparent image pixels (transp) show the background --- *)
+  let bg = rgb 0 0 200 in
+  set_color bg;
+  fill_rect 0 0 w h;
+  let tm = Array.make_matrix 4 4 (rgb 255 0 0) in
+  tm.(2).(2) <- transp;
+  let timg = make_image tm in
+  draw_image timg 120 120;
+  (* image top-left canvas = (120, h-4-120); matrix (row,col) -> canvas
+     (120+col, (h-4-120)+row) *)
+  let top = h - 4 - 120 in
+  let transp_px = raw_read (120 + 2) (top + 2) in
+  let opaque_px = raw_read (120 + 0) (top + 0) in
+  check
+    "transparent image pixel shows the background"
+    (transp_px = (0, 0, 200))
+    (Printf.sprintf "transp pixel = %s (want background blue)" (hex transp_px));
+  check
+    "opaque image pixel shows the image colour"
+    (opaque_px = (255, 0, 0))
+    (Printf.sprintf "opaque pixel = %s" (hex opaque_px));
+
+  (* --- Test 24: clear_graph empties the canvas --- *)
+  set_color (rgb 123 0 0);
+  fill_rect 0 0 w h;
+  clear_graph ();
+  let cleared = point_color 100 100 in
+  check
+    "clear_graph clears the canvas"
+    (cleared = 0)
+    (Printf.sprintf "point_color after clear = 0x%06x" cleared);
+
+  (* --- Test 25: get_context / set_context round-trip and route drawing --- *)
+  let saved = get_context () in
+  set_context saved;
+  white ();
+  set_color (rgb 0 0 0);
+  plot 70 70;
+  check
+    "set_context (round-trip) keeps drawing on the same canvas"
+    (raw_read 70 (canvas_row 70) = (0, 0, 0))
+    "plot landed on the main canvas after set_context";
+
+  (* drawing is routed to whichever context is current *)
+  let canvas2 = Html.createCanvas Html.document in
+  canvas2##.width := w;
+  canvas2##.height := h;
+  Dom.appendChild Html.document##.body canvas2;
+  let ctx2 = canvas2##getContext Html._2d_ in
+  open_canvas canvas2;
+  (* now canvas2 is current *)
+  set_color (rgb 255 0 0);
+  fill_rect 0 0 w h;
+  set_context main_ctx;
+  set_color (rgb 0 255 0);
+  fill_rect 0 0 w h;
+  let on_main = raw_read 100 100 in
+  let on_two = read_ctx ctx2 100 100 in
+  check
+    "open_canvas/set_context route drawing to the current context"
+    (on_main = (0, 255, 0) && on_two = (255, 0, 0))
+    (Printf.sprintf "main=%s canvas2=%s" (hex on_main) (hex on_two));
+  set_context main_ctx;
+
+  (* --- Test 26: resize_window updates the reported and canvas size --- *)
+  let canvas3 = Html.createCanvas Html.document in
+  canvas3##.width := w;
+  canvas3##.height := h;
+  Dom.appendChild Html.document##.body canvas3;
+  open_canvas canvas3;
+  resize_window 120 90;
+  check
+    "resize_window updates size_x/size_y and the canvas"
+    (size_x () = 120 && size_y () = 90 && canvas3##.width = 120 && canvas3##.height = 90)
+    (Printf.sprintf
+       "size=(%d,%d) canvas=(%d,%d)"
+       (size_x ())
+       (size_y ())
+       canvas3##.width
+       canvas3##.height);
+
+  (* --- Test 27: close_graph tears the canvas down --- *)
+  close_graph ();
+  check
+    "close_graph zeroes the canvas dimensions"
+    (canvas3##.width = 0 && canvas3##.height = 0)
+    (Printf.sprintf "canvas=(%d,%d)" canvas3##.width canvas3##.height);
+  set_context main_ctx;
+
+  (* --- open_graph opens a popup window (globalThis.open); in a headless
+     or popup-blocked environment it raises a clean failure, otherwise it
+     makes the popup canvas current. Either way the runtime must stay
+     usable once we restore the main context. --- *)
+  let opened =
+    try
+      open_graph " 100x80";
+      true
+    with _ -> false
+  in
+  set_context main_ctx;
+  white ();
+  set_color (rgb 0 0 0);
+  plot 90 90;
+  check
+    "open_graph is callable; main context usable afterwards"
+    (raw_read 90 (canvas_row 90) = (0, 0, 0))
+    (Printf.sprintf
+       "open_graph %s; plot after restore works"
+       (if opened then "opened a window" else "raised (popup blocked)"));
+
+  (* --- Test 28: unimplemented primitives fail cleanly (must raise) --- *)
+  check
+    "synchronize raises (unimplemented)"
+    (raises (fun () -> synchronize ()))
+    "Graphics_js.synchronize";
+  check
+    "display_mode raises (unimplemented)"
+    (raises (fun () -> display_mode true))
+    "Graphics_js.display_mode";
+  check
+    "remember_mode raises (unimplemented)"
+    (raises (fun () -> remember_mode true))
+    "Graphics_js.remember_mode";
+  check
+    "wait_next_event raises (use Graphics_js loop instead)"
+    (raises (fun () -> ignore (wait_next_event [ Poll ])))
+    "Graphics_js.wait_next_event";
+  check
+    "key_pressed raises (unimplemented polling)"
+    (raises (fun () -> ignore (key_pressed ())))
+    "Graphics_js.key_pressed";
+  check
+    "sound raises (no primitive)"
+    (raises (fun () -> sound 440 100))
+    "Graphics_js.sound";
+  check
+    "auto_synchronize raises (delegates to synchronize)"
+    (raises (fun () -> auto_synchronize true))
+    "Graphics_js.auto_synchronize";
+
+  (* --- Test 29: the Lwt event API installs handlers without blocking --- *)
+  let event_api_ok =
+    not
+      (raises (fun () ->
+           ignore (mouse_pos ());
+           ignore (button_down ());
+           ignore (read_key ());
+           loop [] (fun _ -> ());
+           loop_at_exit [] (fun _ -> ())))
+  in
+  check
+    "Lwt event API (mouse_pos/button_down/read_key/loop) installs handlers"
+    event_api_ok
+    "interactive handlers installed without blocking";
+
+  (* leave the main context current for any at_exit loop *)
+  set_context main_ctx;
+
+  (* --- Report --- *)
+  Buffer.add_string results (Printf.sprintf "SUMMARY: %d passed, %d failed\n" !pass !fail);
+  let txt = Buffer.contents results in
+  Console.console##log (Js.string txt);
+  let pre = Html.createPre Html.document in
+  pre##.id := Js.string "results";
+  pre##.textContent := Js.some (Js.string txt);
+  Dom.appendChild Html.document##.body pre

--- a/runtime/js/graphics.js
+++ b/runtime/js/graphics.js
@@ -212,7 +212,7 @@ function caml_gr_plot(x, y) {
   d[3] = 0xff; //a
   s.x = x;
   s.y = y;
-  s.context.putImageData(im, x, s.height - y);
+  s.context.putImageData(im, x, s.height - 1 - y);
   return 0;
 }
 
@@ -220,7 +220,7 @@ function caml_gr_plot(x, y) {
 //Requires: caml_gr_state_get
 function caml_gr_point_color(x, y) {
   var s = caml_gr_state_get();
-  var im = s.context.getImageData(x, s.height - y, 1, 1);
+  var im = s.context.getImageData(x, s.height - 1 - y, 1, 1);
   var d = im.data;
   return (d[0] << 16) + (d[1] << 8) + d[2];
 }
@@ -278,7 +278,9 @@ function caml_gr_arc_aux(ctx, cx, cy, ry, rx, a1, a2) {
   var space = 2;
   var num = (((a2 - a1) * Math.PI * ((rx + ry) / 2)) / space) | 0;
   var delta = ((a2 - a1) * Math.PI) / num;
-  var i = a1 * Math.PI;
+  // negate the angle: the canvas y axis is flipped, so the OCaml angle
+  // is the negative of the canvas angle
+  var i = -a1 * Math.PI;
   for (var j = 0; j <= num; j++) {
     xPos =
       cx -
@@ -457,15 +459,12 @@ function caml_gr_draw_image(im, x, y) {
     canvas.width = s.width;
     canvas.height = s.height;
     canvas.getContext("2d").putImageData(im, 0, 0);
-    var image = new globalThis.Image();
-    image.onload = function () {
-      s.context.drawImage(image, x, s.height - im.height - y);
-      im.image = image;
-    };
-    image.src = canvas.toDataURL("image/png");
-  } else {
-    s.context.drawImage(im.image, x, s.height - im.height - y);
+    // a canvas is a valid drawImage source immediately, so draw it
+    // directly instead of round-tripping through an Image + data URL
+    // (which made the first draw asynchronous)
+    im.image = canvas;
   }
+  s.context.drawImage(im.image, x, s.height - im.height - y);
   return 0;
 }
 //Provides: caml_gr_create_image
@@ -719,7 +718,7 @@ function gr_plot_for_wasm(x, y) {
   d[3] = 0xff;
   s.x = x;
   s.y = y;
-  s.context.putImageData(im, x, s.height - y);
+  s.context.putImageData(im, x, s.height - 1 - y);
 }
 
 //Provides: gr_point_color_for_wasm
@@ -727,7 +726,7 @@ function gr_plot_for_wasm(x, y) {
 //If: wasm
 function gr_point_color_for_wasm(x, y) {
   var s = caml_gr_state;
-  var im = s.context.getImageData(x, s.height - y, 1, 1);
+  var im = s.context.getImageData(x, s.height - 1 - y, 1, 1);
   var d = im.data;
   return (d[0] << 16) + (d[1] << 8) + d[2];
 }
@@ -887,15 +886,12 @@ function gr_draw_image_for_wasm(im, x, y) {
     canvas.width = s.width;
     canvas.height = s.height;
     canvas.getContext("2d").putImageData(im, 0, 0);
-    var image = new globalThis.Image();
-    image.onload = function () {
-      s.context.drawImage(image, x, s.height - im.height - y);
-      im.image = image;
-    };
-    image.src = canvas.toDataURL("image/png");
-  } else {
-    s.context.drawImage(im.image, x, s.height - im.height - y);
+    // a canvas is a valid drawImage source immediately, so draw it
+    // directly instead of round-tripping through an Image + data URL
+    // (which made the first draw asynchronous)
+    im.image = canvas;
   }
+  s.context.drawImage(im.image, x, s.height - im.height - y);
 }
 
 //Provides: gr_blit_image_for_wasm

--- a/runtime/js/graphics.js
+++ b/runtime/js/graphics.js
@@ -107,6 +107,9 @@ function caml_gr_state_init() {
 //Requires: caml_string_of_jsbytes
 function caml_gr_state_create(canvas, w, h) {
   var context = canvas.getContext("2d");
+  // the native X11 backend draws thick lines with round caps and joins
+  context.lineCap = "round";
+  context.lineJoin = "round";
   return {
     context: context,
     canvas: canvas,
@@ -197,8 +200,34 @@ function caml_gr_set_color(color) {
   s.context.strokeStyle = c_str;
   return 0;
 }
+// Coordinate helpers. Graphics uses a bottom-left origin; the canvas uses a
+// top-left origin, so the row of the bottom-left-origin coordinate y is
+// height-1-y. Two conventions are used, shared by the JS and the wasm paths:
+//   - caml_gr_y: the pixel row itself. plot, point_color, fill_rect and
+//     fill_poly address whole pixels, so they use this.
+//   - caml_gr_xc / caml_gr_yc: the centre of the pixel (x+0.5, row+0.5).
+//     Strokes use it so a 1px line lands crisply on the pixel grid, and
+//     curved fills use it so a disc/ellipse is centred on the pixel rather
+//     than on the pixel corner (which would shift it half a pixel).
+
+//Provides: caml_gr_y
+function caml_gr_y(s, y) {
+  return s.height - 1 - y;
+}
+
+//Provides: caml_gr_xc
+function caml_gr_xc(x) {
+  return x + 0.5;
+}
+
+//Provides: caml_gr_yc
+//Requires: caml_gr_y
+function caml_gr_yc(s, y) {
+  return caml_gr_y(s, y) + 0.5;
+}
+
 //Provides: caml_gr_plot
-//Requires: caml_gr_state_get
+//Requires: caml_gr_state_get, caml_gr_y
 function caml_gr_plot(x, y) {
   var s = caml_gr_state_get();
   var im = s.context.createImageData(1, 1);
@@ -212,15 +241,15 @@ function caml_gr_plot(x, y) {
   d[3] = 0xff; //a
   s.x = x;
   s.y = y;
-  s.context.putImageData(im, x, s.height - 1 - y);
+  s.context.putImageData(im, x, caml_gr_y(s, y));
   return 0;
 }
 
 //Provides: caml_gr_point_color
-//Requires: caml_gr_state_get
+//Requires: caml_gr_state_get, caml_gr_y
 function caml_gr_point_color(x, y) {
   var s = caml_gr_state_get();
-  var im = s.context.getImageData(x, s.height - 1 - y, 1, 1);
+  var im = s.context.getImageData(x, caml_gr_y(s, y), 1, 1);
   var d = im.data;
   return (d[0] << 16) + (d[1] << 8) + d[2];
 }
@@ -246,22 +275,36 @@ function caml_gr_current_y() {
   return s.y;
 }
 //Provides: caml_gr_lineto
-//Requires: caml_gr_state_get
+//Requires: caml_gr_state_get, caml_gr_xc, caml_gr_yc
 function caml_gr_lineto(x, y) {
   var s = caml_gr_state_get();
   s.context.beginPath();
-  s.context.moveTo(s.x, s.height - s.y);
-  s.context.lineTo(x, s.height - y);
+  s.context.moveTo(caml_gr_xc(s.x), caml_gr_yc(s, s.y));
+  s.context.lineTo(caml_gr_xc(x), caml_gr_yc(s, y));
   s.context.stroke();
   s.x = x;
   s.y = y;
   return 0;
 }
 //Provides: caml_gr_draw_rect
-//Requires: caml_gr_state_get
+//Requires: caml_gr_state_get, caml_gr_xc, caml_gr_yc
 function caml_gr_draw_rect(x, y, w, h) {
   var s = caml_gr_state_get();
-  s.context.strokeRect(x, s.height - y, w, -h);
+  // explicit path rather than strokeRect: strokeRect renders its left edge
+  // half a pixel off from its right edge in some browsers
+  var x0 = caml_gr_xc(x);
+  var y0 = caml_gr_yc(s, y);
+  var x1 = caml_gr_xc(x + w);
+  var y1 = caml_gr_yc(s, y + h);
+  s.context.beginPath();
+  s.context.moveTo(x0, y0);
+  s.context.lineTo(x1, y0);
+  s.context.lineTo(x1, y1);
+  s.context.lineTo(x0, y1);
+  // close with an explicit lineTo, not closePath(): the closePath segment is
+  // anti-aliased half a pixel off, while an explicit edge stays crisp
+  s.context.lineTo(x0, y0);
+  s.context.stroke();
   return 0;
 }
 
@@ -305,11 +348,11 @@ function caml_gr_arc_aux(ctx, cx, cy, ry, rx, a1, a2) {
 }
 
 //Provides: caml_gr_draw_arc
-//Requires: caml_gr_state_get, caml_gr_arc_aux
+//Requires: caml_gr_state_get, caml_gr_arc_aux, caml_gr_xc, caml_gr_yc
 function caml_gr_draw_arc(x, y, rx, ry, a1, a2) {
   var s = caml_gr_state_get();
   s.context.beginPath();
-  caml_gr_arc_aux(s.context, x, s.height - y, rx, ry, a1, a2);
+  caml_gr_arc_aux(s.context, caml_gr_xc(x), caml_gr_yc(s, y), rx, ry, a1, a2);
   s.context.stroke();
   return 0;
 }
@@ -320,46 +363,62 @@ function caml_gr_set_line_width(w) {
   var s = caml_gr_state_get();
   s.line_width = w;
   s.context.lineWidth = w;
+  // resizing the canvas resets these to their defaults; restore them
+  s.context.lineCap = "round";
+  s.context.lineJoin = "round";
   return 0;
 }
 
 //Provides: caml_gr_fill_rect
-//Requires: caml_gr_state_get
+//Requires: caml_gr_state_get, caml_gr_y
 function caml_gr_fill_rect(x, y, w, h) {
   var s = caml_gr_state_get();
-  s.context.fillRect(x, s.height - y, w, -h);
+  // match the native X11 backend, which fills (w+1)x(h+1) pixels: the far
+  // edges (column x+w and row y+h) are included. The bottom-left pixel is
+  // (x, caml_gr_y(s, y)); fill up and to the right from there.
+  s.context.fillRect(x, caml_gr_y(s, y) - h, w + 1, h + 1);
   return 0;
 }
 //Provides: caml_gr_fill_poly
-//Requires: caml_gr_state_get
+//Requires: caml_gr_state_get, caml_gr_y
 function caml_gr_fill_poly(ar) {
   var s = caml_gr_state_get();
   s.context.beginPath();
-  s.context.moveTo(ar[1][1], s.height - ar[1][2]);
+  s.context.moveTo(ar[1][1], caml_gr_y(s, ar[1][2]));
   for (var i = 2; i < ar.length; i++)
-    s.context.lineTo(ar[i][1], s.height - ar[i][2]);
-  s.context.lineTo(ar[1][1], s.height - ar[1][2]);
+    s.context.lineTo(ar[i][1], caml_gr_y(s, ar[i][2]));
+  s.context.lineTo(ar[1][1], caml_gr_y(s, ar[1][2]));
   s.context.fill();
   return 0;
 }
 
 //Provides: caml_gr_fill_arc
-//Requires: caml_gr_state_get, caml_gr_arc_aux
+//Requires: caml_gr_state_get, caml_gr_arc_aux, caml_gr_xc, caml_gr_yc
 function caml_gr_fill_arc(x, y, rx, ry, a1, a2) {
   var s = caml_gr_state_get();
+  // centre the arc on the pixel (x, height-1-y), as native does, instead of
+  // on the pixel corner (which shifts a filled ellipse/disc half a pixel)
+  var cx = caml_gr_xc(x);
+  var cy = caml_gr_yc(s, y);
   s.context.beginPath();
-  caml_gr_arc_aux(s.context, x, s.height - y, rx, ry, a1, a2);
+  caml_gr_arc_aux(s.context, cx, cy, rx, ry, a1, a2);
+  // close through the centre so a partial arc fills a pie slice (like the
+  // native X11 backend), not the circular segment a bare fill() would give
+  s.context.lineTo(cx, cy);
   s.context.fill();
   return 0;
 }
 
 //Provides: caml_gr_draw_str
-//Requires: caml_gr_state_get
+//Requires: caml_gr_state_get, caml_gr_y
 function caml_gr_draw_str(str) {
   var s = caml_gr_state_get();
   var m = s.context.measureText(str);
   var dx = m.width;
-  s.context.fillText(str, s.x, s.height - s.y);
+  // the text baseline sits at the current point; it is placed one row below
+  // the pixel row (the continuous bottom-left-origin coordinate), which is
+  // caml_gr_y(s, s.y) + 1
+  s.context.fillText(str, s.x, caml_gr_y(s, s.y) + 1);
   s.x += dx | 0;
   return 0;
 }
@@ -451,7 +510,7 @@ function caml_gr_dump_image(im) {
   return data;
 }
 //Provides: caml_gr_draw_image
-//Requires: caml_gr_state_get
+//Requires: caml_gr_state_get, caml_gr_y
 function caml_gr_draw_image(im, x, y) {
   var s = caml_gr_state_get();
   if (!im.image) {
@@ -464,7 +523,8 @@ function caml_gr_draw_image(im, x, y) {
     // (which made the first draw asynchronous)
     im.image = canvas;
   }
-  s.context.drawImage(im.image, x, s.height - im.height - y);
+  // the image's bottom row is caml_gr_y(s, y); drawImage takes the top-left
+  s.context.drawImage(im.image, x, caml_gr_y(s, y) - im.height + 1);
   return 0;
 }
 //Provides: caml_gr_create_image
@@ -474,12 +534,13 @@ function caml_gr_create_image(x, y) {
   return s.context.createImageData(x, y);
 }
 //Provides: caml_gr_blit_image
-//Requires: caml_gr_state_get
+//Requires: caml_gr_state_get, caml_gr_y
 function caml_gr_blit_image(im, x, y) {
   var s = caml_gr_state_get();
+  // the image's bottom row is caml_gr_y(s, y); getImageData takes the top-left
   var im2 = s.context.getImageData(
     x,
-    s.height - im.height - y,
+    caml_gr_y(s, y) - im.height + 1,
     im.width,
     im.height,
   );
@@ -555,6 +616,8 @@ function gr_state_for_wasm() {
 //If: wasm
 function gr_state_create_for_wasm(canvas, w, h) {
   var context = canvas.getContext("2d");
+  context.lineCap = "round";
+  context.lineJoin = "round";
   return {
     context: context,
     canvas: canvas,
@@ -705,7 +768,7 @@ function gr_set_color_for_wasm(color) {
 }
 
 //Provides: gr_plot_for_wasm
-//Requires: caml_gr_state
+//Requires: caml_gr_state, caml_gr_y
 //If: wasm
 function gr_plot_for_wasm(x, y) {
   var s = caml_gr_state;
@@ -718,63 +781,82 @@ function gr_plot_for_wasm(x, y) {
   d[3] = 0xff;
   s.x = x;
   s.y = y;
-  s.context.putImageData(im, x, s.height - 1 - y);
+  s.context.putImageData(im, x, caml_gr_y(s, y));
 }
 
 //Provides: gr_point_color_for_wasm
-//Requires: caml_gr_state
+//Requires: caml_gr_state, caml_gr_y
 //If: wasm
 function gr_point_color_for_wasm(x, y) {
   var s = caml_gr_state;
-  var im = s.context.getImageData(x, s.height - 1 - y, 1, 1);
+  var im = s.context.getImageData(x, caml_gr_y(s, y), 1, 1);
   var d = im.data;
   return (d[0] << 16) + (d[1] << 8) + d[2];
 }
 
 //Provides: gr_lineto_for_wasm
-//Requires: caml_gr_state
+//Requires: caml_gr_state, caml_gr_xc, caml_gr_yc
 //If: wasm
 function gr_lineto_for_wasm(x, y) {
   var s = caml_gr_state;
   s.context.beginPath();
-  s.context.moveTo(s.x, s.height - s.y);
-  s.context.lineTo(x, s.height - y);
+  s.context.moveTo(caml_gr_xc(s.x), caml_gr_yc(s, s.y));
+  s.context.lineTo(caml_gr_xc(x), caml_gr_yc(s, y));
   s.context.stroke();
   s.x = x;
   s.y = y;
 }
 
 //Provides: gr_draw_rect_for_wasm
-//Requires: caml_gr_state
+//Requires: caml_gr_state, caml_gr_xc, caml_gr_yc
 //If: wasm
 function gr_draw_rect_for_wasm(x, y, w, h) {
-  caml_gr_state.context.strokeRect(x, caml_gr_state.height - y, w, -h);
+  var s = caml_gr_state;
+  // explicit path (see caml_gr_draw_rect): strokeRect can render its left
+  // edge half a pixel off from its right edge
+  var x0 = caml_gr_xc(x);
+  var y0 = caml_gr_yc(s, y);
+  var x1 = caml_gr_xc(x + w);
+  var y1 = caml_gr_yc(s, y + h);
+  s.context.beginPath();
+  s.context.moveTo(x0, y0);
+  s.context.lineTo(x1, y0);
+  s.context.lineTo(x1, y1);
+  s.context.lineTo(x0, y1);
+  s.context.lineTo(x0, y0);
+  s.context.stroke();
 }
 
 //Provides: gr_fill_rect_for_wasm
-//Requires: caml_gr_state
+//Requires: caml_gr_state, caml_gr_y
 //If: wasm
 function gr_fill_rect_for_wasm(x, y, w, h) {
-  caml_gr_state.context.fillRect(x, caml_gr_state.height - y, w, -h);
+  // match the native X11 backend: fill (w+1)x(h+1) pixels (see caml_gr_fill_rect)
+  var s = caml_gr_state;
+  s.context.fillRect(x, caml_gr_y(s, y) - h, w + 1, h + 1);
 }
 
 //Provides: gr_draw_arc_for_wasm
-//Requires: caml_gr_state, caml_gr_arc_aux
+//Requires: caml_gr_state, caml_gr_arc_aux, caml_gr_xc, caml_gr_yc
 //If: wasm
 function gr_draw_arc_for_wasm(x, y, rx, ry, a1, a2) {
   var s = caml_gr_state;
   s.context.beginPath();
-  caml_gr_arc_aux(s.context, x, s.height - y, rx, ry, a1, a2);
+  caml_gr_arc_aux(s.context, caml_gr_xc(x), caml_gr_yc(s, y), rx, ry, a1, a2);
   s.context.stroke();
 }
 
 //Provides: gr_fill_arc_for_wasm
-//Requires: caml_gr_state, caml_gr_arc_aux
+//Requires: caml_gr_state, caml_gr_arc_aux, caml_gr_xc, caml_gr_yc
 //If: wasm
 function gr_fill_arc_for_wasm(x, y, rx, ry, a1, a2) {
   var s = caml_gr_state;
+  var cx = caml_gr_xc(x);
+  var cy = caml_gr_yc(s, y);
   s.context.beginPath();
-  caml_gr_arc_aux(s.context, x, s.height - y, rx, ry, a1, a2);
+  caml_gr_arc_aux(s.context, cx, cy, rx, ry, a1, a2);
+  // pie slice (close through the centre), matching native fill_arc
+  s.context.lineTo(cx, cy);
   s.context.fill();
 }
 
@@ -784,6 +866,8 @@ function gr_fill_arc_for_wasm(x, y, rx, ry, a1, a2) {
 function gr_set_line_width_for_wasm(w) {
   caml_gr_state.line_width = w;
   caml_gr_state.context.lineWidth = w;
+  caml_gr_state.context.lineCap = "round";
+  caml_gr_state.context.lineJoin = "round";
 }
 
 //Provides: gr_resize_window_for_wasm
@@ -805,13 +889,14 @@ function gr_draw_char_for_wasm(c) {
 }
 
 //Provides: gr_draw_str_for_wasm
-//Requires: caml_gr_state
+//Requires: caml_gr_state, caml_gr_y
 //If: wasm
 function gr_draw_str_for_wasm(str) {
   var s = caml_gr_state;
   var m = s.context.measureText(str);
   var dx = m.width;
-  s.context.fillText(str, s.x, s.height - s.y);
+  // text baseline = current point, one row below the pixel (see caml_gr_draw_str)
+  s.context.fillText(str, s.x, caml_gr_y(s, s.y) + 1);
   s.x += dx | 0;
 }
 
@@ -857,15 +942,15 @@ function gr_text_size_h_for_wasm() {
 }
 
 //Provides: gr_fill_poly_for_wasm
-//Requires: caml_gr_state
+//Requires: caml_gr_state, caml_gr_y
 //If: wasm
 function gr_fill_poly_for_wasm(ar, n) {
   var s = caml_gr_state;
   s.context.beginPath();
-  s.context.moveTo(ar[0], s.height - ar[1]);
+  s.context.moveTo(ar[0], caml_gr_y(s, ar[1]));
   for (var i = 1; i < n; i++)
-    s.context.lineTo(ar[i * 2], s.height - ar[i * 2 + 1]);
-  s.context.lineTo(ar[0], s.height - ar[1]);
+    s.context.lineTo(ar[i * 2], caml_gr_y(s, ar[i * 2 + 1]));
+  s.context.lineTo(ar[0], caml_gr_y(s, ar[1]));
   s.context.fill();
 }
 
@@ -877,7 +962,7 @@ function gr_create_image_for_wasm(x, y) {
 }
 
 //Provides: gr_draw_image_for_wasm
-//Requires: caml_gr_state
+//Requires: caml_gr_state, caml_gr_y
 //If: wasm
 function gr_draw_image_for_wasm(im, x, y) {
   var s = caml_gr_state;
@@ -891,17 +976,19 @@ function gr_draw_image_for_wasm(im, x, y) {
     // (which made the first draw asynchronous)
     im.image = canvas;
   }
-  s.context.drawImage(im.image, x, s.height - im.height - y);
+  // the image's bottom row is caml_gr_y(s, y); drawImage takes the top-left
+  s.context.drawImage(im.image, x, caml_gr_y(s, y) - im.height + 1);
 }
 
 //Provides: gr_blit_image_for_wasm
-//Requires: caml_gr_state
+//Requires: caml_gr_state, caml_gr_y
 //If: wasm
 function gr_blit_image_for_wasm(im, x, y) {
   var s = caml_gr_state;
+  // the image's bottom row is caml_gr_y(s, y); getImageData takes the top-left
   var im2 = s.context.getImageData(
     x,
-    s.height - im.height - y,
+    caml_gr_y(s, y) - im.height + 1,
     im.width,
     im.height,
   );


### PR DESCRIPTION
Makes the `js_of_ocaml-lwt.graphics` canvas backend match the native X11
`Graphics` backend, and adds the first test suite for it. All runtime fixes
are applied identically to both the JS primitive and its `_for_wasm` copy.

## Origin / arc / async fixes (from #2270)

- **`caml_gr_plot` / `caml_gr_point_color`** converted the OCaml bottom-left
  origin with canvas row `height - y`, but the pixel is at `height - 1 - y`.
  So `plot x 0` drew off-canvas, `point_color x 0` read out of bounds, and the
  pair disagreed by one row with `fill_rect`/`draw_image`. Now `height - 1 - y`.
- **`caml_gr_arc_aux`** started the parametric angle at `+a1`, but the canvas
  y-flip makes the OCaml angle the *negative* of the canvas angle, so
  `draw_arc x y r r 90 180` rendered the wrong quadrant. The start angle is
  negated. (Arcs starting at 0, incl. full circles, worked by accident before.)
- **`caml_gr_draw_image`** drew the first occurrence of an image asynchronously
  (inside `Image.onload` after a `toDataURL` round trip), so an immediate
  `point_color`/`dump_image` saw stale pixels. A `<canvas>` is a valid
  `drawImage` source immediately, so the temp canvas is drawn directly (and
  cached) — synchronous.

## Aligning the rest of the primitives with native X11

Comparing the canvas output against the native backend pixel-for-pixel
surfaced several more discrepancies, all now fixed:

- **`fill_rect`** fills `(w+1)x(h+1)` pixels — the far edge column `x+w` and
  row `y+h` are included, as in X11 `XFillRectangle`.
- **`lineto` / `draw_rect` / `draw_arc` / `fill_arc` / `fill_poly`** used
  `height - y` instead of `height - 1 - y`, leaving them shifted one pixel down
  relative to `plot`/`fill_rect` and to native. Now consistent.
- **`fill_arc`** closes a partial arc through the **centre** (a pie slice, like
  native `XFillArc`) instead of the circular segment a bare `fill()` produced —
  a 270° arc differed by a whole quarter wedge.
- **Strokes and filled curves** are centred on the pixel grid (a half-pixel
  offset) so 1px lines stay crisp instead of blurring across two rows, and
  filled discs/ellipses are centred on the pixel rather than the pixel corner.
- **Line caps and joins are round**, matching X11 thick lines (canvas default
  is butt/miter).
- **`draw_rect`** draws an explicit 4-segment path; `strokeRect`/`closePath`
  anti-aliased the left edge half a pixel off in some browsers.

All coordinate math now goes through three small helpers — `caml_gr_y` (pixel
row), `caml_gr_xc`/`caml_gr_yc` (pixel-centre column/row) — shared by the JS
and wasm paths, so the y-flip and the whole-pixel-vs-pixel-centre choice each
live in exactly one place.

## Tests (`compiler/tests-graphics/`)

First test suite for `Graphics_js`. **Not run by `make tests`** — they need a
real `<canvas>` (`getImageData`), which Node has none of; they build under
`dune build @all` and are run manually (see `README.md`):

- `test.ml` — ~50 browser-driven self-checks over the whole API (origin,
  fills, strokes, curves, images/transparency, text metrics, context
  management, unimplemented-primitive errors).
- `compare/` — renders one shared scene with native X11 `Graphics` and with the
  canvas backend, then diffs the rasters. Axis-aligned fills / plots / images
  must match native **pixel-for-pixel**; anti-aliased curves and (non-portable)
  text are tolerated.

## Verification

`make lint-js` (Biome) clean; full tests-jsoo JS build green; the 50-check
self-test passes in headless Chromium; and the native-vs-canvas comparison
reports **0** exact-zone differences (every solid fill, plot and image matches
the X11 backend exactly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
