### PR TITLE
Runtime/wasm: fix wax conversion of unix.wat uid/gid stubs

### DIFF
--- a/runtime/wasm/unix.wat
+++ b/runtime/wasm/unix.wat
@@ -2616,9 +2616,15 @@
    ;; WASI has no notion of user/group ids; return 1 like the JS runtime's
    ;; fallback when [process.getuid] and friends are unavailable.
    (func (export "unix_getuid") (export "caml_unix_getuid")
-      (export "unix_geteuid") (export "caml_unix_geteuid")
-      (export "unix_getgid") (export "caml_unix_getgid")
-      (export "unix_getegid") (export "caml_unix_getegid")
+      (param (ref eq)) (result (ref eq))
+      (ref.i31 (i32.const 1)))
+   (func (export "unix_geteuid") (export "caml_unix_geteuid")
+      (param (ref eq)) (result (ref eq))
+      (ref.i31 (i32.const 1)))
+   (func (export "unix_getgid") (export "caml_unix_getgid")
+      (param (ref eq)) (result (ref eq))
+      (ref.i31 (i32.const 1)))
+   (func (export "unix_getegid") (export "caml_unix_getegid")
       (param (ref eq)) (result (ref eq))
       (ref.i31 (i32.const 1)))
 )


### PR DESCRIPTION
## Problem

The `wax` CI job (converts every `runtime/wasm/*.wat` to `.wax` with the latest `wax` from git) is failing on `unix.wat`:

```
✗ unix.wat - CONVERSION FAILED
    Error: A function named 'unix_getuid' is already bound.
    Hint: reachable when not wasi
```

The `unix_get{u,eu,g,eg}id` block introduced in #2346 is structurally asymmetric across the `@if $wasi` branches:

- `@then` (wasi) defines **one** function exporting all eight names
- `@else` (node) defines **four** separate functions

The newer `wax` converter can't reconcile a branch defining one function against a branch defining four with the same export names.

## Fix

Split the wasi `@then` branch into four parallel functions, one export-pair each, mirroring the shape already used elsewhere (e.g. `sys.wat`'s `caml_sys_time`, which keeps both `@if` branches structurally identical). The generated wasm is unchanged.

## Testing

- `dune build @runtest-wasm runtime/wasm/` passes (binaryen assembles the patched `.wat`)
- `dune build @compiler/tests-jsoo/runtest-wasm` passes (Unix wasm tests)
- local `wax` conversion of `unix.wat` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)