### PR TITLE
Runtime: marshal fixes (to_buffer length, error message, bigarray dims)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,13 @@
 * Runtime/wasm: add the missing `Unix.getegid` stub and fix the
   `Unix.getgrgid` export (it was registered under the typo
   `caml_unix_getgruid`); both were missing primitives (#2263)
+* Runtime: `Marshal.to_buffer` returns the number of bytes written
+  instead of 0, in both the JavaScript and Wasm runtimes (#2263)
+* Runtime/wasm: more marshalling fixes — `input_value` on a bad object
+  raises `Failure "input_value: bad object"` instead of using the
+  `Marshal.data_size` prefix; and bigarray deserialization rejects an
+  out-of-range dimension count or an oversized dimension instead of
+  truncating it (#2263)
 * Runtime: the QuickJS standard file descriptors raise on a write or
   read error instead of returning 0; an error on stdout (e.g. EPIPE)
   used to make the flush/write loop spin forever, and a read error was

--- a/compiler/tests-wasm_of_ocaml/dune
+++ b/compiler/tests-wasm_of_ocaml/dune
@@ -15,6 +15,10 @@
  (modes wasm))
 
 (tests
+ (names marshal_fixes)
+ (modes js wasm))
+
+(tests
  (names readdir_after_closedir unix_ids)
  (modes wasm)
  (libraries unix))

--- a/compiler/tests-wasm_of_ocaml/marshal_fixes.ml
+++ b/compiler/tests-wasm_of_ocaml/marshal_fixes.ml
@@ -1,0 +1,30 @@
+(* Regression tests for the wasm marshalling fixes (marshal.wat,
+   bigarray.wat).
+
+   - [Marshal.to_buffer] returned 0 instead of the number of bytes
+     written.
+   - [bigarray_deserialize] now validates the dimension count and size;
+     this checks that valid bigarrays still round-trip. *)
+
+let () =
+  (* to_buffer must return the number of bytes written. *)
+  let v = 1, "hello", [ 2; 3; 4 ] in
+  let s = Marshal.to_string v [] in
+  let buf = Bytes.create (String.length s + 16) in
+  let n = Marshal.to_buffer buf 0 (Bytes.length buf) v [] in
+  assert (n = String.length s);
+  (* and the written prefix must round-trip. *)
+  assert (Marshal.from_bytes buf 0 = v);
+
+  (* A valid bigarray must still round-trip through marshalling. *)
+  let a = Bigarray.Array1.create Bigarray.int Bigarray.c_layout 5 in
+  for i = 0 to 4 do
+    Bigarray.Array1.set a i (i * i)
+  done;
+  let b : (int, Bigarray.int_elt, Bigarray.c_layout) Bigarray.Array1.t =
+    Marshal.from_string (Marshal.to_string a []) 0
+  in
+  assert (Bigarray.Array1.dim b = 5);
+  for i = 0 to 4 do
+    assert (Bigarray.Array1.get b i = i * i)
+  done

--- a/runtime/js/marshal.js
+++ b/runtime/js/marshal.js
@@ -853,5 +853,6 @@ function caml_output_value_to_buffer(s, ofs, len, v, flags) {
   var t = caml_output_val(v, flags);
   if (t.length > len) caml_failwith("Marshal.to_buffer: buffer overflow");
   caml_blit_bytes(caml_bytes_of_uint8_array(t), 0, s, ofs, t.length);
-  return 0;
+  // Return the number of bytes written, like the native runtime.
+  return t.length;
 }

--- a/runtime/wasm/bigarray.wat
+++ b/runtime/wasm/bigarray.wat
@@ -1077,6 +1077,12 @@
       (local $i i32) (local $len i32)
       (local $l i64)
       (local.set $num_dims (call $caml_deserialize_int_4 (local.get $s)))
+      ;; CAML_BA_MAX_NUM_DIMS is 16; the unsigned test also rejects a
+      ;; negative (hostile) count.
+      (if (i32.gt_u (local.get $num_dims) (i32.const 16))
+         (then
+            (call $caml_failwith
+               (@string "input_value: wrong number of bigarray dimensions"))))
       (local.set $flags (call $caml_deserialize_int_4 (local.get $s)))
       (local.set $kind (i32.and (local.get $flags) (i32.const 0xff)))
       (local.set $dim (array.new $int_array (i32.const 0) (local.get $num_dims)))
@@ -1087,10 +1093,14 @@
                   (call $caml_deserialize_uint_2 (local.get $s)))
                (if (i32.eq (local.get $len) (i32.const 0xffff))
                   (then
-                     ;; ZZZ overflows?
-                     (local.set $len
-                        (i32.wrap_i64
-                           (call $caml_deserialize_int_8 (local.get $s))))))
+                     ;; A dimension that does not fit in a 32-bit machine
+                     ;; integer would be silently truncated; fail instead.
+                     (local.set $l (call $caml_deserialize_int_8 (local.get $s)))
+                     (if (i64.gt_u (local.get $l) (i64.const 0x7fffffff))
+                        (then
+                           (call $caml_failwith
+                              (@string "input_value: size overflow for bigarray"))))
+                     (local.set $len (i32.wrap_i64 (local.get $l)))))
                (array.set $int_array (local.get $dim) (local.get $i)
                   (local.get $len))
                (local.set $i (i32.add (local.get $i) (i32.const 1)))

