### PR TITLE
Runtime/wasm (WASI): name errors with no WASI errno equivalent

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -97,6 +97,10 @@
   open output channel, not only stdout/stderr; the WASI runtime now tracks
   all output channels like the C runtime, so buffered data on user file
   channels is no longer lost (#2263)
+* Runtime/wasm (WASI): `Unix.error_message` of an error variant with no
+  WASI errno equivalent (`EWOULDBLOCK`, `ESHUTDOWN`, ...) reports the error
+  name instead of `"Unknown error -1"`, matching the JS runtime's fallback
+  (#2263)
 * Runtime: `Unix.localtime` computes `tm_yday` from the calendar date
   instead of the wall-clock distance to January 1, which was off by one
   during DST; the js and wasm-on-node backends share the fix (#2304)

--- a/compiler/tests-jsoo/test_unix.ml
+++ b/compiler/tests-jsoo/test_unix.ml
@@ -245,3 +245,15 @@ let%expect_test "is_directory follows symlinks" =
     symlink->dir: true
     symlink->file: false
     |}]
+
+(* An error variant with no WASI errno equivalent (e.g. EWOULDBLOCK) must
+   still produce a real message, not "Unknown error -1". The exact text is
+   backend-specific (a descriptive string natively / under node, the error
+   name under WASI), so only the invariant is checked. *)
+let%expect_test "error_message of a non-WASI error code" =
+  let m = Unix.error_message Unix.EWOULDBLOCK in
+  Printf.printf
+    "%b %b\n"
+    (String.length m > 0)
+    (not (String.starts_with ~prefix:"Unknown error" m));
+  [%expect {| true true |}]

--- a/runtime/wasm/unix.wat
+++ b/runtime/wasm/unix.wat
@@ -279,6 +279,36 @@
          (i32.const 33) (i32.const 34) (i32.const 35) (i32.const -1)
          (i32.const 62) (i32.const -1) (i32.const 36) (i32.const -1)))
 
+   ;; Names of the Unix.error variants, in declaration order. Used as the
+   ;; message for variants that have no WASI errno equivalent (EWOULDBLOCK,
+   ;; ESHUTDOWN, ...), matching the JS runtime's "unix_error[errno]" fallback
+   ;; instead of reporting "Unknown error -1".
+   (global $error_names (ref $block)
+      (array.new_fixed $block 68
+         (@string "E2BIG") (@string "EACCES") (@string "EAGAIN")
+         (@string "EBADF") (@string "EBUSY") (@string "ECHILD")
+         (@string "EDEADLK") (@string "EDOM") (@string "EEXIST")
+         (@string "EFAULT") (@string "EFBIG") (@string "EINTR")
+         (@string "EINVAL") (@string "EIO") (@string "EISDIR")
+         (@string "EMFILE") (@string "EMLINK") (@string "ENAMETOOLONG")
+         (@string "ENFILE") (@string "ENODEV") (@string "ENOENT")
+         (@string "ENOEXEC") (@string "ENOLCK") (@string "ENOMEM")
+         (@string "ENOSPC") (@string "ENOSYS") (@string "ENOTDIR")
+         (@string "ENOTEMPTY") (@string "ENOTTY") (@string "ENXIO")
+         (@string "EPERM") (@string "EPIPE") (@string "ERANGE")
+         (@string "EROFS") (@string "ESPIPE") (@string "ESRCH")
+         (@string "EXDEV") (@string "EWOULDBLOCK") (@string "EINPROGRESS")
+         (@string "EALREADY") (@string "ENOTSOCK") (@string "EDESTADDRREQ")
+         (@string "EMSGSIZE") (@string "EPROTOTYPE") (@string "ENOPROTOOPT")
+         (@string "EPROTONOSUPPORT") (@string "ESOCKTNOSUPPORT")
+         (@string "EOPNOTSUPP") (@string "EPFNOSUPPORT") (@string "EAFNOSUPPORT")
+         (@string "EADDRINUSE") (@string "EADDRNOTAVAIL") (@string "ENETDOWN")
+         (@string "ENETUNREACH") (@string "ENETRESET") (@string "ECONNABORTED")
+         (@string "ECONNRESET") (@string "ENOBUFS") (@string "EISCONN")
+         (@string "ENOTCONN") (@string "ESHUTDOWN") (@string "ETOOMANYREFS")
+         (@string "ETIMEDOUT") (@string "ECONNREFUSED") (@string "EHOSTDOWN")
+         (@string "EHOSTUNREACH") (@string "ELOOP") (@string "EOVERFLOW")))
+
    (func $caml_unix_error_of_code (param $errcode i32) (result (ref eq))
       (local $err i32)
       (if (i32.le_u (local.get $errcode) (i32.const 76))
@@ -338,6 +368,16 @@
       (if (i32.ge_u (local.get $errcode)
              (array.len (global.get $error_messages)))
          (then
+            ;; A known variant with no WASI errno equivalent (EWOULDBLOCK, ...)
+            ;; is reported by its name, like the JS runtime, rather than as
+            ;; "Unknown error -1". EUNKNOWNERR(n) (a block) still falls through.
+            (if (i32.and (ref.test (ref i31) (local.get $err))
+                         (i32.lt_u (local.get $n)
+                            (array.len (global.get $error_names))))
+               (then
+                  (return
+                     (array.get $block (global.get $error_names)
+                        (local.get $n)))))
             (return_call $caml_string_concat
                (@string "Unknown error ")
                (call $caml_format_int (@string "%d")


### PR DESCRIPTION
`unix_error_message` (WASI, `runtime/wasm/unix.wat`) reverse-mapped an error
variant to a WASI errno through the `error_codes` table. For variants that have
**no WASI errno equivalent** — `EWOULDBLOCK`, `ESHUTDOWN`, `EHOSTDOWN`, … — the
reverse lookup returned `-1`, and the message came out as `"Unknown error -1"`.

This adds an `error_names` table (the `Unix.error` constant constructors in
declaration order) and, for such a variant, reports its **name** — matching the
JS runtime's `unix_error[errno]` fallback. `EUNKNOWNERR(n)` (a block) still
reports `"Unknown error n"`.

### Test

`compiler/tests-jsoo/test_unix.ml` asserts `Unix.error_message EWOULDBLOCK` is
non-empty and does not start with `"Unknown error"`. The exact text is
backend-specific (a descriptive string natively / under node, the error name
under WASI), so only the invariant is checked. Runs on js, wasm and native.

### Verification

js + native pass; `unix.wat` assembles under the `wasi` profile. I could not run
the WASI backend — the available wasmtime (45.0.2) panics on jsoo's WasmGC output
(`gc_runtime.rs:481`) — so the WASI path needs CI.

Part of the Wasm runtime review (#2263).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
