### PR TITLE
Runtime/wasm: align lexer engine with the C/JS runtime (guard run_mem on pc_off > 0)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -58,6 +58,10 @@
   unwrapped and recast the value unconditionally), and `blit_data` from
   an empty source now clears the destination instead of leaving its old
   data in place (#2263)
+* Runtime/wasm: the lexer engine only runs the position-memory moves on
+  transitions that have a memory action (`pc_off > 0`), matching the C
+  and JS runtimes; previously a redundant no-op call was made on
+  memoryless transitions (#2263)
 * Runtime: the QuickJS standard file descriptors raise on a write or
   read error instead of returning 0; an error on stdout (e.g. EPIPE)
   used to make the flush/write loop spin forever, and a read error was

--- a/runtime/wasm/lexing.wat
+++ b/runtime/wasm/lexing.wat
@@ -378,9 +378,17 @@
                (else
                   (call $get (local.get $lex_default_code)
                      (local.get $pstate)))))
-         (call $run_mem (local.get $lex_code) (local.get $pc_off)
-            (local.get $lexbuf)
-            (array.get $block (local.get $lexbuf) (global.get $lex_curr_pos)))
+         ;; Only perform memory moves when the transition has a memory
+         ;; action, like the C and JS runtimes. (ocamllex reserves code
+         ;; address 0 for the empty action, so an unguarded call would just
+         ;; read the 0xff terminator and return; this keeps us aligned with
+         ;; the reference and skips a redundant call.)
+         (if (i32.gt_s (local.get $pc_off) (i32.const 0))
+            (then
+               (call $run_mem (local.get $lex_code) (local.get $pc_off)
+                  (local.get $lexbuf)
+                  (array.get $block (local.get $lexbuf)
+                     (global.get $lex_curr_pos)))))
          (if (i32.eq (local.get $c) (i32.const 256))
             (then
                (array.set $block (local.get $lexbuf)


### PR DESCRIPTION
## Summary

`caml_new_lex_engine` in `runtime/wasm/lexing.wat` called `run_mem`
(the position-memory move helper for ocamllex `as`-bindings)
**unconditionally**, whereas both reference runtimes guard it:

- C runtime `runtime/lexing.c`: `if (pc_off > 0) run_mem(...)`
- JS runtime `runtime/js/lexing.js:227`: `if (pc_off > 0) caml_lex_run_mem(...)`

This realigns the Wasm engine with that guard.

### Severity: harmless alignment, not a live bug

This was flagged during the [#2263](https://github.com/ocsigen/js_of_ocaml/issues/2263) re-review as a potential
position-memory corruption, but on closer inspection it is **not**
observable. ocamllex reserves code address 0 for the empty action:

```ocaml
(* lex/compact.ml *)
(* Code address 0 is the empty code (ie do nothing) *)
let _ = mem_emit_code []
```

so `lex_code[0]` is always the `0xff` terminator. With `pc_off = 0`
(a transition with no memory action) the unguarded call read that
terminator and returned immediately — a redundant no-op. The guard
removes the redundant call and keeps us faithful to the reference
implementations (and is robust should a non-ocamllex table ever place a
real action at address 0).

## Test

Adds the first test exercising this path under Wasm: an ocamllex lexer
with several `as` bindings, which compiles to a non-empty `lex_code`
table and drives `run_mem` with real memory actions. The existing lexer
tests (`calc_lexer`, `lexer_1307`) all compile to an empty `lex_code`,
so this path was previously untested. The test runs under native, js
and wasm.

## Test plan

- `dune build @compiler/tests-jsoo/runtest @compiler/tests-jsoo/runtest-js`
- `WASM_OF_OCAML=true dune build @compiler/tests-jsoo/runtest-wasm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)