### PR TITLE
Runtime: empty path raises ENOENT on the JS backend + fix lint-fmt

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -126,6 +126,10 @@
 * Runtime/wasm (WASI): `Unix.utimes` follows symlinks like native and the
   other path operations; it passed `lookupflags = 0`, so it set the times
   on the symlink itself instead of its target (#2263)
+* Runtime: an empty path is no longer resolved to the current directory on
+  the JavaScript backend but fails with `ENOENT` like native (and the Wasm
+  runtime), so `Unix.stat ""`, `Unix.opendir ""`, etc. raise instead of
+  silently operating on the cwd; `Sys.file_exists ""` returns false (#2354)
 * Runtime: `Unix.localtime` computes `tm_yday` from the calendar date
   instead of the wall-clock distance to January 1, which was off by one
   during DST; the js and wasm-on-node backends share the fix (#2304)

--- a/compiler/tests-compiler/unix_fs.ml
+++ b/compiler/tests-compiler/unix_fs.ml
@@ -414,7 +414,7 @@ let f () =
     let oc = open_out "ccc" in
     close_out oc;
     print_endline "files created";
-    let dh = Unix.opendir "" in
+    let dh = Unix.opendir "." in
     print_endline "got directory handle";
     read dh;
     read dh;

--- a/compiler/tests-jsoo/test_unix.ml
+++ b/compiler/tests-jsoo/test_unix.ml
@@ -262,10 +262,10 @@ let%expect_test "error_message of a non-WASI error code" =
    native (open ""/stat "" etc.). *)
 let%expect_test "empty path is ENOENT" =
   (match Unix.stat "" with
-   | _ -> print_endline "ok"
-   | exception Unix.Unix_error (Unix.ENOENT, _, _) -> print_endline "ENOENT"
-   | exception Unix.Unix_error (e, _, _) ->
-       print_endline (String.lowercase_ascii (Unix.error_message e)));
+  | _ -> print_endline "ok"
+  | exception Unix.Unix_error (Unix.ENOENT, _, _) -> print_endline "ENOENT"
+  | exception Unix.Unix_error (e, _, _) ->
+      print_endline (String.lowercase_ascii (Unix.error_message e)));
   [%expect {| ENOENT |}]
 
 (* Unix.utimes follows symlinks (it is utimes, not lutimes): setting the

--- a/runtime/js/fs.js
+++ b/runtime/js/fs.js
@@ -85,9 +85,20 @@ var path_is_absolute = make_path_is_absolute();
 
 //Provides: caml_make_path
 //Requires: caml_current_dir
-//Requires: caml_jsstring_of_string, path_is_absolute
-function caml_make_path(name) {
+//Requires: caml_jsstring_of_string, path_is_absolute, caml_raise_system_error
+function caml_make_path(name, raise_unix) {
   name = caml_jsstring_of_string(name);
+  // An empty path is invalid: like native (and the wasm runtime), it must not
+  // resolve to the current directory but fail with ENOENT. [raise_unix]
+  // selects Unix_error (Unix callers) vs Sys_error (Sys callers).
+  if (name === "")
+    caml_raise_system_error(
+      raise_unix,
+      "ENOENT",
+      "",
+      "No such file or directory",
+      "",
+    );
   if (!path_is_absolute(name)) name = caml_current_dir + name;
   var comp0 = path_is_absolute(name);
   var comp = comp0[1].split(/[/\\]/);
@@ -168,8 +179,8 @@ function caml_list_mount_point() {
 
 //Provides: resolve_fs_device
 //Requires: caml_make_path, jsoo_mount_point, caml_raise_sys_error, caml_get_root, MlNodeDevice, caml_trailing_slash, fs_node_supported
-function resolve_fs_device(name) {
-  var path = caml_make_path(name);
+function resolve_fs_device(name, raise_unix) {
+  var path = caml_make_path(name, raise_unix);
   var name = path.join("/");
   var name_slash = caml_trailing_slash(name);
   var res;
@@ -268,8 +279,11 @@ function caml_raise_no_such_file(name, raise_unix, cmd) {
 }
 
 //Provides: caml_sys_file_exists
-//Requires: resolve_fs_device
+//Requires: resolve_fs_device, caml_jsstring_of_string
 function caml_sys_file_exists(name) {
+  // An empty path exists nowhere; like native, return false rather than
+  // resolving "" to the current directory (which always exists).
+  if (caml_jsstring_of_string(name) === "") return 0;
   var root = resolve_fs_device(name);
   return root.device.exists(root.rest);
 }

--- a/runtime/js/unix.js
+++ b/runtime/js/unix.js
@@ -274,7 +274,7 @@ function caml_unix_chdir(dir) {
 //Requires: resolve_fs_device, caml_failwith
 //Alias: unix_stat
 function caml_unix_stat(name) {
-  var root = resolve_fs_device(name);
+  var root = resolve_fs_device(name, /* raise Unix_error */ 1);
   if (!root.device.stat) {
     caml_failwith("caml_unix_stat: not implemented");
   }
@@ -289,7 +289,7 @@ function caml_unix_stat(name) {
 //Requires: resolve_fs_device, caml_failwith
 //Alias: unix_stat_64
 function caml_unix_stat_64(name) {
-  var root = resolve_fs_device(name);
+  var root = resolve_fs_device(name, /* raise Unix_error */ 1);
   if (!root.device.stat) {
     caml_failwith("caml_unix_stat_64: not implemented");
   }
@@ -304,7 +304,7 @@ function caml_unix_stat_64(name) {
 //Requires: resolve_fs_device, caml_failwith
 //Alias: unix_lstat
 function caml_unix_lstat(name) {
-  var root = resolve_fs_device(name);
+  var root = resolve_fs_device(name, /* raise Unix_error */ 1);
   if (!root.device.lstat) {
     caml_failwith("caml_unix_lstat: not implemented");
   }
@@ -319,7 +319,7 @@ function caml_unix_lstat(name) {
 //Requires: resolve_fs_device, caml_failwith
 //Alias: unix_lstat_64
 function caml_unix_lstat_64(name) {
-  var root = resolve_fs_device(name);
+  var root = resolve_fs_device(name, /* raise Unix_error */ 1);
   if (!root.device.lstat) {
     caml_failwith("caml_unix_lstat_64: not implemented");
   }
@@ -334,7 +334,7 @@ function caml_unix_lstat_64(name) {
 //Requires: resolve_fs_device, caml_failwith
 //Alias: unix_chmod
 function caml_unix_chmod(name, perms) {
-  var root = resolve_fs_device(name);
+  var root = resolve_fs_device(name, /* raise Unix_error */ 1);
   if (!root.device.chmod) {
     caml_failwith("caml_unix_chmod: not implemented");
   }
@@ -346,8 +346,8 @@ function caml_unix_chmod(name, perms) {
 //Requires: caml_raise_system_error
 //Alias: unix_rename
 function caml_unix_rename(o, n) {
-  var o_root = resolve_fs_device(o);
-  var n_root = resolve_fs_device(n);
+  var o_root = resolve_fs_device(o, /* raise Unix_error */ 1);
+  var n_root = resolve_fs_device(n, /* raise Unix_error */ 1);
   if (o_root.device !== n_root.device)
     caml_raise_system_error(/* raise Unix_error */ 1, "EXDEV", "rename");
   if (!o_root.device.rename) caml_failwith("caml_sys_rename: not implemented");
@@ -358,7 +358,7 @@ function caml_unix_rename(o, n) {
 //Requires: resolve_fs_device, caml_failwith
 //Alias: unix_mkdir
 function caml_unix_mkdir(name, perm) {
-  var root = resolve_fs_device(name);
+  var root = resolve_fs_device(name, /* raise Unix_error */ 1);
   if (!root.device.mkdir) {
     caml_failwith("caml_unix_mkdir: not implemented");
   }
@@ -369,7 +369,7 @@ function caml_unix_mkdir(name, perm) {
 //Requires: resolve_fs_device, caml_failwith
 //Alias: unix_rmdir
 function caml_unix_rmdir(name) {
-  var root = resolve_fs_device(name);
+  var root = resolve_fs_device(name, /* raise Unix_error */ 1);
   if (!root.device.rmdir) {
     caml_failwith("caml_unix_rmdir: not implemented");
   }
@@ -380,8 +380,8 @@ function caml_unix_rmdir(name) {
 //Requires: resolve_fs_device, caml_failwith, caml_raise_system_error
 //Alias: unix_link
 function caml_unix_link(follow, src, dst) {
-  var src_root = resolve_fs_device(src);
-  var dst_root = resolve_fs_device(dst);
+  var src_root = resolve_fs_device(src, /* raise Unix_error */ 1);
+  var dst_root = resolve_fs_device(dst, /* raise Unix_error */ 1);
   if (!src_root.device.link) {
     caml_failwith("caml_unix_link: not implemented");
   }
@@ -402,7 +402,7 @@ function caml_unix_link(follow, src, dst) {
 //Requires: resolve_fs_device, caml_failwith, caml_jsstring_of_string
 //Alias: unix_symlink
 function caml_unix_symlink(to_dir, src, dst) {
-  var dst_root = resolve_fs_device(dst);
+  var dst_root = resolve_fs_device(dst, /* raise Unix_error */ 1);
   if (!dst_root.device.symlink) {
     caml_failwith("caml_unix_symlink: not implemented");
   }
@@ -418,7 +418,7 @@ function caml_unix_symlink(to_dir, src, dst) {
 //Requires: resolve_fs_device, caml_failwith
 //Alias: unix_readlink
 function caml_unix_readlink(name) {
-  var root = resolve_fs_device(name);
+  var root = resolve_fs_device(name, /* raise Unix_error */ 1);
   if (!root.device.readlink) {
     caml_failwith("caml_unix_readlink: not implemented");
   }
@@ -429,7 +429,7 @@ function caml_unix_readlink(name) {
 //Requires: resolve_fs_device, caml_failwith
 //Alias: unix_unlink
 function caml_unix_unlink(name) {
-  var root = resolve_fs_device(name);
+  var root = resolve_fs_device(name, /* raise Unix_error */ 1);
   if (!root.device.unlink) {
     caml_failwith("caml_unix_unlink: not implemented");
   }
@@ -441,7 +441,7 @@ function caml_unix_unlink(name) {
 //Requires: resolve_fs_device, caml_failwith
 //Alias: unix_utimes
 function caml_unix_utimes(name, atime, mtime) {
-  var root = resolve_fs_device(name);
+  var root = resolve_fs_device(name, /* raise Unix_error */ 1);
   if (!root.device.utimes) {
     caml_failwith("caml_unix_utimes: not implemented");
   }
@@ -453,7 +453,7 @@ function caml_unix_utimes(name, atime, mtime) {
 //Requires: resolve_fs_device, caml_failwith
 //Alias: unix_truncate
 function caml_unix_truncate(name, len) {
-  var root = resolve_fs_device(name);
+  var root = resolve_fs_device(name, /* raise Unix_error */ 1);
   if (!root.device.truncate) {
     caml_failwith("caml_unix_truncate: not implemented");
   }
@@ -465,7 +465,7 @@ function caml_unix_truncate(name, len) {
 //Requires: resolve_fs_device, caml_failwith, caml_int64_to_float
 //Alias: unix_truncate_64
 function caml_unix_truncate_64(name, len) {
-  var root = resolve_fs_device(name);
+  var root = resolve_fs_device(name, /* raise Unix_error */ 1);
   if (!root.device.truncate) {
     caml_failwith("caml_unix_truncate_64: not implemented");
   }
@@ -499,7 +499,7 @@ function caml_unix_access(name, flags) {
     }
     flags = flags[2];
   }
-  var root = resolve_fs_device(name);
+  var root = resolve_fs_device(name, /* raise Unix_error */ 1);
   if (!root.device.access) {
     caml_failwith("caml_unix_access: not implemented");
   }
@@ -550,7 +550,7 @@ function caml_unix_open(name, flags, perms) {
     }
     flags = flags[2];
   }
-  var root = resolve_fs_device(name);
+  var root = resolve_fs_device(name, /* raise Unix_error */ 1);
   var file = root.device.open(root.rest, f, perms, /* raise Unix_error */ true);
   var idx = caml_sys_fds.length;
   caml_sys_fds[idx] = { file: file };
@@ -809,7 +809,7 @@ function caml_unix_has_symlink(_unit) {
 //Requires: resolve_fs_device, caml_failwith
 //Alias: unix_opendir
 function caml_unix_opendir(path) {
-  var root = resolve_fs_device(path);
+  var root = resolve_fs_device(path, /* raise Unix_error */ 1);
   if (!root.device.opendir) {
     caml_failwith("caml_unix_opendir: not implemented");
   }


### PR DESCRIPTION
Fixes two CI failures on `master` introduced by the recent WASI commit series (#2241).

## 1. `js_of_ocaml` tests (all platforms) — `test_unix.ml` "empty path is ENOENT"
`d27c7a42f` made `stat ""`/`open ""` raise `ENOENT` on native and the Wasm runtime, and added a test asserting it on **js/wasm/native**. But the JS runtime was never changed: `caml_make_path` collapses `""` → `caml_current_dir`, so `Unix.stat ""` silently statted the cwd and returned `ok`, failing the test.

Fix at the root-cause site: `caml_make_path` (and `resolve_fs_device`) take a `raise_unix` argument and reject an empty path with `ENOENT`:
- Unix path ops pass `raise_unix=1` → `Unix_error(ENOENT)`,
- Sys ops keep the default → `Sys_error`,
- `Sys.file_exists ""` short-circuits to `false`, matching native.

Verified against native: `Unix.stat "" → Unix_error(ENOENT)`, `Sys.is_directory "" → Sys_error`, `Sys.file_exists "" → false`.

`tests-compiler/unix_fs.ml` used `Unix.opendir ""` as a shorthand for the cwd (relying on the old behavior); switched to `Unix.opendir "."`, which native supports and which keeps the test exercising `readdir`/`rewinddir`. Expected output unchanged.

## 2. `lint` → lint-fmt — `test_unix.ml` not ocamlformat-clean
The new WASI tests were merged unformatted. Separate commit re-runs ocamlformat.

(The WASI-runtime CI crash from the same series was fixed separately in #2352.)