### PR TITLE
doc: list the full Ocsigen family in the hosted table

### DIFF
--- a/doc/wodoc
+++ b/doc/wodoc
@@ -20,16 +20,6 @@
 (packages js_of_ocaml js_of_ocaml-lwt js_of_ocaml-tyxml js_of_ocaml-toplevel)
 (doc-manual true)              ; also build @doc-manual (the interactive examples)
 (manual-files js_of_ocaml)    ; copy _build/.../manual/files into js_of_ocaml/files
-;; Sibling Ocsigen projects whose ocaml.org xrefs (produced by odoc_driver
-;; --remap) are rewritten to relative links into their own wodoc docs:
-;;   (pkg deploy-dir layout wrapper-module)
-;; layout = subdir (each opam package under its own <pkg>/, whole family) |
-;; root (modules at the version root). Non-Ocsigen deps (react) stay on
-;; ocaml.org; lwt is added once its docs are rebuilt with wodoc (ocsigen/lwt#1109).
-(hosted
-  (tyxml        tyxml        subdir)
-  (lwt          lwt          subdir)
-  (reactiveData reactiveData root))
 (nav
   (section "Getting Started"
     (link "Overview"      js_of_ocaml/overview.html   overview)
@@ -64,3 +54,17 @@
   (section "Try it"
     (link "OCaml toplevel"        js_of_ocaml/files/toplevel/index.html)
     (link "Examples and projects" js_of_ocaml/examples.html examples)))
+
+;; Sibling Ocsigen projects, so wodoc rewrites their ocaml.org cross-references
+;; to relative links into their deployed docs on ocsigen.org. The full family is
+;; listed (not only the ones this doc currently links to) so that adding a link
+;; later never silently breaks. (pkg deploy-dir layout wrapper-module)
+(hosted
+  (eliom           eliom           true  Eliom)
+  (ocsigen-toolkit ocsigen-toolkit true  Ot)
+  (ocsigen-start   ocsigen-start   true  Os)
+  (ocsigenserver   ocsigenserver   false Ocsigen)
+  (js_of_ocaml     js_of_ocaml     subdir)
+  (tyxml           tyxml           subdir)
+  (lwt             lwt             subdir)
+  (reactiveData    reactiveData    root))


### PR DESCRIPTION
The `(hosted …)` table now lists the **whole** Ocsigen family (eliom, toolkit, start, ocsigenserver, js_of_ocaml, tyxml, lwt, reactiveData), not only the projects this doc currently links to. This way, adding a cross-project link later is automatically rewritten for ocsigen.org instead of silently staying an unresolved reference. Same canonical table as eliom/toolkit/start.