### PR TITLE
Runtime: raise Failure on marshalling oversize blocks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,10 @@
   negativity instead of the current offset, so `seek_in ch (-5)` raises
   `Sys_error "Invalid argument"` instead of silently corrupting the file
   descriptor offset (#2325)
+* Runtime: marshalling a block with 2^22 or more fields raises
+  `Failure "output_value: array cannot be read back on 32-bit platform"`
+  instead of silently truncating the size in the `CODE_BLOCK32` header
+  (`tag | sz << 10`); the js and wasm runtimes share the fix (#2328)
 * Runtime: `Unix.localtime` computes `tm_yday` from the calendar date
   instead of the wall-clock distance to January 1, which was off by one
   during DST; the js and wasm-on-node backends share the fix (#2304)

--- a/runtime/js/marshal.js
+++ b/runtime/js/marshal.js
@@ -758,12 +758,17 @@ var caml_output_val = (function () {
             8,
             0x80 /*cst.PREFIX_SMALL_BLOCK*/ + v[0] + ((v.length - 1) << 4),
           );
-        else
+        else {
+          if (v.length - 1 >= 0x400000 /* 2^22 */)
+            caml_failwith(
+              "output_value: array cannot be read back on 32-bit platform",
+            );
           writer.write_code(
             32,
             0x08 /*cst.CODE_BLOCK32*/,
             ((v.length - 1) << 10) | v[0],
           );
+        }
         writer.size_32 += v.length;
         writer.size_64 += v.length;
         if (v.length > 1) stack.push(v, 1);

--- a/runtime/wasm/marshal.wat
+++ b/runtime/wasm/marshal.wat
@@ -1193,6 +1193,8 @@
                    (i32.or (local.get $tag)
                       (i32.shl (local.get $sz) (i32.const 4))))))
          (else
+            (if (i32.ge_u (local.get $sz) (i32.const 0x400000))
+               (then (call $caml_failwith (global.get $array_too_large))))
             (call $writecode32 (local.get $s) (global.get $CODE_BLOCK32)
                (i32.or (local.get $tag)
                   (i32.shl (local.get $sz) (i32.const 10)))))))
@@ -1292,6 +1294,8 @@
       (call $caml_invalid_argument (global.get $cust_value))
       (return (i32.const 0) (i32.const 0)))
 
+   (@string $array_too_large
+      "output_value: array cannot be read back on 32-bit platform")
    (@string $func_value "output_value: functional value")
    (@string $cont_value "output_value: continuation value")
    (@string $js_value "output_value: abstract value (JavaScript value)")


### PR DESCRIPTION
## Summary

The marshal writers (`runtime/wasm/marshal.wat` `$extern_header` and `runtime/js/marshal.js` `caml_output_val`) encode a non-small block header as a 32-bit `CODE_BLOCK32` word built from `tag | sz << 10`. That leaves only 22 bits for the size, so a block with `sz >= 2^22` (4,194,304+ fields) silently overflows the size field — the high bits are dropped and the serialized data is corrupted (it deserializes with a wrong, smaller size).

Both writers now raise `Failure "output_value: array cannot be read back on 32-bit platform"` for such blocks instead of truncating, matching the message style of the reader-side 32-bit-platform check. Neither writer emits `CODE_BLOCK64`, so raising is the safe behavior here.

The JS and Wasm runtimes are parallel and share the same logic, so the fix is applied to both.

## Test plan
- Marshalling a block with `< 2^22` fields is unchanged.
- Marshalling a block with `>= 2^22` fields now raises `Failure` instead of producing corrupt output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)