### PR TITLE
Runtime/wasm (WASI): empty path is ENOENT; move absolute-target symlink tests out of WASI

### DIFF
--- a/compiler/tests-jsoo/dune
+++ b/compiler/tests-jsoo/dune
@@ -183,6 +183,7 @@
    test_custom_name
    test_text_codec_fallback
    test_unix
+   test_unix_symlink
    channel_refill
    test_promise
    test_lwt_promise
@@ -232,6 +233,29 @@
   (<> %{profile} quickjs))
  (modules test_unix)
  (libraries unix compiler-libs.common js_of_ocaml-compiler)
+ (inline_tests
+  (deps
+   (sandbox preserve_file_kind))
+  (modes js wasm best))
+ (preprocess
+  (pps ppx_expect)))
+
+; test_unix_symlink creates symlinks and stats through them. WASI rejects
+; symlinks to absolute targets with EPERM (its capability model forbids
+; escaping a preopen); the QuickJS shim does not implement [Unix.symlink];
+; and on Windows node cannot [stat] a directory symlink without elevation.
+; So it only runs on Unix-like hosts under the JS / wasm-on-unix runtimes.
+
+(library
+ (name jsoo_testsuite_symlink)
+ (enabled_if
+  (and
+   (<> %{profile} quickjs)
+   (<> %{profile} wasi)
+   (<> %{profile} wasi-with-native-effects)
+   (<> %{os_type} Win32)))
+ (modules test_unix_symlink)
+ (libraries unix)
  (inline_tests
   (deps
    (sandbox preserve_file_kind))

--- a/compiler/tests-jsoo/test_unix.ml
+++ b/compiler/tests-jsoo/test_unix.ml
@@ -222,30 +222,6 @@ let%expect_test "closed fds do not resolve" =
   Sys.remove f;
   [%expect {| EBADF |}]
 
-(* Sys.is_directory follows symlinks (uses stat, not lstat), like native:
-   a symlink to a directory is a directory, a symlink to a file is not. *)
-let%expect_test "is_directory follows symlinks" =
-  let d = Filename.temp_file "jsoo_symdir" "" in
-  Sys.remove d;
-  Unix.mkdir d 0o755;
-  let f = Filename.temp_file "jsoo_symfile" ".dat" in
-  let ld = Filename.temp_file "jsoo_lnd" "" in
-  Sys.remove ld;
-  let lf = Filename.temp_file "jsoo_lnf" "" in
-  Sys.remove lf;
-  Unix.symlink d ld;
-  Unix.symlink f lf;
-  Printf.printf "symlink->dir: %b\n" (Sys.is_directory ld);
-  Printf.printf "symlink->file: %b\n" (Sys.is_directory lf);
-  Sys.remove ld;
-  Sys.remove lf;
-  Sys.remove f;
-  Unix.rmdir d;
-  [%expect {|
-    symlink->dir: true
-    symlink->file: false
-    |}]
-
 (* An error variant with no WASI errno equivalent (e.g. EWOULDBLOCK) must
    still produce a real message, not "Unknown error -1". The exact text is
    backend-specific (a descriptive string natively / under node, the error
@@ -267,16 +243,3 @@ let%expect_test "empty path is ENOENT" =
   | exception Unix.Unix_error (e, _, _) ->
       print_endline (String.lowercase_ascii (Unix.error_message e)));
   [%expect {| ENOENT |}]
-
-(* Unix.utimes follows symlinks (it is utimes, not lutimes): setting the
-   times through a symlink updates the target. *)
-let%expect_test "utimes follows symlinks" =
-  let f = Filename.temp_file "jsoo_utf" ".dat" in
-  let l = Filename.temp_file "jsoo_utl" "" in
-  Sys.remove l;
-  Unix.symlink f l;
-  Unix.utimes l 12345.0 12345.0;
-  Printf.printf "%b\n" ((Unix.stat f).Unix.st_mtime = 12345.0);
-  Sys.remove l;
-  Sys.remove f;
-  [%expect {| true |}]

--- a/compiler/tests-jsoo/test_unix_symlink.ml
+++ b/compiler/tests-jsoo/test_unix_symlink.ml
@@ -1,0 +1,42 @@
+(* These tests create symlinks whose target is an absolute path (returned by
+   [Filename.temp_file]). WASI's capability model rejects such symlinks with
+   EPERM, so they live in their own library, disabled under the wasi profile.
+   Symlinks with relative targets (exercised in test_unix.ml) work under WASI
+   and stay there. *)
+
+(* Sys.is_directory follows symlinks (uses stat, not lstat), like native:
+   a symlink to a directory is a directory, a symlink to a file is not. *)
+let%expect_test "is_directory follows symlinks" =
+  let d = Filename.temp_file "jsoo_symdir" "" in
+  Sys.remove d;
+  Unix.mkdir d 0o755;
+  let f = Filename.temp_file "jsoo_symfile" ".dat" in
+  let ld = Filename.temp_file "jsoo_lnd" "" in
+  Sys.remove ld;
+  let lf = Filename.temp_file "jsoo_lnf" "" in
+  Sys.remove lf;
+  Unix.symlink d ld;
+  Unix.symlink f lf;
+  Printf.printf "symlink->dir: %b\n" (Sys.is_directory ld);
+  Printf.printf "symlink->file: %b\n" (Sys.is_directory lf);
+  Sys.remove ld;
+  Sys.remove lf;
+  Sys.remove f;
+  Unix.rmdir d;
+  [%expect {|
+    symlink->dir: true
+    symlink->file: false
+    |}]
+
+(* Unix.utimes follows symlinks (it is utimes, not lutimes): setting the
+   times through a symlink updates the target. *)
+let%expect_test "utimes follows symlinks" =
+  let f = Filename.temp_file "jsoo_utf" ".dat" in
+  let l = Filename.temp_file "jsoo_utl" "" in
+  Sys.remove l;
+  Unix.symlink f l;
+  Unix.utimes l 12345.0 12345.0;
+  Printf.printf "%b\n" ((Unix.stat f).Unix.st_mtime = 12345.0);
+  Sys.remove l;
+  Sys.remove f;
+  [%expect {| true |}]

--- a/runtime/wasm/fs.wat
+++ b/runtime/wasm/fs.wat
@@ -200,9 +200,10 @@
       (param $path (ref $bytes)) (result (ref $bytes))
       (local $need_slash i32) (local $i i32) (local $abs_path (ref $bytes))
       (if (i32.eqz (array.len (local.get $path)))
-         (then ;; empty path: leave it empty so it matches no preopen and the
-               ;; operation fails with ENOENT, like native (open "" etc.),
-               ;; rather than silently resolving to the current directory
+         (then ;; empty path: left empty here; wasi_resolve_path rejects it
+               ;; with ENOENT before resolution, like native (stat ""/open
+               ;; "" etc.). It cannot be rejected from the resolved path
+               ;; because "" would also match the current-directory preopen.
             (return (local.get $path))))
       (if (i32.eq (i32.const 47) ;; '/'
              (array.get_u $bytes (local.get $path) (i32.const 0)))
@@ -362,6 +363,12 @@
       (result (;fd;) i32 (;address;) i32 (;length;) i32)
       (local $res_0 i32) (local $res_1 (ref $bytes))
       (local $p i32)
+      ;; An empty path matches no entry and fails with ENOENT like native,
+      ;; rather than resolving to the current directory. This is checked on
+      ;; the original path: make_absolute would turn "" into current_dir,
+      ;; which is indistinguishable from ".".
+      (if (i32.eqz (array.len (ref.cast (ref $bytes) (local.get $vpath))))
+         (then (return (i32.const -1) (i32.const 0) (i32.const 0))))
       (call $resolve_abs_path
          (call $make_absolute
             (ref.cast (ref $bytes) (local.get $vpath))))


### PR DESCRIPTION
Fixes the remaining `wasm_of_ocaml` / WASI CI failure on `master`. After #2352 stopped the `prefix_match` crash from aborting the WASI test run, three `tests-jsoo/test_unix.ml` tests turned out not to pass under node's WASI runtime.

## 1. `empty path is ENOENT` — was returning `ok` under WASI
`d27c7a42f` left an empty path empty in `make_absolute`, intending it to "match no preopen" and fail with ENOENT. But an empty path **does** match the current-directory preopen (its normalized prefix is empty), so `stat ""`/`open ""` silently resolved to the cwd under the Wasm runtime — unlike native and the JS backend (#2354).

Reject the empty path in `wasi_resolve_path`, before `make_absolute`, where the original argument is still available (`make_absolute` would turn `""` into `current_dir`, indistinguishable from `"."`). The `fd=-1` result flows through the existing not-found path, so Unix ops raise `Unix_error(ENOENT)` and Sys ops raise `Sys_error`, each matching native.

Validated under the `wasi-with-native-effects` profile locally: `Unix.stat "" → ENOENT`.

## 2. `is_directory follows symlinks` / `utimes follows symlinks` — EPERM under WASI
Both create symlinks whose **target is an absolute path** (`Filename.temp_file`). WASI's capability model forbids that, so `Unix.symlink` raises `EPERM`. Moved them to `test_unix_symlink.ml`, in a library disabled under the wasi profiles (and quickjs, like the other Unix tests). Symlink tests with **relative** targets work under WASI and stay in `test_unix.ml`.

(The earlier `prefix_match` crash was fixed in #2352; the JS-backend half of the empty-path fix is #2354.)