### PR TITLE
doc: link Lwt docs internally (ocsigen.org)

### DIFF
--- a/doc/wodoc
+++ b/doc/wodoc
@@ -27,6 +27,7 @@
 ;; ocaml.org; lwt is added once its docs are rebuilt with wodoc (ocsigen/lwt#1109).
 (hosted
   (tyxml        tyxml        subdir)
+  (lwt          lwt          subdir)
   (reactiveData reactiveData root))
 (nav
   (section "Getting Started"


### PR DESCRIPTION
Now that Lwtʼs documentation is built with wodoc and deployed under the standard per-package layout (`/lwt/latest/lwt/…`, `/lwt/latest/lwt_react/…`, see ocsigen/lwt#1109, released as 6.1), add `(lwt lwt subdir)` to the `(hosted …)` table so references to Lwt — and the `lwt_react` / `lwt_ppx` / `lwt_retry` family — are rewritten from ocaml.org to relative links into our own deploy.

This is the final piece of the cross-project documentation links work.