### PR TITLE
Runtime: fix Unix.localtime tm_yday during DST and tm_isdst for Europe/Dublin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,9 @@
   Pretty-printed output (`--pretty`) is unchanged. (#1117)
 
 ## Bug fixes
+* Runtime: `Unix.localtime` computes `tm_yday` from the calendar date
+  instead of the wall-clock distance to January 1, which was off by one
+  during DST; the js and wasm-on-node backends share the fix (#2304)
 * Runtime/wasm: `Str.replace`/`Str.global_replace` raise `Failure` on a
   backreference to a group one past the last (e.g. `"\1"` against a
   group-less regexp) instead of trapping with an out-of-bounds access;

--- a/lib/tests/test_sys.ml
+++ b/lib/tests/test_sys.ml
@@ -353,4 +353,4 @@ let%expect_test "localtime tm_yday under DST" =
     tm.Unix.tm_min
     tm.Unix.tm_yday
     tm.Unix.tm_isdst;
-  [%expect {| 2021-07-01 00:30 yday=180 dst=true |}]
+  [%expect {| 2021-07-01 00:30 yday=181 dst=true |}]

--- a/lib/tests/test_sys.ml
+++ b/lib/tests/test_sys.ml
@@ -354,3 +354,26 @@ let%expect_test "localtime tm_yday under DST" =
     tm.Unix.tm_yday
     tm.Unix.tm_isdst;
   [%expect {| 2021-07-01 00:30 yday=181 dst=true |}]
+
+let%expect_test "localtime tm_isdst for Europe/Dublin (negative DST)" =
+  ignore (Js.Unsafe.js_expr {|(process.env.TZ = "Europe/Dublin")|});
+  (* Dublin uses "negative DST": winter (GMT) is the daylight deviation
+     from its summer standard (IST), so tm_isdst must match the native
+     runtime, which reports it inverted from the usual offset heuristic *)
+  let show t =
+    let tm = Unix.localtime t in
+    Printf.printf
+      "%d-%02d-%02d %02d:%02d dst=%b\n"
+      (tm.Unix.tm_year + 1900)
+      (tm.Unix.tm_mon + 1)
+      tm.Unix.tm_mday
+      tm.Unix.tm_hour
+      tm.Unix.tm_min
+      tm.Unix.tm_isdst
+  in
+  show 1610712000. (* 2021-01-15 12:00 GMT, winter *);
+  show 1625137200. (* 2021-07-01 12:00 IST, summer *);
+  [%expect {|
+    2021-01-15 12:00 dst=true
+    2021-07-01 12:00 dst=false
+    |}]

--- a/lib/tests/test_sys.ml
+++ b/lib/tests/test_sys.ml
@@ -337,3 +337,20 @@ let%expect_test "Unix.error_message" =
     EDEADLK
     true
     |}]
+
+let%expect_test "localtime tm_yday under DST" =
+  ignore (Js.Unsafe.js_expr {|(process.env.TZ = "America/New_York")|});
+  (* 2021-07-01T04:30:00Z is 2021-07-01 00:30 in New York, with DST in
+     effect; tm_yday must not be computed from the wall-clock distance
+     to January 1 *)
+  let tm = Unix.localtime 1625113800. in
+  Printf.printf
+    "%d-%02d-%02d %02d:%02d yday=%d dst=%b\n"
+    (tm.Unix.tm_year + 1900)
+    (tm.Unix.tm_mon + 1)
+    tm.Unix.tm_mday
+    tm.Unix.tm_hour
+    tm.Unix.tm_min
+    tm.Unix.tm_yday
+    tm.Unix.tm_isdst;
+  [%expect {| 2021-07-01 00:30 yday=180 dst=true |}]

--- a/runtime/js/unix.js
+++ b/runtime/js/unix.js
@@ -63,6 +63,22 @@ function caml_unix_localtime(t) {
     jan.getTimezoneOffset(),
     jul.getTimezoneOffset(),
   );
