### PR TITLE
doc: link TyXML and ReactiveData docs internally (ocsigen.org)

### DIFF
--- a/doc/wodoc
+++ b/doc/wodoc
@@ -19,6 +19,15 @@
 (packages js_of_ocaml js_of_ocaml-lwt js_of_ocaml-tyxml js_of_ocaml-toplevel)
 (doc-manual true)              ; also build @doc-manual (the interactive examples)
 (manual-files js_of_ocaml)    ; copy _build/.../manual/files into js_of_ocaml/files
+;; Sibling Ocsigen projects whose ocaml.org xrefs (produced by odoc_driver
+;; --remap) are rewritten to relative links into their own wodoc docs:
+;;   (pkg deploy-dir layout wrapper-module)
+;; layout = subdir (each opam package under its own <pkg>/, whole family) |
+;; root (modules at the version root). Non-Ocsigen deps (react) stay on
+;; ocaml.org; lwt is added once its docs are rebuilt with wodoc (ocsigen/lwt#1109).
+(hosted
+  (tyxml        tyxml        subdir)
+  (reactiveData reactiveData root))
 (nav
   (section "Getting Started"
     (link "Overview"      js_of_ocaml/overview.html   overview)


### PR DESCRIPTION
## Why

The js_of_ocaml API is built with `odoc_driver --remap` (since 26c2a52691), so references to other packages resolve to absolute `https://ocaml.org/p/…` links. References to **TyXML** and **ReactiveData** — Ocsigen projects whose docs live on ocsigen.org — therefore pointed at ocaml.org.

## What

Add a `(hosted …)` table (like eliom/toolkit/start):
- `tyxml` → `subdir` layout (covers `tyxml-ppx` etc.).
- `reactiveData` → `root` layout.

`react` (Daniel Bünzliʼs, not an Ocsigen project) stays on ocaml.org. **lwt** is intentionally left out until its docs are rebuilt with wodoc — see ocsigen/lwt#1109; it will then be added as `(lwt lwt subdir)`.

## Depends on

Requires wodoc with the `subdir` layout: **ocsigen/wodoc#4** (the doc CI pins wodoc from master). Merge wodoc#4 first.

Also fixes a stale TyXML `@see` link in #2322 (separate).