### PR TITLE
Runtime/wasm: drop dead closedir-on-end path in caml_unix_findnext

### DIFF
--- a/runtime/wasm/unix.wat
+++ b/runtime/wasm/unix.wat
@@ -1370,9 +1370,12 @@
 
    (func $win_find_next (export "win_findnext") (export "caml_unix_findnext")
       (param $dir (ref eq)) (result (ref eq))
+      ;; Like native [win_findnext] and the JS runtime, raise End_of_file at
+      ;; the end without closing the handle -- the caller closes it through
+      ;; [findclose]. [readdir_helper] already raises End_of_file (it never
+      ;; returns null), so the final raise here is just the type-level tail.
       (block $return (result (ref eq))
          (br_on_non_null $return (call $readdir_helper (local.get $dir)))
-         (drop (call $unix_closedir (local.get $dir)))
          (call $caml_raise_end_of_file)
          (ref.i31 (i32.const 0))))
 


### PR DESCRIPTION
`caml_unix_findnext` (`runtime/wasm/unix.wat`) closed the directory handle on
the end-of-directory path:

```wat
(block $return (result (ref eq))
   (br_on_non_null $return (call $readdir_helper (local.get $dir)))
   (drop (call $unix_closedir (local.get $dir)))   ;; <- never reached
   (call $caml_raise_end_of_file)
   (ref.i31 (i32.const 0)))
```

That `closedir` is dead code: neither `$readdir_helper` variant ever returns
null (the WASI one raises `End_of_file`, the JS-backed one breaks to `$end` and
raises), so `br_on_non_null` either branches with an entry or the call raises
straight past — control never falls through to the `closedir`.

Removing it keeps the *reachable* behavior, which is also the correct one and
matches both native `win_findnext` and the JS runtime (`caml_unix_findnext` =
`caml_unix_readdir`): raise `End_of_file` at the end **without** closing the
handle — the caller releases it through `findclose`. Had the line ever run it
would have been a bug (a later `findclose` would double-close → `EBADF`). After
this change `caml_unix_findnext` mirrors `caml_unix_readdir`.

No behaviour change on any reachable path (unreachable-code removal), so there is
nothing new to test and no CHANGES entry. Found in the Wasm runtime review
(#2263).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
