### PR TITLE
Docs: update supported-engine baseline (ES2020, Node 18+, QuickJS-NG)

### DIFF
--- a/ECMASCRIPT.md
+++ b/ECMASCRIPT.md
@@ -3,6 +3,18 @@
 The goal of the document is to list features we rely on for the runtime and the generated code.
 Features are grouped by ECMAScript version.
 
+## Supported engines
+
+The generated code and runtime target **ECMAScript 2020 (ES2020)**. They run on:
+
+- Node.js 18 or later
+- Any evergreen browser released since early 2020 (Chrome 80+, Firefox 74+, Safari 13.4+, Edge 80+)
+- [QuickJS-NG](https://github.com/quickjs-ng/quickjs)
+
+The ES2021 features below (`WeakRef`, `FinalizationRegistry`) are optional: they
+are used when available and degrade gracefully otherwise. To target an older
+engine, transpile the output down to ES5 (see `manual/browser-compat.mld`).
+
 ## ECMAScript 2015
 
 ### Arrow function expressions

--- a/README.md
+++ b/README.md
@@ -38,8 +38,14 @@ wasm_of_ocaml-compiler additionally depends on a system installation of binaryen
 
 ## Supported engines
 
-The generated code works with Node.js 16 or any recent web-browser compatible with ECMAScript 6.
+The generated code and runtime target ECMAScript 2020 (ES2020). Out of the box
+they run on Node.js 18 or later and any evergreen web browser released since
+early 2020 (Chrome 80+, Firefox 74+, Safari 13.4+, Edge 80+). QuickJS-NG is also
+supported.
+
 We optionally rely on js `WeakRef`, which is part of ECMAScript 2021, to implement `Stdlib.Weak` and `Stdlib.Ephemeron`.
+For older engines, the output can be transpiled down to ES5 — see the
+[browser compatibility](https://ocsigen.org/js_of_ocaml/latest/manual/browser-compat) section of the manual.
 
 ### Toplevel requirements
 

--- a/manual/browser-compat.mld
+++ b/manual/browser-compat.mld
@@ -1,8 +1,8 @@
 {0 Targeting older browsers}
 
 Js_of_ocaml's generated code and runtime target {b ECMAScript 2020 (ES2020)}.
-Out of the box, the output runs on Node.js 16+ and any evergreen browser
-released since early 2020 (Chrome 80+, Firefox 74+, Safari 13.4+, Edge 80+).
+Out of the box, the output runs on Node.js 18+, QuickJS-NG, and any evergreen
+browser released since early 2020 (Chrome 80+, Firefox 74+, Safari 13.4+, Edge 80+).
 
 If you need to support an older engine, you can post-process the
 generated JavaScript with {{:https://babeljs.io}Babel} and ship

--- a/manual/install.mld
+++ b/manual/install.mld
@@ -17,8 +17,9 @@
 {1:supported-environments Supported environments}
 
 The generated JavaScript works with:
-- Node.js 16 or later
+- Node.js 18 or later
 - Any modern browser supporting ECMAScript 2020 (ES2020) — Chrome 80+, Firefox 74+, Safari 13.4+, Edge 80+
+- QuickJS-NG
 
 {b Note}: [Stdlib.Weak] and [Stdlib.Ephemeron] require [WeakRef] support (ECMAScript 2021), available in all modern browsers and Node.js 14.6+.
 


### PR DESCRIPTION
## Summary

The `README.md` "Supported engines" section claimed *"Node.js 16 or any recent web-browser compatible with ECMAScript 6"*, which is stale:

- the runtime relies on **ES2020** features unconditionally (optional chaining — `?.` appears 104× in `runtime/js`, plus `globalThis`, `BigInt`);
- Node 16 is EOL;
- **QuickJS-NG** is now a tested engine (there's a `quickjs.yml` CI workflow and a `CHANGES.md` "initial support for quickjs-ng" entry) but wasn't documented;
- the manual (`browser-compat.mld`, `install.mld`) already said ES2020, so the README was inconsistent with the rest of the docs.

## Changes

Aligned all four docs on a single baseline — **ES2020, Node.js 18+, evergreen browsers (Chrome 80+/Firefox 74+/Safari 13.4+/Edge 80+), and QuickJS-NG**:

- `README.md` — rewrote the "Supported engines" paragraph; kept the `WeakRef`/ES2021 optional note and added a pointer to the browser-compat (ES5 transpile) docs.
- `ECMASCRIPT.md` — added a "Supported engines" intro section.
- `manual/install.mld` — Node.js 16 → 18, added QuickJS-NG.
- `manual/browser-compat.mld` — Node.js 16+ → 18+, added QuickJS-NG.

Docs-only; no code or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)