### PR TITLE
CI: cancel superseded in-progress runs to avoid contention

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -11,6 +11,10 @@ on:
       - synchronize
       - unlabeled
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   check-changelog:
     name: Check changelog

--- a/.github/workflows/js_of_ocaml.yml
+++ b/.github/workflows/js_of_ocaml.yml
@@ -9,6 +9,10 @@ on:
     # Prime the caches every Monday
     - cron: 0 1 * * MON
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     env:

--- a/.github/workflows/js_parser.yml
+++ b/.github/workflows/js_parser.yml
@@ -9,6 +9,10 @@ on:
     # Prime the caches every Monday
     - cron: 0 1 * * MON
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   js-parser:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,10 @@ on:
     # Prime the caches every Monday
     - cron: 0 1 * * MON
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint-opam:
     runs-on: ubuntu-latest

--- a/.github/workflows/quickjs.yml
+++ b/.github/workflows/quickjs.yml
@@ -9,6 +9,10 @@ on:
     # Prime the caches every Monday
     - cron: 0 1 * * MON
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   quickjs:
     name: QuickJS-NG / Ubuntu / Tests

--- a/.github/workflows/wasm_of_ocaml.yml
+++ b/.github/workflows/wasm_of_ocaml.yml
@@ -9,6 +9,10 @@ on:
     # Prime the caches every Monday
     - cron: 0 1 * * MON
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     env:

--- a/.github/workflows/wax.yml
+++ b/.github/workflows/wax.yml
@@ -9,6 +9,10 @@ on:
     # Prime the caches every Monday
     - cron: 0 1 * * MON
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   wax:
     name: Wax / Ubuntu / Convert runtime


### PR DESCRIPTION
## Problem

Most workflows have no `concurrency` group, so pushing new commits to an open PR starts fresh runs **without cancelling the previous push's runs**. Across the large `js_of_ocaml` (~15 jobs) and `wasm_of_ocaml` (~12 jobs) matrices, a few rapid pushes leave dozens of stale jobs draining the shared runner pool — the CI contention.

## Change

Add the same concurrency group to every workflow that lacked one (`doc.yml` already had its own):

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

- Groups by workflow + PR source branch (falls back to `github.ref`).
- `cancel-in-progress` is gated to `pull_request` events, so:
  - superseded **PR** runs get cancelled on the next push,
  - pushes to **master** and the weekly scheduled **cache-priming** runs are never cancelled.

Files touched: `changelog.yml`, `js_of_ocaml.yml`, `js_parser.yml`, `lint.yml`, `quickjs.yml`, `wasm_of_ocaml.yml`, `wax.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)