### PR TITLE
Runtime: raise on QuickJS std fd read/write errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,10 @@
 * Lib: add Intl.RelativeTimeFormat (#2070)
 
 ## Bug fixes
+* Runtime: the QuickJS standard file descriptors raise on a write or
+  read error instead of returning 0; an error on stdout (e.g. EPIPE)
+  used to make the flush/write loop spin forever, and a read error was
+  silently turned into EOF (#2270)
 * Runtime: float arrays are marshalled as a `CODE_DOUBLE_ARRAY` block
   like the native runtime, instead of a generic tag-254 block with
   per-element double codes; jsoo-marshalled float arrays can now be

--- a/runtime/js/fs_quickjs.js
+++ b/runtime/js/fs_quickjs.js
@@ -410,7 +410,7 @@ class MlQuickJSFd {}
 // for the standard streams; opt-in like the rest of fs_quickjs.
 
 //Provides: MlQuickJSStdFd
-//Requires: MlFile, caml_raise_system_error
+//Requires: MlFile, caml_raise_system_error, caml_raise_qjs_error
 class MlQuickJSStdFd extends MlFile {
   constructor(fd, flags) {
     super();
@@ -439,7 +439,9 @@ class MlQuickJSStdFd extends MlFile {
     var ab = a.buffer || a;
     var base = a.byteOffset || 0;
     var n = this.os.read(this.fd, ab, base + buf_offset, len);
-    return n < 0 ? 0 : n;
+    // a negative return is an error, not EOF
+    if (n < 0) caml_raise_qjs_error(n, "read", "", raise_unix);
+    return n;
   }
 
   write(buf, buf_offset, len, raise_unix) {
@@ -453,7 +455,10 @@ class MlQuickJSStdFd extends MlFile {
     var ab = buf.buffer || buf;
     var base = buf.byteOffset || 0;
     var n = this.os.write(this.fd, ab, base + buf_offset, len);
-    return n < 0 ? 0 : n;
+    // a negative return is an error; returning 0 would make the
+    // flush/write loop spin forever
+    if (n < 0) caml_raise_qjs_error(n, "write", "", raise_unix);
+    return n;
   }
 
   seek(_offset, _whence, raise_unix) {


### PR DESCRIPTION
`MlQuickJSStdFd.write` (`fs_quickjs.js:445-457`) mapped a negative `os.write` return — an error such as EPIPE — to `0`. Both `caml_ml_flush` and `caml_unix_write` loop until all bytes are written, so an error on stdout made the program **spin forever** instead of raising. `read` likewise mapped a negative return to `0`, silently turning an I/O error into EOF. Both now raise a system error (`caml_raise_qjs_error`) on a negative return.

Fix-only: triggering the busy loop needs a closed pipe on a QuickJS stdout, which the test harness can't set up. Verified through `make lint-js`, a full tests-jsoo js build, and native. (The `--profile=quickjs` lib/tests run has a pre-existing, unrelated failure — an intentional "boom" promise-rejection test — present on master without this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)