### PR TITLE
Runtime/wasm: fix ephemeron get_data trap and blit_data of empty source

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,11 @@
   `Marshal.data_size` prefix; and bigarray deserialization rejects an
   out-of-range dimension count or an oversized dimension instead of
   truncating it (#2263)
+* Runtime/wasm: ephemeron data fixes — `Ephemeron.get_data` no longer
+  traps when the data is a JS value reached through an integer key (it
+  unwrapped and recast the value unconditionally), and `blit_data` from
+  an empty source now clears the destination instead of leaving its old
+  data in place (#2263)
 * Runtime: the QuickJS standard file descriptors raise on a write or
   read error instead of returning 0; an error on stdout (e.g. EPIPE)
   used to make the flush/write loop spin forever, and a read error was

--- a/compiler/tests-jsoo/dune
+++ b/compiler/tests-jsoo/dune
@@ -174,6 +174,7 @@
    test_ugeint
    ugeint_bytecode_probe
    test_runtime_value
+   ephemeron_data
    runtime_events_register
    test_custom_name
    test_text_codec_fallback
@@ -252,6 +253,18 @@
   (javascript_files custom.js))
  (wasm_of_ocaml
   (javascript_files custom.js custom.wat))
+ (modes js wasm))
+
+; Uses Js values (Js.string/Js.null), so it cannot run natively or under
+; the WASI runtime; exercised on both the JavaScript and wasm runtimes.
+(test
+ (name ephemeron_data)
+ (modules ephemeron_data)
+ (libraries js_of_ocaml)
+ (enabled_if
+  (and
+   (<> %{profile} wasi)
+   (<> %{profile} wasi-with-native-effects)))
  (modes js wasm))
 
 ; Forces a major GC through node's v8/vm modules to observe ephemeron

--- a/compiler/tests-jsoo/ephemeron_data.ml
+++ b/compiler/tests-jsoo/ephemeron_data.ml
@@ -1,0 +1,43 @@
+(* Regression tests for ephemeron data handling, exercised through the
+   low-level [Obj.Ephemeron] primitives on both the JavaScript and wasm
+   runtimes.
+
+   - [caml_ephe_get_data] used to trap in the wasm runtime (weak.wat): it
+     unwrapped and recast the stored data unconditionally, so when the data
+     is a JS value reached through an integer key (no weak map threads it),
+     the unwrap stripped the JS box and the recast (or [ref.as_non_null] on
+     JS null) trapped instead of returning the value.
+
+   - [caml_ephe_blit_data] from an empty source left the destination's old
+     data in place in the wasm runtime ([caml_ephe_set_data_opt] ignored
+     [None]); native and the JS runtime clear it. *)
+
+module E = Obj.Ephemeron
+module Js = Js_of_ocaml.Js
+
+let () =
+  (* blit_data from an empty source must clear the destination. *)
+  let dst = E.create 1 in
+  E.set_data dst (Obj.repr 42);
+  assert (E.check_data dst);
+  let src = E.create 1 in
+  E.blit_data src dst;
+  assert (not (E.check_data dst));
+
+  (* get_data must not trap when the data is a JS value reached through
+     an integer key. *)
+  let e = E.create 1 in
+  E.set_key e 0 (Obj.repr 5);
+  E.set_data e (Obj.repr (Js.string "hello"));
+  (match E.get_data e with
+  | Some d -> assert (Js.to_string (Obj.obj d) = "hello")
+  | None -> assert false);
+
+  (* Same, with a JS value that unwraps to null (used to trap on
+     [ref.as_non_null]). *)
+  let e2 = E.create 1 in
+  E.set_key e2 0 (Obj.repr 7);
+  E.set_data e2 (Obj.repr Js.null);
+  match E.get_data e2 with
+  | Some _ -> () (* reached without trapping *)
+  | None -> assert false

--- a/runtime/wasm/weak.wat
+++ b/runtime/wasm/weak.wat
@@ -69,8 +69,8 @@
       (param $vx (ref eq)) (result (ref eq))
       (local $x (ref $block))
       (local $d (ref eq)) (local $v (ref eq))
-      (local $m (ref any))
-      (local $i i32) (local $len i32)
+      (local $m (ref null any))
+      (local $i i32) (local $len i32) (local $traversed i32)
       (local.set $x (ref.cast (ref $block) (local.get $vx)))
       (local.set $d
          (array.get $block (local.get $x) (global.get $caml_ephe_data_offset)))
