### PR TITLE
Misc runtime fixes and test portability improvements

### DIFF
--- a/compiler/tests-check-prim/main.5.2+ox.output
+++ b/compiler/tests-check-prim/main.5.2+ox.output
@@ -336,7 +336,6 @@ From +jslib.js:
 caml_is_js
 caml_trampoline
 caml_trampoline_return
-caml_wrap_exception
 
 From +marshal.js:
 caml_marshal_constants
@@ -350,9 +349,9 @@ caml_string_concat
 caml_to_js_string (deprecated)
 
 From +runtime_events.js:
-caml_runtime_events_create_cursor
-caml_runtime_events_free_cursor
-caml_runtime_events_read_poll
+caml_ml_runtime_events_create_cursor
+caml_ml_runtime_events_free_cursor
+caml_ml_runtime_events_read_poll
 caml_runtime_events_user_resolve
 
 From +stdlib.js:

--- a/compiler/tests-check-prim/unix-Unix.5.2+ox.output
+++ b/compiler/tests-check-prim/unix-Unix.5.2+ox.output
@@ -412,7 +412,6 @@ From +jslib.js:
 caml_is_js
 caml_trampoline
 caml_trampoline_return
-caml_wrap_exception
 
 From +marshal.js:
 caml_marshal_constants
@@ -426,9 +425,9 @@ caml_string_concat
 caml_to_js_string (deprecated)
 
 From +runtime_events.js:
-caml_runtime_events_create_cursor
-caml_runtime_events_free_cursor
-caml_runtime_events_read_poll
+caml_ml_runtime_events_create_cursor
+caml_ml_runtime_events_free_cursor
+caml_ml_runtime_events_read_poll
 caml_runtime_events_user_resolve
 
 From +stdlib.js:


### PR DESCRIPTION
## Summary

A collection of runtime fixes and test portability/gating improvements. Highlights:

- **Runtime fixes**
  - Order immediate before custom block in `compare`
  - Allocate a fresh channel per `open_descriptor` call
  - Fix swapped `typ`/`tag` in runtime_events `user_register` (wasm)
  - Align Graphics primitives with the native X11 backend; fix plot/point origin, arc angle, async `draw_image`
  - Fix off-by-one in `re_replacement_text` group bound (wasm)
  - Hash float arrays and skip abstract blocks like native
  - Fix `Sys.command` exit code, `getenv`, `isatty`
  - Raise on QuickJS std fd read/write errors

- **Tests**
  - Add a `Graphics_js` test suite (`compiler/tests-graphics`)
  - Portability/gating: make `is_binary_mode` test portable on Windows, gate it on OCaml >= 5.2, gate `tests-re` inline tests out of WASI, gate `isatty_tty` build on OCaml >= 5.1, move `Sys.command`/`blake2_long_key` tests out of WASI runs
  - Various new tests covering the runtime fixes above
  - Update check-prim output for the runtime_events primitive rename

## Test plan

- `make tests`
- `make tests-wasm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)