### PR TITLE
Runtime: reach Intl via globalThis.Intl?. in Unix.localtime

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,10 @@
 * Runtime: `Unix.localtime` computes `tm_yday` from the calendar date
   instead of the wall-clock distance to January 1, which was off by one
   during DST; the js and wasm-on-node backends share the fix (#2304)
+* Runtime: `Unix.localtime` reaches `Intl` through `globalThis.Intl?.`
+  (with an optional call on `DateTimeFormat?.()`) so the runtime
+  free-variable check passes and hosts without `Intl` fall back to the
+  offset heuristic instead of throwing (#2324)
 * Runtime/wasm: `Str.replace`/`Str.global_replace` raise `Failure` on a
   backreference to a group one past the last (e.g. `"\1"` against a
   group-less regexp) instead of trapping with an out-of-bounds access;

--- a/compiler/tests-jsoo/dune
+++ b/compiler/tests-jsoo/dune
@@ -257,6 +257,7 @@
 
 ; Uses Js values (Js.string/Js.null), so it cannot run natively or under
 ; the WASI runtime; exercised on both the JavaScript and wasm runtimes.
+
 (test
  (name ephemeron_data)
  (modules ephemeron_data)

--- a/runtime/js/sys.js
+++ b/runtime/js/sys.js
@@ -120,8 +120,7 @@ function jsoo_sys_getenv(n) {
   if (Object.hasOwn(jsoo_static_env, n)) return jsoo_static_env[n];
   var process = globalThis.process;
   //nodejs env
-  if (process && process.env && Object.hasOwn(process.env, n))
-    return process.env[n];
+  if (process?.env && Object.hasOwn(process.env, n)) return process.env[n];
   //QuickJS: no `process`, but the host environment is reachable via `std`.
   var std = globalThis.std;
   if (std && typeof std.getenviron === "function") {

--- a/runtime/js/unix.js
+++ b/runtime/js/unix.js
@@ -72,13 +72,11 @@ function caml_unix_localtime(t) {
   // for every other zone).
   if (
     stdTimezoneOffset === 0 &&
-    jan.getTimezoneOffset() !== jul.getTimezoneOffset()
-  ) {
-    try {
-      if (Intl.DateTimeFormat().resolvedOptions().timeZone === "Europe/Dublin")
-        isdst = !isdst;
-    } catch (e) {}
-  }
+    jan.getTimezoneOffset() !== jul.getTimezoneOffset() &&
+    globalThis.Intl?.DateTimeFormat?.().resolvedOptions().timeZone ===
+      "Europe/Dublin"
+  )
+    isdst = !isdst;
   return BLOCK(
     0,
     d.getSeconds(),

--- a/runtime/wasm/runtime.js
+++ b/runtime/wasm/runtime.js
@@ -465,15 +465,11 @@
       // to avoid the Intl lookup for every other zone).
       if (
         stdTimezoneOffset === 0 &&
-        jan.getTimezoneOffset() !== jul.getTimezoneOffset()
-      ) {
-        try {
-          if (
-            Intl.DateTimeFormat().resolvedOptions().timeZone === "Europe/Dublin"
-          )
-            isdst = !isdst;
-        } catch (e) {}
-      }
+        jan.getTimezoneOffset() !== jul.getTimezoneOffset() &&
+        globalThis.Intl?.DateTimeFormat?.().resolvedOptions().timeZone ===
+          "Europe/Dublin"
+      )
+        isdst = !isdst;
       return caml_alloc_tm(
         d.getSeconds(),
         d.getMinutes(),


### PR DESCRIPTION
Follow-up to #2304, which is already on `master`.

The Dublin `tm_isdst` check in `Unix.localtime` referenced the bare global
`Intl`. The runtime free-variable linter (`gen/gen.exe`, warnings-as-errors)
rejects unknown globals, so building any runtime primitive now fails on
`master`:

```
Warning [free-variables]: free variables in primitive code "caml_unix_localtime"
vars: Intl
gen/gen.exe: all warnings being treated as errors
```

### Fix

Reach `Intl` through `globalThis.Intl?.` (`globalThis` is a known global in
`reserved.ml`), with an optional call on `DateTimeFormat?.()`:

```js
globalThis.Intl?.DateTimeFormat?.().resolvedOptions().timeZone === "Europe/Dublin"
```

- `globalThis.Intl?.` short-circuits the whole chain when `Intl` is absent.
- `DateTimeFormat?.()` guards the remaining gap (a host with `Intl` but no
  `DateTimeFormat`); once it short-circuits, `resolvedOptions().timeZone` is
  skipped too.
- This lets the previous `try/catch` be dropped — a host without `Intl` (or
  with a partial `Intl`) falls back to the offset heuristic instead of
  throwing.

Applied to both `runtime/js/unix.js` and the parallel `runtime/wasm/runtime.js`.

Also includes a small unrelated lint cleanup: `jsoo_sys_getenv` uses
`process?.env` to silence the biome `useOptionalChain` warning
(behavior-preserving).

### Verified

- Runtime free-variable lint passes; `make lint-js` and Biome clean.
- `Unix.localtime` tests green under both JS and Wasm (Dublin matches native
  with `Intl`; falls back to the heuristic without throwing when `Intl` is
  absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
