### PR TITLE
Runtime/wasm: fix off-by-one in re_replacement_text group bound

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,10 @@
   Pretty-printed output (`--pretty`) is unchanged. (#1117)
 
 ## Bug fixes
+* Runtime/wasm: `Str.replace`/`Str.global_replace` raise `Failure` on a
+  backreference to a group one past the last (e.g. `"\1"` against a
+  group-less regexp) instead of trapping with an out-of-bounds access;
+  the group bound check was off by one (#2263)
 * Runtime: the QuickJS standard file descriptors raise on a write or
   read error instead of returning 0; an error on stdout (e.g. EPIPE)
   used to make the flush/write loop spin forever, and a read error was

--- a/compiler/tests-re/dune
+++ b/compiler/tests-re/dune
@@ -5,5 +5,15 @@
 
 (tests
  (names test_str)
+ (modules test_str)
  (libraries str re)
  (modes js wasm))
+
+(library
+ (name tests_re_replace)
+ (modules str_replace)
+ (libraries str)
+ (inline_tests
+  (modes js wasm best))
+ (preprocess
+  (pps ppx_expect)))

--- a/compiler/tests-re/str_replace.ml
+++ b/compiler/tests-re/str_replace.ml
@@ -1,0 +1,30 @@
+(* Regression test for [re_replacement_text], the replacement-text engine
+   behind [Str.global_replace] / [Str.replace_matched].
+
+   A backreference to a group that does not exist, or that did not take
+   part in the match, must raise [Failure] on every backend. The wasm
+   runtime used to trap with an out-of-bounds access because the group
+   bound check was off by one (see runtime/wasm/str.wat). *)
+
+let show ~repl ~re s =
+  match Str.global_replace (Str.regexp re) repl s with
+  | r -> Printf.printf "%S\n" r
+  | exception Failure msg -> Printf.printf "Failure: %s\n" msg
+
+let%expect_test "backreference past the last group" =
+  show ~repl:"\\1" ~re:"a" "banana";
+  [%expect {| Failure: Str.replace: reference to unmatched group |}];
+  show ~repl:"\\2" ~re:{|\(a\)|} "banana";
+  [%expect {| Failure: Str.replace: reference to unmatched group |}];
+  show ~repl:"\\9" ~re:"abc" "abc";
+  [%expect {| Failure: Str.replace: reference to unmatched group |}]
+
+let%expect_test "backreference to an unmatched group" =
+  show ~repl:"\\1" ~re:{|\(a\)\|\(b\)|} "b";
+  [%expect {| Failure: Str.replace: reference to unmatched group |}]
+
+let%expect_test "valid backreferences" =
+  show ~repl:{|[\1]|} ~re:{|\(a\)|} "banana";
+  [%expect {| "b[a]n[a]n[a]" |}];
+  show ~repl:"\\0!" ~re:"a" "banana";
+  [%expect {| "ba!na!na!" |}]

--- a/runtime/wasm/str.wat
+++ b/runtime/wasm/str.wat
@@ -644,7 +644,7 @@
                      (local.set $len (i32.add (local.get $len) (i32.const 2)))
                      (br $loop)))
                (local.set $c (i32.shl (local.get $c) (i32.const 1)))
-               (if (i32.gt_u (i32.add (local.get $c) (i32.const 1))
+               (if (i32.ge_u (i32.add (local.get $c) (i32.const 1))
                       (array.len (local.get $groups)))
                   (then (call $caml_failwith (global.get $unmatched_group))))
                (local.set $start
@@ -697,7 +697,7 @@
                      (local.set $j (i32.add (local.get $j) (i32.const 2)))
                      (br $loop)))
                (local.set $c (i32.shl (local.get $c) (i32.const 1)))
-               (if (i32.gt_u (i32.add (local.get $c) (i32.const 1))
+               (if (i32.ge_u (i32.add (local.get $c) (i32.const 1))
                       (array.len (local.get $groups)))
                   (then (call $caml_failwith (global.get $unmatched_group))))
                (local.set $start


### PR DESCRIPTION
`re_replacement_text` (wasm runtime, `runtime/wasm/str.wat`) validates a replacement backreference `\n` against the groups array, then reads the group's start at `groups[2n+1]` and end at `groups[2n+2]`. The bound check used `>` where it should be `>=`:

```wat
(if (i32.gt_u (i32.add (local.get $c) (i32.const 1))   ;; (2n + 1) > len  -- wrong
      (array.len (local.get $groups)))
   (then (call $caml_failwith (global.get $unmatched_group))))
```

For a reference to the group one past the last (e.g. `"\1"` against a group-less regexp, or `"\2"` with a single group), `2n+1 == len(groups)`, so the `>` check passes and the following `array.get` at `2n+2` reads past the end:

```
RuntimeError: array element access out of bounds
    at re_replacement_text (...)
```

`Str.global_replace (Str.regexp "a") "\\1" s` killed the process with an uncatchable trap where the JS runtime (and native) raise `Failure "Str.replace: reference to unmatched group"`.

Fixed by using `i32.ge_u`, matching the JS runtime's `c * 2 >= groups.length - 1` check. The bug was present in **both** loops (length computation and fill).

### Test

Adds `compiler/tests-wasm_of_ocaml/str_replace.ml`: it reproduces the out-of-bounds trap against the unpatched runtime (boundary cases `"\1"` on `a` and `"\2"` on `\(a\)`), covers references further past the end and an existing-but-unmatched group, and checks that valid backreferences (`"[\1]"`, `"\0"`) still work. It passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)