### PR TITLE
Review-driven fixes and cleanups in lib/js_of_ocaml

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -118,6 +118,9 @@
 * Lib: `EventSource`'s `onopen`/`onerror` handlers now receive a plain
   `Dom.event` instead of a `messageEvent`; these events carry no
   `data`/`origin`/`lastEventId` (only `onmessage` does) (#2350)
+* Lib: `CSS.Color.js_t_of_js_string` now rejects malformed colors with
+  empty channels such as `"rgb(,,)"` and `"rgba(1,2,3,)"`, which were
+  previously accepted (#2350)
 * Runtime/wasm: `Str.replace`/`Str.global_replace` raise `Failure` on a
   backreference to a group one past the last (e.g. `"\1"` against a
   group-less regexp) instead of trapping with an out-of-bounds access;

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -51,6 +51,8 @@
   `Dom_html`/`Lwt_js_events` handlers can be attached to them (#519), and fix
   the `prop`/`readonly_prop` split (e.g. writable `SVGPoint`/`SVGMatrix`
   coordinates).
+* Lib: add `Console` bindings for `table`, `count`, `countReset` and
+  `timeLog` (#2350)
 * Lib: remove dead legacy-browser code from the DOM bindings: the
   IE `attachEvent`/`detachEvent` fallback in
   `Dom.addEventListenerWithOptions`, the IE `createElement` HTML-string

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -112,6 +112,9 @@
 * Lib: `CSS.Angle.ml` now parses integer-valued angles such as `"45deg"`;
   the parser previously required a decimal point and raised
   `Invalid_argument` otherwise (#2350)
+* Lib: fix the return type of `IntersectionObserver`'s `takeRecords`
+  method, which was missing a `Js.t` wrapper around the result array
+  (#2350)
 * Runtime/wasm: `Str.replace`/`Str.global_replace` raise `Failure` on a
   backreference to a group one past the last (e.g. `"\1"` against a
   group-less regexp) instead of trapping with an out-of-bounds access;

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -127,6 +127,9 @@
 * Lib: `Dom.attr`'s `ownerElement` is now typed `element t opt
   readonly_prop` (per spec it is read-only and null for a detached
   attribute) (#2350)
+* Lib: `Regexp.replace_first` now preserves all flags of the regexp
+  except `g` (it previously kept only `i`/`m`, silently dropping `u`,
+  `s`, `y`); a `flags` accessor was added to `Js.regExp` (#2350)
 * Runtime/wasm: `Str.replace`/`Str.global_replace` raise `Failure` on a
   backreference to a group one past the last (e.g. `"\1"` against a
   group-less regexp) instead of trapping with an out-of-bounds access;

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -51,6 +51,16 @@
   `Dom_html`/`Lwt_js_events` handlers can be attached to them (#519), and fix
   the `prop`/`readonly_prop` split (e.g. writable `SVGPoint`/`SVGMatrix`
   coordinates).
+* Lib: remove dead legacy-browser code from the DOM bindings: the
+  IE `attachEvent`/`detachEvent` fallback in
+  `Dom.addEventListenerWithOptions`, the IE `createElement` HTML-string
+  hack, the `cancelBubble` fallback in `Dom_html.stopPropagation`, and
+  the prefixed `requestAnimationFrame` probes. Removes the obsolete
+  Gecko `MouseScrollEvent`/`_DOMMouseScroll` bindings (breaking: drops
+  the `mouseScrollEvent` type, the `MouseScrollEvent` `taggedEvent`
+  variant, `Dom_html.CoerceTo.mouseScrollEvent` and
+  `Dom_html.Event._DOMMouseScroll`). `File.filename` no longer consults
+  the nonstandard Firefox 3.x `fileName` property. (#2350)
 
 ## Bug fixes
 * Runtime/wasm: `caml_seek_in` validates the seek destination for

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -109,6 +109,9 @@
   (#2329)
 * Runtime/wasm: `caml_unregister_named_value` can remove entries that are
   not the head of their hash bucket (#2331)
+* Lib: `CSS.Angle.ml` now parses integer-valued angles such as `"45deg"`;
+  the parser previously required a decimal point and raised
+  `Invalid_argument` otherwise (#2350)
 * Runtime/wasm: `Str.replace`/`Str.global_replace` raise `Failure` on a
   backreference to a group one past the last (e.g. `"\1"` against a
   group-less regexp) instead of trapping with an out-of-bounds access;

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -124,6 +124,9 @@
 * Lib: `Intl.Collator`'s `compare` method now returns a `Js.number_t`
   instead of an `int`, faithfully reflecting that it returns a JS number
   (use `Js.float_of_number` to inspect the sign) (#2350)
+* Lib: `Dom.attr`'s `ownerElement` is now typed `element t opt
+  readonly_prop` (per spec it is read-only and null for a detached
+  attribute) (#2350)
 * Runtime/wasm: `Str.replace`/`Str.global_replace` raise `Failure` on a
   backreference to a group one past the last (e.g. `"\1"` against a
   group-less regexp) instead of trapping with an out-of-bounds access;

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -121,6 +121,9 @@
 * Lib: `CSS.Color.js_t_of_js_string` now rejects malformed colors with
   empty channels such as `"rgb(,,)"` and `"rgba(1,2,3,)"`, which were
   previously accepted (#2350)
+* Lib: `Intl.Collator`'s `compare` method now returns a `Js.number_t`
+  instead of an `int`, faithfully reflecting that it returns a JS number
+  (use `Js.float_of_number` to inspect the sign) (#2350)
 * Runtime/wasm: `Str.replace`/`Str.global_replace` raise `Failure` on a
   backreference to a group one past the last (e.g. `"\1"` against a
   group-less regexp) instead of trapping with an out-of-bounds access;

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -115,6 +115,9 @@
 * Lib: fix the return type of `IntersectionObserver`'s `takeRecords`
   method, which was missing a `Js.t` wrapper around the result array
   (#2350)
+* Lib: `EventSource`'s `onopen`/`onerror` handlers now receive a plain
+  `Dom.event` instead of a `messageEvent`; these events carry no
+  `data`/`origin`/`lastEventId` (only `onmessage` does) (#2350)
 * Runtime/wasm: `Str.replace`/`Str.global_replace` raise `Failure` on a
   backreference to a group one past the last (e.g. `"\1"` against a
   group-less regexp) instead of trapping with an out-of-bounds access;

--- a/lib/js_of_ocaml/cSS.ml
+++ b/lib/js_of_ocaml/cSS.ml
@@ -675,25 +675,32 @@ module Color = struct
   (* TODO? be more restrictive, clip values into standard range *)
   let js_t_of_js_string s =
     let rgb_re =
-      new%js Js.regExp (Js.bytestring "^rgb\\(\\s*\\d*,\\s*\\d*,\\s*\\d*\\)$")
+      new%js Js.regExp (Js.bytestring "^rgb\\(\\s*\\d+,\\s*\\d+,\\s*\\d+\\)$")
     in
     let rgb_pct_re =
-      new%js Js.regExp (Js.bytestring "^rgb\\(\\s*\\d*%,\\s*\\d*%,\\s*\\d*%\\)$")
+      new%js Js.regExp (Js.bytestring "^rgb\\(\\s*\\d+%,\\s*\\d+%,\\s*\\d+%\\)$")
     in
     let rgba_re =
       new%js Js.regExp
-        (Js.bytestring "^rgba\\(\\s*\\d*,\\s*\\d*,\\s*\\d*,\\d*\\.?\\d*\\)$")
+        (Js.bytestring "^rgba\\(\\s*\\d+,\\s*\\d+,\\s*\\d+,\\d*\\.?\\d+\\)$")
     in
     let rgba_pct_re =
       new%js Js.regExp
-        (Js.bytestring "^rgba\\(\\s*\\d*%,\\s*\\d*%,\\s*\\d*%,\\d*\\.?\\d*\\)$")
+        (Js.bytestring "^rgba\\(\\s*\\d+%,\\s*\\d+%,\\s*\\d+%,\\d*\\.?\\d+\\)$")
     in
     let hsl_re =
-      new%js Js.regExp (Js.bytestring "^hsl\\(\\s*\\d*,\\s*\\d*%,\\s*\\d*%\\)$")
+      new%js Js.regExp (Js.bytestring "^hsl\\(\\s*\\d+,\\s*\\d+%,\\s*\\d+%\\)$")
     in
     let hsla_re =
       new%js Js.regExp
-        (Js.bytestring "^hsla\\(\\s*\\d*,\\s*\\d*%,\\s*\\d*%,\\d*\\.?\\d*\\)$")
+        (Js.bytestring "^hsla\\(\\s*\\d+,\\s*\\d+%,\\s*\\d+%,\\d*\\.?\\d+\\)$")
+    in
+    (* [s] is a valid color if it matches one of the functional notations
+       above or is a known color name ([name_of_string] raises otherwise). *)
+    let is_color_name () =
+      match name_of_string (Js.to_string s) with
+      | _ -> true
+      | exception _ -> false
     in
     if
       Js.to_bool (rgb_re##test s)
@@ -702,11 +709,9 @@ module Color = struct
       || Js.to_bool (rgba_pct_re##test s)
       || Js.to_bool (hsl_re##test s)
       || Js.to_bool (hsla_re##test s)
+      || is_color_name ()
     then s
-    else
-      match name_of_string (Js.to_string s) with
-      | _ -> s
-      | exception _ -> raise (Invalid_argument (Js.to_string s ^ " is not a valid color"))
+    else raise (Invalid_argument (Js.to_string s ^ " is not a valid color"))
 
   let js c = Js.string (string_of_t c)
 

--- a/lib/js_of_ocaml/cSS.ml
+++ b/lib/js_of_ocaml/cSS.ml
@@ -900,8 +900,8 @@ module Angle = struct
 
   let ml j =
     let s = Js.to_string j in
-    let re = Regexp.regexp "^(\\d*(?:\\.\\d*))(deg|grad|rad|turns)$" in
-    let fail () = raise (Invalid_argument (s ^ " is not a valid length")) in
+    let re = Regexp.regexp "^(\\d*(?:\\.\\d*)?)(deg|grad|rad|turns)$" in
+    let fail () = raise (Invalid_argument (s ^ " is not a valid angle")) in
     match Regexp.string_match re s 0 with
     | None -> fail ()
     | Some r -> (
@@ -911,7 +911,7 @@ module Angle = struct
           | Some f -> (
               try float_of_string f
               with Invalid_argument s ->
-                raise (Invalid_argument ("length conversion error: " ^ s)))
+                raise (Invalid_argument ("angle conversion error: " ^ s)))
         in
         match Regexp.matched_group r 2 with
         | Some "deg" -> Deg f

--- a/lib/js_of_ocaml/console.ml
+++ b/lib/js_of_ocaml/console.ml
@@ -118,7 +118,19 @@ class type console = object
 
   method groupEnd : unit meth
 
+  method table : _ -> unit meth
+
+  method count : unit meth
+
+  method count_ : js_string t -> unit meth
+
+  method countReset : unit meth
+
+  method countReset_ : js_string t -> unit meth
+
   method time : js_string t -> unit meth
+
+  method timeLog : js_string t -> unit meth
 
   method timeEnd : js_string t -> unit meth
 end

--- a/lib/js_of_ocaml/console.mli
+++ b/lib/js_of_ocaml/console.mli
@@ -122,7 +122,19 @@ class type console = object
 
   method groupEnd : unit meth
 
+  method table : _ -> unit meth
+
+  method count : unit meth
+
+  method count_ : js_string t -> unit meth
+
+  method countReset : unit meth
+
+  method countReset_ : js_string t -> unit meth
+
   method time : js_string t -> unit meth
+
+  method timeLog : js_string t -> unit meth
 
   method timeEnd : js_string t -> unit meth
 end

--- a/lib/js_of_ocaml/dom.ml
+++ b/lib/js_of_ocaml/dom.ml
@@ -504,24 +504,17 @@ class type event_listener_options = object
 end
 
 let addEventListenerWithOptions (e : < .. > t) typ ?capture ?once ?passive h =
-  if not (Js.Optdef.test (Js.Unsafe.coerce e)##.addEventListener)
-  then
-    let ev = (Js.string "on")##concat typ in
-    let callback e = Js.Unsafe.call (h, e, [||]) in
-    let () = (Js.Unsafe.coerce e)##attachEvent ev callback in
-    fun () -> (Js.Unsafe.coerce e)##detachEvent ev callback
-  else
-    let opts : event_listener_options t = Js.Unsafe.obj [||] in
-    let iter t f =
-      match t with
-      | None -> ()
-      | Some b -> f b
-    in
-    iter capture (fun b -> opts##.capture := b);
-    iter once (fun b -> opts##.once := b);
-    iter passive (fun b -> opts##.passive := b);
-    let () = (Js.Unsafe.coerce e)##addEventListener typ h opts in
-    fun () -> (Js.Unsafe.coerce e)##removeEventListener typ h opts
+  let opts : event_listener_options t = Js.Unsafe.obj [||] in
+  let iter t f =
+    match t with
+    | None -> ()
+    | Some b -> f b
+  in
+  iter capture (fun b -> opts##.capture := b);
+  iter once (fun b -> opts##.once := b);
+  iter passive (fun b -> opts##.passive := b);
+  let () = (Js.Unsafe.coerce e)##addEventListener typ h opts in
+  fun () -> (Js.Unsafe.coerce e)##removeEventListener typ h opts
 
 let addEventListener (e : < .. > t) typ h capt =
   addEventListenerWithOptions e typ ~capture:capt h

--- a/lib/js_of_ocaml/dom.ml
+++ b/lib/js_of_ocaml/dom.ml
@@ -151,7 +151,7 @@ and attr = object
 
   method value : js_string t prop
 
-  method ownerElement : element t prop
+  method ownerElement : element t opt readonly_prop
 end
 
 (** Specification of [NamedNodeMap] objects. *)

--- a/lib/js_of_ocaml/dom.mli
+++ b/lib/js_of_ocaml/dom.mli
@@ -151,7 +151,7 @@ and attr = object
 
   method value : js_string t prop
 
-  method ownerElement : element t prop
+  method ownerElement : element t opt readonly_prop
 end
 
 (** Specification of [NamedNodeMap] objects. *)
@@ -328,8 +328,8 @@ end
 
 val insertBefore : #node t -> #node t -> #node t opt -> unit
 (** [insertBefore p n c] inserts node [n] as child of node [p],
-      just before node [c], or as last child if [p] is empty.
-      The expression [insertBefore n c p] behave the same as
+      just before node [c], or as last child if [c] is null.
+      The expression [insertBefore p n c] behave the same as
       [p##insertBefore n c] but avoid the need of coercing the
       different objects to [node t]. *)
 

--- a/lib/js_of_ocaml/dom_html.ml
+++ b/lib/js_of_ocaml/dom_html.ml
@@ -21,8 +21,6 @@
 open Js
 open! Import
 
-external html_escape : js_string t -> js_string t = "caml_js_html_escape"
-
 external html_entities : js_string t -> js_string t opt = "caml_js_html_entities"
 
 let decode_html_entities s =
@@ -696,19 +694,6 @@ and wheelEvent = object
 end
 
 and mousewheelEvent = wheelEvent
-
-and mouseScrollEvent = object
-  (* Deprecated *)
-  inherit mouseEvent
-
-  method detail : int readonly_prop
-
-  method axis : int optdef readonly_prop
-
-  method _HORIZONTAL_AXIS : int optdef readonly_prop
-
-  method _VERTICAL_AXIS : int optdef readonly_prop
-end
 
 and touchEvent = object
   inherit event
@@ -1520,8 +1505,6 @@ module Event = struct
   let mousewheel = Dom.Event.make "mousewheel"
 
   let wheel = Dom.Event.make "wheel"
-
-  let _DOMMouseScroll = Dom.Event.make "DOMMouseScroll"
 
   let touchstart = Dom.Event.make "touchstart"
 
@@ -3767,41 +3750,11 @@ let createElement (doc : document t) name = doc##createElement (Js.string name)
 
 let unsafeCreateElement doc name = Js.Unsafe.coerce (createElement doc name)
 
-let createElementSyntax = ref `Unknown
-
-let rec unsafeCreateElementEx ?_type ?name doc elt =
-  if Poly.(_type = None) && Poly.(name = None)
-  then Js.Unsafe.coerce (createElement doc elt)
-  else
-    match !createElementSyntax with
-    | `Standard ->
-        let res = Js.Unsafe.coerce (createElement doc elt) in
-        opt_iter _type (fun t -> res##._type := t);
-        opt_iter name (fun n -> res##.name := n);
-        res
-    | `Extended ->
-        let a = new%js Js.array_empty in
-        ignore (a##push_2 (Js.string "<") (Js.string elt));
-        opt_iter _type (fun t ->
-            ignore (a##push_3 (Js.string " type=\"") (html_escape t) (Js.string "\"")));
-        opt_iter name (fun n ->
-            ignore (a##push_3 (Js.string " name=\"") (html_escape n) (Js.string "\"")));
-        ignore (a##push (Js.string ">"));
-        Js.Unsafe.coerce (doc##createElement (a##join (Js.string "")))
-    | `Unknown ->
-        createElementSyntax :=
-          if
-            try
-              let el : inputElement Js.t =
-                Js.Unsafe.coerce
-                  (document##createElement (Js.string "<input name=\"x\">"))
-              in
-              Js.equals el##.tagName##toLowerCase (Js.string "input")
-              && Js.equals el##.name (Js.string "x")
-            with _ -> false
-          then `Extended
-          else `Standard;
-        unsafeCreateElementEx ?_type ?name doc elt
+let unsafeCreateElementEx ?_type ?name doc elt =
+  let res = Js.Unsafe.coerce (createElement doc elt) in
+  opt_iter _type (fun t -> res##._type := t);
+  opt_iter name (fun n -> res##.name := n);
+  res
 
 let createHtml doc : htmlElement t = unsafeCreateElement doc "html"
 
@@ -4145,8 +4098,6 @@ module CoerceTo = struct
   let keyboardEvent ev = unsafeCoerceEvent Js.Unsafe.global##._KeyboardEvent ev
 
   let wheelEvent ev = unsafeCoerceEvent Js.Unsafe.global##._WheelEvent ev
-
-  let mouseScrollEvent ev = unsafeCoerceEvent Js.Unsafe.global##._MouseScrollEvent ev
 
   let popStateEvent ev = unsafeCoerceEvent Js.Unsafe.global##._PopStateEvent ev
 
@@ -4887,7 +4838,6 @@ type taggedEvent =
   | KeyboardEvent of keyboardEvent t
   | MessageEvent of messageEvent t
   | MousewheelEvent of mousewheelEvent t
-  | MouseScrollEvent of mouseScrollEvent t
   | PopStateEvent of popStateEvent t
   | OtherEvent of event t
 
@@ -4902,17 +4852,13 @@ let taggedEvent (ev : #event Js.t) =
             (CoerceTo.wheelEvent ev)
             (fun () ->
               Js.Opt.case
-                (CoerceTo.mouseScrollEvent ev)
+                (CoerceTo.popStateEvent ev)
                 (fun () ->
                   Js.Opt.case
-                    (CoerceTo.popStateEvent ev)
-                    (fun () ->
-                      Js.Opt.case
-                        (CoerceTo.messageEvent ev)
-                        (fun () -> OtherEvent (ev :> event t))
-                        (fun ev -> MessageEvent ev))
-                    (fun ev -> PopStateEvent ev))
-                (fun ev -> MouseScrollEvent ev))
+                    (CoerceTo.messageEvent ev)
+                    (fun () -> OtherEvent (ev :> event t))
+                    (fun ev -> MessageEvent ev))
+                (fun ev -> PopStateEvent ev))
             (fun ev -> MousewheelEvent ev))
         (fun ev -> KeyboardEvent ev))
     (fun ev -> MouseEvent ev)
@@ -4921,10 +4867,7 @@ let opt_taggedEvent ev = Opt.case ev (fun () -> None) (fun ev -> Some (taggedEve
 
 let stopPropagation ev =
   let e = Js.Unsafe.coerce ev in
-  Optdef.case
-    e##.stopPropagation
-    (fun () -> e##.cancelBubble := Js._true)
-    (fun _ -> e##_stopPropagation)
+  e##_stopPropagation
 
 module DomStringMap = struct
   let get (m : domStringMap t) (k : js_string t) : js_string t optdef = Js.Unsafe.get m k
@@ -5042,18 +4985,10 @@ let makeOptionalEffectTiming
 let _requestAnimationFrame : (unit -> unit) Js.callback -> unit =
   Js.Unsafe.pure_expr (fun _ ->
       let w = Js.Unsafe.coerce window in
-      let l =
-        [ w##.requestAnimationFrame
-        ; w##.mozRequestAnimationFrame
-        ; w##.webkitRequestAnimationFrame
-        ; w##.oRequestAnimationFrame
-        ; w##.msRequestAnimationFrame
-        ]
-      in
-      try
-        let req = List.find (fun c -> Js.Optdef.test c) l in
-        fun callback -> Js.Unsafe.fun_call req [| Js.Unsafe.inject callback |]
-      with Not_found ->
+      let req = w##.requestAnimationFrame in
+      if Js.Optdef.test req
+      then fun callback -> Js.Unsafe.fun_call req [| Js.Unsafe.inject callback |]
+      else
         let now () = Js.to_float (new%js Js.date_now)##getTime in
         let last = ref (now ()) in
         fun callback ->

--- a/lib/js_of_ocaml/dom_html.mli
+++ b/lib/js_of_ocaml/dom_html.mli
@@ -710,19 +710,6 @@ end
 
 and mousewheelEvent = (* Deprecated *) wheelEvent
 
-and mouseScrollEvent = object
-  (* Deprecated *)
-  inherit mouseEvent
-
-  method detail : int readonly_prop
-
-  method axis : int optdef readonly_prop
-
-  method _HORIZONTAL_AXIS : int optdef readonly_prop
-
-  method _VERTICAL_AXIS : int optdef readonly_prop
-end
-
 and touchEvent = object
   inherit event
 
@@ -3661,8 +3648,6 @@ module Event : sig
 
   val mousewheel : mousewheelEvent t typ
 
-  val _DOMMouseScroll : mouseScrollEvent t typ
-
   val wheel : wheelEvent t typ
 
   val touchstart : touchEvent t typ
@@ -4355,7 +4340,6 @@ type taggedEvent =
   | KeyboardEvent of keyboardEvent t
   | MessageEvent of messageEvent t
   | MousewheelEvent of mousewheelEvent t
-  | MouseScrollEvent of mouseScrollEvent t
   | PopStateEvent of popStateEvent t
   | OtherEvent of event t
 
@@ -4576,8 +4560,6 @@ module CoerceTo : sig
   val keyboardEvent : #event t -> keyboardEvent t opt
 
   val wheelEvent : #event t -> mousewheelEvent t opt
-
-  val mouseScrollEvent : #event t -> mouseScrollEvent t opt
 
   val popStateEvent : #event t -> popStateEvent t opt
 

--- a/lib/js_of_ocaml/eventSource.ml
+++ b/lib/js_of_ocaml/eventSource.ml
@@ -35,7 +35,6 @@ class type ['a] messageEvent = object
   method origin : js_string t readonly_prop
 
   method lastEventId : js_string t readonly_prop
-  (* method source : unit *)
 end
 
 class type eventSource = object ('self)

--- a/lib/js_of_ocaml/eventSource.ml
+++ b/lib/js_of_ocaml/eventSource.ml
@@ -47,11 +47,11 @@ class type eventSource = object ('self)
 
   method close : unit meth
 
-  method onopen : ('self t, 'self messageEvent t) event_listener writeonly_prop
+  method onopen : ('self t, 'self Dom.event t) event_listener writeonly_prop
 
   method onmessage : ('self t, 'self messageEvent t) event_listener writeonly_prop
 
-  method onerror : ('self t, 'self messageEvent t) event_listener writeonly_prop
+  method onerror : ('self t, 'self Dom.event t) event_listener writeonly_prop
 end
 
 class type options = object

--- a/lib/js_of_ocaml/eventSource.mli
+++ b/lib/js_of_ocaml/eventSource.mli
@@ -35,7 +35,6 @@ class type ['a] messageEvent = object
   method origin : js_string t readonly_prop
 
   method lastEventId : js_string t readonly_prop
-  (* method source : unit *)
 end
 
 class type eventSource = object ('self)

--- a/lib/js_of_ocaml/eventSource.mli
+++ b/lib/js_of_ocaml/eventSource.mli
@@ -47,11 +47,11 @@ class type eventSource = object ('self)
 
   method close : unit meth
 
-  method onopen : ('self t, 'self messageEvent t) event_listener writeonly_prop
+  method onopen : ('self t, 'self Dom.event t) event_listener writeonly_prop
 
   method onmessage : ('self t, 'self messageEvent t) event_listener writeonly_prop
 
-  method onerror : ('self t, 'self messageEvent t) event_listener writeonly_prop
+  method onerror : ('self t, 'self Dom.event t) event_listener writeonly_prop
 end
 
 class type options = object

--- a/lib/js_of_ocaml/fetch.ml
+++ b/lib/js_of_ocaml/fetch.ml
@@ -37,9 +37,7 @@ end
 let headers : headers Js.t Js.constr = Js.Unsafe.global##._Headers
 
 let headers_of_list (l : (string * string) list) : headers Js.t =
-  let h : headers Js.t =
-    Js.Unsafe.new_obj (Js.Unsafe.global##._Headers : _ Js.constr) [||]
-  in
+  let h = new%js headers in
   List.iter (fun (k, v) -> h##append (Js.string k) (Js.string v)) l;
   h
 

--- a/lib/js_of_ocaml/file.ml
+++ b/lib/js_of_ocaml/file.ml
@@ -94,21 +94,7 @@ class type file = object
   (** @deprecated Use [lastModified] instead. *)
 end
 
-(* in firefox 3.0-3.5 file.name is not available, we use the nonstandard fileName instead *)
-class type file_name_only = object
-  method name : js_string t optdef readonly_prop
-
-  method fileName : js_string t optdef readonly_prop
-end
-
-let filename file =
-  let file : file_name_only t = Js.Unsafe.coerce file in
-  match Optdef.to_option file##.name with
-  | None -> (
-      match Optdef.to_option file##.fileName with
-      | None -> failwith "can't retrieve file name: not implemented"
-      | Some name -> name)
-  | Some name -> name
+let filename file = file##.name
 
 type file_any = < > t
 

--- a/lib/js_of_ocaml/file.ml
+++ b/lib/js_of_ocaml/file.ml
@@ -37,16 +37,9 @@ let blob_constr = Unsafe.global##._Blob
 type 'a make_blob =
   ?contentType:string -> ?endings:[ `Transparent | `Native ] -> 'a -> blob t
 
-let rec filter_map f = function
-  | [] -> []
-  | v :: q -> (
-      match f v with
-      | None -> filter_map f q
-      | Some v' -> v' :: filter_map f q)
-
 let make_blob_options contentType endings =
   let options =
-    filter_map
+    List.filter_map
       (fun (name, v) ->
         match v with
         | None -> None

--- a/lib/js_of_ocaml/file.mli
+++ b/lib/js_of_ocaml/file.mli
@@ -130,18 +130,6 @@ class type fileReader = object ('self)
 
   method error : fileError t readonly_prop
 
-  method onloadstart : ('self t, 'self progressEvent t) event_listener writeonly_prop
-
-  method onprogress : ('self t, 'self progressEvent t) event_listener writeonly_prop
-
-  method onload : ('self t, 'self progressEvent t) event_listener writeonly_prop
-
-  method onabort : ('self t, 'self progressEvent t) event_listener writeonly_prop
-
-  method onerror : ('self t, 'self progressEvent t) event_listener writeonly_prop
-
-  method onloadend : ('self t, 'self progressEvent t) event_listener writeonly_prop
-
   inherit progressEventTarget
 end
 

--- a/lib/js_of_ocaml/file.mli
+++ b/lib/js_of_ocaml/file.mli
@@ -150,7 +150,7 @@ module ReaderEvent : sig
 end
 
 val filename : file t -> js_string t
-(** [filename] handles old firefox without name property *)
+(** [filename file] is the name of [file] (equivalent to [file##.name]). *)
 
 val fileReader : fileReader t constr
 

--- a/lib/js_of_ocaml/form.ml
+++ b/lib/js_of_ocaml/form.ml
@@ -42,13 +42,6 @@ type form_contents =
   | `FormData of formData t
   ]
 
-let rec filter_map f = function
-  | [] -> []
-  | v :: q -> (
-      match f v with
-      | None -> filter_map f q
-      | Some v' -> v' :: filter_map f q)
-
 class type submittableElement = object
   method disabled : bool t prop
 
@@ -76,7 +69,7 @@ let get_select_val (elt : selectElement t) =
       let options =
         Array.init elt##.options##.length (fun i -> Opt.to_option (elt##.options##item i))
       in
-      filter_map
+      List.filter_map
         (function
           | None -> None
           | Some e ->
@@ -111,7 +104,7 @@ let get_input_val ?(get = false) (elt : inputElement t) =
                 | None -> []
                 | Some file -> [ name, `File file ]
               else
-                filter_map
+                List.filter_map
                   (fun f ->
                     match Opt.to_option f with
                     | None -> None

--- a/lib/js_of_ocaml/form.mli
+++ b/lib/js_of_ocaml/form.mli
@@ -31,9 +31,6 @@ val formData : formData t constr
 
 val formData_form : (Dom_html.formElement t -> formData t) constr
 
-(* be careful, this might not be implemented in all browser.
-   To check availability, use [Js.Optdef.to_option (Js.def formData)] *)
-
 type form_elt =
   [ `String of js_string t
   | `File of File.file t

--- a/lib/js_of_ocaml/geolocation.ml
+++ b/lib/js_of_ocaml/geolocation.ml
@@ -84,8 +84,6 @@ let empty_position_options () = Js.Unsafe.obj [||]
 
 let geolocation =
   let x = Js.Unsafe.global##.navigator in
-  if Js.Optdef.test x then x##.geolocation else x
-
-(* undefined *)
+  if Js.Optdef.test x then x##.geolocation else x (* undefined *)
 
 let is_supported () = Js.Optdef.test geolocation

--- a/lib/js_of_ocaml/intersectionObserver.ml
+++ b/lib/js_of_ocaml/intersectionObserver.ml
@@ -53,7 +53,7 @@ class type intersectionObserver = object
 
   method disconnect : unit Js.meth
 
-  method takeRecords : intersectionObserverEntry Js.t Js.js_array Js.meth
+  method takeRecords : intersectionObserverEntry Js.t Js.js_array Js.t Js.meth
 end
 
 let empty_intersection_observer_options () : intersectionObserverOptions Js.t =

--- a/lib/js_of_ocaml/intersectionObserver.mli
+++ b/lib/js_of_ocaml/intersectionObserver.mli
@@ -59,7 +59,7 @@ class type intersectionObserver = object
 
   method disconnect : unit Js.meth
 
-  method takeRecords : intersectionObserverEntry Js.t Js.js_array Js.meth
+  method takeRecords : intersectionObserverEntry Js.t Js.js_array Js.t Js.meth
 end
 
 val empty_intersection_observer_options : unit -> intersectionObserverOptions Js.t

--- a/lib/js_of_ocaml/intl.ml
+++ b/lib/js_of_ocaml/intl.ml
@@ -100,7 +100,8 @@ module Collator = struct
     end
 
   class type t = object
-    method compare : (Js.js_string Js.t -> Js.js_string Js.t -> int) Js.readonly_prop
+    method compare :
+      (Js.js_string Js.t -> Js.js_string Js.t -> Js.number_t) Js.readonly_prop
 
     method resolvedOptions : unit -> resolved_options Js.t Js.meth
   end

--- a/lib/js_of_ocaml/intl.mli
+++ b/lib/js_of_ocaml/intl.mli
@@ -47,7 +47,7 @@ then (
              let collator =
                new%js Intl.collator_constr (def (array [| lang |])) undefined
              in
-             Js.float (float_of_int (collator##.compare a b))));
+             collator##.compare a b));
       letters
     in
     let a = jas [| "a"; "z"; "ä" |] in
@@ -72,7 +72,9 @@ then (
 
     let firstAlphabetical locale letter1 letter2 =
       let collator = new%js Intl.collator_constr (def (array [| locale |])) undefined in
-      if collator##.compare letter1 letter2 > 0 then letter1 else letter2
+      if Js.float_of_number (collator##.compare letter1 letter2) > 0.
+      then letter1
+      else letter2
     in
     fc (firstAlphabetical (string "de") (string "z") (string "ä"));
     fc (firstAlphabetical (string "sv") (string "z") (string "ä"));
@@ -82,8 +84,7 @@ then (
       new%js Intl.collator_constr (def (jas [| "de-u-co-phonebk" |])) undefined
     in
     let a =
-      a##sort
-        (wrap_callback (fun v1 v2 -> Js.float (float_of_int (collator##.compare v1 v2))))
+      a##sort (wrap_callback (fun v1 v2 -> collator##.compare v1 v2))
     in
     fc (a##join (string ", "));
 
@@ -94,7 +95,9 @@ then (
     let collator = new%js Intl.collator_constr (def (jas [| "fr" |])) (def options) in
     let s = string "congres" in
     let matches =
-      a##filter (wrap_callback (fun v _ _ -> bool (collator##.compare v s = 0)))
+      a##filter
+        (wrap_callback (fun v _ _ ->
+             bool (Js.float_of_number (collator##.compare v s) = 0.)))
     in
     fc (matches##join (string ", "));
 
@@ -410,7 +413,8 @@ module Collator : sig
   val options : unit -> options Js.t
 
   class type t = object
-    method compare : (Js.js_string Js.t -> Js.js_string Js.t -> int) Js.readonly_prop
+    method compare :
+      (Js.js_string Js.t -> Js.js_string Js.t -> Js.number_t) Js.readonly_prop
 
     method resolvedOptions : unit -> resolved_options Js.t Js.meth
   end

--- a/lib/js_of_ocaml/js.ml
+++ b/lib/js_of_ocaml/js.ml
@@ -348,6 +348,8 @@ module Js = struct
 
     method source : js_string t readonly_prop
 
+    method flags : js_string t readonly_prop
+
     method global : bool t readonly_prop
 
     method ignoreCase : bool t readonly_prop

--- a/lib/js_of_ocaml/js.mli
+++ b/lib/js_of_ocaml/js.mli
@@ -319,6 +319,8 @@ and regExp = object
 
   method source : js_string t readonly_prop
 
+  method flags : js_string t readonly_prop
+
   method global : bool t readonly_prop
 
   method ignoreCase : bool t readonly_prop

--- a/lib/js_of_ocaml/js.mli
+++ b/lib/js_of_ocaml/js.mli
@@ -128,7 +128,7 @@ type 'a writeonly_prop = < set : 'a -> unit > gen_prop
 type 'a prop = < get : 'a ; set : 'a -> unit > gen_prop
 (** Type of read/write properties:
       a Javascript object
-        [<p : t Js.writeonly_prop> Js.t]
+        [<p : t Js.prop> Js.t]
       has a read/write property [p] of type [t]. *)
 
 type 'a optdef_prop = < get : 'a optdef ; set : 'a -> unit > gen_prop
@@ -567,30 +567,30 @@ val date_fromTimeValue : (number_t -> date t) constr
       [Date] object initialized with the time value [t]. *)
 
 val date_month : (int -> int -> date t) constr
-(** Constructor of [Date] objects: [new%js date_fromTimeValue y m]
+(** Constructor of [Date] objects: [new%js date_month y m]
       returns a [Date] object corresponding to year [y] and month [m]. *)
 
 val date_day : (int -> int -> int -> date t) constr
-(** Constructor of [Date] objects: [new%js date_fromTimeValue y m d]
+(** Constructor of [Date] objects: [new%js date_day y m d]
       returns a [Date] object corresponding to year [y], month [m] and
       day [d]. *)
 
 val date_hour : (int -> int -> int -> int -> date t) constr
-(** Constructor of [Date] objects: [new%js date_fromTimeValue y m d h]
+(** Constructor of [Date] objects: [new%js date_hour y m d h]
       returns a [Date] object corresponding to year [y] to hour [h]. *)
 
 val date_min : (int -> int -> int -> int -> int -> date t) constr
-(** Constructor of [Date] objects: [new%js date_fromTimeValue y m d h m']
+(** Constructor of [Date] objects: [new%js date_min y m d h m']
       returns a [Date] object corresponding to year [y] to minute [m']. *)
 
 val date_sec : (int -> int -> int -> int -> int -> int -> date t) constr
 (** Constructor of [Date] objects:
-      [new%js date_fromTimeValue y m d h m' s]
+      [new%js date_sec y m d h m' s]
       returns a [Date] object corresponding to year [y] to second [s]. *)
 
 val date_ms : (int -> int -> int -> int -> int -> int -> int -> date t) constr
 (** Constructor of [Date] objects:
-      [new%js date_fromTimeValue y m d h m' s ms]
+      [new%js date_ms y m d h m' s ms]
       returns a [Date] object corresponding to year [y]
       to millisecond [ms]. *)
 
@@ -776,8 +776,12 @@ val unescape : js_string t -> js_string t
 val isNaN : 'a -> bool
 
 val parseInt : js_string t -> int
+(** Parse a string as an integer. Raises [Failure "parseInt"] if the
+      string does not start with a number. *)
 
 val parseFloat : js_string t -> number_t
+(** Parse a string as a floating-point number. Raises
+      [Failure "parseFloat"] if the string does not start with a number. *)
 
 (** {2 Conversion functions between Javascript and OCaml types} *)
 
@@ -823,14 +827,14 @@ external float_of_number : number t -> float = "caml_js_to_float"
 (** Conversion of Javascript number objects to OCaml floats. *)
 
 external int32 : int32 -> number_t = "caml_js_from_int32"
-(** Conversion of OCaml floats to Javascript numbers. *)
+(** Conversion of OCaml 32-bit integers to Javascript numbers. *)
 
 external to_int32 : number_t -> int32 = "caml_js_to_int32"
 (** Conversion of Javascript numbers to OCaml 32-bits. The given
     floating-point number is truncated to an integer. *)
 
 external nativeint : nativeint -> number_t = "caml_js_from_nativeint"
-(** Conversion of OCaml 32-bits integers to Javascript numbers. *)
+(** Conversion of OCaml native integers to Javascript numbers. *)
 
 external to_nativeint : number_t -> nativeint = "caml_js_to_nativeint"
 (** Conversion of Javascript numbers to OCaml native integers. The

--- a/lib/js_of_ocaml/js_of_ocaml_stubs.c
+++ b/lib/js_of_ocaml/js_of_ocaml_stubs.c
@@ -12,10 +12,6 @@ void caml_js_html_entities () {
   caml_fatal_error("Unimplemented Javascript primitive caml_js_html_entities!");
 }
 
-void caml_js_html_escape () {
-  caml_fatal_error("Unimplemented Javascript primitive caml_js_html_escape!");
-}
-
 void caml_xmlhttprequest_create () {
   caml_fatal_error("Unimplemented Javascript primitive caml_xmlhttprequest_create!");
 }

--- a/lib/js_of_ocaml/json.mli
+++ b/lib/js_of_ocaml/json.mli
@@ -24,7 +24,11 @@ val output : 'a -> Js.js_string Js.t
 
 val unsafe_input : Js.js_string Js.t -> 'a
 (** Unmarshal a string in JSON format as an OCaml value (unsafe but
-    fast !). *)
+    fast !).
+
+    Raises [Failure] under the wasm_of_ocaml backend, where the encoding
+    of OCaml values is ambiguous (integers and floats both map to
+    numbers). *)
 
 (**/**)
 

--- a/lib/js_of_ocaml/regexp.ml
+++ b/lib/js_of_ocaml/regexp.ml
@@ -62,14 +62,16 @@ let global_replace r s s_by =
   Js.to_bytestring (Js.bytestring s)##(replace r (quote_repl s_by))
 
 let replace_first r s s_by =
+  (* Reuse all the flags of [r] except [g], so that only the first match is
+     replaced; dropping [g] this way preserves [i], [m], [u], [s], [y], ... *)
   let flags =
-    match Js.to_bool r##.ignoreCase, Js.to_bool r##.multiline with
-    | false, false -> Js.string ""
-    | false, true -> Js.string "m"
-    | true, false -> Js.string "i"
-    | true, true -> Js.string "mi"
+    let b = Buffer.create 8 in
+    String.iter
+      (fun c -> if not (Char.equal c 'g') then Buffer.add_char b c)
+      (Js.to_string r##.flags);
+    Buffer.contents b
   in
-  let r' = new%js Js.regExp_withFlags r##.source flags in
+  let r' = new%js Js.regExp_withFlags r##.source (Js.string flags) in
   Js.to_bytestring (Js.bytestring s)##(replace r' (quote_repl s_by))
 
 let list_of_js_array a =

--- a/lib/js_of_ocaml/regexp.mli
+++ b/lib/js_of_ocaml/regexp.mli
@@ -77,7 +77,8 @@ val matched_string : result -> string
 
 val matched_group : result -> int -> string option
 (** [matched_group r i] is the [i]th group matched. Groups in matches are
-  * obtained with parentheses. Groups are 1-based. *)
+  * obtained with parentheses and are 1-based; index [0] returns the whole
+  * matched substring (as [matched_string] does). *)
 
 val global_replace : regexp -> string -> string -> string
 (** [global_replace r s by] replaces all of the matches of [r] in [s] by [by]. *)

--- a/lib/js_of_ocaml/url.ml
+++ b/lib/js_of_ocaml/url.ml
@@ -81,9 +81,7 @@ type file_url =
 type url =
   | Http of http_url
   | Https of http_url
-  | File of file_url
-      (** The type for urls. [File] is for local files and [Exotic s] is for
-    unknown/unsupported protocols. *)
+  | File of file_url  (** The type for urls. [File] is for local files. *)
 
 exception Not_an_http_protocol
 

--- a/lib/js_of_ocaml/worker.ml
+++ b/lib/js_of_ocaml/worker.ml
@@ -72,5 +72,5 @@ let set_onmessage handler =
 
 let post_message msg =
   if not (Js.Optdef.test Unsafe.global##.postMessage)
-  then invalid_arg "Worker.onmessage is undefined";
+  then invalid_arg "Worker.postMessage is undefined";
   Unsafe.global##postMessage msg

--- a/lib/lwt/lwt_js_events.ml
+++ b/lib/lwt/lwt_js_events.ml
@@ -339,10 +339,6 @@ let mousewheel ?use_capture ?passive target =
                            above. *));
   t
 
-(* let _DOMMouseScroll ?use_capture ?passive target =
-   make_event Dom_html.Event._DOMMouseScroll ?use_capture ?passive target
-*)
-
 let wheel ?use_capture ?passive target =
   make_event Dom_html.Event.wheel ?use_capture ?passive target
 

--- a/lib/tests/test_css_angle.ml
+++ b/lib/tests/test_css_angle.ml
@@ -60,9 +60,9 @@ let%expect_test "parse angle without decimal point" =
     [ "45deg"; "100grad"; "2turns"; "1rad"; "0.5deg" ];
   [%expect
     {|
-    45deg -> Invalid_argument("45deg is not a valid length")
-    100grad -> Invalid_argument("100grad is not a valid length")
-    2turns -> Invalid_argument("2turns is not a valid length")
-    1rad -> Invalid_argument("1rad is not a valid length")
+    45deg -> 45.000000deg
+    100grad -> 100.000000grad
+    2turns -> 2.000000turns
+    1rad -> 1.000000rad
     0.5deg -> 0.500000deg
     |}]

--- a/lib/tests/test_css_angle.ml
+++ b/lib/tests/test_css_angle.ml
@@ -45,3 +45,24 @@ let%expect_test _ =
       with exn -> print_endline (Printexc.to_string exn))
     a;
   [%expect {||}]
+
+(* [CSS.Angle.js] always formats with a decimal point, so the round-trip test
+   above never exercises parsing an integer-valued angle (e.g. "45deg"), which
+   is the common form found in actual CSS values. [js_t] is private, so coerce
+   a raw string to feed it to [ml] the way a DOM value would. *)
+let%expect_test "parse angle without decimal point" =
+  let as_js_t s : CSS.Angle.js_t = Obj.magic (Js.string s) in
+  List.iter
+    (fun s ->
+      match CSS.Angle.ml (as_js_t s) with
+      | a -> Printf.printf "%s -> %s\n%!" s (CSS.Angle.string_of_t a)
+      | exception exn -> Printf.printf "%s -> %s\n%!" s (Printexc.to_string exn))
+    [ "45deg"; "100grad"; "2turns"; "1rad"; "0.5deg" ];
+  [%expect
+    {|
+    45deg -> Invalid_argument("45deg is not a valid length")
+    100grad -> Invalid_argument("100grad is not a valid length")
+    2turns -> Invalid_argument("2turns is not a valid length")
+    1rad -> Invalid_argument("1rad is not a valid length")
+    0.5deg -> 0.500000deg
+    |}]

--- a/lib/tests/test_css_color.ml
+++ b/lib/tests/test_css_color.ml
@@ -71,8 +71,8 @@ let%expect_test "js_t_of_js_string validation" =
     rgb(10%,3%,60%)        -> ok
     hsl(120,75%,56%)       -> ok
     hotpink                -> ok
-    rgb(,,)                -> ok
+    rgb(,,)                -> rejected
     rgb()                  -> rejected
-    rgba(1,2,3,)           -> ok
+    rgba(1,2,3,)           -> rejected
     notacolor              -> rejected
     |}]

--- a/lib/tests/test_css_color.ml
+++ b/lib/tests/test_css_color.ml
@@ -45,3 +45,34 @@ let%expect_test _ =
       with exn -> print_endline (Printexc.to_string exn))
     cols;
   [%expect {||}]
+
+(* [js_t_of_js_string] validates a string as a CSS color. Empty channels such
+   as "rgb(,,)" must be rejected, not accepted. *)
+let%expect_test "js_t_of_js_string validation" =
+  List.iter
+    (fun s ->
+      match CSS.Color.js_t_of_js_string (Js.string s) with
+      | (_ : CSS.Color.js_t) -> Printf.printf "%-22s -> ok\n%!" s
+      | exception Invalid_argument _ -> Printf.printf "%-22s -> rejected\n%!" s)
+    [ "rgb(120,3,56)"
+    ; "rgba(120,3,56,0.5)"
+    ; "rgb(10%,3%,60%)"
+    ; "hsl(120,75%,56%)"
+    ; "hotpink"
+    ; "rgb(,,)"
+    ; "rgb()"
+    ; "rgba(1,2,3,)"
+    ; "notacolor"
+    ];
+  [%expect
+    {|
+    rgb(120,3,56)          -> ok
+    rgba(120,3,56,0.5)     -> ok
+    rgb(10%,3%,60%)        -> ok
+    hsl(120,75%,56%)       -> ok
+    hotpink                -> ok
+    rgb(,,)                -> ok
+    rgb()                  -> rejected
+    rgba(1,2,3,)           -> ok
+    notacolor              -> rejected
+    |}]

--- a/lib/tests/test_regexp.ml
+++ b/lib/tests/test_regexp.ml
@@ -57,4 +57,4 @@ let%expect_test _ =
 let%expect_test "replace_first preserves non-g flags" =
   let re = Regexp.regexp_with_flag "a.b" "s" in
   Printf.printf "%S\n" (Regexp.replace_first re "a\nb" "X");
-  [%expect {| "a\nb" |}]
+  [%expect {| "X" |}]

--- a/lib/tests/test_regexp.ml
+++ b/lib/tests/test_regexp.ml
@@ -50,3 +50,11 @@ let%expect_test _ =
   | None -> print_endline "Quote 3 3"
   | Some _ -> ());
   [%expect {||}]
+
+(* [replace_first] must keep every flag of the regexp except [g]. Here the
+   [s] (dotAll) flag lets [.] match the newline; dropping it would leave the
+   string unchanged. *)
+let%expect_test "replace_first preserves non-g flags" =
+  let re = Regexp.regexp_with_flag "a.b" "s" in
+  Printf.printf "%S\n" (Regexp.replace_first re "a\nb" "X");
+  [%expect {| "a\nb" |}]


### PR DESCRIPTION
A pass over the bindings in `lib/js_of_ocaml/`, fixing correctness bugs, tightening types, and removing dead legacy-browser code. Each behavioural change has a regression test where one is meaningful (CSS.Angle, CSS.Color, Regexp), committed test-first.

## Bug fixes
- **`CSS.Angle.ml`** — the angle regexp required a decimal point, so integer angles like `"45deg"` raised `Invalid_argument`. Made the fraction optional; also fixed two "length" → "angle" error messages.
- **`IntersectionObserver.takeRecords`** — return type was missing the `Js.t` wrapper around the result array.
- **`EventSource` `onopen`/`onerror`** — now receive a plain `Dom.event` instead of `messageEvent` (those events carry no `data`/`origin`/`lastEventId`; only `onmessage` does).
- **`CSS.Color.js_t_of_js_string`** — rejected nothing useful: `\d*` channels let `"rgb(,,)"`/`"rgba(1,2,3,)"` validate. Tightened to `\d+`, and rewrote the confusing name-validation branch.
- **`Intl.Collator.compare`** — now returns `Js.number_t` instead of `int` (it returns a JS number, not necessarily a small integer).
- **`Dom.attr.ownerElement`** — retyped `element t opt readonly_prop` (read-only and nullable per spec).
- **`Regexp.replace_first`** — preserved only `i`/`m`, silently dropping `u`/`s`/`y`. Now reuses all flags except `g`; added a `flags` accessor to `Js.regExp`.

## Documentation
Doc/comment fixes in `js.mli` (`'a prop`, all `date_*` constructor examples, `int32`/`nativeint` conversions, `parseInt`/`parseFloat` partiality), `url.ml` (stale `Exotic` reference), `json.mli` (`unsafe_input` raises under wasm), `regexp.mli` (`matched_group 0`), `dom.mli` (`insertBefore` arg order), `form.mli` (obsolete FormData caveat), `file.mli` (duplicate `fileReader` methods), `worker.ml` (wrong `post_message` error string).

## Changes / cleanups
- **Remove dead legacy-browser code** from the DOM bindings: IE `attachEvent`/`detachEvent` fallback, the IE `createElement` HTML-string hack, the `cancelBubble` fallback, the prefixed `requestAnimationFrame` probes, and the Firefox 3.x `File.filename` fallback. **Breaking:** removes the obsolete Gecko `MouseScrollEvent`/`_DOMMouseScroll` bindings (the `mouseScrollEvent` type, the `MouseScrollEvent` `taggedEvent` variant, `CoerceTo.mouseScrollEvent`, `Event._DOMMouseScroll`).
- **`Console`** — added `table`, `count`, `countReset`, `timeLog` bindings.
- Small cleanups: `Fetch.headers_of_list` builds via `new%js headers`; `EventSource`/`Geolocation` stray comments removed; `Form`/`File` use `List.filter_map`.

A couple of reviewed items were intentionally left unchanged: `crossorigin` can't take `[@@deprecated]` (OCaml rejects deprecation attributes on object methods — confirmed empirically), and webGL was left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)