### PR TITLE
Runtime: hash JS strings losslessly and consistently across backends

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,6 +48,12 @@
   `Failure "output_value: array cannot be read back on 32-bit platform"`
   instead of silently truncating the size in the `CODE_BLOCK32` header
   (`tag | sz << 10`); the js and wasm runtimes share the fix (#2328)
+* Runtime: hashing a JavaScript string with code points above U+00FF now
+  mixes two 16-bit code units per word, instead of packing the raw code units
+  four per word as for a byte string (which overlapped their high bits and
+  lost information); ASCII and Latin-1 strings hash exactly as before. The
+  wasm runtime, which used to mix one code unit at a time, is brought in line
+  so a `Js.string` hashes to the same value on both backends (#2263)
 * Runtime: `Unix.localtime` computes `tm_yday` from the calendar date
   instead of the wall-clock distance to January 1, which was off by one
   during DST; the js and wasm-on-node backends share the fix (#2304)

--- a/compiler/tests-jsoo/dune
+++ b/compiler/tests-jsoo/dune
@@ -175,6 +175,7 @@
    ugeint_bytecode_probe
    test_runtime_value
    ephemeron_data
+   hash_jsstring
    runtime_events_register
    test_custom_name
    test_text_codec_fallback
@@ -305,6 +306,21 @@
    (<> %{profile} wasi)
    (<> %{profile} wasi-with-native-effects)))
  (modes js wasm))
+
+; JS-string hashing matches the JS runtime; uses Js values, js and wasm only.
+
+(library
+ (name hash_jsstring)
+ (modules hash_jsstring)
+ (enabled_if
+  (and
+   (<> %{profile} wasi)
+   (<> %{profile} wasi-with-native-effects)))
+ (inline_tests
+  (modes js wasm))
+ (libraries js_of_ocaml)
+ (preprocess
+  (pps ppx_expect)))
 
 ; The js accessor lives in the optional +toplevel.js runtime fragment, so it
 ; is linked explicitly; --toplevel is deliberately NOT passed, so the bytecode

--- a/compiler/tests-jsoo/hash_jsstring.ml
+++ b/compiler/tests-jsoo/hash_jsstring.ml
@@ -1,0 +1,64 @@
+(* Hashing a JS string must agree on the js and wasm runtimes. A string whose
+   code units all fit in a byte (every ASCII string, and Latin-1) is mixed
+   directly, four code units per word; a string with larger code points is
+   mixed by its UTF-8 bytes, since packing the raw code units would overlap
+   their high bits and lose information.
+
+   We pin the hash of [Js.string s] for a range of inputs; the js and wasm
+   runtimes share this [%expect] block, so any divergence between them — or from
+   the recorded reference values — is caught. For an ASCII string the JS string
+   and the equivalent OCaml string share their bytes, so their hashes must also
+   agree; we assert that. *)
+
+open Js_of_ocaml
+
+let is_ascii s = String.for_all (fun c -> Char.code c < 128) s
+
+let check s =
+  let js = Hashtbl.hash (Js.string s) in
+  Printf.printf "%S -> %d\n" s js;
+  if is_ascii s
+  then begin
+    let ocaml = Hashtbl.hash s in
+    if js <> ocaml then Printf.printf "  MISMATCH vs OCaml string: %d\n" ocaml
+  end
+
+let%expect_test "JS string hashing matches the JS runtime (ASCII and UTF-8)" =
+  List.iter
+    check
+    [ (* ASCII *)
+      ""
+    ; "a"
+    ; "ab"
+    ; "abc"
+    ; "abcd"
+    ; "abcde"
+    ; "hello world"
+    ; "a longer ascii string of some length"
+    ; (* UTF-8 encoded non-ASCII *)
+      "é"
+    ; "héllo"
+    ; "naïve café"
+    ; "Σ"
+    ; "日本語"
+    ; "🎉"
+    ; "café — résumé"
+    ];
+  [%expect
+    {|
+    "" -> 0
+    "a" -> 721651713
+    "ab" -> 856662637
+    "abc" -> 767105082
+    "abcd" -> 65890154
+    "abcde" -> 335633756
+    "hello world" -> 1053319576
+    "a longer ascii string of some length" -> 423036158
+    "\195\169" -> 145260179
+    "h\195\169llo" -> 46355517
+    "na\195\175ve caf\195\169" -> 359129460
+    "\206\163" -> 642168663
+    "\230\151\165\230\156\172\232\170\158" -> 802525496
+    "\240\159\142\137" -> 313031078
+    "caf\195\169 \226\128\148 r\195\169sum\195\169" -> 782065221
+    |}]

