### PR TITLE
Runtime: Unix.close removes the descriptor from the fd table

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -78,6 +78,9 @@
   read error instead of returning 0; an error on stdout (e.g. EPIPE)
   used to make the flush/write loop spin forever, and a read error was
   silently turned into EOF (#2270)
+* Runtime: `Unix.close` removes the descriptor from the fd table, so a
+  closed fd no longer resolves to its old file and the slot can be
+  reused (#2303)
 * Runtime: float arrays are marshalled as a `CODE_DOUBLE_ARRAY` block
   like the native runtime, instead of a generic tag-254 block with
   per-element double codes; jsoo-marshalled float arrays can now be

--- a/compiler/tests-jsoo/test_unix.ml
+++ b/compiler/tests-jsoo/test_unix.ml
@@ -207,3 +207,14 @@ let%expect_test "readdir includes . and .." =
     .
     ..
     |}]
+
+let%expect_test "closed fds do not resolve" =
+  let f = Filename.temp_file "jsoo_close" ".dat" in
+  let fd = Unix.openfile f [ Unix.O_RDONLY ] 0 in
+  Unix.close fd;
+  (try
+     ignore (Unix.fstat fd);
+     print_endline "ok"
+   with Unix.Unix_error (Unix.EBADF, _, _) -> print_endline "EBADF");
+  Sys.remove f;
+  [%expect {| ok |}]

--- a/compiler/tests-jsoo/test_unix.ml
+++ b/compiler/tests-jsoo/test_unix.ml
@@ -217,4 +217,4 @@ let%expect_test "closed fds do not resolve" =
      print_endline "ok"
    with Unix.Unix_error (Unix.EBADF, _, _) -> print_endline "EBADF");
   Sys.remove f;
-  [%expect {| ok |}]
+  [%expect {| EBADF |}]

--- a/runtime/js/unix.js
+++ b/runtime/js/unix.js
@@ -721,10 +721,11 @@ function caml_unix_ftruncate_64(fd, len) {
 
 //Provides: caml_unix_close
 //Alias: unix_close
-//Requires: caml_unix_lookup_file
+//Requires: caml_unix_lookup_file, caml_sys_fds
 function caml_unix_close(fd) {
   var file = caml_unix_lookup_file(fd, "close");
   file.close(/* raise unix_error */ 1);
+  delete caml_sys_fds[fd];
   return 0;
 }
 


### PR DESCRIPTION
`caml_unix_close` left the descriptor in `caml_sys_fds`, so a closed fd
still resolved in `caml_unix_lookup_file` — `fstat` and friends
succeeded instead of raising `EBADF`, and the slot was never reused.
Delete the entry on close.

Split out of #2287.

🤖 Generated with [Claude Code](https://claude.com/claude-code)