### PR TITLE
Doc: use conventional comment style in JavaScript examples

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,9 @@
   from `0.x` fractions, normalise exponent forms (`1e+05` → `1e5`), and
   pick backticks for string literals when they reduce escape count.
   Pretty-printed output (`--pretty`) is unchanged. (#1117)
+* Doc: use the more conventional spaced form `// Provides:` (instead of
+  `//Provides:`) for runtime annotations and `const` (instead of `var`)
+  in the manual's JavaScript examples (#NNNN)
 
 ## Bug fixes
 * Runtime/wasm: `Str.replace`/`Str.global_replace` raise `Failure` on a

--- a/lib/js_of_ocaml/js.mli
+++ b/lib/js_of_ocaml/js.mli
@@ -966,7 +966,7 @@ module Unsafe : sig
 
   external runtime_value : string -> 'a = "caml_jsoo_runtime_value"
   (** [runtime_value "FOO"] returns the JavaScript value FOO provided
-      by the JavaScript runtime (with '//Provides: FOO'). The string
+      by the JavaScript runtime (with '// Provides: FOO'). The string
       argument must be a string literal. *)
 
   val global : < .. > t

--- a/manual/javascript-interop.mld
+++ b/manual/javascript-interop.mld
@@ -404,7 +404,7 @@ let result =
 
 {2 Calling runtime primitives}
 
-For JavaScript functions declared in runtime files (with [//Provides:]),
+For JavaScript functions declared in runtime files (with [// Provides:]),
 you can use OCaml [external] declarations:
 
 {@ocaml[
@@ -582,19 +582,19 @@ For type-safe JSON handling, use {{!page-"ppx-deriving"}ppx_deriving_json}.
 
 {1:runtime-values Accessing runtime values}
 
-JavaScript values declared with [//Provides:] in runtime files can be
+JavaScript values declared with [// Provides:] in runtime files can be
 accessed from OCaml. There are two approaches depending on whether you're
 accessing a function or a non-function value.
 
 See {{!page-"linker".writing-primitives}writing JavaScript primitives}
-for more about the [//Provides:] syntax.
+for more about the [// Provides:] syntax.
 
 {2 Functions: use [external]}
 
 For JavaScript {b functions}, use OCaml's [external] declaration:
 
 {@javascript[
-//Provides: my_add
+// Provides: my_add
 function my_add(x, y) { return x + y; }
 ]}
 
@@ -612,8 +612,8 @@ For JavaScript {b objects, constants, or other non-function values}, use
 {{!Js_of_ocaml.Js.Unsafe.runtime_value}Js.runtime_value}:
 
 {@javascript[
-//Provides: myConfig
-var myConfig = { debug: true, version: 42 };
+// Provides: myConfig
+const myConfig = { debug: true, version: 42 };
 ]}
 
 {@ocaml[

--- a/manual/linker.mld
+++ b/manual/linker.mld
@@ -64,9 +64,9 @@ additional information.
 
 Annotations are single line comments with the following syntax
 {v
-//Provides: primitive_name [const|mutable]
-//Requires: other_primitive[,another_primitive]*
-//Version: version_constraint[,version_constraint]*
+// Provides: primitive_name [const|mutable]
+// Requires: other_primitive[,another_primitive]*
+// Version: version_constraint[,version_constraint]*
 
 function primitive_name(arg1, arg2) {
   // JavaScript implementation
@@ -75,35 +75,35 @@ v}
 
 {2 Annotations explained}
 
-{b [//Provides: name [modifier]]} - Declares a primitive:
+{b [// Provides: name [modifier]]} - Declares a primitive:
 - [const] - No side effects (pure function)
 - [mutable] - No side effects, but return value may be affected by other primitives
 - [mutator] (or empty) - May have side effects
 
-{b [//Requires: name1, name2]} - Lists primitives that must be loaded first
+{b [// Requires: name1, name2]} - Lists primitives that must be loaded first
 
-{b [//Version: < 4.12.0]} - OCaml version constraint
+{b [// Version: < 4.12.0]} - OCaml version constraint
 
-{b [//Alias: other_name]} - Makes this primitive an alias for another
+{b [// Alias: other_name]} - Makes this primitive an alias for another
 
-{b [//Weakdef]} - Allows this primitive to be overridden by another definition
+{b [// Weakdef]} - Allows this primitive to be overridden by another definition
 
-{b [//Always]} - Always include this code, even if not referenced
+{b [// Always]} - Always include this code, even if not referenced
 
-{b [//If: flag]} - Only include if flag is enabled (e.g., [//If: effects])
+{b [// If: flag]} - Only include if flag is enabled (e.g., [// If: effects])
 
-{b [//Ifnot: flag]} - Only include if flag is disabled
+{b [// Ifnot: flag]} - Only include if flag is disabled
 
-{b [//Deprecated: message]} - Mark primitive as deprecated
+{b [// Deprecated: message]} - Mark primitive as deprecated
 
-All JavaScript code after a [//Provides] annotation belongs to that
-primitive, until the next [//Provides].
+All JavaScript code after a [// Provides] annotation belongs to that
+primitive, until the next [// Provides].
 
 {2 Example: custom primitive}
 
 {v
-//Provides: my_log_primitive
-//Requires: caml_jsstring_of_string
+// Provides: my_log_primitive
+// Requires: caml_jsstring_of_string
 function my_log_primitive(msg) {
   console.log(caml_jsstring_of_string(msg));
   return 0;  // Return unit

--- a/manual/rev-bindings.mld
+++ b/manual/rev-bindings.mld
@@ -129,7 +129,7 @@ $ ocamlfind ocamlc -package js_of_ocaml,js_of_ocaml-ppx \
     -linkpkg math.ml -o math.byte
 $ js_of_ocaml math.byte -o math.js
 $ node
-> var math = require("./math.js");
+> const math = require("./math.js");
 > math.add(2, 3)
 5
 > math.mul(4, 5)


### PR DESCRIPTION
The manual consistently wrote runtime annotation comments without a space after `//` (e.g. `//Provides:`), and a couple of JavaScript examples used `var`. This updates the documentation to a more conventional style:

- Use the spaced form `// Provides:` (and `// Requires:`, `// Version:`, etc.) for runtime annotations. Both forms are accepted by the linker; the spaced form is more idiomatic for JavaScript comments.
- Use `const` instead of `var` in the JavaScript examples.

Only the documentation is touched (`manual/*.mld`, the `Js.Unsafe.runtime_value` doc comment, and a `CHANGES.md` entry). The runtime sources themselves are left unchanged.