### PR TITLE
Runtime: store Domain.spawn error using the version's state layout

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -66,7 +66,11 @@
   `Domain.join` re-raises the exception, instead of the exception
   escaping `spawn` and leaving the domain id and termination mutex in
   a broken state; the Wasm runtime additionally now sets the spawned
-  domain's id (#2263, #2270)
+  domain's id. The `Finished (Error _)` termination payload also uses
+  the layout expected by the running OCaml version — the bare `exn`
+  before 5.5 and `exn * raw_backtrace` from 5.5 — so `Domain.join` no
+  longer re-raises a malformed exception on OCaml 5.2–5.4 (#2263,
+  #2270, #2302)
 * Runtime: `Float.Array.sub`/`append`/`concat` return a proper
   tag-254 float array (their result had tag 0); `Array.make` of an
   invalid length raises `Invalid_argument "Array.make"` instead of

--- a/runtime/js/domain.js
+++ b/runtime/js/domain.js
@@ -212,7 +212,7 @@ var caml_domain_id = 0;
 //Requires: caml_domain_id
 //Requires: caml_callback
 //Requires: caml_wrap_exception, caml_get_exception_raw_backtrace
-//Version: >= 5.2
+//Version: >= 5.5
 var caml_domain_latest_idx = 1;
 function caml_domain_spawn(f, term_sync) {
   var id = caml_domain_latest_idx++;
@@ -226,6 +226,32 @@ function caml_domain_spawn(f, term_sync) {
     // term_sync.state = Finished (Error (exn, backtrace))
     var exn = caml_wrap_exception(e);
     result = [0, [1, [0, exn, caml_get_exception_raw_backtrace(0)]]];
+  }
+  caml_domain_id = old;
+  caml_ml_mutex_unlock(term_sync[2]);
+  term_sync[1] = result;
+  return id;
+}
+
+//Provides: caml_domain_spawn
+//Requires: caml_ml_mutex_unlock
+//Requires: caml_domain_id
+//Requires: caml_callback
+//Requires: caml_wrap_exception
+//Version: >= 5.2, < 5.5
+var caml_domain_latest_idx = 1;
+function caml_domain_spawn(f, term_sync) {
+  var id = caml_domain_latest_idx++;
+  var old = caml_domain_id;
+  caml_domain_id = id;
+  var result;
+  try {
+    // term_sync.state = Finished (Ok res)
+    result = [0, [0, caml_callback(f, [0])]];
+  } catch (e) {
+    // term_sync.state = Finished (Error exn)
+    var exn = caml_wrap_exception(e);
+    result = [0, [1, exn]];
   }
   caml_domain_id = old;
   caml_ml_mutex_unlock(term_sync[2]);

--- a/runtime/wasm/domain.wat
+++ b/runtime/wasm/domain.wat
@@ -265,13 +265,18 @@
                         (local.get $f) (ref.i31 (i32.const 0)))))))
          (catch $ocaml_exception
             (local.set $exn (pop (ref eq)))
-            ;; state = Finished (Error (exn, backtrace))
+            ;; state = Finished (Error exn) for OCaml < 5.5
+            ;; state = Finished (Error (exn, backtrace)) for OCaml >= 5.5
             (local.set $result
                (array.new_fixed $block 2 (ref.i31 (i32.const 0))
                   (array.new_fixed $block 2 (ref.i31 (i32.const 1))
-                     (array.new_fixed $block 3 (ref.i31 (i32.const 0))
-                        (local.get $exn)
-                        (array.new_fixed $block 1 (ref.i31 (i32.const 0)))))))))
+                     (@if (>= ocaml_version (5 5 0))
+                     (@then
+                        (array.new_fixed $block 3 (ref.i31 (i32.const 0))
+                           (local.get $exn)
+                           (array.new_fixed $block 1 (ref.i31 (i32.const 0)))))
+                     (@else
+                        (local.get $exn))))))))
       (global.set $caml_domain_id (local.get $old))
       (drop (call $caml_ml_mutex_unlock (array.get $block (local.get $ts) (i32.const 2))))
       (array.set $block (local.get $ts) (i32.const 1)


### PR DESCRIPTION
## Problem

`compiler/tests-ocaml/effects/test_lazy.ml` failed under `wasm_of_ocaml` with:

```
Fatal error: exception CamlinternalLazy.Undefined(_)
```

The test forces a `lazy` value that is already being forced from inside a `Domain.spawn`, and expects `Domain.join` to re-raise `CamlinternalLazy.Undefined` so the surrounding `try ... with CamlinternalLazy.Undefined ->` handler catches it.

## Root cause

The OCaml stdlib `Domain` termination-state layout changed in OCaml 5.5:

- **5.2–5.4:** `Finished of ('a, exn) result` — `Error` holds the bare `exn`; `join` does `Error ex -> raise ex`.
- **5.5+:** `Finished of ('a, exn * raw_backtrace) result` — `Error` holds an `(exn, backtrace)` tuple; `join` does `Error (ex, bt) -> Printexc.raise_with_backtrace ex bt`.

Both `runtime/js/domain.js` and `runtime/wasm/domain.wat` unconditionally built the **tuple** form for every version `>= 5.2`. On 5.2–5.4, `join` then ran `raise ex` against that tuple, raising a malformed value that no handler matched, so the exception escaped (rendered as `Undefined(_)`, the `(_)` being the stray backtrace field).

The JS test happened to pass only because under `--effects cps` a spawned exception bypasses the `Domain.spawn` try/catch entirely and propagates straight to the enclosing handler. The Wasm runtime correctly catches it, which is what exposed the latent layout mismatch.

## Fix

Version-gate the `Error` payload in both runtimes:

- `runtime/wasm/domain.wat`: inline `(@if (>= ocaml_version (5 5 0)) ...)` — tuple for ≥5.5, bare `exn` for 5.2–5.4.
- `runtime/js/domain.js`: split into `//Version: >= 5.5` (tuple) and `//Version: >= 5.2, < 5.5` (bare `exn`).

## Testing

- `@compiler/tests-ocaml/effects/runtest-wasm` (the originally-failing target) now passes.
- JS and Wasm `effects` and `lazy` suites pass with no regressions.
- A standalone `Domain.spawn`/`Domain.join` exception-propagation test matches native bytecode behavior in both JS-direct and Wasm-jspi modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)