### PR TITLE
Runtime/wasm: build a float array for the double-array tag in obj_block

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -74,6 +74,10 @@
   `Failure "Program not compiled with --toplevel"` when the sections are
   absent, like the JS runtime, instead of trapping with an
   uncatchable "illegal cast" or silently returning 0 (#2263)
+* Runtime/wasm: `Obj.new_block` with the double-array tag now builds a
+  float array with the dedicated representation, so float-array
+  primitives on the result work instead of trapping (it previously
+  always built a generic block) (#2263)
 * Runtime: the QuickJS standard file descriptors raise on a write or
   read error instead of returning 0; an error on stdout (e.g. EPIPE)
   used to make the flush/write loop spin forever, and a read error was

--- a/compiler/tests-jsoo/dune
+++ b/compiler/tests-jsoo/dune
@@ -186,6 +186,7 @@
    test_str
    test_weak_gc
    toplevel_sections
+   obj_block_float
    calc_parser
    calc_lexer))
  (libraries unix compiler-libs.common js_of_ocaml-compiler)
@@ -240,6 +241,11 @@
   (>= %{ocaml_version} 5.1))
  (modules runtime_events_register)
  (libraries runtime_events)
+ (modes js wasm native))
+
+(test
+ (name obj_block_float)
+ (modules obj_block_float)
  (modes js wasm native))
 
 (test

--- a/compiler/tests-jsoo/obj_block_float.ml
+++ b/compiler/tests-jsoo/obj_block_float.ml
@@ -1,0 +1,20 @@
+(* Regression test for [caml_obj_block] with the double-array tag, run on
+   both the JS and Wasm runtimes.
+
+   Float arrays have a dedicated representation in the wasm runtime
+   ([$float_array], distinct from a generic block). [Obj.new_block] with
+   the double-array tag used to build a generic block there, so the first
+   float-array primitive on the result trapped instead of working as in
+   the native and JS runtimes. *)
+
+let () =
+  let o = Obj.new_block Obj.double_array_tag 3 in
+  assert (Obj.tag o = Obj.double_array_tag);
+  let a : float array = Obj.obj o in
+  assert (Array.length a = 3);
+  a.(0) <- 1.5;
+  a.(1) <- 2.5;
+  a.(2) <- 3.5;
+  assert (a.(0) = 1.5);
+  assert (a.(1) = 2.5);
+  assert (a.(2) = 3.5)

--- a/compiler/tests-jsoo/obj_block_float.ml
+++ b/compiler/tests-jsoo/obj_block_float.ml
@@ -1,5 +1,5 @@
 (* Regression test for [caml_obj_block] with the double-array tag, run on
-   both the JS and Wasm runtimes.
+   the native, JS and Wasm runtimes.
 
    Float arrays have a dedicated representation in the wasm runtime
    ([$float_array], distinct from a generic block). [Obj.new_block] with
@@ -8,7 +8,16 @@
    the native and JS runtimes. *)
 
 let () =
-  let o = Obj.new_block Obj.double_array_tag 3 in
+  (* [Obj.new_block double_array_tag n] takes [n] as a word count on the
+     native and bytecode backends (a float spans [64 / Sys.word_size] words,
+     i.e. 2 on 32-bit), but as an element count on the js and wasm backends.
+     Size the block so it holds 3 floats on every backend. *)
+  let words_per_float =
+    match Sys.backend_type with
+    | Sys.Other _ -> 1
+    | Sys.Native | Sys.Bytecode -> 64 / Sys.word_size
+  in
+  let o = Obj.new_block Obj.double_array_tag (3 * words_per_float) in
   assert (Obj.tag o = Obj.double_array_tag);
   let a : float array = Obj.obj o in
   assert (Array.length a = 3);

--- a/runtime/wasm/obj.wat
+++ b/runtime/wasm/obj.wat
@@ -278,13 +278,19 @@
    (func (export "caml_obj_block")
       (param $tag (ref eq)) (param $size (ref eq)) (result (ref eq))
       (local $res (ref $block))
-      ;; ZZZ float array / specific types?
-      ;; TODO: fail for value that are not represented as an array
+      (local $n i32)
+      ;; TODO: fail for values that are not represented as an array
+      (local.set $n (i31.get_s (ref.cast (ref i31) (local.get $size))))
+      ;; Float arrays have a dedicated representation; a generic block
+      ;; would trap on the first float-array primitive.
+      (if (i32.eq (i31.get_s (ref.cast (ref i31) (local.get $tag)))
+                  (global.get $double_array_tag))
+         (then
+            (return (array.new $float_array (f64.const 0) (local.get $n)))))
       (local.set $res
          (array.new $block
             (ref.i31 (i32.const 0))
-            (i32.add (i31.get_s (ref.cast (ref i31) (local.get $size)))
-                     (i32.const 1))))
+            (i32.add (local.get $n) (i32.const 1))))
       (array.set $block (local.get $res) (i32.const 0) (local.get $tag))
       (local.get $res))
 


### PR DESCRIPTION
Float arrays have a dedicated representation in the wasm runtime (`$float_array`, an array of `f64`, distinct from a generic `$block`). `caml_obj_block` (`runtime/wasm/obj.wat`) always built a generic block regardless of tag (with an acknowledged `;; ZZZ float array / specific types?` comment), so `Obj.new_block Obj.double_array_tag n` produced a block on which the first float-array primitive trapped — while the native and JS runtimes work (the JS float array *is* a generic array, so its `caml_obj_block` needs no special case).

Fixed by building a `$float_array` when the tag is `double_array_tag` (254).

Other tags (string/closure/custom) are still built as generic blocks, matching the JS runtime — constructing those through `new_block` is not well defined (e.g. the string size is in words vs bytes, and closures/custom blocks have no array form).

### Test

Adds `compiler/tests-wasm_of_ocaml/obj_block_float.ml`: `Obj.new_block Obj.double_array_tag 3`, then uses the result as a `float array` (length, set, get). Verified it errors against the unpatched runtime (using a generic block as a float array) and passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)