### PR TITLE
Runtime/wasm: fix caml_seek_in validating wrong offset

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,10 @@
   Pretty-printed output (`--pretty`) is unchanged. (#1117)
 
 ## Bug fixes
+* Runtime/wasm: `caml_seek_in` validates the seek destination for
+  negativity instead of the current offset, so `seek_in ch (-5)` raises
+  `Sys_error "Invalid argument"` instead of silently corrupting the file
+  descriptor offset (#2325)
 * Runtime: `Unix.localtime` computes `tm_yday` from the calendar date
   instead of the wall-clock distance to January 1, which was off by one
   during DST; the js and wasm-on-node backends share the fix (#2304)

--- a/runtime/wasm/io.wat
+++ b/runtime/wasm/io.wat
@@ -1070,7 +1070,7 @@
                   (i32.wrap_i64
                      (i64.sub (local.get $offset) (local.get $dest))))))
          (else
-            (if (i64.lt_s (local.get $offset) (i64.const 0))
+            (if (i64.lt_s (local.get $dest) (i64.const 0))
                (then (call $caml_raise_sys_error (@string "Invalid argument"))))
             (struct.set $fd_offset $offset (local.get $fd_offset)
                (local.get $dest))


### PR DESCRIPTION
## Summary

`caml_seek_in` (the `@else` / non-WASI branch in `runtime/wasm/io.wat`) validated the channel's **current** fd offset for negativity instead of the **seek destination**, then stored the destination unconditionally:

```wat
(else
   (if (i64.lt_s (local.get $offset) (i64.const 0))   ;; $offset = current offset, wrong
      (then (call $caml_raise_sys_error (@string "Invalid argument"))))
   (struct.set $fd_offset $offset (local.get $fd_offset)
      (local.get $dest)))                              ;; stores $dest regardless
```

So `seek_in ch (-5)` did not raise — it silently wrote a negative destination into the fd offset, causing confusing later read failures and bogus `pos_in` values. `caml_seek_out` in the same file validates the destination correctly; this change mirrors that, checking `$dest` instead of `$offset`.

## Test plan
- `seek_in ch (-5)` now raises `Sys_error "Invalid argument"` instead of corrupting the offset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)