--- a/runtime/js/hash.js
+++ b/runtime/js/hash.js
@@ -147,11 +147,39 @@ function caml_hash_mix_string(h, v) {
   return caml_hash_mix_jsbytes(h, caml_jsbytes_of_string(v));
 }
 
+//Provides: caml_jsstring_is_bytes
+function caml_jsstring_is_bytes(s) {
+  // Whether every code unit fits in a byte, i.e. no code point above U+00FF.
+  for (var i = 0; i < s.length; i++) if (s.charCodeAt(i) > 0xff) return false;
+  return true;
+}
+
+//Provides: caml_hash_mix_jsstring
+//Requires: caml_hash_mix_jsbytes, caml_hash_mix_int, caml_jsstring_is_bytes
+function caml_hash_mix_jsstring(h, s) {
+  // A string whose code units all fit in a byte (every ASCII string, all of
+  // Latin-1, and any raw byte string) is mixed four per word, leaving its hash
+  // unchanged and, for an OCaml string's bytes, matching the OCaml string hash.
+  if (caml_jsstring_is_bytes(s)) return caml_hash_mix_jsbytes(h, s);
+  // Genuine Unicode text: mix two 16-bit code units per word, so no information
+  // is lost. Packing the code units four per word at byte offsets (as for a
+  // byte string) would overlap their high bits.
+  var len = s.length,
+    i,
+    w;
+  for (i = 0; i + 2 <= len; i += 2) {
+    w = s.charCodeAt(i) | (s.charCodeAt(i + 1) << 16);
+    h = caml_hash_mix_int(h, w);
+  }
+  if (len & 1) h = caml_hash_mix_int(h, s.charCodeAt(i));
+  return h ^ len;
+}
+
 //Provides: caml_hash mutable
 //Requires: caml_is_ml_string, caml_is_ml_bytes
 //Requires: caml_hash_mix_int, caml_hash_mix_final
 //Requires: caml_hash_mix_float, caml_hash_mix_string, caml_hash_mix_bytes, caml_custom_ops
-//Requires: caml_hash_mix_jsbytes
+//Requires: caml_hash_mix_jsstring
 //Requires: caml_is_continuation_tag
 function caml_hash(count, limit, seed, obj) {
   var queue, rd, wr, sz, num, h, v, i, len;
@@ -216,7 +244,7 @@ function caml_hash(count, limit, seed, obj) {
       h = caml_hash_mix_string(h, v);
       num--;
     } else if (typeof v === "string") {
-      h = caml_hash_mix_jsbytes(h, v);
+      h = caml_hash_mix_jsstring(h, v);
       num--;
     } else if (v === (v | 0)) {
       // Integer

--- a/runtime/wasm/hash.wat
+++ b/runtime/wasm/hash.wat
@@ -345,6 +345,9 @@
                         (i32.eqz (call $jsstring_test (local.get $str)))))
                      (local.set $h
                         (call $jsstring_hash (local.get $h) (local.get $str)))
+                     ;; count the string against the budget, like every other
+                     ;; hashed leaf (and like the JS runtime)
+                     (local.set $num (i32.sub (local.get $num) (i32.const 1)))
                      (ref.i31 (i32.const 0))))
 ))
                   ;; closures and continuations and other js values are ignored

--- a/runtime/wasm/runtime.js
+++ b/runtime/wasm/runtime.js
@@ -166,9 +166,57 @@
     h = (h << 13) | (h >>> 19); //ROTL32(h, 13);
     return (((h + (h << 2)) | 0) + (0xe6546b64 | 0)) | 0;
   }
