### PR TITLE
Compiler: speed up variable naming and free-variable passes (byte-identical)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
   work on the Wasm runtime as on the JavaScript one (#2263)
 * Compiler: initial support for OCaml 5.5.0 (#2197, #2220)
 * Compiler: added a variable coalescing pass (#2166)
+* Compiler: faster variable naming and free-variable passes (#2321)
 * Wasm dynlink/toplevel support (#2186)
 * OxCaml support (#2105, #2225)
 * Runtime/wasm: faster copy between a Wasm string and an JavaScript array buffer (#2124)

--- a/compiler/lib/js_assign.ml
+++ b/compiler/lib/js_assign.ml
@@ -237,14 +237,14 @@ while compiling the OCaml toplevel:
     in
     let all =
       match block with
-      | Normal -> all
+      | Let_scope | Var_scope -> all
       | Params _ -> all
       | Catch (p, _) ->
           let ids = bound_idents_of_binding p in
           List.fold_left ids ~init:all ~f:(fun all i -> Javascript.IdentSet.add i all)
     in
     match block with
-    | Normal -> add_constraints state all ~offset:0 []
+    | Let_scope | Var_scope -> add_constraints state all ~offset:0 []
     | Catch (v, _) -> add_constraints state all ~offset:5 (bound_idents_of_binding v)
     | Params p -> add_constraints state all ~offset:0 (bound_idents_of_params p)
 end
@@ -271,7 +271,7 @@ module Preserve : Strategy = struct
       | Catch (p, _) ->
           bound_idents_of_binding p
           @ Javascript.IdentSet.elements scope.Js_traverse.def_local
-      | Normal -> Javascript.IdentSet.elements scope.Js_traverse.def_local
+      | Let_scope | Var_scope -> Javascript.IdentSet.elements scope.Js_traverse.def_local
       | Params _ ->
           Javascript.IdentSet.elements
             (IdentSet.union scope.Js_traverse.def_var scope.Js_traverse.def_local)
@@ -379,7 +379,16 @@ class traverse record_block =
     inherit Js_traverse.free as super
 
     method! record_block b =
-      record_block m#state b;
+      (* A [Let_scope] (lexical) block that binds nothing block-scoped only
+         constrains naming through identifiers that its enclosing scope also
+         records (its [var]s hoist and its uses propagate up via
+         [merge_block_info]). Recording it would add a redundant constraint
+         table, so skip it. [Var_scope]/[Params]/[Catch] anchor their own
+         bindings and are always recorded. *)
+      (match b with
+      | Js_traverse.Let_scope
+        when Javascript.IdentSet.is_empty m#state.Js_traverse.def_local -> ()
+      | Let_scope | Var_scope | Params _ | Catch _ -> record_block m#state b);
       super#record_block b
   end
 
@@ -435,7 +444,9 @@ let program' (module Strategy : Strategy) p =
     let o = new traverse_idents_and_labels ~idents:count ~labels in
     o#program p
   in
-  mapper#record_block Normal;
+  (* The program top level anchors its own [var]s and has no enclosing scope
+     to record them, so it is a [Var_scope] (never skipped). *)
+  mapper#record_block Var_scope;
   let freevar =
     IdentSet.fold
       (fun ident acc ->

--- a/compiler/lib/js_traverse.ml
+++ b/compiler/lib/js_traverse.ml
@@ -1019,7 +1019,16 @@ let empty = { use = IdentSet.empty; def_var = IdentSet.empty; def_local = IdentS
 type block =
   | Catch of formal_parameter
   | Params of formal_parameter_list
-  | Normal
+  | Var_scope
+    (* A scope that anchors [var] declarations but has no parameters: the
+         program top level and class static initialization blocks. Like
+         [Params], its [var]s do not propagate to an enclosing scope, so it
+         must always be recorded. *)
+  | Let_scope
+(* A lexical block: it anchors block-scoped ([let]/[const]/[using])
+         bindings. Its [var]s hoist to the nearest [Params]/[Var_scope]
+         ancestor and its uses propagate up via [merge_block_info], so it only
+         constrains naming when it binds something block-scoped. *)
 
 class type freevar = object ('a)
   inherit mapper
@@ -1130,7 +1139,7 @@ class free =
               ident_o
           in
           let cl_decl = cbody#class_decl cl_decl in
-          cbody#record_block Normal;
+          cbody#record_block Let_scope;
           m#merge_block_info cbody;
           EClass (ident_o, cl_decl)
       | EAssignTarget (ArrayTarget l) ->
@@ -1162,7 +1171,7 @@ class free =
       let same_level = level in
       let tbody = {<state_ = empty; level = same_level>} in
       let b = tbody#statements b in
-      tbody#record_block Normal;
+      tbody#record_block Let_scope;
       m#merge_block_info tbody;
       b
 
@@ -1171,7 +1180,9 @@ class free =
       | CEStaticBLock l ->
           let tbody = {<state_ = empty; level = level + 1>} in
           let l = tbody#statements l in
-          tbody#record_block Normal;
+          (* A static block anchors its own [var]s (merged with [merge_info],
+             so they do not propagate up): it must always be recorded. *)
+          tbody#record_block Var_scope;
           m#merge_info tbody;
           CEStaticBLock l
       | _ -> super#class_element x
@@ -1192,7 +1203,7 @@ class free =
           let same_level = level in
           let cbody = {<state_ = empty; level = same_level>} in
           let cl_decl = cbody#class_decl cl_decl in
-          cbody#record_block Normal;
+          cbody#record_block Let_scope;
           m#merge_block_info cbody;
           m#def_local id;
           Class_declaration (id, cl_decl)
@@ -1204,7 +1215,7 @@ class free =
           let e1 = Option.map ~f:m'#expression e1 in
           let e2 = Option.map ~f:m'#expression e2 in
           let st = m'#statement st in
-          m'#record_block Normal;
+          m'#record_block Let_scope;
           m#merge_block_info m';
           For_statement (Right (k, l), e1, e2, (st, m#loc loc))
       | ForIn_statement (Right (((Const | Let) as k), l), e2, (st, loc)) ->
@@ -1213,7 +1224,7 @@ class free =
           let l = m'#for_binding k l in
           let e2 = m'#expression e2 in
           let st = m'#statement st in
-          m'#record_block Normal;
+          m'#record_block Let_scope;
           m#merge_block_info m';
           ForIn_statement (Right (k, l), e2, (st, m#loc loc))
       | ForOf_statement (Right (((Const | Let) as k), l), e2, (st, loc)) ->
@@ -1222,7 +1233,7 @@ class free =
           let l = m'#for_binding k l in
           let e2 = m'#expression e2 in
           let st = m'#statement st in
-          m'#record_block Normal;
+          m'#record_block Let_scope;
           m#merge_block_info m';
           ForOf_statement (Right (k, l), e2, (st, m#loc loc))
       | ForAwaitOf_statement (Right (((Const | Let) as k), l), e2, (st, loc)) ->
@@ -1231,7 +1242,7 @@ class free =
           let l = m'#for_binding k l in
           let e2 = m'#expression e2 in
           let st = m'#statement st in
-          m'#record_block Normal;
+          m'#record_block Let_scope;
           m#merge_block_info m';
           ForAwaitOf_statement (Right (k, l), e2, (st, m#loc loc))
       | Switch_statement (e, l, def, l') ->
@@ -1245,7 +1256,7 @@ class free =
             | Some l -> Some (m'#statements l)
           in
           let e = m#expression e in
-          m'#record_block Normal;
+          m'#record_block Let_scope;
           m#merge_block_info m';
           Switch_statement (e, l, def, l')
       | Try_statement (b, w, f) ->
@@ -1330,8 +1341,24 @@ let declared scope params body =
   | Fun_block None -> ()
   | Fun_block (Some x) -> decl_var x);
   List.iter params ~f:(fun x -> decl_var x);
+  (* Scopes that hoist [var] declarations ([Fun_block]/[Module]) must be
+     scanned recursively to collect vars nested at any depth. Lexical scopes
+     ([Lexical_block]/[Script]) only ever declare names at their own top level
+     (they never hoist [var], and block-scoped declarations below the top level
+     belong to the inner scope), so descending into nested block/loop/switch
+     scopes would be wasted work that re-scans the same statements once per
+     enclosing scope (quadratic in nesting depth). *)
+  let descend_into_nested_scopes =
+    match scope with
+    | Fun_block _ | Module -> true
+    | Lexical_block | Script -> false
+  in
   (object (self)
-     val depth = 0
+     (* [nested] becomes [true] once we descend into an inner block/loop/switch
+        scope (only done when [descend_into_nested_scopes]). Below the top level
+        we collect only hoisted [var]s; block-scoped [let]/[const] and
+        function/class declarations belong to the inner scope. *)
+     val nested = false
 
      inherit iter as super
 
@@ -1344,7 +1371,7 @@ let declared scope params body =
      method statement x =
        match scope, x with
        | (Lexical_block | Fun_block _ | Module), Function_declaration (id, fd) ->
-           if depth = 0 then decl_var id;
+           if not nested then decl_var id;
            self#fun_decl fd
        | Script, Function_declaration (_, fd) ->
            (* ECMAScript 8.2.10: At the top level of a function or
@@ -1353,29 +1380,27 @@ let declared scope params body =
            self#fun_decl fd
        | (Lexical_block | Fun_block _ | Module | Script), Class_declaration (id, cl_decl)
          ->
-           if depth = 0 then decl_var id;
+           if not nested then decl_var id;
            self#class_decl cl_decl
-       | _, For_statement (Right (((Const | Let) as k), l), _e1, _e2, (st, _loc)) ->
-           let m = {<depth = depth + 1>} in
-           List.iter ~f:(m#variable_declaration k) l;
-           m#statement st
-       | _, ForOf_statement (Right (((Const | Let) as k), l), _e2, (st, _loc)) ->
-           let m = {<depth = depth + 1>} in
-           m#for_binding k l;
-           m#statement st
-       | _, ForAwaitOf_statement (Right (((Const | Let) as k), l), _e2, (st, _loc)) ->
-           let m = {<depth = depth + 1>} in
-           m#for_binding k l;
-           m#statement st
-       | _, ForIn_statement (Right (((Const | Let) as k), l), _e2, (st, _loc)) ->
-           let m = {<depth = depth + 1>} in
-           m#for_binding k l;
-           m#statement st
+       | _, For_statement (Right ((Const | Let), _), _, _, (st, _))
+       | _, ForOf_statement (Right ((Const | Let), _), _, (st, _))
+       | _, ForAwaitOf_statement (Right ((Const | Let), _), _, (st, _))
+       | _, ForIn_statement (Right ((Const | Let), _), _, (st, _)) ->
+           (* A [let]/[const] for-binding is block-scoped: it belongs to the
+              loop, not the enclosing scope. Since we reach here with
+              [nested = true], the binding would not be collected anyway, so we
+              only need to look for hoisted vars in the body. *)
+           if descend_into_nested_scopes
+           then
+             let m = {<nested = true>} in
+             m#statement st
        | _, Switch_statement (_, l, def, l') ->
-           let m = {<depth = depth + 1>} in
-           List.iter l ~f:(fun (_, s) -> m#statements s);
-           Option.iter def ~f:(fun l -> m#statements l);
-           List.iter l' ~f:(fun (_, s) -> m#statements s)
+           if descend_into_nested_scopes
+           then (
+             let m = {<nested = true>} in
+             List.iter l ~f:(fun (_, s) -> m#statements s);
+             Option.iter def ~f:(fun l -> m#statements l);
+             List.iter l' ~f:(fun (_, s) -> m#statements s))
        | _, Import ({ kind; from = _; withClause = _ }, _loc) -> (
            match kind with
            | DeferNamespace i -> decl_var i
@@ -1396,10 +1421,10 @@ let declared scope params body =
        | ExportClass (_id, _f) -> ()
        | ExportNames l -> List.iter ~f:(fun (id, _) -> self#ident id) l
        | ExportDefaultFun (Some id, decl) ->
-           if depth = 0 then decl_var id;
+           if not nested then decl_var id;
            self#fun_decl decl
        | ExportDefaultClass (Some id, decl) ->
-           if depth = 0 then decl_var id;
+           if not nested then decl_var id;
            self#class_decl decl
        | ExportDefaultFun (None, decl) -> self#fun_decl decl
        | ExportDefaultClass (None, decl) -> self#class_decl decl
@@ -1409,26 +1434,24 @@ let declared scope params body =
 
      method variable_declaration k l =
        if
-         match scope, k with
-         | ( (Lexical_block | Fun_block _ | Module | Script)
-           , (Let | Const | Using | AwaitUsing) ) -> depth = 0
-         | (Lexical_block | Script), Var -> false
-         | (Fun_block _ | Module), Var -> true
+         match k with
+         | Let | Const | Using | AwaitUsing -> not nested
+         | Var -> descend_into_nested_scopes
        then
          let ids = bound_idents_of_variable_declaration l in
          List.iter ids ~f:decl_var
 
      method block l =
-       let m = {<depth = depth + 1>} in
-       m#statements l
+       if descend_into_nested_scopes
+       then
+         let m = {<nested = true>} in
+         m#statements l
 
      method for_binding k p =
        if
-         match scope, k with
-         | ( (Lexical_block | Fun_block _ | Module | Script)
-           , (Let | Const | Using | AwaitUsing) ) -> depth = 0
-         | (Lexical_block | Script), Var -> false
-         | (Fun_block _ | Module), Var -> true
+         match k with
+         | Let | Const | Using | AwaitUsing -> not nested
+         | Var -> descend_into_nested_scopes
        then
          match p with
          | BindingIdent i -> decl_var i

--- a/compiler/lib/js_traverse.mli
+++ b/compiler/lib/js_traverse.mli
@@ -133,7 +133,14 @@ type t =
 type block =
   | Catch of formal_parameter
   | Params of formal_parameter_list
-  | Normal
+  | Var_scope
+      (** A scope that anchors [var] declarations but has no parameters: the
+          program top level and class static initialization blocks. Its [var]s
+          do not propagate to an enclosing scope. *)
+  | Let_scope
+      (** A lexical block: it anchors block-scoped ([let]/[const]/[using])
+          bindings. Its [var]s hoist to the nearest enclosing
+          [Params]/[Var_scope] scope. *)
 
 class type freevar = object ('a)
   inherit mapper


### PR DESCRIPTION
Two output-preserving (byte-identical) speedups to the **coloring** and **free-variable** phases of the JS backend. Both run over the full generated AST, which on large programs (e.g. Fiat-Crypto) is where a sizable share of compile time goes (`coloring` ≈ 11%, `free vars` ≈ 4%).

### 1. `Js_traverse.declared` — don't re-walk nested scopes for non-var-hoisting scopes
`declared` collects the names declared by a scope. For scopes that do **not** hoist `var`s (lexical blocks and scripts), nothing is collectible below depth 0, yet the traversal still recursed into nested block/loop/switch scopes — re-scanning the same statements once per enclosing scope (quadratic in nesting depth). It now skips that recursion for those scopes, producing the **same** declared-name set.

### 2. `Js_assign` (variable coloring) — skip redundant interference tables
`js_assign` records one constraint table per scope. A lexical block that binds nothing block-scoped (`Let_scope` with empty `def_local` — only `var`s/uses) is **provably redundant**: its `var`s hoist and `merge_block_info` propagates its uses + `def_var` to an enclosing scope whose table already records a superset, so the greedy allocation is identical. Those tables are now skipped.

To make the skip decision safe and centralized in `js_assign`, the `Js_traverse.block` type gains **`Var_scope`** — scopes that anchor their own `var`s and must always be recorded (the program top level and class `static` blocks, which merge via `merge_info` so their `def_var` does not propagate up) — distinct from a lexical block. `Normal` is renamed to **`Let_scope`** to make the pair self-documenting:

```ocaml
type block =
  | Catch of formal_parameter        (* catch binding *)
  | Params of formal_parameter_list  (* function scope: params + hoisted vars *)
  | Var_scope                        (* anchors var, no params: top level / static block *)
  | Let_scope                        (* lexical block: anchors let/const/using *)
```

### Verification
- **Byte-identical output**: `tests-jsoo` passes; `tests-compiler` shows no new diffs; `cmp` on `jsoo_minify` output (vs `master`) is identical.
- **Speedup**: ~20% on the `coloring` phase for deeply-nested `var`-block code (min-of-5: 6.5s vs 8.1s via `jsoo_minify`); marginal on flat output, scaling with redundant nesting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)