### PR TITLE
Runtime/wasm (WASI): track all output channels for flush_all

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -93,6 +93,10 @@
   (not produced by `Printf`): the `#` flag no longer overwrites the sign
   of a negative base-10 integer (`"%#d" (-5)` gave `"05"`), and `"%+f"` /
   `"% f"` without a precision no longer raise `Invalid_argument` (#2263)
+* Runtime/wasm (WASI): `flush_all` (and the at-exit flush) reaches every
+  open output channel, not only stdout/stderr; the WASI runtime now tracks
+  all output channels like the C runtime, so buffered data on user file
+  channels is no longer lost (#2263)
 * Runtime: `Unix.localtime` computes `tm_yday` from the calendar date
   instead of the wall-clock distance to January 1, which was off by one
   during DST; the js and wasm-on-node backends share the fix (#2304)

--- a/compiler/tests-jsoo/test_io.ml
+++ b/compiler/tests-jsoo/test_io.ml
@@ -115,3 +115,18 @@ let%expect_test "channel_of_descr channels are distinct" =
   close_out oc;
   Sys.remove f;
   [%expect {| false |}]
+
+(* flush_all must reach every open output channel, not just stdout/stderr;
+   a buffered user channel is flushed to disk by flush_all alone. *)
+let%expect_test "flush_all flushes user channels" =
+  let f = Filename.temp_file "jsoo_flushall" ".txt" in
+  let oc = open_out f in
+  output_string oc "hello";
+  flush_all ();
+  let ic = open_in f in
+  let s = really_input_string ic (in_channel_length ic) in
+  close_in ic;
+  close_out oc;
+  Sys.remove f;
+  print_endline s;
+  [%expect {| hello |}]

--- a/runtime/wasm/io.wat
+++ b/runtime/wasm/io.wat
@@ -213,14 +213,42 @@
    (global $caml_stdout
       (mut (ref eq)) (ref.i31 (i32.const 0)))
 
+   ;; List of all open output channels, like the C runtime's
+   ;; caml_all_opened_channels, so flush_all / at-exit reaches every channel
+   ;; (the registry hooks are invoked from open_descriptor_out / close_channel).
+   ;; Kept functional (cons cells are never mutated) so a list previously
+   ;; returned by caml_ml_out_channels_list stays valid across register/close.
+   (global $out_channels (mut (ref eq)) (ref.i31 (i32.const 0)))
+
    (func $register_channel (param $ch (ref eq))
       (if (i32.eq
              (struct.get $channel $fd (ref.cast (ref $channel) (local.get $ch)))
              (i32.const 1))
          (then
-            (global.set $caml_stdout (local.get $ch)))))
+            (global.set $caml_stdout (local.get $ch))))
+      (global.set $out_channels
+         (array.new_fixed $block 3 (ref.i31 (i32.const 0))
+            (local.get $ch) (global.get $out_channels))))
 
-   (func $unregister_channel (param (ref eq)))
+   (func $unregister_channel (param $ch (ref eq))
+      (local $cur (ref eq)) (local $new (ref eq)) (local $cell (ref $block))
+      (local.set $cur (global.get $out_channels))
+      (local.set $new (ref.i31 (i32.const 0)))
+      (block $done
+         (loop $loop
+            (br_if $done (ref.test (ref i31) (local.get $cur)))
+            (local.set $cell (ref.cast (ref $block) (local.get $cur)))
+            (if (i32.eqz
+                   (ref.eq (array.get $block (local.get $cell) (i32.const 1))
+                      (local.get $ch)))
+               (then
+                  (local.set $new
+                     (array.new_fixed $block 3 (ref.i31 (i32.const 0))
+                        (array.get $block (local.get $cell) (i32.const 1))
+                        (local.get $new)))))
+            (local.set $cur (array.get $block (local.get $cell) (i32.const 2)))
+            (br $loop)))
+      (global.set $out_channels (local.get $new)))
    (func $map_new (result (ref extern))
       (extern.convert_any (ref.i31 (i32.const 0))))
    (func $map_get (param (ref extern)) (param i32) (result (ref $fd_offset))
@@ -588,9 +616,7 @@
 (@then
    (func (export "caml_ml_out_channels_list")
       (param (ref eq)) (result (ref eq))
-      (call $push_channel
-         (call $push_channel (ref.i31 (i32.const 0)) (global.get $caml_stdout))
-         (global.get $caml_stderr)))
+      (global.get $out_channels))
 )
 (@else
    (func (export "caml_ml_out_channels_list")


### PR DESCRIPTION
`caml_ml_out_channels_list` on the WASI runtime (`runtime/wasm/io.wat`) only
returned stdout/stderr, so `flush_all` — and the at-exit flush — never reached
user output channels, losing their buffered data. (The non-WASI runtime tracks
all channels via a WeakRef set in `runtime.js`.)

The WASI runtime now keeps a list of all open output channels, like the C
runtime's `caml_all_opened_channels`: `register_channel` (already called from
`caml_ml_open_descriptor_out`) prepends, and `unregister_channel` (already called
from `caml_ml_close_channel`) removes. Both are functional — cons cells are never
mutated — so a list previously returned by `caml_ml_out_channels_list` stays valid
across later opens/closes. The list holds strong references and entries are
dropped on close, like native (no leak).

### Test

`compiler/tests-jsoo/test_io.ml`: a buffered user channel written but not
explicitly flushed is on disk after `flush_all` alone. Runs on js, wasm, native.

### Verification

js + native pass; `io.wat` assembles under the `wasi` profile. The WASI backend
can't run here (wasmtime 45.0.2 panics on jsoo's WasmGC output), so the WASI path
needs CI.

(`$push_channel` and the `$caml_stdout` global are now unused on the WASI path and
could be dropped in a follow-up.)

Part of the Wasm runtime review (#2263).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
