### PR TITLE
Runtime/wasm (WASI): follow symlinks in Unix.utimes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -123,6 +123,9 @@
   comparison required an exact length and never matched. The empty path is
   no longer treated as the current directory but fails with `ENOENT` like
   native (#2263)
+* Runtime/wasm (WASI): `Unix.utimes` follows symlinks like native and the
+  other path operations; it passed `lookupflags = 0`, so it set the times
+  on the symlink itself instead of its target (#2263)
 * Runtime: `Unix.localtime` computes `tm_yday` from the calendar date
   instead of the wall-clock distance to January 1, which was off by one
   during DST; the js and wasm-on-node backends share the fix (#2304)

--- a/compiler/tests-jsoo/test_unix.ml
+++ b/compiler/tests-jsoo/test_unix.ml
@@ -267,3 +267,16 @@ let%expect_test "empty path is ENOENT" =
    | exception Unix.Unix_error (e, _, _) ->
        print_endline (String.lowercase_ascii (Unix.error_message e)));
   [%expect {| ENOENT |}]
+
+(* Unix.utimes follows symlinks (it is utimes, not lutimes): setting the
+   times through a symlink updates the target. *)
+let%expect_test "utimes follows symlinks" =
+  let f = Filename.temp_file "jsoo_utf" ".dat" in
+  let l = Filename.temp_file "jsoo_utl" "" in
+  Sys.remove l;
+  Unix.symlink f l;
+  Unix.utimes l 12345.0 12345.0;
+  Printf.printf "%b\n" ((Unix.stat f).Unix.st_mtime = 12345.0);
+  Sys.remove l;
+  Sys.remove f;
+  [%expect {| true |}]

--- a/runtime/wasm/unix.wat
+++ b/runtime/wasm/unix.wat
@@ -742,7 +742,7 @@
       (local.set $res
          (call $path_filestat_set_times
             (local.get $p_fd)
-            (i32.const 0)
+            (i32.const 1) ;; symlink_follow, like every other path op and native
             (local.get $p_addr)
             (local.get $p_len)
             (local.get $atim)


### PR DESCRIPTION
`caml_unix_utimes` (WASI path, `runtime/wasm/unix.wat`) passed `lookupflags = 0`
to `path_filestat_set_times`, so it did **not** follow symlinks and set the times
on the link itself rather than its target. Every other path operation in the file
passes `symlink_follow` (`1`, e.g. `path_open` at `fs.wat:495` and the
`path_filestat_get` stat calls), and native `Unix.utimes` follows symlinks (it is
not `lutimes`). Pass `1`.

### Test

`compiler/tests-jsoo/test_unix.ml` gains a case asserting that `Unix.utimes`
through a symlink updates the target's mtime. It runs on js, wasm-on-node and
native (all already correct via their follow-symlink paths) and on **WASI in CI**,
where the fix takes effect.

> Note: I could not run the WASI backend locally to confirm — the available
> wasmtime (45.0.2) panics on jsoo's WasmGC output
> (`gc_runtime.rs:481`). The fix is a one-flag change matching the established
> `symlink_follow` convention and native semantics, and assembles cleanly.

Found in the Wasm runtime review (#2263).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