+  var isdst = d.getTimezoneOffset() < stdTimezoneOffset;
+  // Europe/Dublin uses "negative DST": the IANA database marks winter
+  // (GMT) as the daylight deviation from its summer standard (IST), so the
+  // native runtime reports tm_isdst inverted from the offset heuristic.
+  // The offsets alone cannot distinguish it from Europe/London, so match
+  // it by name (guarded to the GMT/+1 signature to avoid the Intl lookup
+  // for every other zone).
+  if (
+    stdTimezoneOffset === 0 &&
+    jan.getTimezoneOffset() !== jul.getTimezoneOffset()
+  ) {
+    try {
+      if (Intl.DateTimeFormat().resolvedOptions().timeZone === "Europe/Dublin")
+        isdst = !isdst;
+    } catch (e) {}
+  }
   return BLOCK(
     0,
     d.getSeconds(),
@@ -73,8 +89,7 @@ function caml_unix_localtime(t) {
     d.getFullYear() - 1900,
     d.getDay(),
     doy,
-    (d.getTimezoneOffset() < stdTimezoneOffset) |
-      0 /* daylight savings time  field. */,
+    isdst | 0 /* daylight savings time  field. */,
   );
 }
 

--- a/runtime/js/unix.js
+++ b/runtime/js/unix.js
@@ -50,13 +50,13 @@ function caml_unix_gmtime(t) {
 //Alias: unix_localtime
 function caml_unix_localtime(t) {
   var d = new Date(t * 1000);
-  var y = d.getFullYear();
-  // compute tm_yday from the date: the wall-clock distance to
-  // January 1 is off by one hour when DST is in effect
-  var cumul = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334];
-  var leap = (y % 4 === 0 && y % 100 !== 0) || y % 400 === 0;
-  var doy =
-    cumul[d.getMonth()] + d.getDate() - 1 + (leap && d.getMonth() > 1 ? 1 : 0);
+  // tm_yday is the distance in days to January 1; compute it in UTC so
+  // that the one-hour DST shift of wall-clock arithmetic does not apply
+  var doy = Math.floor(
+    (Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()) -
+      Date.UTC(d.getFullYear(), 0, 1)) /
+      86400000,
+  );
   var jan = new Date(d.getFullYear(), 0, 1);
   var jul = new Date(d.getFullYear(), 6, 1);
   var stdTimezoneOffset = Math.max(

--- a/runtime/js/unix.js
+++ b/runtime/js/unix.js
@@ -50,9 +50,13 @@ function caml_unix_gmtime(t) {
 //Alias: unix_localtime
 function caml_unix_localtime(t) {
   var d = new Date(t * 1000);
-  var d_num = d.getTime();
-  var januaryfirst = new Date(d.getFullYear(), 0, 1).getTime();
-  var doy = Math.floor((d_num - januaryfirst) / 86400000);
+  var y = d.getFullYear();
+  // compute tm_yday from the date: the wall-clock distance to
+  // January 1 is off by one hour when DST is in effect
+  var cumul = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334];
+  var leap = (y % 4 === 0 && y % 100 !== 0) || y % 400 === 0;
+  var doy =
+    cumul[d.getMonth()] + d.getDate() - 1 + (leap && d.getMonth() > 1 ? 1 : 0);
   var jan = new Date(d.getFullYear(), 0, 1);
   var jul = new Date(d.getFullYear(), 6, 1);
   var stdTimezoneOffset = Math.max(

--- a/runtime/wasm/runtime.js
+++ b/runtime/wasm/runtime.js
@@ -456,6 +456,24 @@
         jan.getTimezoneOffset(),
         jul.getTimezoneOffset(),
       );
+      var isdst = d.getTimezoneOffset() < stdTimezoneOffset;
+      // Europe/Dublin uses "negative DST": the IANA database marks winter
+      // (GMT) as the daylight deviation from its summer standard (IST), so
+      // the native runtime reports tm_isdst inverted from the offset
+      // heuristic. The offsets alone cannot distinguish it from
+      // Europe/London, so match it by name (guarded to the GMT/+1 signature
+      // to avoid the Intl lookup for every other zone).
+      if (
+        stdTimezoneOffset === 0 &&
+        jan.getTimezoneOffset() !== jul.getTimezoneOffset()
+      ) {
+        try {
+          if (
+            Intl.DateTimeFormat().resolvedOptions().timeZone === "Europe/Dublin"
+          )
+            isdst = !isdst;
+        } catch (e) {}
+      }
       return caml_alloc_tm(
         d.getSeconds(),
         d.getMinutes(),
@@ -465,7 +483,7 @@
         d.getFullYear() - 1900,
         d.getDay(),
         doy,
-        d.getTimezoneOffset() < stdTimezoneOffset,
+        isdst,
       );
     },
     mktime: (year, month, day, h, m, s) =>

--- a/runtime/wasm/runtime.js
+++ b/runtime/wasm/runtime.js
@@ -443,9 +443,16 @@
     },
     localtime: (t) => {
       var d = new Date(t * 1000);
-      var d_num = d.getTime();
-      var januaryfirst = new Date(d.getFullYear(), 0, 1).getTime();
-      var doy = Math.floor((d_num - januaryfirst) / 86400000);
+      var y = d.getFullYear();
+      // compute tm_yday from the date: the wall-clock distance to
+      // January 1 is off by one hour when DST is in effect
+      var cumul = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334];
+      var leap = (y % 4 === 0 && y % 100 !== 0) || y % 400 === 0;
+      var doy =
+        cumul[d.getMonth()] +
+        d.getDate() -
+        1 +
+        (leap && d.getMonth() > 1 ? 1 : 0);
       var jan = new Date(d.getFullYear(), 0, 1);
       var jul = new Date(d.getFullYear(), 6, 1);
       var stdTimezoneOffset = Math.max(

--- a/runtime/wasm/runtime.js
+++ b/runtime/wasm/runtime.js
@@ -443,16 +443,13 @@
     },
     localtime: (t) => {
       var d = new Date(t * 1000);
-      var y = d.getFullYear();
-      // compute tm_yday from the date: the wall-clock distance to
-      // January 1 is off by one hour when DST is in effect
-      var cumul = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334];
-      var leap = (y % 4 === 0 && y % 100 !== 0) || y % 400 === 0;
-      var doy =
-        cumul[d.getMonth()] +
-        d.getDate() -
-        1 +
-        (leap && d.getMonth() > 1 ? 1 : 0);
+      // tm_yday is the distance in days to January 1; compute it in UTC so
+      // that the one-hour DST shift of wall-clock arithmetic does not apply
+      var doy = Math.floor(
+        (Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()) -
+          Date.UTC(d.getFullYear(), 0, 1)) /
+          86400000,
+      );
       var jan = new Date(d.getFullYear(), 0, 1);
       var jul = new Date(d.getFullYear(), 6, 1);
       var stdTimezoneOffset = Math.max(


### PR DESCRIPTION
`caml_unix_localtime` had two timezone-related issues, fixed here for both
the JS runtime (`runtime/js/unix.js`) and the wasm-on-node binding
(`runtime/wasm/runtime.js`).

### `tm_yday` was off by one during DST

`tm_yday` was derived from the wall-clock millisecond distance between the
date and local January 1. When DST is in effect that distance is off by one
hour, so `Math.floor` truncated `tm_yday` to the previous day.

It is now computed as the day distance to January 1 **in UTC**:

```js
var doy = Math.floor(
  (Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()) -
    Date.UTC(d.getFullYear(), 0, 1)) / 86400000,
);
```

UTC has no DST and JS UTC days are always exactly 86_400_000 ms, so the
quotient is always an exact integer — no off-by-one and no rounding risk.
This also removes the hardcoded cumulative-days table and the explicit
leap-year correction, making the code easier to review.

### `tm_isdst` did not match native for `Europe/Dublin`

`tm_isdst` is inferred from the offset heuristic (`offset < max(jan, jul)`),
which matches the native runtime for every conventional zone. `Europe/Dublin`
uses **negative DST**: the IANA database marks winter (GMT) as the daylight
deviation from its summer standard (IST), so native reports `tm_isdst`
inverted. The UTC offsets alone cannot distinguish Dublin from `Europe/London`
(both GMT/+1), so we detect the zone by name — guarded to the GMT/+1 offset
signature to avoid the `Intl` lookup for every other zone — and invert.

### Tests

Expect tests under both JS and Wasm:
- `tm_yday` under DST (`America/New_York`)
- `tm_isdst` for `Europe/Dublin` (negative DST), winter and summer

Split out of #2287.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
