### PR TITLE
Runtime/wasm (WASI): fix preopen prefix matching and empty-path resolution

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -120,7 +120,9 @@
   filesystem operation (#2263)
 * Runtime/wasm (WASI): a preopen whose prefix carries a trailing slash
   (e.g. `wasmtime --dir=tmp/`) now matches paths underneath it; the prefix
-  comparison required an exact length and never matched (#2263)
+  comparison required an exact length and never matched. The empty path is
+  no longer treated as the current directory but fails with `ENOENT` like
+  native (#2263)
 * Runtime: `Unix.localtime` computes `tm_yday` from the calendar date
   instead of the wall-clock distance to January 1, which was off by one
   during DST; the js and wasm-on-node backends share the fix (#2304)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -118,6 +118,9 @@
   prefix name underflowed to a huge unsigned value and the following
   `array.copy` trapped with an out-of-bounds access on the first
   filesystem operation (#2263)
+* Runtime/wasm (WASI): a preopen whose prefix carries a trailing slash
+  (e.g. `wasmtime --dir=tmp/`) now matches paths underneath it; the prefix
+  comparison required an exact length and never matched (#2263)
 * Runtime: `Unix.localtime` computes `tm_yday` from the calendar date
   instead of the wall-clock distance to January 1, which was off by one
   during DST; the js and wasm-on-node backends share the fix (#2304)

--- a/compiler/tests-jsoo/test_unix.ml
+++ b/compiler/tests-jsoo/test_unix.ml
@@ -257,3 +257,13 @@ let%expect_test "error_message of a non-WASI error code" =
     (String.length m > 0)
     (not (String.starts_with ~prefix:"Unknown error" m));
   [%expect {| true true |}]
+
+(* The empty path is not the current directory: it fails with ENOENT like
+   native (open ""/stat "" etc.). *)
+let%expect_test "empty path is ENOENT" =
+  (match Unix.stat "" with
+   | _ -> print_endline "ok"
+   | exception Unix.Unix_error (Unix.ENOENT, _, _) -> print_endline "ENOENT"
+   | exception Unix.Unix_error (e, _, _) ->
+       print_endline (String.lowercase_ascii (Unix.error_message e)));
+  [%expect {| ENOENT |}]

--- a/runtime/wasm/fs.wat
+++ b/runtime/wasm/fs.wat
@@ -200,8 +200,10 @@
       (param $path (ref $bytes)) (result (ref $bytes))
       (local $need_slash i32) (local $i i32) (local $abs_path (ref $bytes))
       (if (i32.eqz (array.len (local.get $path)))
-         (then ;; empty path
-            (return (global.get $current_dir))))
+         (then ;; empty path: leave it empty so it matches no preopen and the
+               ;; operation fails with ENOENT, like native (open "" etc.),
+               ;; rather than silently resolving to the current directory
+            (return (local.get $path))))
       (if (i32.eq (i32.const 47) ;; '/'
              (array.get_u $bytes (local.get $path) (i32.const 0)))
          (then ;; absolute path

--- a/runtime/wasm/fs.wat
+++ b/runtime/wasm/fs.wat
@@ -283,6 +283,13 @@
       (param $prefix (ref $bytes)) (param $path (ref $bytes)) (result i32)
       (local $i i32) (local $len i32)
       (local.set $len (array.len (local.get $prefix)))
+      ;; A preopen prefix may carry a trailing slash (e.g. "--dir=tmp/");
+      ;; ignore it so it still matches "<prefix>/<rest>".
+      (if (i32.and (i32.gt_u (local.get $len) (i32.const 0))
+                   (i32.eq (array.get_u $bytes (local.get $prefix)
+                              (i32.sub (local.get $len) (i32.const 1)))
+                           (i32.const 47))) ;; '/'
+         (then (local.set $len (i32.sub (local.get $len) (i32.const 1)))))
       (if (i32.lt_u (array.len (local.get $path)) (local.get $len))
          (then (return (i32.const 0))))
       (if (i32.gt_u (array.len (local.get $path)) (local.get $len))


### PR DESCRIPTION
Two WASI path-resolution fixes in `runtime/wasm/fs.wat` from the review (#2263):

**Preopen prefix with a trailing slash** — `prefix_match` required a path to start
with the preopen prefix followed by `/` (or equal it). If the prefix itself ended
in a slash (e.g. `wasmtime --dir=tmp/`), it looked for `/` at the wrong offset and
never matched, so the first filesystem operation failed. A single trailing slash
on the prefix is now ignored (only affects the previously-broken case).

**Empty path** — `make_absolute` turned an empty path into the current directory,
so `stat ""` / `open ""` etc. silently operated on the cwd. The empty path is now
left empty, matches no preopen, and `unix_resolve_path` / `caml_sys_resolve_path`
raise `ENOENT`, like native.

### Tests

`compiler/tests-jsoo/test_unix.ml` gains `stat "" → ENOENT` (js, wasm, native).
The trailing-slash case is WASI-config-specific (a `--dir=x/` preopen) so it has
no portable test.

### Verification

js + native pass; `fs.wat` assembles under the `wasi` profile. The WASI backend
can't be run here — wasmtime 45.0.2 panics on jsoo's WasmGC output
(`gc_runtime.rs:481`) — so the WASI paths need CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
