### PR TITLE
doc: fix broken odoc cross-references, markup, and stale doc URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ optimized:
 - self recursive functions (when the tail calls are the function itself) are
   compiled using a loop.
 - trampolines are used otherwise.
-  [More](http://ocsigen.org/js_of_ocaml/dev/manual/tailcall) about tail call
+  [More](https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/tailcall.html) about tail call
   optimization.
 
 Effect handlers are supported with the `--effects={cps,double-translation}`

--- a/README_wasm_of_ocaml.md
+++ b/README_wasm_of_ocaml.md
@@ -28,7 +28,7 @@ OCaml 5.x code using effect handlers can be compiled in three different ways:
 
 ## Installation and usage
 
-Installation and usage documentation can be found in [the js_of_ocaml manual](https://ocsigen.org/js_of_ocaml/dev/manual/wasm_overview).
+Installation and usage documentation can be found in [the js_of_ocaml manual](https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/wasm_overview.html).
 
 ## Running the test suite
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,6 +1,6 @@
 # Benchmarks 
 
-These benchmarks are used to generate charts such as the ones available at https://ocsigen.org/js_of_ocaml/dev/manual/performances.
+These benchmarks are used to generate charts such as the ones available at https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/performances.html.
 
 ## Quick start
 ```

--- a/dune-project
+++ b/dune-project
@@ -9,8 +9,8 @@
 (authors "Ocsigen team <dev@ocsigen.org>")
 (maintainers "Ocsigen team <dev@ocsigen.org>")
 (source (github ocsigen/js_of_ocaml))
-(homepage "https://ocsigen.org/js_of_ocaml/latest/manual/overview")
-(documentation "https://ocsigen.org/js_of_ocaml/latest/manual/overview")
+(homepage "https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/overview.html")
+(documentation "https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/overview.html")
 (license "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception")
 
 (package

--- a/js_of_ocaml-compiler.opam
+++ b/js_of_ocaml-compiler.opam
@@ -8,8 +8,8 @@ authors: ["Ocsigen team <dev@ocsigen.org>"]
 license: [
   "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 ]
-homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
-doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+homepage: "https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/overview.html"
+doc: "https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/overview.html"
 bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
 depends: [
   "dune" {>= "3.20"}

--- a/js_of_ocaml-lwt.opam
+++ b/js_of_ocaml-lwt.opam
@@ -8,8 +8,8 @@ authors: ["Ocsigen team <dev@ocsigen.org>"]
 license: [
   "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 ]
-homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
-doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+homepage: "https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/overview.html"
+doc: "https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/overview.html"
 bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
 depends: [
   "dune" {>= "3.20"}

--- a/js_of_ocaml-ppx.opam
+++ b/js_of_ocaml-ppx.opam
@@ -8,8 +8,8 @@ authors: ["Ocsigen team <dev@ocsigen.org>"]
 license: [
   "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 ]
-homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
-doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+homepage: "https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/overview.html"
+doc: "https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/overview.html"
 bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
 depends: [
   "dune" {>= "3.20"}

--- a/js_of_ocaml-ppx_deriving_json.opam
+++ b/js_of_ocaml-ppx_deriving_json.opam
@@ -8,8 +8,8 @@ authors: ["Ocsigen team <dev@ocsigen.org>"]
 license: [
   "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 ]
-homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
-doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+homepage: "https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/overview.html"
+doc: "https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/overview.html"
 bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
 depends: [
   "dune" {>= "3.20"}

--- a/js_of_ocaml-toplevel.opam
+++ b/js_of_ocaml-toplevel.opam
@@ -8,8 +8,8 @@ authors: ["Ocsigen team <dev@ocsigen.org>"]
 license: [
   "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 ]
-homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
-doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+homepage: "https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/overview.html"
+doc: "https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/overview.html"
 bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
 depends: [
   "dune" {>= "3.20"}

--- a/js_of_ocaml-tyxml.opam
+++ b/js_of_ocaml-tyxml.opam
@@ -8,8 +8,8 @@ authors: ["Ocsigen team <dev@ocsigen.org>"]
 license: [
   "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 ]
-homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
-doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+homepage: "https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/overview.html"
+doc: "https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/overview.html"
 bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
 depends: [
   "dune" {>= "3.20"}

--- a/js_of_ocaml.opam
+++ b/js_of_ocaml.opam
@@ -8,8 +8,8 @@ authors: ["Ocsigen team <dev@ocsigen.org>"]
 license: [
   "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 ]
-homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
-doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+homepage: "https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/overview.html"
+doc: "https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/overview.html"
 bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
 depends: [
   "dune" {>= "3.20"}

--- a/manual/compilation-modes.mld
+++ b/manual/compilation-modes.mld
@@ -26,7 +26,7 @@ js_of_ocaml program.byte -o program.js
 v}
 
 Some libraries require additional runtime files. See
-{{!page-"linker".finding-runtime}JavaScript primitives} for how to discover them.
+{{!page-"linker".finding_runtime}JavaScript primitives} for how to discover them.
 
 The compiler performs global dead-code elimination and cross-module optimizations,
 producing smaller and faster output.
@@ -42,7 +42,7 @@ js_of_ocaml build-runtime -o runtime.js
 v}
 
 Some libraries require additional runtime files. See
-{{!page-"linker".finding-runtime}JavaScript primitives} for how to discover them.
+{{!page-"linker".finding_runtime}JavaScript primitives} for how to discover them.
 
 {2 2. Compile units and libraries}
 

--- a/manual/debug.mld
+++ b/manual/debug.mld
@@ -104,7 +104,7 @@ Or compile with:
 js_of_ocaml --enable with-js-error program.byte
 v}
 
-See {{!page-"errors".stack-traces}Error handling} for details.
+See {{!page-"errors".stack_traces}Error handling} for details.
 
 {1:devtools-tips Chrome DevTools tips}
 

--- a/manual/environment-variable.mld
+++ b/manual/environment-variable.mld
@@ -1,3 +1,3 @@
 {0 Environment variables}
 
-This page has been moved to {{!page-"options".env-vars}Command-line options}.
+This page has been moved to {{!page-"options".env_vars}Command-line options}.

--- a/manual/errors.mld
+++ b/manual/errors.mld
@@ -82,7 +82,7 @@ try {
 For better JavaScript interoperability, raise JavaScript errors instead of
 OCaml exceptions
 
-{1:stack-traces Stack traces for OCaml exceptions}
+{1:stack_traces Stack traces for OCaml exceptions}
 
 By default, OCaml exceptions don't carry JavaScript stack traces. This makes
 debugging difficult since you can't see where an exception originated in

--- a/manual/install.mld
+++ b/manual/install.mld
@@ -2,7 +2,7 @@
 
 {1:requirements Requirements}
 
-{b OCaml}: 4.13 to 5.4
+{b OCaml}: 4.13 to 5.5
 
 {b Build tools}:
 - dune >= 3.19

--- a/manual/javascript-interop.mld
+++ b/manual/javascript-interop.mld
@@ -412,7 +412,7 @@ external my_primitive : int -> int -> int = "my_js_function"
 ]}
 
 This calls the JavaScript function [my_js_function] directly, without the
-overhead of [Js.Unsafe] wrappers. See {{!page-"linker".writing-primitives}writing JavaScript primitives}
+overhead of [Js.Unsafe] wrappers. See {{!page-"linker".writing_primitives}writing JavaScript primitives}
 for how to define such functions.
 
 {1:callbacks Passing OCaml functions to JavaScript}
@@ -586,7 +586,7 @@ JavaScript values declared with [//Provides:] in runtime files can be
 accessed from OCaml. There are two approaches depending on whether you're
 accessing a function or a non-function value.
 
-See {{!page-"linker".writing-primitives}writing JavaScript primitives}
+See {{!page-"linker".writing_primitives}writing JavaScript primitives}
 for more about the [//Provides:] syntax.
 
 {2 Functions: use [external]}

--- a/manual/linker.mld
+++ b/manual/linker.mld
@@ -19,7 +19,7 @@ Pass JavaScript files (must have ".js" extension) directly:
 js_of_ocaml myruntime.js program.byte
 v}
 
-{1:finding-runtime Finding runtime files}
+{1:finding_runtime Finding runtime files}
 
 OCaml libraries often require JavaScript runtime files. The js_of_ocaml compiler
 does not automatically locate these files - They must be passed explicitly on the command line.
@@ -53,7 +53,7 @@ v}
 
 With {b dune}, this is handled automatically.
 
-{1:writing-primitives Writing JavaScript primitives}
+{1:writing_primitives Writing JavaScript primitives}
 
 User-defined primitives need to be implemented in a separate JavaScript file.
 See {{!page-"runtime-representation"}runtime representation} for how

--- a/manual/options.mld
+++ b/manual/options.mld
@@ -82,7 +82,7 @@ The [--file] flag is also supported by wasm_of_ocaml.
  | [--no-extern-fs] | Only allow files embedded at compile time (js_of_ocaml only) |
 }
 
-{1:env-vars Environment variables}
+{1:env_vars Environment variables}
 
 {t
  | Option | Description |

--- a/manual/wasm_runtime.mld
+++ b/manual/wasm_runtime.mld
@@ -67,8 +67,8 @@ The preprocessor allows optional compilation based on the OCaml version:
    (@else ...))
 v}
 
-Variables are referenced with a {{{$}}} prefix (for instance
-{{{$ocaml_version}}}, {{{$wasi}}}, {{{$oxcaml}}}).
+Variables are referenced with a [$] prefix (for instance
+[$ocaml_version], [$wasi], [$oxcaml]).
 
 Available operators:
 - Comparisons: [=], [>], [>=], [<], [<=], [<>]

--- a/wasm_of_ocaml-compiler.opam
+++ b/wasm_of_ocaml-compiler.opam
@@ -8,8 +8,8 @@ authors: ["Ocsigen team <dev@ocsigen.org>"]
 license: [
   "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 ]
-homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
-doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+homepage: "https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/overview.html"
+doc: "https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/overview.html"
 bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
 depends: [
   "dune" {>= "3.20"}


### PR DESCRIPTION
Release-prep review of the manual and READMEs. Doc-only — no `CHANGES.md` entry.

## 1. Broken cross-page section links (manual)
Four `{{!page-"X".label}…}` references to **hyphenated** section labels silently dropped their anchor — readers landed on the page top instead of the section. odoc reads the text before the last hyphen as a *kind qualifier*, so a label name containing `-` is unreferenceable (hyphen-free labels like `.conversions` work fine; verified in the generated HTML, which produced `linker.html` with no `#…`).

Fixed by renaming the four referenced labels to use `_`, so the anchors resolve:
- `linker.html#finding_runtime` (from compilation-modes ×2)
- `linker.html#writing_primitives` (from javascript-interop ×2)
- `errors.html#stack_traces` (from debug)
- `options.html#env_vars` (from environment-variable)

## 2. Invalid markup in `wasm_runtime.mld`
`{{{$}}}`, `{{{$ocaml_version}}}` etc. raised "bad markup" / "unpaired `}`". Changed to inline-code `[$]`, `[$ocaml_version]`, … matching the surrounding style.

## 3. Stale version in `install.mld`
Said "OCaml 4.13 to **5.4**"; `dune-project` pins `(>= 4.13) (< 5.6)`, so the range is **5.5**.

## 4. Stale published doc URLs (READMEs + package metadata)
The odoc/wodoc migration changed the manual URL layout from `…/<label>/manual/<page>` to `…/<label>/js_of_ocaml/<page>.html`, but the READMEs and package metadata still used the old path, which now **404s**. Repointed to the new structure, standardising on `https` and the `latest` label:
- `README.md` (tailcall), `README_wasm_of_ocaml.md` (wasm_overview), `benchmarks/README.md` (performances)
- `dune-project` `homepage`/`documentation` and the generated `*.opam` (were pointing at the dead `latest/manual/overview`)

`dune build @doc` is clean (no manual-authored warnings).