### PR TITLE
Runtime/wasm: fix caml_parse_float trap and reject non-decimal literals

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,10 @@
   Pretty-printed output (`--pretty`) is unchanged. (#1117)
 
 ## Bug fixes
+* Runtime/wasm: `float_of_string` no longer traps on inputs like `"nin"`
+  (the `nan`/`inf` detection read past the end of the string) and no
+  longer accepts JavaScript binary/octal literals such as `"0b101"` or
+  `"0o17"`; both now raise `Failure` like the native runtime (#2263)
 * Runtime: the QuickJS standard file descriptors raise on a write or
   read error instead of returning 0; an error on stdout (e.g. EPIPE)
   used to make the flush/write loop spin forever, and a read error was

--- a/compiler/tests-wasm_of_ocaml/dune
+++ b/compiler/tests-wasm_of_ocaml/dune
@@ -11,7 +11,7 @@
  (modes js wasm))
 
 (tests
- (names marshal_regressions)
+ (names marshal_regressions parse_float)
  (modes wasm))
 
 (tests

--- a/compiler/tests-wasm_of_ocaml/parse_float.ml
+++ b/compiler/tests-wasm_of_ocaml/parse_float.ml
@@ -1,0 +1,36 @@
+(* Regression test for [caml_parse_float] (wasm runtime, float.wat).
+
+   - "nin" used to trap with an uncatchable exception: the "nan" branch
+     advanced the cursor, then the "inf" check -- which was not an [else]
+     of the "nan" check -- read past the end of the string.
+   - "0b101"/"0o17" were accepted through JS number coercion (returning
+     5. / 15.) where the native runtime raises [Failure]. *)
+
+let fails s =
+  match float_of_string s with
+  | (_ : float) -> false
+  | exception Failure _ -> true
+
+let () =
+  (* Used to trap instead of raising. *)
+  assert (fails "nin");
+  assert (fails "nif");
+  assert (fails "ina");
+  (* Used to be wrongly accepted. *)
+  assert (fails "0b101");
+  assert (fails "0o17");
+  assert (fails "1d0");
+  assert (fails "");
+  (* Valid values must still parse. *)
+  assert (float_of_string "1.5" = 1.5);
+  assert (float_of_string "1e3" = 1000.);
+  assert (float_of_string ".5" = 0.5);
+  assert (float_of_string "5." = 5.);
+  assert (float_of_string "-2.5" = -2.5);
+  assert (float_of_string "1_000.5" = 1000.5);
+  assert (Float.is_nan (float_of_string "nan"));
+  assert (Float.is_nan (float_of_string "-nan"));
+  assert (float_of_string "inf" = infinity);
+  assert (float_of_string "-inf" = neg_infinity);
+  assert (float_of_string "infinity" = infinity);
+  assert (float_of_string "0x1p4" = 16.)

--- a/runtime/wasm/float.wat
+++ b/runtime/wasm/float.wat
@@ -647,7 +647,8 @@
                                  (@char "N"))
                         (then
                            (return
-                              (struct.new $float (f64.const nan)))))))))
+                              (struct.new $float (f64.const nan))))))))
+               (else
                (if (i32.eq (i32.and (local.get $c) (i32.const 0xdf))
                            (@char "I")) (then
                   (local.set $i (i32.add (local.get $i) (i32.const 1)))
@@ -666,7 +667,7 @@
                                  (select
                                     (f64.const -inf)
                                     (f64.const inf)
-                                    (local.get $negative))))))))))))
+                                    (local.get $negative))))))))))))))
          (if (i32.eq (i32.add (local.get $i) (i32.const 8)) (local.get $len))
             (then
                (local.set $c (array.get_u $bytes (local.get $s) (local.get $i)))
@@ -741,6 +742,33 @@
               (i32.add (local.get $buf) (local.get $len))))
 )
 (@else
+         ;; The JS number coercion below accepts things OCaml does not,
+         ;; e.g. binary/octal literals ("0b101", "0o17"); only a plain
+         ;; decimal float can reach this point, so reject any character
+         ;; that cannot appear in one.
+         (local.set $i (i32.const 0))
+         (loop $check_decimal
+            (if (i32.lt_u (local.get $i) (local.get $len))
+               (then
+                  (local.set $c
+                     (array.get_u $bytes (local.get $s) (local.get $i)))
+                  (br_if $error
+                     (i32.eqz
+                        (i32.or
+                           (i32.and
+                              (i32.ge_u (local.get $c) (@char "0"))
+                              (i32.le_u (local.get $c) (@char "9")))
+                           (i32.or
+                              (i32.eq (local.get $c) (@char "."))
+                              (i32.or
+                                 (i32.eq
+                                    (i32.and (local.get $c) (i32.const 0xdf))
+                                    (@char "E"))
+                                 (i32.or
+                                    (i32.eq (local.get $c) (@char "+"))
+                                    (i32.eq (local.get $c) (@char "-"))))))))
+                  (local.set $i (i32.add (local.get $i) (i32.const 1)))
+                  (br $check_decimal))))
          (local.set $f
             (call $parse_float (call $jsstring_of_bytes (local.get $s))))
          (br_if $error (f64.ne (local.get $f) (local.get $f)))


### PR DESCRIPTION
`caml_parse_float` (wasm runtime, `runtime/wasm/float.wat`) had two bugs, both from the Wasm runtime review (#2263).

### 1. Uncatchable trap on inputs like `"nin"`

The `"inf"` check was a **sibling** of the `"nan"` check rather than an `else` of it, so both ran on the same 3-character window. For `"nin"`, the `"nan"` branch matched the leading `n` and advanced the cursor; the `"inf"` check then resumed from the moved cursor (`i`), matched `i`…`n`, and read one byte **past the end** of the string:

```
RuntimeError: array element access out of bounds
    at caml_parse_float (...)
```

`float_of_string "nin"` killed the process with an uncatchable `WebAssembly.Exception` where native raises `Failure`. Fixed by making the `"inf"` check an `else` of the `"nan"` check.

### 2. Accepts JavaScript binary/octal literals

The non-WASI fallback parsed the decimal path with JS number coercion, which accepts more than OCaml does:

- `float_of_string "0b101"` → `5.`
- `float_of_string "0o17"` → `15.`

native raises `Failure` for both. The fix scans the (underscore-stripped) string and rejects any character that cannot appear in a decimal float before coercing — mirroring the `r_float` guard in the JS runtime (`ieee_754.js`). The WASI path already rejects these via `strtod`'s end-pointer check, so only the `@else` branch changed.

### Test

Adds `compiler/tests-wasm_of_ocaml/parse_float.ml`, covering the trap (`"nin"`, `"nif"`, `"ina"`), the wrongly-accepted literals (`"0b101"`, `"0o17"`, `"1d0"`, `""`), and a range of valid values that must still parse (`"1.5"`, `"1e3"`, `".5"`, `"5."`, `"-2.5"`, `"1_000.5"`, `"nan"`, `"-nan"`, `"inf"`, `"-inf"`, `"infinity"`, `"0x1p4"`). It reproduces the out-of-bounds trap against the unpatched runtime and passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)