### PR TITLE
Runtime/wasm: align Condition.wait / Condition.t with the JS runtime

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -139,6 +139,10 @@
   the JavaScript backend but fails with `ENOENT` like native (and the Wasm
   runtime), so `Unix.stat ""`, `Unix.opendir ""`, etc. raise instead of
   silently operating on the cwd; `Sys.file_exists ""` returns false (#2354)
+* Runtime/wasm: `Condition.wait` is a no-op like the JS runtime instead of
+  raising `Failure`, and each `Condition.t` has a distinct identity (it was
+  the immediate `0`, so all condition variables were physically equal)
+  (#2263)
 * Runtime: `Unix.localtime` computes `tm_yday` from the calendar date
   instead of the wall-clock distance to January 1, which was off by one
   during DST; the js and wasm-on-node backends share the fix (#2304)

--- a/compiler/tests-jsoo/condition.ml
+++ b/compiler/tests-jsoo/condition.ml
@@ -1,0 +1,15 @@
+(* Condition variables must agree between the js and wasm runtimes: each is a
+   distinct value (not all physically equal), and in the single-threaded
+   runtime Condition.wait is a no-op rather than raising. Not run natively,
+   where Condition.wait would block forever. *)
+
+let () =
+  assert (Condition.create () != Condition.create ());
+  let m = Mutex.create () in
+  let c = Condition.create () in
+  Mutex.lock m;
+  Condition.wait c m;
+  Mutex.unlock m;
+  Condition.signal c;
+  Condition.broadcast c;
+  print_endline "ok"

--- a/compiler/tests-jsoo/dune
+++ b/compiler/tests-jsoo/dune
@@ -200,6 +200,7 @@
    bigstring_kind
    wrap_exception
    meth_call_utf8
+   condition
    runtime_events_register
    test_custom_name
    test_text_codec_fallback
@@ -426,6 +427,19 @@
   (and
    (<> %{profile} wasi)
    (<> %{profile} wasi-with-native-effects)))
+ (modes js wasm))
+
+; Condition variables agree between js and wasm. Not run natively: it calls
+; Condition.wait, which blocks forever there.
+
+(test
+ (name condition)
+ ; build_if, not enabled_if: Condition/Mutex are in the threads library on
+ ; OCaml < 5, so enabled_if would still compile (and fail) the module under
+ ; `make all`.
+ (modules condition)
+ (build_if
+  (>= %{ocaml_version} 5))
  (modes js wasm))
 
 ; The js accessor lives in the optional +toplevel.js runtime fragment, so it

--- a/runtime/wasm/sync.wat
+++ b/runtime/wasm/sync.wat
@@ -98,14 +98,35 @@
          (ref.cast (ref $mutex) (local.get 0)) (i32.const 0))
       (ref.i31 (i32.const 0)))
 
-   (func (export "caml_ml_condition_new") (param (ref eq)) (result (ref eq))
-      (ref.i31 (i32.const 0)))
+   (global $condition_ops (ref $custom_operations)
+      (struct.new $custom_operations
+         (@string "_condition")
+         (ref.func $custom_compare_id)
+         (ref.null $compare)
+         (ref.func $custom_hash_id)
+         (ref.null $fixed_length)
+         (ref.null $serialize)
+         (ref.null $deserialize)
+         (ref.null $dup)))
 
-   (@string $condition_failure "Condition.wait: cannot wait")
+   (type $condition
+      (sub final $custom_with_id
+         (struct
+            (field (ref $custom_operations))
+            (field i64))))
+
+   (func (export "caml_ml_condition_new") (param (ref eq)) (result (ref eq))
+      ;; Each condition variable gets a distinct identity, like the JS runtime
+      ;; (which allocates a fresh object). The previous immediate 0 made all
+      ;; condition variables physically equal.
+      (struct.new $condition
+         (global.get $condition_ops) (call $custom_next_id)))
 
    (func (export "caml_ml_condition_wait")
       (param (ref eq)) (param (ref eq)) (result (ref eq))
-      (call $caml_failwith (global.get $condition_failure))
+      ;; A no-op, like the JS runtime: single-threaded, there is nothing to
+      ;; wait for. The two runtimes must agree (the JS one returns 0 rather
+      ;; than raising).
       (ref.i31 (i32.const 0)))
 
    (func (export "caml_ml_condition_signal") (param (ref eq)) (result (ref eq))


### PR DESCRIPTION
Two divergences between the Wasm and JS Condition runtimes, from the review
(#2263):

- `caml_ml_condition_wait` **raised `Failure`** on Wasm, whereas the JS runtime
  returns `0`. In the single-threaded runtime there is nothing to wait for, so
  this makes it a no-op to agree with JS.
- `caml_ml_condition_new` returned the immediate `0`, so **every `Condition.t`
  was physically equal**. Each condition now gets a distinct identity (a custom
  block with a fresh id, like the mutex), matching the JS runtime's fresh object.

### Direction note

I harmonized **Wasm → JS** (no-op `wait`), since the JS behavior is the
established one and the review quotes it. If you'd rather both runtimes *raise*
(so misuse in single-threaded code is loud rather than a silent spin), say so and
I'll flip it the other way instead.

### Test

`compiler/tests-jsoo/condition.ml`: two `Condition.create ()` are physically
distinct, and `wait`/`signal`/`broadcast` don't raise. **js and wasm only** —
`Condition.wait` blocks forever natively. Gated to OCaml ≥ 5.

### Verification

js passes; `sync.wat` assembles. The wasm runtime can't run here (wasmtime panics
on WasmGC / node lacks the effects flag), so wasm is CI-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