--- a/runtime/wasm/marshal.wat
+++ b/runtime/wasm/marshal.wat
@@ -172,10 +172,10 @@
             (local.set $len
                (i32.and (call $read8u (local.get $s)) (i32.const 0x3F)))
             (if (i32.lt_u (local.get $len) (i32.const 5))
-               (then (call $bad_object (global.get $marshal_data_size))))
+               (then (call $bad_object (global.get $input_value))))
             (local.set $len (i32.sub (local.get $len) (i32.const 5)))))
       (if (i32.eqz (local.get $len))
-         (then (call $bad_object (global.get $marshal_data_size))))
+         (then (call $bad_object (global.get $input_value))))
       (if (i32.lt_u
              (call $caml_really_getblock (local.get $ch)
                 (local.get $header) (i32.const 5) (local.get $len))
@@ -1552,7 +1552,8 @@
       (array.copy $bytes $bytes
          (local.get $buf) (local.get $pos)
          (local.get $r_1) (i32.const 0) (i32.const 20))
-      (ref.i31 (i32.const 0)))
+      ;; Return the number of bytes written: 20-byte header + data.
+      (ref.i31 (i32.add (local.get $r_0) (i32.const 20))))
 
    (func (export "caml_output_value")
       (param $ch (ref eq)) (param $v (ref eq)) (param $flags (ref eq))


### PR DESCRIPTION
Marshalling items from the runtime reviews (#2263).

### 1. `Marshal.to_buffer` returned 0 — **both runtimes**

`caml_output_value_to_buffer` computed the marshalled length and discarded it, returning `0`. Native returns the number of bytes written. Fixed in:
- `runtime/wasm/marshal.wat` — returns `data_len + 20` (the 20-byte header plus data), consistent with `caml_output_value_to_string` which allocates exactly that.
- `runtime/js/marshal.js` — returns `t.length` (the JS runtime shares the defect, as noted in #2263).

### 2. Wrong `input_value` error prefix (wasm)

`caml_input_value` raised `Failure "Marshal.data_size: bad object"` on a bad object — a copy-paste of the `Marshal.data_size` prefix. Native raises `"input_value: bad object"`; switched to the existing `$input_value` prefix.

### 3. `bigarray_deserialize` missing validation (wasm)

(The review listed this under `marshal.wat`, but the function lives in `bigarray.wat`.) Deserialization did not validate its header: no dimension-count check, and 8-byte dimensions were silently truncated by `i32.wrap_i64` (flagged `;; ZZZ overflows?`). It now rejects a dimension count outside `[0, 16]` (`"input_value: wrong number of bigarray dimensions"`) and a single dimension that does not fit in a 32-bit integer (`"input_value: size overflow for bigarray"`), matching the native `caml_ba_deserialize`.

### Test

`compiler/tests-wasm_of_ocaml/marshal_fixes.ml`, run in **both js and wasm modes**: checks that `Marshal.to_buffer` returns the right length and the prefix round-trips, and that a valid `Bigarray` still round-trips. Verified the `to_buffer` assertion fails against both unpatched runtimes and passes with the fixes.

### Not in this PR

The BLOCK32 writer truncating block sizes ≥ 2²² (`tag | sz << 10`) is left for a follow-up: it is "lower severity / would be safer", the JS runtime shares the defect, and a correct fix wants `CODE_BLOCK64` support rather than just bailing out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)