### PR TITLE
Runtime/wasm: fix WASI normalize_prefix trap on a relative preopen

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -113,6 +113,11 @@
   WASI errno equivalent (`EWOULDBLOCK`, `ESHUTDOWN`, ...) reports the error
   name instead of `"Unknown error -1"`, matching the JS runtime's fallback
   (#2263)
+* Runtime/wasm: WASI `normalize_prefix` no longer traps on a relative
+  preopen prefix (e.g. `wasmtime --dir=tmp`); the offset for a plain
+  prefix name underflowed to a huge unsigned value and the following
+  `array.copy` trapped with an out-of-bounds access on the first
+  filesystem operation (#2263)
 * Runtime: `Unix.localtime` computes `tm_yday` from the calendar date
   instead of the wall-clock distance to January 1, which was off by one
   during DST; the js and wasm-on-node backends share the fix (#2304)

--- a/runtime/wasm/fs.wat
+++ b/runtime/wasm/fs.wat
@@ -141,9 +141,15 @@
                                  (br $loop))))))))))
       (if (i32.eq (local.get $i) (local.get $len))
          (then (return (@string ""))))
-      (local.set $i (i32.sub (local.get $i) (i32.const 1)))
-      (if (i32.gt_u (local.get $i) (i32.const 0))
+      ;; [$i] points at the first non-prefix character. When some leading
+      ;; component was stripped ([$i] > 1, e.g. "./x" or "//x") keep one
+      ;; leading slash by copying from [$i - 1]. For a plain relative prefix
+      ;; ([$i] = 0, e.g. "x") or a single leading slash ([$i] = 1) the prefix
+      ;; is already normalized, so return it unchanged. Subtracting from
+      ;; [$i = 0] would wrap to a huge unsigned index and trap the copy.
+      (if (i32.gt_u (local.get $i) (i32.const 1))
          (then
+            (local.set $i (i32.sub (local.get $i) (i32.const 1)))
             (local.set $res
                (array.new $bytes (i32.const 0)
                   (i32.sub (local.get $len) (local.get $i))))


### PR DESCRIPTION
From the Wasm runtime review (#2263).

`normalize_prefix` (`runtime/wasm/fs.wat`) strips a leading `./` or `/`
from a WASI preopen directory name, stepping back one byte so a single
leading slash is kept (`"./x"` → `"/x"`). After the scan, `$i` points at
the first real character, and the code did:

```wat
(local.set $i (i32.sub (local.get $i) (i32.const 1)))   ;; i = i - 1
(if (i32.gt_u (local.get $i) (i32.const 0)) ...)          ;; if i > 0 (unsigned)
```

For a **plain relative prefix** — e.g. `wasmtime --dir=tmp`, where
`fd_prestat_dir_name` returns `"tmp"` — the scan consumes nothing and
`$i` ends at `0`. The unconditional `i - 1` then wrapped to `0xFFFFFFFF`,
the unsigned `i32.gt_u 0xFFFFFFFF 0` check passed, and the following
`array.copy` read from source index `0xFFFFFFFF` → **`wasm trap: out of
bounds array access`** on the first filesystem operation (uncatchable,
where the program should just see a normal error).

## Fix

Only subtract and copy when more than one leading byte was consumed
(`$i > 1`). A plain name (`$i = 0`) or a single leading slash (`$i = 1`)
is already normalized and is returned unchanged — which is exactly what
the `$i = 1` path already did before the underflow.

## Verification

Reproduced and fixed with `wasmtime` on a small program that touches the
filesystem, run with a relative `--dir=tmp`:

- **Before:** `wasm trap: out of bounds array access` (exit 134).
- **After:** a normal, catchable `Sys_error` — no trap.

(The current WASI test harness only exercises `--dir=.` → `""` and
`--dir=/tmp` → `"/tmp"`, neither of which hits this path, so the bug was
invisible in CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
