### PR TITLE
Runtime/wasm: decode caml_js_meth_call method name as UTF-8

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -62,6 +62,10 @@
   `Js.Error` only when it is an actual `Error`, like the JS runtime; other
   values become `Failure (String value)`, and a thrown `null`/`undefined`
   no longer crashes the wrapper (it used `value.toString()`) (#2263)
+* Runtime/wasm: `caml_js_meth_call` decodes the method name as UTF-8 like
+  the JS runtime (`caml_jsstring_of_string`) instead of as raw bytes, so a
+  method whose name contains non-ASCII characters resolves to the same
+  property on both backends (#2263)
 * Runtime: `Unix.localtime` computes `tm_yday` from the calendar date
   instead of the wall-clock distance to January 1, which was off by one
   during DST; the js and wasm-on-node backends share the fix (#2304)

--- a/compiler/tests-jsoo/dune
+++ b/compiler/tests-jsoo/dune
@@ -178,6 +178,7 @@
    hash_jsstring
    bigstring_kind
    wrap_exception
+   meth_call_utf8
    runtime_events_register
    test_custom_name
    test_text_codec_fallback
@@ -344,6 +345,19 @@
 (test
  (name wrap_exception)
  (modules wrap_exception)
+ (libraries js_of_ocaml)
+ (enabled_if
+  (and
+   (<> %{profile} wasi)
+   (<> %{profile} wasi-with-native-effects)))
+ (modes js wasm))
+
+; UTF-8 method-name resolution in caml_js_meth_call; uses Js values, so it
+; runs on the JavaScript and wasm runtimes only.
+
+(test
+ (name meth_call_utf8)
+ (modules meth_call_utf8)
  (libraries js_of_ocaml)
  (enabled_if
   (and

--- a/compiler/tests-jsoo/meth_call_utf8.ml
+++ b/compiler/tests-jsoo/meth_call_utf8.ml
@@ -1,0 +1,18 @@
+(* [caml_js_meth_call] must decode the method name as UTF-8, like the JS
+   runtime (which uses [caml_jsstring_of_string]). A method name with a
+   non-ASCII character otherwise resolves differently on the wasm backend
+   (where it used to be read as raw bytes). Exercised on js and wasm. *)
+
+open Js_of_ocaml
+
+let () =
+  (* "café" — the é (U+00E9) is two bytes in UTF-8. *)
+  let name = "café" in
+  let o = Js.Unsafe.obj [||] in
+  (* Install the method under the UTF-8-decoded name (a real JS string). *)
+  Js.Unsafe.set o (Js.string name) (Js.wrap_callback (fun () -> 42));
+  (* Call it through meth_call with the raw OCaml string; the runtime must
+     UTF-8-decode it to find the same property. *)
+  let r : int = Js.Unsafe.meth_call o name [||] in
+  assert (r = 42);
+  print_endline "ok"

--- a/runtime/wasm/jslib.wat
+++ b/runtime/wasm/jslib.wat
@@ -189,9 +189,12 @@
    (func (export "caml_js_meth_call")
       (param $o (ref eq)) (param $f (ref eq)) (param $args (ref eq))
       (result (ref eq))
+      ;; Decode the method name as UTF-8, like the JS runtime
+      ;; (caml_js_meth_call uses caml_jsstring_of_string); a non-ASCII method
+      ;; name otherwise resolved differently than on the JS backend.
       (if (ref.test (ref $bytes) (local.get $f))
          (then
-            (local.set $f (call $caml_jsbytes_of_bytes (local.get $f)))))
+            (local.set $f (call $caml_jsstring_of_bytes (local.get $f)))))
       (return_call $wrap
          (call $meth_call (call $unwrap (local.get $o))
             (call $unwrap (local.get $f))


### PR DESCRIPTION
`caml_js_meth_call` (`runtime/wasm/jslib.wat`) converted the method name with
`caml_jsbytes_of_bytes` (raw bytes), while the JS runtime uses
`caml_jsstring_of_string` (UTF-8). A method whose name contains non-ASCII
characters therefore resolved to a *different* property on the wasm backend than
on the JavaScript one. This decodes it as UTF-8 to match.

(`caml_js_get`/`set`/`delete` are intentionally left alone: the JS runtime keys
them on the raw OCaml byte string — `o[f]` — so the wasm `caml_jsbytes_of_bytes`
already matches there.)

### Test

`compiler/tests-jsoo/meth_call_utf8.ml` installs a method named `"café"` and
calls it through `meth_call`, on the js and wasm runtimes.

### Not included here

The review's other `jslib.wat` item — `caml_wrap_exception` wrapping *any* thrown
value in `Js.Error` (the JS runtime only wraps `instanceof Error`) and the
fallback `toString` throwing on a thrown `null`/`undefined` — is deferred. It sits
on the exception-handling path and is exercised only in wasm mode, which can't be
run in my environment; I'd rather not ship an unverified rewrite of that path in
the same change. Tracked in #2263.

Found in the Wasm runtime review (#2263).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
