### PR TITLE
doc: fix stale TyXML doc link in Tyxml_js

### DIFF
--- a/lib/tyxml/tyxml_js.mli
+++ b/lib/tyxml/tyxml_js.mli
@@ -34,7 +34,7 @@
      )
    ]}
    @see <https://ocsigen.org/tyxml/> the Tyxml project website.
-   @see <https://ocsigen.org/tyxml/dev/api/Html_sigs.T> Html_sigs.T to have a list of available functions to build HTML.
+   @see <https://ocsigen.org/tyxml/latest/tyxml/Html_sigs/module-type-T/index.html> Html_sigs.T to have a list of available functions to build HTML.
 *)
 
 open Js_of_ocaml


### PR DESCRIPTION
The `@see` link in `lib/tyxml/tyxml_js.mli` pointed at the old TyXML doc layout `https://ocsigen.org/tyxml/dev/api/Html_sigs.T` (now **404**). Repoint it at the current deployed page:

`https://ocsigen.org/tyxml/latest/tyxml/Html_sigs/module-type-T/index.html` (200).

Found while making cross-project documentation links point to ocsigen.org. Note: js_of_ocaml builds its docs with `dune @doc` (not `odoc_driver --remap`), so other cross-project API references (to TyXML/Lwt/React types in `Tyxml_js` signatures) render as non-clickable `xref-unresolved` spans rather than ocaml.org links — making those clickable would require switching the doc build to `odoc_driver --remap` (separate, larger change).