### PR TITLE
Runtime/wasm: follow symlinks in is_directory/is_file; isatty in browser

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -70,6 +70,11 @@
   grows its buffer instead of truncating at a fixed 256 bytes, so a long
   `Failure`/`Sys_error` payload is printed in full in the `Fatal error:
   exception ...` message, like the JS runtime (#2263)
+* Runtime/wasm: `Sys.is_directory`/`Sys.file_exists`-style checks now
+  follow symlinks (`stat`, not `lstat`) like native and the JS runtime, so
+  a symlink to a directory is reported as a directory; and `isatty` returns
+  `false` in a browser instead of throwing on the undefined `require`
+  (#2263)
 * Runtime: `Unix.localtime` computes `tm_yday` from the calendar date
   instead of the wall-clock distance to January 1, which was off by one
   during DST; the js and wasm-on-node backends share the fix (#2304)

--- a/compiler/tests-jsoo/test_unix.ml
+++ b/compiler/tests-jsoo/test_unix.ml
@@ -221,3 +221,27 @@ let%expect_test "closed fds do not resolve" =
    with Unix.Unix_error (Unix.EBADF, _, _) -> print_endline "EBADF");
   Sys.remove f;
   [%expect {| EBADF |}]
+
+(* Sys.is_directory follows symlinks (uses stat, not lstat), like native:
+   a symlink to a directory is a directory, a symlink to a file is not. *)
+let%expect_test "is_directory follows symlinks" =
+  let d = Filename.temp_file "jsoo_symdir" "" in
+  Sys.remove d;
+  Unix.mkdir d 0o755;
+  let f = Filename.temp_file "jsoo_symfile" ".dat" in
+  let ld = Filename.temp_file "jsoo_lnd" "" in
+  Sys.remove ld;
+  let lf = Filename.temp_file "jsoo_lnf" "" in
+  Sys.remove lf;
+  Unix.symlink d ld;
+  Unix.symlink f lf;
+  Printf.printf "symlink->dir: %b\n" (Sys.is_directory ld);
+  Printf.printf "symlink->file: %b\n" (Sys.is_directory lf);
+  Sys.remove ld;
+  Sys.remove lf;
+  Sys.remove f;
+  Unix.rmdir d;
+  [%expect {|
+    symlink->dir: true
+    symlink->file: false
+    |}]

--- a/runtime/wasm/runtime.js
+++ b/runtime/wasm/runtime.js
@@ -602,7 +602,9 @@
       if (res.error) throw res.error;
       return res.signal ? 255 : res.status;
     },
-    isatty: (fd) => +require("node:tty").isatty(fd),
+    // In a browser there is no tty and no [require]; report false instead of
+    // throwing on the undefined [require].
+    isatty: (fd) => (isNode ? +require("node:tty").isatty(fd) : 0),
     time: () => performance.now(),
     getcwd: () => (isNode ? globalThis.process.cwd() : "/static"),
     chdir: (x) => globalThis.process.chdir(x),
@@ -654,12 +656,14 @@
     is_directory: (p) => {
       if (virtual_dirs.has(p)) return 1;
       if (virtual_files.has(p)) return 0;
-      return +fs.lstatSync(p).isDirectory();
+      // Follow symlinks, like native and the JS runtime (statSync, not lstat).
+      return +fs.statSync(p).isDirectory();
     },
     is_file: (p) => {
       if (virtual_files.has(p)) return 1;
       if (virtual_dirs.has(p)) return 0;
-      return +fs.lstatSync(p).isFile();
+      // Follow symlinks, like native and the JS runtime (statSync, not lstat).
+      return +fs.statSync(p).isFile();
     },
     utimes: (p, a, m) => fs.utimesSync(p, a, m),
     truncate: (p, l) => fs.truncateSync(p, l),


### PR DESCRIPTION
Two divergences in the Wasm runtime's `runtime.js` from native / the JS runtime,
from the review (#2263):

- **`is_directory` / `is_file` used `fs.lstatSync`**, so a symlink to a directory
  answered "not a directory". Native and the JS runtime use `stat` (follow
  symlinks); switched to `fs.statSync`.
- **`isatty` called `require("node:tty")` unconditionally**, which throws in a
  browser where `require` is undefined. Now guarded on `isNode`, returning
  `false` (no tty) otherwise — matching native / the JS runtime.

### Test

`compiler/tests-jsoo/test_unix.ml` gains an `is_directory follows symlinks` case
(symlink→dir is a directory, symlink→file is not), run on js, wasm and native.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