+  function jsstring_is_bytes(s) {
+    // Whether every code unit fits in a byte, i.e. no code point above U+00FF.
+    for (var i = 0; i < s.length; i++) if (s.charCodeAt(i) > 0xff) return false;
+    return true;
+  }
+  function caml_hash_mix_jsbytes(h, s) {
+    // Mix a byte string four code units per word, like the JS runtime.
+    var len = s.length,
+      i,
+      w;
+    for (i = 0; i + 4 <= len; i += 4) {
+      w =
+        s.charCodeAt(i) |
+        (s.charCodeAt(i + 1) << 8) |
+        (s.charCodeAt(i + 2) << 16) |
+        (s.charCodeAt(i + 3) << 24);
+      h = hash_int(h, w);
+    }
+    w = 0;
+    switch (len & 3) {
+      // biome-ignore lint/suspicious/noFallthroughSwitchClause: falls through
+      case 3:
+        w = s.charCodeAt(i + 2) << 16;
+      // falls through
+      // biome-ignore lint/suspicious/noFallthroughSwitchClause: falls through
+      case 2:
+        w |= s.charCodeAt(i + 1) << 8;
+      // falls through
+      case 1:
+        w |= s.charCodeAt(i);
+        h = hash_int(h, w);
+    }
+    return h ^ len;
+  }
   function hash_string(h, s) {
-    for (var i = 0; i < s.length; i++) h = hash_int(h, s.charCodeAt(i));
-    return h ^ s.length;
+    // A string whose code units all fit in a byte (every ASCII string, all of
+    // Latin-1) is mixed as bytes, leaving its hash unchanged and matching the
+    // JS runtime.
+    if (jsstring_is_bytes(s)) return caml_hash_mix_jsbytes(h, s);
+    // Genuine Unicode text: mix two 16-bit code units per word, so no
+    // information is lost (packing them four per word at byte offsets would
+    // overlap their high bits).
+    var len = s.length,
+      i,
+      w;
+    for (i = 0; i + 2 <= len; i += 2) {
+      w = s.charCodeAt(i) | (s.charCodeAt(i + 1) << 16);
+      h = hash_int(h, w);
+    }
+    if (len & 1) h = hash_int(h, s.charCodeAt(i));
+    return h ^ len;
   }
 
   function getenv(n) {


### PR DESCRIPTION
Hashing a JavaScript string packed its raw UTF-16 code units **four per word**
at byte offsets (`caml_hash_mix_jsbytes` / wasm `hash_string`). That is lossless
only when every code unit fits in a byte. For code points **above U+00FF** the
`<< 8/16/24` shifts overlap, smearing the high bits of adjacent code units
together — losing information and needlessly raising the collision rate (e.g.
for CJK, Greek, em-dashes, emoji).

### Fix

Hash a string with code points `> 0xFF` by mixing **two 16-bit code units per
word** (`charCodeAt(i) | (charCodeAt(i+1) << 16)`), so each code unit keeps a
full 16 bits and nothing overlaps — lossless, no UTF-8 decode, no allocation.

Strings whose code units all fit in a byte — **every ASCII string, all of
Latin-1, and any raw byte string** — keep the existing four-per-word packing, so
their hash is **unchanged** (and still matches the hash of the equivalent OCaml
string).

### Both runtimes

- **js** (`runtime/js/hash.js`): the `typeof v === "string"` branch now routes
  through a new `caml_hash_mix_jsstring` doing the `> 0xFF` split. This is a
  behavior change for the js backend too (only large-code-point strings change).
- **wasm** (`runtime/wasm/runtime.js`): `hash_string` additionally mixed one code
  unit at a time, and `caml_hash` did **not** decrement the hash budget after a
  JS string the way it does for every other leaf. Both are fixed, so a
  `Js.string` hashes to the same value on both backends.

### Test

`compiler/tests-jsoo/hash_jsstring.ml` is a `ppx_expect` test (runs on **js and
wasm**) pinning the hash of `Js.string s` for a range of ASCII and non-ASCII
inputs; the shared `[%expect]` block catches any divergence between the two
backends. It also asserts `Hashtbl.hash (Js.string s) = Hashtbl.hash s` for
ASCII. Found in the wasm runtime review (#2263).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
