### PR TITLE
doc: update doc/wodoc for wodoc's new defaults

### DIFF
--- a/doc/wodoc
+++ b/doc/wodoc
@@ -4,7 +4,8 @@
 ;;               --menu <shared menu.html> [--latest]
 (project js_of_ocaml)
 (title Js_of_ocaml)
-(pub /js_of_ocaml)
+(url-prefix /js_of_ocaml)
+(css /css/style.css /css/ocsigen-odoc.css)  ; shared Ocsigen theme (wodoc css default changed)
 (landing js_of_ocaml/index.html)
 ;; no (highlight …): wodoc's default starter already colours js_of_ocaml/lwt/eliom syntax.
 ;; Build the API with odoc_driver (the engine ocaml.org uses) on the INSTALLED


### PR DESCRIPTION
wodoc master now ships a built-in default theme and renames the `pub` stanza to `url-prefix` (see ocsigen/wodoc). This keeps js_of_ocaml's doc on the shared Ocsigen theme and adopts the new name:

- add `(css /css/style.css /css/ocsigen-odoc.css)` (wodoc's css default changed to a self-contained built-in theme, so this is now needed to keep the shared `/css/` look);
- rename `(pub …)` → `(url-prefix …)`.

The doc CI tracks wodoc master, so no CI change is needed.