### PR TITLE
Runtime: remove the orphan caml_js_html_escape primitive

### DIFF
--- a/runtime/js/jslib_js_of_ocaml.js
+++ b/runtime/js/jslib_js_of_ocaml.js
@@ -19,16 +19,6 @@
 
 ///////////// Jslib: code specific to Js_of_ocaml
 
-//Provides: caml_js_html_escape const (const)
-var caml_js_regexps = { amp: /&/g, lt: /</g, quot: /"/g, all: /[&<"]/ };
-function caml_js_html_escape(s) {
-  if (!caml_js_regexps.all.test(s)) return s;
-  return s
-    .replace(caml_js_regexps.amp, "&amp;")
-    .replace(caml_js_regexps.lt, "&lt;")
-    .replace(caml_js_regexps.quot, "&quot;");
-}
-
 //Provides: caml_js_html_entities
 function caml_js_html_entities(s) {
   var entity = /^&#?[0-9a-zA-Z]+;$/;

--- a/runtime/wasm/jslib_js_of_ocaml.wat
+++ b/runtime/wasm/jslib_js_of_ocaml.wat
@@ -28,17 +28,11 @@
       (func $caml_js_new (param (ref eq)) (param (ref eq)) (result (ref eq))))
    (import "jslib" "caml_js_from_array"
       (func $caml_js_from_array (param (ref eq)) (result (ref eq))))
-   (import "js" "caml_js_html_escape"
-      (func $caml_js_html_escape_js (param anyref) (result anyref)))
    (import "js" "caml_js_html_entities"
       (func $caml_js_html_entities_js (param anyref) (result anyref)))
 
    (type $block (array (mut (ref eq))))
    (type $bytes (array (mut i8)))
-
-   (func (export "caml_js_html_escape") (param (ref eq)) (result (ref eq))
-      (return_call $wrap
-         (call $caml_js_html_escape_js (call $unwrap (local.get 0)))))
 
    (func (export "caml_js_html_entities") (param (ref eq)) (result (ref eq))
       (return_call $wrap


### PR DESCRIPTION
`caml_js_html_escape`'s last OCaml binding was removed in 9a4b0d059 ("Lib: remove dead legacy-browser code from the DOM bindings"), leaving it provided by `runtime/js/jslib_js_of_ocaml.js` and `runtime/wasm/jslib_js_of_ocaml.wat` but referenced by nothing.

The `-linkall` `tests-check-prim` test flagged it as a newly-unreferenced primitive (`From +jslib_js_of_ocaml.js: caml_js_html_escape`), which turned the `js_of_ocaml` CI job red on `master` (the `git diff --exit-code` step).

Removes it from both runtimes. `caml_js_html_entities` (still bound via `Dom_html.decode_html_entities`) is kept. Build + check-prim green; no `.output` snapshot change needed since the primitive simply no longer exists.