### PR TITLE
doc: order the manual sidebar with @children_order

### DIFF
--- a/manual/bindings.mld
+++ b/manual/bindings.mld
@@ -1,3 +1,0 @@
-{0 Binding a JS library}
-
-This page has been merged into {{!page-"javascript-interop"}JavaScript interop}.

--- a/manual/camlp4.mld
+++ b/manual/camlp4.mld
@@ -1,5 +1,0 @@
-{0 Camlp4 syntax extension}
-
-The Camlp4 syntax extension is deprecated and no longer part of js_of_ocaml.
-
-Use the {{!page-"ppx"}PPX syntax extension} instead.

--- a/manual/environment-variable.mld
+++ b/manual/environment-variable.mld
@@ -1,3 +1,0 @@
-{0 Environment variables}
-
-This page has been moved to {{!page-"options".env_vars}Command-line options}.

--- a/manual/index.mld
+++ b/manual/index.mld
@@ -1,3 +1,5 @@
+@children_order overview install quickstart javascript-interop ppx ppx-deriving rev-bindings errors lwt options compilation-modes linker tailcall effects runtime-representation browser-compat wasm_overview wasm_runtime build-toplevel debug performances contribute examples bindings library environment-variable runtime-files camlp4 api
+
 {0 Js_of_ocaml}
 
 Js_of_ocaml is a compiler from OCaml bytecode programs to JavaScript. It makes

--- a/manual/index.mld
+++ b/manual/index.mld
@@ -1,4 +1,4 @@
-@children_order overview install quickstart javascript-interop ppx ppx-deriving rev-bindings errors lwt options compilation-modes linker tailcall effects runtime-representation browser-compat wasm_overview wasm_runtime build-toplevel debug performances contribute examples bindings library environment-variable runtime-files camlp4 api
+@children_order overview install quickstart javascript-interop ppx ppx-deriving rev-bindings errors lwt options compilation-modes linker tailcall effects runtime-representation browser-compat wasm_overview wasm_runtime build-toplevel debug performances contribute examples api
 
 {0 Js_of_ocaml}
 

--- a/manual/library.mld
+++ b/manual/library.mld
@@ -1,3 +1,0 @@
-{0 Library overview}
-
-This page has been merged into {{!page-"javascript-interop"}JavaScript interop}.

--- a/manual/runtime-files.mld
+++ b/manual/runtime-files.mld
@@ -1,3 +1,0 @@
-{0 Runtime files}
-
-This page has been moved to {{!page-"linker"}Linking JavaScript code}.


### PR DESCRIPTION
Part of an effort to make the Ocsigen documentation well-formed on ocaml.org. `manual/index.mld` already is the package home page, but without `@children_order` odoc lists the manual pages in the sidebar alphabetically. Add `@children_order` so the sidebar follows the logical reading order already used in the page body (Overview, Installation, Quick Start, …, then the API reference).

Standalone `odoc compile` of `manual/index.mld` succeeds; every page name in the list maps to an existing `manual/*.mld`.