@@ -82,7 +82,6 @@
 (@then
             (local.set $i (global.get $caml_ephe_key_offset))
             (local.set $len (array.len (local.get $x)))
-            (local.set $m (ref.as_non_null (call $unwrap (local.get $d))))
             (loop $loop
                (if (i32.lt_u (local.get $i) (local.get $len))
                   (then
@@ -95,11 +94,23 @@
                      (local.set $v
                         (br_on_null $released
                            (call $weak_deref (call $unwrap (local.get $v)))))
+                     ;; The data is wrapped in weak maps only when a live
+                     ;; key threads it; unwrap lazily so that JS-valued
+                     ;; data with no such key (e.g. a string with an int
+                     ;; key) is returned as is rather than unwrapped and
+                     ;; recast -- which traps.
+                     (if (i32.eqz (local.get $traversed))
+                        (then
+                           (local.set $traversed (i32.const 1))
+                           (local.set $m
+                              (ref.as_non_null (call $unwrap (local.get $d))))))
                      (local.set $m
                         (br_on_null $released
-                           (call $map_get (local.get $m) (local.get $v))))
+                           (call $map_get (ref.as_non_null (local.get $m))
+                              (local.get $v))))
                      (br $loop))))
-            (local.set $d (ref.cast (ref eq) (local.get $m)))
+            (if (local.get $traversed)
+               (then (local.set $d (ref.cast (ref eq) (local.get $m)))))
 ))
             (return
               (array.new_fixed $block 2 (ref.i31 (i32.const 0))
@@ -170,7 +181,7 @@
          (local.get $data))
       (ref.i31 (i32.const 0)))
 
-   (func (export "caml_ephe_unset_data")
+   (func $caml_ephe_unset_data (export "caml_ephe_unset_data")
       (param $vx (ref eq)) (result (ref eq))
       (local $x (ref $block))
       (local.set $x (ref.cast (ref $block) (local.get $vx)))
@@ -336,8 +347,14 @@
 
    (func (export "caml_ephe_blit_data")
       (param $x (ref eq)) (param $y (ref eq)) (result (ref eq))
-      (call $caml_ephe_set_data_opt
-         (local.get $y) (call $caml_ephe_get_data (local.get $x)))
+      (local $d (ref eq))
+      (local.set $d (call $caml_ephe_get_data (local.get $x)))
+      ;; [get_data] returns [Some data] (a block) or [None] (an int).
+      ;; An empty source must clear the destination, not leave its old
+      ;; data in place.
+      (if (ref.test (ref $block) (local.get $d))
+         (then (call $caml_ephe_set_data_opt (local.get $y) (local.get $d)))
+         (else (drop (call $caml_ephe_unset_data (local.get $y)))))
       (ref.i31 (i32.const 0)))
 
    (export "caml_weak_blit" (func $caml_ephe_blit_key))


### PR DESCRIPTION
Two ephemeron bugs in `runtime/wasm/weak.wat`, both from the Wasm runtime review (#2263).

### 1. `get_data` traps on JS-valued data behind an integer key

The ephemeron's data is stored threaded through a chain of weak maps, one per live (non-integer) key. `caml_ephe_get_data` unwrapped the stored value and recast it to `(ref eq)` **unconditionally**, before walking the keys. When no live key threads the data — e.g. JS-valued data with only an integer key — there is no weak map, so the unwrap stripped the `$js` box off the value itself and the subsequent `ref.cast (ref eq)` trapped:

```
RuntimeError: illegal cast
```

(and `ref.as_non_null` trapped when the data unwrapped to JS `null`).

Fixed by unwrapping **lazily** — only when actually descending into a weak map — and only recasting when at least one key was traversed. Data that isn't threaded through any weak map is returned as is, matching the JS runtime (which keeps `data = x[data_offset]` and only `.get`s for `WeakRef` keys).

### 2. `blit_data` from an empty source leaves stale data

`caml_ephe_blit_data` forwarded the source's data through `caml_ephe_set_data_opt`, which is a no-op for `None`, so blitting from an empty ephemeron left the destination's old data untouched. Native and the JS runtime clear it.

Fixed in `blit_data` itself: when the source has no data, call `caml_ephe_unset_data` on the destination. I deliberately did **not** change `caml_ephe_set_data_opt`'s no-op-on-`None` contract — `caml_ephe_set_key`/`caml_ephe_unset_key` rely on it to leave the data untouched when an integer key changes (they skip `get_data` in that case and pass `None` to mean "leave alone").

### Test

Adds `compiler/tests-wasm_of_ocaml/ephemeron_data.ml` (using `Obj.Ephemeron` + `js_of_ocaml` for the JS value). It checks that `blit_data` from an empty source clears the destination, and that `get_data` returns JS-valued data (a string, and JS `null`) behind an integer key without trapping. Verified that it reproduces both failures (`illegal cast` and the failed assertion) against the unpatched runtime and passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)