### PR TITLE
Runtime/wasm: apply float size limit in caml_make_vect float branch

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -54,6 +54,10 @@
   lost information); ASCII and Latin-1 strings hash exactly as before. The
   wasm runtime, which used to mix one code unit at a time, is brought in line
   so a `Js.string` hashes to the same value on both backends (#2263)
+* Runtime/wasm: `Array.make`/`caml_make_vect` with a float initial value
+  applies the dedicated float-array size limit (`0x7ffffff`) like the other
+  floatarray primitives, instead of the larger generic limit, since it
+  builds an unboxed float array (#2263)
 * Runtime: `Unix.localtime` computes `tm_yday` from the calendar date
   instead of the wall-clock distance to January 1, which was off by one
   during DST; the js and wasm-on-node backends share the fix (#2304)

--- a/runtime/wasm/array.wat
+++ b/runtime/wasm/array.wat
@@ -41,6 +41,11 @@
             (struct.get $float 0
                (br_on_cast_fail $not_float (ref eq) (ref $float)
                   (local.get $v))))
+         ;; A float init builds an unboxed float array, which has the tighter
+         ;; size limit of the dedicated floatarray primitives, not the generic
+         ;; one checked above.
+         (if (i32.ge_u (local.get $sz) (i32.const 0x7ffffff))
+            (then (call $caml_invalid_argument (global.get $Array_make))))
          (return (array.new $float_array (local.get $f) (local.get $sz)))))
       (local.set $b
          (array.new $block (local.get $v)


### PR DESCRIPTION
`caml_make_vect` checks the requested size against the **generic** array limit
(`0xfffffff`) before it knows the element type, then builds an **unboxed float
array** when the init value is a float. The dedicated floatarray primitives
(`caml_floatarray_make`/`caml_floatarray_create`) use the tighter `0x7ffffff`
limit, so a float `Array.make` of a size in `[0x7ffffff, 0xfffffff)` produced an
array that the dedicated primitives would reject. This applies the float limit in
that branch too.

No test: exercising the limit requires a multi-GB allocation, and the cap is
wasm-specific (native and the JS runtime represent these arrays differently, with
different limits). Assembly-checked. Found in the Wasm runtime review (#2263).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
