### PR TITLE
Runtime/wasm: fail in the bytecode-section accessors without --toplevel

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -65,6 +65,11 @@
   transitions that have a memory action (`pc_off > 0`), matching the C
   and JS runtimes; previously a redundant no-op call was made on
   memoryless transitions (#2263)
+* Runtime/wasm: the bytecode-section accessors
+  (`caml_get_section_table`, `caml_dynlink_get_bytecode_sections`) raise
+  `Failure "Program not compiled with --toplevel"` when the sections are
+  absent, like the JS runtime, instead of trapping with an
+  uncatchable "illegal cast" or silently returning 0 (#2263)
 * Runtime: the QuickJS standard file descriptors raise on a write or
   read error instead of returning 0; an error on stdout (e.g. EPIPE)
   used to make the flush/write loop spin forever, and a read error was

--- a/compiler/tests-jsoo/dune
+++ b/compiler/tests-jsoo/dune
@@ -185,6 +185,7 @@
    test_sys_command
    test_str
    test_weak_gc
+   toplevel_sections
    calc_parser
    calc_lexer))
  (libraries unix compiler-libs.common js_of_ocaml-compiler)
@@ -266,6 +267,25 @@
    (<> %{profile} wasi)
    (<> %{profile} wasi-with-native-effects)))
  (modes js wasm))
+
+; The js accessor lives in the optional +toplevel.js runtime fragment, so it
+; is linked explicitly; --toplevel is deliberately NOT passed, so the bytecode
+; sections stay absent and the accessor raises like in a non-toplevel program.
+
+(test
+ (name toplevel_sections)
+ (modules toplevel_sections)
+ (enabled_if
+  (and
+   (<> %{profile} wasi)
+   (<> %{profile} wasi-with-native-effects)))
+ (modes js wasm)
+ (js_of_ocaml
+  (compilation_mode whole_program)
+  (flags
+   (:standard +toplevel.js)))
+ (wasm_of_ocaml
+  (compilation_mode whole_program)))
 
 ; Forces a major GC through node's v8/vm modules to observe ephemeron
 ; liveness, so it only runs in js mode under node.

--- a/compiler/tests-jsoo/toplevel_sections.ml
+++ b/compiler/tests-jsoo/toplevel_sections.ml
@@ -1,0 +1,13 @@
+(* Regression test for the bytecode-sections accessors in both the JS
+   (toplevel.js) and Wasm (toplevel.wat) runtimes. When the program is not
+   compiled with --toplevel, the accessor must raise
+   Failure "Program not compiled with --toplevel". The wasm runtime used to
+   cast the absent sections to a block (trapping with "illegal cast") or
+   return it silently instead. *)
+
+external get_bytecode_sections : unit -> Obj.t = "caml_dynlink_get_bytecode_sections"
+
+let () =
+  match get_bytecode_sections () with
+  | (_ : Obj.t) -> assert false
+  | exception Failure msg -> assert (msg = "Program not compiled with --toplevel")

--- a/runtime/wasm/toplevel.wat
+++ b/runtime/wasm/toplevel.wat
@@ -203,6 +203,21 @@
             (br $loop)))
       (local.get $acc))
 
+   ;; Return the bytecode sections record, or fail like the JS runtime
+   ;; when the program was not compiled with --toplevel (the field is
+   ;; left as the integer 0 instead of a record block).
+   (func $get_sections (result (ref $block))
+      (local $s (ref eq))
+      (local.set $s
+         (array.get $block (global.get $link_info)
+            (global.get $LINK_INFO_SECTIONS)))
+      (if (ref.test (ref i31) (local.get $s))
+         (then
+            (call $caml_failwith
+               (@string "Program not compiled with --toplevel"))
+            (unreachable)))
+      (ref.cast (ref $block) (local.get $s)))
+
 (@if (< $ocaml_version (5 3 0))
 (@then
    (func (export "caml_get_section_table")
@@ -212,8 +227,7 @@
       (local $crcs (ref eq))
       (local $prim (ref eq))
       (local $dlpt (ref eq))
-      (local.set $sections
-         (ref.cast (ref $block) (array.get $block (global.get $link_info) (global.get $LINK_INFO_SECTIONS))))
+      (local.set $sections (call $get_sections))
       (local.set $symb (array.get $block (local.get $sections) (i32.const 1)))
       (local.set $crcs  (array.get $block (local.get $sections) (i32.const 2)))
       (local.set $prim
@@ -255,11 +269,11 @@
    ;; { symb: GlobalMap.t; crcs: ...; prim: string list; dlpt: string list }
    (func (export "caml_dynlink_get_bytecode_sections")
       (param (ref eq)) (result (ref eq))
-      (array.get $block (global.get $link_info) (global.get $LINK_INFO_SECTIONS)))
+      (call $get_sections))
 
    (func (export "wasm_get_bytecode_sections")
       (param (ref eq)) (result (ref eq))
-      (array.get $block (global.get $link_info) (global.get $LINK_INFO_SECTIONS)))
+      (call $get_sections))
 
    (func (export "wasm_get_runtime_aliases")
       (param (ref eq)) (result (ref eq))


### PR DESCRIPTION
When a program is not compiled with `--toplevel`, the `sections` field of `link_info` is left as the integer `0` (the default; `caml_set_link_info` is never called with a real sections record). The wasm bytecode-section accessors in `runtime/wasm/toplevel.wat` mishandled this:

- `caml_get_section_table` (OCaml < 5.3) did `ref.cast (ref $block)` on it → uncatchable `RuntimeError: illegal cast`.
- `caml_dynlink_get_bytecode_sections` and `wasm_get_bytecode_sections` returned the `0` silently.

The JS runtime raises `Failure "Program not compiled with --toplevel"` in all these cases — which is also what this file's own comment says these stubs should do (so failures surface as OCaml exceptions, not JS errors that become "illegal cast" in exception handlers).

Fixed by routing all three through a `$get_sections` helper that raises `Failure "Program not compiled with --toplevel"` when the sections field is an integer (absent) rather than a record block.

The aliases accessor (`wasm_get_runtime_aliases`) is intentionally left as is: it's outside the item's scope (lines 264-266), and unlike `sections`, an absent aliases field is `0` — indistinguishable from a legitimately empty alias list `[]` — so a naive check would wrongly fail a real toplevel with no aliases.

### Test

Adds `compiler/tests-wasm_of_ocaml/toplevel_sections.ml` (whole-program mode, which is where `sections` is left absent — separate compilation populates it): it calls `caml_dynlink_get_bytecode_sections` from a non-toplevel program and asserts `Failure "Program not compiled with --toplevel"`. Verified that it reproduces the silent `0` return against the unpatched runtime and passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)