### PR TITLE
Runtime/wasm (WASI): fix out-of-bounds read on empty preopen prefix

### DIFF
--- a/runtime/wasm/fs.wat
+++ b/runtime/wasm/fs.wat
@@ -286,12 +286,15 @@
       (local $i i32) (local $len i32)
       (local.set $len (array.len (local.get $prefix)))
       ;; A preopen prefix may carry a trailing slash (e.g. "--dir=tmp/");
-      ;; ignore it so it still matches "<prefix>/<rest>".
-      (if (i32.and (i32.gt_u (local.get $len) (i32.const 0))
-                   (i32.eq (array.get_u $bytes (local.get $prefix)
-                              (i32.sub (local.get $len) (i32.const 1)))
-                           (i32.const 47))) ;; '/'
-         (then (local.set $len (i32.sub (local.get $len) (i32.const 1)))))
+      ;; ignore it so it still matches "<prefix>/<rest>". The length guard
+      ;; must be an enclosing `if`: `i32.and` evaluates both operands, so
+      ;; folding it in would still read $prefix[$len - 1] when $len is 0.
+      (if (i32.gt_u (local.get $len) (i32.const 0))
+         (then
+            (if (i32.eq (array.get_u $bytes (local.get $prefix)
+                           (i32.sub (local.get $len) (i32.const 1)))
+                        (i32.const 47)) ;; '/'
+               (then (local.set $len (i32.sub (local.get $len) (i32.const 1)))))))
       (if (i32.lt_u (array.len (local.get $path)) (local.get $len))
          (then (return (i32.const 0))))
       (if (i32.gt_u (array.len (local.get $path)) (local.get $len))


### PR DESCRIPTION
Follow-up to #2341 (review comment https://github.com/ocsigen/js_of_ocaml/pull/2341#discussion_r3443944700).

The trailing-slash guard in `$prefix_match` was written as a single `i32.and`, which evaluates **both** operands. The `$len > 0` check therefore did not protect the `array.get_u` at index `$len - 1`: an empty prefix (`$len = 0`) read `$prefix[0xFFFFFFFF]` and trapped out of bounds on the first filesystem operation.

Hoist the length check into an enclosing `if` — the only short-circuiting construct in wasm — matching the convention already used elsewhere in this file (e.g. the `./` and `..` handling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)