### PR TITLE
Runtime/wasm: fix format-string corner cases (%#d sign, %+f/% f)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -88,6 +88,11 @@
   a symlink to a directory is reported as a directory; and `isatty` returns
   `false` in a browser instead of throwing on the undefined `require`
   (#2263)
+* Runtime/wasm: format-string corner cases reachable through the
+  `caml_format_int`/`caml_int64_format`/`caml_format_float` primitives
+  (not produced by `Printf`): the `#` flag no longer overwrites the sign
+  of a negative base-10 integer (`"%#d" (-5)` gave `"05"`), and `"%+f"` /
+  `"% f"` without a precision no longer raise `Invalid_argument` (#2263)
 * Runtime: `Unix.localtime` computes `tm_yday` from the calendar date
   instead of the wall-clock distance to January 1, which was off by one
   during DST; the js and wasm-on-node backends share the fix (#2304)

--- a/compiler/tests-jsoo/format_corner_cases.ml
+++ b/compiler/tests-jsoo/format_corner_cases.ml
@@ -1,0 +1,52 @@
+(* Corner cases of the integer/float formatting primitives that [Printf]
+   never produces but that are reachable by calling the externals directly.
+   Run on js, wasm and native (the oracle). *)
+
+external format_int : string -> int -> string = "caml_format_int"
+
+external format_int64 : string -> int64 -> string = "caml_int64_format"
+
+external format_float : string -> float -> string = "caml_format_float"
+
+(* The "#" flag is ignored for base 10 (as in C) and must not overwrite the
+   sign of a negative number; for octal/hex it adds the 0/0x prefix. *)
+let%expect_test "format_int alternate flag and sign" =
+  let p fmt n = print_endline (format_int fmt n) in
+  p "%#d" (-5);
+  p "%#d" 5;
+  p "%#x" 255;
+  p "%#o" 8;
+  p "%#d" 0;
+  [%expect {|
+    -5
+    5
+    0xff
+    010
+    0
+    |}]
+
+let%expect_test "format_int64 alternate flag and sign" =
+  let p fmt n = print_endline (format_int64 fmt n) in
+  p "%#d" (-5L);
+  p "%#x" 255L;
+  p "%#o" 8L;
+  [%expect {|
+    -5
+    0xff
+    010
+    |}]
+
+(* "%+f" / "% f" with no precision: the conversion letter must still be
+   recognised (it used to be mistaken for the sign flag and raise). *)
+let%expect_test "format_float sign flag without precision" =
+  let p fmt x = print_endline (format_float fmt x) in
+  p "%+f" 1.5;
+  p "% f" 1.5;
+  p "%+e" 1.5;
+  p "%+g" 1.5;
+  [%expect {|
+    +1.500000
+     1.500000
+    +1.500000e+00
+    +1.5
+    |}]

--- a/runtime/wasm/float.wat
+++ b/runtime/wasm/float.wat
@@ -257,6 +257,11 @@
                                  (i32.sub (local.get $c) (@char "0"))))
                            (br $precision)))))
                (else
+                  ;; No precision: [$c] still holds the char read for the "."
+                  ;; test (a sign flag like "+"/" " when one was consumed), not
+                  ;; the conversion letter. Load it so the checks below see the
+                  ;; real conversion, otherwise "%+f"/"% f" wrongly raise.
+                  (local.set $c (array.get_u $bytes (local.get $s) (local.get $i)))
                   (local.set $precision (i32.const 6))))
             (br_if $bad_format
               (i32.ne (i32.add (local.get $i) (i32.const 1)) (local.get $len)))

--- a/runtime/wasm/int64.wat
+++ b/runtime/wasm/int64.wat
@@ -303,7 +303,12 @@
                      (else
                         (array.set $bytes (local.get $s) (i32.const 0)
                            (@char " "))))))))
-      (if (local.get $alternate)
+      ;; The "#" flag only prefixes octal/hex; for base 10 it is ignored (as
+      ;; in C). Guarding on base here also stops the "0" from overwriting the
+      ;; sign, since the digit-count phase above only reserves prefix room for
+      ;; base 8/16.
+      (if (i32.and (local.get $alternate)
+                   (i64.ne (local.get $base) (i64.const 10)))
          (then
             (if (local.get $i)
                (then

--- a/runtime/wasm/ints.wat
+++ b/runtime/wasm/ints.wat
@@ -376,7 +376,12 @@
                      (else
                         (array.set $bytes (local.get $s) (i32.const 0)
                            (@char " "))))))))
-      (if (local.get $alternate)
+      ;; The "#" flag only prefixes octal/hex; for base 10 it is ignored (as
+      ;; in C). Guarding on base here also stops the "0" from overwriting the
+      ;; sign, since the digit-count phase above only reserves prefix room for
+      ;; base 8/16.
+      (if (i32.and (local.get $alternate)
+                   (i32.ne (local.get $base) (i32.const 10)))
          (then
             (if (local.get $i)
                (then


### PR DESCRIPTION
Two corner cases of the Wasm integer/float formatting, both **unreachable from
`Printf`** (which pre-normalizes the format) but reachable by calling the runtime
primitives directly. Found in the Wasm runtime review (#2263).

### `caml_format_int` / `caml_int64_format` — `#` flag overwrites the sign

With the `#` (alternate) flag on a negative **base-10** number, the
alternate-prefix phase wrote a leading `"0"` at index 0 unconditionally,
clobbering the sign that had just been written there: `caml_format_int "%#d" (-5)`
returned `"05"` instead of `"-5"`.

`#` is a no-op for base 10 (as in C); the fix guards the prefix on base 8/16,
which also matches the digit-count phase that only reserves prefix room for those
bases. Octal/hex (`"%#x"`, `"%#o"`) are unaffected.

### `caml_format_float` `parse_format` — `"%+f"` / `"% f"` without precision

When no precision was given, `$c` still held the character read for the `"."`
test — which, when a `"+"`/`" "` sign flag had been consumed, is the sign flag,
not the conversion letter. The conversion check then failed and raised
`Invalid_argument`. The fix loads the conversion letter in the no-precision
branch.

### Tests

`compiler/tests-jsoo/format_corner_cases.ml` declares the externals and runs on
**js, wasm and native**, with native as the oracle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
