### PR TITLE
Runtime/wasm: caml_wrap_exception matches the JS runtime

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -58,6 +58,10 @@
   applies the dedicated float-array size limit (`0x7ffffff`) like the other
   floatarray primitives, instead of the larger generic limit, since it
   builds an unboxed float array (#2263)
+* Runtime/wasm: `caml_wrap_exception` wraps a thrown JavaScript value in
+  `Js.Error` only when it is an actual `Error`, like the JS runtime; other
+  values become `Failure (String value)`, and a thrown `null`/`undefined`
+  no longer crashes the wrapper (it used `value.toString()`) (#2263)
 * Runtime: `Unix.localtime` computes `tm_yday` from the calendar date
   instead of the wall-clock distance to January 1, which was off by one
   during DST; the js and wasm-on-node backends share the fix (#2304)

--- a/compiler/tests-jsoo/dune
+++ b/compiler/tests-jsoo/dune
@@ -177,6 +177,7 @@
    ephemeron_data
    hash_jsstring
    bigstring_kind
+   wrap_exception
    runtime_events_register
    test_custom_name
    test_text_codec_fallback
@@ -337,6 +338,18 @@
  (libraries js_of_ocaml)
  (preprocess
   (pps js_of_ocaml-ppx ppx_expect)))
+
+; caml_wrap_exception wrapping of thrown JS values; uses Js, js and wasm only.
+
+(test
+ (name wrap_exception)
+ (modules wrap_exception)
+ (libraries js_of_ocaml)
+ (enabled_if
+  (and
+   (<> %{profile} wasi)
+   (<> %{profile} wasi-with-native-effects)))
+ (modes js wasm))
 
 ; The js accessor lives in the optional +toplevel.js runtime fragment, so it
 ; is linked explicitly; --toplevel is deliberately NOT passed, so the bytecode

--- a/compiler/tests-jsoo/wrap_exception.ml
+++ b/compiler/tests-jsoo/wrap_exception.ml
@@ -1,0 +1,21 @@
+(* caml_wrap_exception must match the JS runtime: a thrown JS value that is
+   not an Error becomes Failure (String value), not a Js.Error, and a thrown
+   null/undefined must not crash the wrapper (String() is null-safe, unlike
+   value.toString()). Exercised on js and wasm. *)
+
+open Js_of_ocaml
+
+let classify f =
+  match f () with
+  | () -> "no exception"
+  | exception Failure m -> "Failure " ^ m
+  | exception e -> "other: " ^ Printexc.to_string e
+
+let () =
+  assert (
+    classify (fun () -> ignore (Js.Unsafe.eval_string "(function(){throw 'boom'})()"))
+    = "Failure boom");
+  assert (
+    classify (fun () -> ignore (Js.Unsafe.eval_string "(function(){throw null})()"))
+    = "Failure null");
+  print_endline "ok"

--- a/runtime/wasm/jslib.wat
+++ b/runtime/wasm/jslib.wat
@@ -33,6 +33,10 @@
    (import "bindings" "delete" (func $delete (param anyref) (param anyref)))
    (import "bindings" "instanceof"
       (func $instanceof (param anyref) (param anyref) (result i32)))
+   (import "bindings" "is_js_error"
+      (func $is_js_error (param anyref) (result i32)))
+   (import "bindings" "to_js_string"
+      (func $to_js_string (param anyref) (result anyref)))
    (import "bindings" "typeof" (func $typeof (param anyref) (result anyref)))
    (import "bindings" "equals"
       (func $equals (param anyref) (param anyref) (result i32)))
@@ -637,21 +641,21 @@
       (local $exn anyref)
       (local.set $exn (any.convert_extern (local.get 0)))
       ;; ZZZ special case for stack overflows?
-      (block $undef
+      ;; Wrap in Js.Error only an actual JS Error, like the JS runtime; other
+      ;; thrown values fall through to Failure below.
+      (block $fallback
+         (br_if $fallback (i32.eqz (call $is_js_error (local.get $exn))))
          (return
             (array.new_fixed $block 3 (ref.i31 (i32.const 0))
-               (br_on_null $undef
+               (br_on_null $fallback
                   (call $caml_named_value (global.get $jsError)))
                (call $wrap (local.get $exn)))))
+      ;; Failure(String(exn)). String() is null/undefined-safe, unlike calling
+      ;; exn.toString() which throws on a thrown null/undefined.
       (array.new_fixed $block 3 (ref.i31 (i32.const 0))
          (call $caml_failwith_tag)
          (call $caml_string_of_jsstring
-            (call $wrap
-               (call $meth_call
-                  (local.get $exn)
-                  (call $unwrap
-                     (call $caml_jsstring_of_bytes (global.get $toString)))
-                  (any.convert_extern (call $new_array (i32.const 0))))))))
+            (call $wrap (call $to_js_string (local.get $exn))))))
 
    (func (export "caml_js_error_option_of_exception")
       (param (ref eq)) (result (ref eq))

--- a/runtime/wasm/runtime.js
+++ b/runtime/wasm/runtime.js
@@ -286,6 +286,8 @@
     set: (x, y, z) => (x[y] = z),
     delete: (x, y) => delete x[y],
     instanceof: (x, y) => x instanceof y,
+    is_js_error: (x) => x instanceof Error,
+    to_js_string: (x) => String(x),
     typeof: (x) => typeof x,
     // biome-ignore lint/suspicious/noDoubleEquals: ..
     equals: (x, y) => x == y,


### PR DESCRIPTION
`caml_wrap_exception` (`runtime/wasm/jslib.wat`) diverged from the JS runtime in
two ways flagged by the review (#2263):

- it wrapped **any** thrown JS value in `Js.Error` (when the `jsError` exception
  was registered), whereas the JS runtime only wraps a value that is
  `instanceof Error`; other values should become `Failure (String value)`;
- the fallback built the `Failure` message by calling `value.toString()`, which
  itself **throws** when the thrown value is `null`/`undefined`.

Now it wraps in `Js.Error` only an actual `Error`, and otherwise builds
`Failure (String value)` via a null/undefined-safe `String()`. Two small bindings
are added to the (non-WASI) `runtime.js`: `is_js_error` (`x instanceof Error`) and
`to_js_string` (`String(x)`).

### Test

`compiler/tests-jsoo/wrap_exception.ml`: throwing a plain string yields
`Failure "boom"` (not a `Js.Error`), and throwing `null` yields a `Failure`
without crashing. Runs on js and wasm.

### Verification

js passes; `jslib.wat` assembles and `runtime.js` lints clean. The wasm runtime
can't be executed here (node lacks `--experimental-wasm-wasmfx`; wasmtime panics
on WasmGC), so the wasm path is CI-verified.

Completes the `jslib.wat` items from #2263 (the sibling `caml_js_meth_call` UTF-8
fix shipped in #2335).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
