### PR TITLE
Runtime: do not mask Str instruction arguments to 8 bits

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,9 @@
 * Lib: add Intl.RelativeTimeFormat (#2070)
 
 ## Bug fixes
+* Runtime: the Str engine no longer masks instruction arguments to 8
+  bits; regexps with more than 256 constant-pool entries (large
+  alternations) indexed the wrong pool slot and mismatched (#2270)
 * Compiler: bound the statement-nesting depth of generated functions by
   emitting a flat dispatch loop instead of a deep tower of nested labelled
   blocks when a block has many sibling merge-node branch targets. Deep

--- a/compiler/tests-jsoo/test_str.ml
+++ b/compiler/tests-jsoo/test_str.ml
@@ -45,3 +45,16 @@ let%expect_test "simple star and plus at end of string" =
   let b = Str.string_match (Str.regexp "x[^;]+") "xabc" 0 in
   Printf.printf "%b %s\n" b (Str.matched_string "xabc");
   [%expect {| true xabc |}]
+
+(* A regexp with many alternatives produces more than 256 constant-pool
+   entries; matching a late alternative indexes a high pool slot, which
+   must not be truncated to 8 bits. *)
+let%expect_test "large alternation" =
+  let alts = List.init 300 (fun i -> Printf.sprintf "x%03d" i) in
+  let re = Str.regexp (String.concat "\\|" alts) in
+  let ok = ref 0 in
+  List.iter
+    (fun a -> if Str.string_match re a 0 && Str.matched_string a = a then incr ok)
+    alts;
+  Printf.printf "%d/300\n" !ok;
+  [%expect {| 256/300 |}]

--- a/compiler/tests-jsoo/test_str.ml
+++ b/compiler/tests-jsoo/test_str.ml
@@ -57,4 +57,4 @@ let%expect_test "large alternation" =
     (fun a -> if Str.string_match re a 0 && Str.matched_string a = a then incr ok)
     alts;
   Printf.printf "%d/300\n" !ok;
-  [%expect {| 256/300 |}]
+  [%expect {| 300/300 |}]

--- a/runtime/js/str.js
+++ b/runtime/js/str.js
@@ -127,7 +127,10 @@ var re_match = (function () {
     while (!quit) {
       var op = prog[pc] & 0xff,
         sarg = prog[pc] >> 8,
-        uarg = sarg & 0xff,
+        // uarg is used as a constant-pool / group / register index and
+        // as a character code, all non-negative; it must not be masked
+        // to 8 bits or large pools index the wrong slot
+        uarg = sarg,
         c = s[pos],
         group;
 


### PR DESCRIPTION
`re_match` (`str.js:128-130`) computed `uarg = sarg & 0xff`, but `uarg` is used as a constant-pool index (STRING/STRINGNORM/CHARCLASS/SIMPLEOPT/SIMPLESTAR/SIMPLEPLUS), a group index (REFGROUP/BEGGROUP/ENDGROUP) and a register index (SETMARK/CHECKPROGRESS) — all non-negative and potentially > 255 — in addition to holding character codes (CHAR/CHARNORM, where the value is already ≤ 255). So a regexp with more than 256 constant-pool entries (a large alternation) indexed the wrong pool slot and silently mismatched. The C engine's `Arg` macro and `str.wat`'s `i32.shr_u` keep the full argument.

`sarg = prog[pc] >> 8` is already the correct non-negative value for every `uarg` use, so the fix just drops the `& 0xff` (the signed-displacement opcodes GOTO/PUSHBACK already use `sarg` directly).

Test-first: a 300-alternative regexp matches only `256/300` on the buggy runtime (the truncation drops every alternative whose pool index exceeds 255), `300/300` after the fix — verified identical on js and native.

🤖 Generated with [Claude Code](https://claude.com/claude-code)