### PR TITLE
Lib/doc/examples: deriving_json + Lwt edge-case fixes, manual corrections, toplevel Wasm fallback

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -183,6 +183,11 @@
   opinion"), with new `Dom.listener`/`full_listener` and a typed
   `beforeUnloadEvent`
 * Lib: fix several `Dom_html` bindings (#2221)
+* Lib: `Deriving_Json` now round-trips non-finite floats — the writer emits
+  `NaN`/`Infinity`/`-Infinity` (matching the reader) instead of OCaml's
+  `nan`/`inf`/`-inf`, which the reader rejected
+* Lib: drop a stray `console.log` fired on every event in
+  `Lwt_js_events.mousewheel`
 
 # 6.3.2 (2026-02-15) - Lille
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -188,6 +188,13 @@
   `nan`/`inf`/`-inf`, which the reader rejected
 * Lib: drop a stray `console.log` fired on every event in
   `Lwt_js_events.mousewheel`
+* Lib: `Lwt_file` read functions now fail the thread with an exception on a
+  read error or abort instead of raising `assert false`
+* Lib: `Lwt_xmlHttpRequest` frame `content_xml` returns `None` for non-default
+  response types (text/json/blob/arraybuffer/document) instead of raising
+  `assert false`
+* Lib: `Lwt_js_events.request_animation_frame` is now cancellable — cancelling
+  the thread cancels the pending animation-frame callback
 
 # 6.3.2 (2026-02-15) - Lille
 

--- a/lib/deriving_json/deriving_Json.ml
+++ b/lib/deriving_json/deriving_Json.ml
@@ -261,11 +261,19 @@ module Json_float = Defaults (struct
   type a = float
 
   let write buffer f =
-    (* "%.15g" can be (much) shorter; "%.17g" is round-trippable *)
-    let s = Printf.sprintf "%.15g" f in
-    if Poly.(float_of_string s = f)
-    then Buffer.add_string buffer s
-    else Printf.bprintf buffer "%.17g" f
+    if Float.is_finite f
+    then begin
+      (* "%.15g" can be (much) shorter; "%.17g" is round-trippable *)
+      let s = Printf.sprintf "%.15g" f in
+      if Poly.(float_of_string s = f)
+      then Buffer.add_string buffer s
+      else Printf.bprintf buffer "%.17g" f
+    end
+    else if Float.is_nan f
+    then Buffer.add_string buffer "NaN"
+    else if Poly.(f > 0.)
+    then Buffer.add_string buffer "Infinity"
+    else Buffer.add_string buffer "-Infinity"
 
   let read buf = Lexer.read_number buf
 end)

--- a/lib/deriving_json/deriving_Json.mli
+++ b/lib/deriving_json/deriving_Json.mli
@@ -166,6 +166,7 @@ module Json_int32 : Json with type a = int32
 
 module Json_int64 : Json with type a = int64
 
+(* Unimplemented: [read] and [write] both raise [Failure]. *)
 module Json_nativeint : Json with type a = nativeint
 
 (* module Json_num       : Json with type a = Num.num *)

--- a/lib/deriving_json/deriving_Json_lexer.mll
+++ b/lib/deriving_json/deriving_Json_lexer.mll
@@ -260,7 +260,7 @@ and read_int32 v = parse
 and read_int64 v = parse
     '-'? positive_int    { try Int64.of_string (Lexing.lexeme lexbuf)
          with _ ->
-           lexer_error "Int32 overflow" v lexbuf }
+           lexer_error "Int64 overflow" v lexbuf }
   | _                    { lexer_error "Expected int64 but found" v lexbuf }
   | eof                  { eof_error v lexbuf }
 

--- a/lib/deriving_json/tests/json_convert.ml
+++ b/lib/deriving_json/tests/json_convert.ml
@@ -79,3 +79,26 @@ type i64 = int64 [@@deriving json]
 let%expect_test _ =
   test i64_json 100000000000000000L;
   [%expect {||}]
+
+type f = float [@@deriving json]
+
+(* The generic [test] helper can't be reused for floats: [nan = nan] is
+   [false], so compare nan specially. Guards the writer/lexer agreement on
+   non-finite floats. *)
+let test_float v =
+  let v' = Deriving_Json.from_string f_json (Deriving_Json.to_string f_json v) in
+  let ok =
+    match classify_float v with
+    | FP_nan -> Float.is_nan v'
+    | _ -> v = v'
+  in
+  if ok then () else print_endline "Not equal"
+
+let%expect_test _ =
+  test_float 3.14;
+  test_float 0.;
+  test_float (-0.);
+  test_float infinity;
+  test_float neg_infinity;
+  test_float nan;
+  [%expect {||}]

--- a/lib/lwt/lwt_file.ml
+++ b/lib/lwt/lwt_file.ml
@@ -29,15 +29,16 @@ let read_with_filereader (fileReader : fileReader t constr) kind file =
   let res, w = Lwt.task () in
   reader##.onloadend :=
     handler (fun _ ->
-        if reader##.readyState == DONE
-        then
-          Lwt.wakeup
-            w
-            (match Opt.to_option (CoerceTo.string reader##.result) with
-            | None -> assert false (* can't happen: called with good readAs_ *)
-            | Some s -> s)
-        else ();
-        (* CCC TODO: handle errors *)
+        (if reader##.readyState == DONE
+         then
+           match Opt.to_option (CoerceTo.string reader##.result) with
+           | Some s -> Lwt.wakeup_later w s
+           | None ->
+               (* [result] is null on a read error or after [abort] (which is
+                  also how cancelling [res] tears down the read); since we hold
+                  the only resolver, [res] is non-sleeping here only when
+                  cancelled, and [wakeup_later_exn] is a no-op in that case. *)
+               Lwt.wakeup_later_exn w (Failure "Lwt_file: could not read file"));
         Js._false);
   Lwt.on_cancel res (fun () -> reader##abort);
   (match kind with

--- a/lib/lwt/lwt_js_events.ml
+++ b/lib/lwt/lwt_js_events.ml
@@ -330,7 +330,6 @@ let mousewheel ?use_capture ?passive target =
          ?passive:(opt_map Js.bool passive)
          target
          (fun (ev : #Dom_html.event Js.t) ~dx ~dy ->
-           Console.console##log ev;
            cancel ();
            Lwt.wakeup w (ev, (dx, dy));
            Js.bool true)

--- a/lib/lwt/lwt_js_events.ml
+++ b/lib/lwt/lwt_js_events.ml
@@ -603,11 +603,12 @@ let transitioncancels ?cancel_handler ?use_capture ?passive t =
   seq_loop transitioncancel ?cancel_handler ?use_capture ?passive t
 
 let request_animation_frame () =
-  let t, s = Lwt.wait () in
-  let (_ : Dom_html.animation_frame_request_id) =
+  let t, s = Lwt.task () in
+  let id =
     Dom_html.window##requestAnimationFrame
       (Js.wrap_callback (fun (_ : Js.number_t) -> Lwt.wakeup s ()))
   in
+  Lwt.on_cancel t (fun () -> Dom_html.window##cancelAnimationFrame id);
   t
 
 let onload () = make_event Dom_html.Event.load Dom_html.window

--- a/lib/lwt/lwt_xmlHttpRequest.ml
+++ b/lib/lwt/lwt_xmlHttpRequest.ml
@@ -63,7 +63,7 @@ let text_response url code headers req =
   { url
   ; code
   ; content = Js.Opt.case req##.responseText (fun () -> Js.string "") (fun x -> x)
-  ; content_xml = (fun () -> assert false)
+  ; content_xml = (fun () -> None)
   ; headers
   }
 
@@ -71,7 +71,7 @@ let document_response url code headers req =
   { url
   ; code
   ; content = File.CoerceTo.document req##.response
-  ; content_xml = (fun () -> assert false)
+  ; content_xml = (fun () -> None)
   ; headers
   }
 
@@ -79,7 +79,7 @@ let json_response url code headers req =
   { url
   ; code
   ; content = File.CoerceTo.json req##.response
-  ; content_xml = (fun () -> assert false)
+  ; content_xml = (fun () -> None)
   ; headers
   }
 
@@ -87,7 +87,7 @@ let blob_response url code headers req =
   { url
   ; code
   ; content = File.CoerceTo.blob req##.response
-  ; content_xml = (fun () -> assert false)
+  ; content_xml = (fun () -> None)
   ; headers
   }
 
@@ -95,7 +95,7 @@ let arraybuffer_response url code headers req =
   { url
   ; code
   ; content = File.CoerceTo.arrayBuffer req##.response
-  ; content_xml = (fun () -> assert false)
+  ; content_xml = (fun () -> None)
   ; headers
   }
 

--- a/manual/install.mld
+++ b/manual/install.mld
@@ -5,12 +5,12 @@
 {b OCaml}: 4.13 to 5.5
 
 {b Build tools}:
-- dune >= 3.19
+- dune >= 3.20
 - menhir
 
 {b Libraries}:
 - cmdliner >= 2.0
-- ppxlib >= 0.35
+- ppxlib >= 0.33
 - sedlex >= 3.3
 - yojson >= 2.1
 

--- a/manual/javascript-interop.mld
+++ b/manual/javascript-interop.mld
@@ -609,7 +609,7 @@ This is efficient and integrates naturally with OCaml code.
 {2 Non-function values: use [runtime_value]}
 
 For JavaScript {b objects, constants, or other non-function values}, use
-{{!Js_of_ocaml.Js.Unsafe.runtime_value}Js.runtime_value}:
+{{!Js_of_ocaml.Js.Unsafe.runtime_value}Js.Unsafe.runtime_value}:
 
 {@javascript[
 //Provides: myConfig
@@ -618,7 +618,7 @@ var myConfig = { debug: true, version: 42 };
 
 {@ocaml[
 let config : < debug : bool Js.t Js.prop; version : int Js.prop > Js.t =
-  Js.runtime_value "myConfig"
+  Js.Unsafe.runtime_value "myConfig"
 ]}
 
 {b Important}: The argument must be a string literal, not a variable.

--- a/manual/linker.mld
+++ b/manual/linker.mld
@@ -92,7 +92,7 @@ v}
 
 {b [//If: flag]} - Only include if flag is enabled (e.g., [//If: effects])
 
-{b [//Ifnot: flag]} - Only include if flag is disabled
+{b [//If: !flag]} - Only include if flag is disabled
 
 {b [//Deprecated: message]} - Mark primitive as deprecated
 

--- a/manual/ppx-deriving.mld
+++ b/manual/ppx-deriving.mld
@@ -25,17 +25,19 @@ type person = {
 }
 [@@deriving json]
 
-(* Serialize to JSON *)
-let json_str = person_to_json { name = "Alice"; age = 30 }
+(* Serialize to a JSON string *)
+let json_str = Deriving_Json.to_string person_json { name = "Alice"; age = 30 }
 
-(* Deserialize from JSON *)
-let alice = person_of_json json_str
+(* Deserialize from a JSON string *)
+let alice = Deriving_Json.from_string person_json json_str
 ]}
 
 The [[@@deriving json]] attribute generates:
-- [person_of_json] — deserialize from JSON
-- [person_to_json] — serialize to JSON
-- [person_json] — a [Deriving_Json.t] witness
+- [person_to_json : Buffer.t -> person -> unit] — write a value to a buffer
+- [person_of_json : Deriving_Json_lexer.lexbuf -> person] — read a value from a lexer buffer
+- [person_json : person Deriving_Json.t] — a witness, usable with
+  [Deriving_Json.to_string] and [Deriving_Json.from_string] for string conversion
+  (as in the example above)
 
 {b Note}: For types named [t], the prefix is omitted (e.g., [of_json] instead of [t_of_json]).
 

--- a/manual/runtime-representation.mld
+++ b/manual/runtime-representation.mld
@@ -130,7 +130,7 @@ Arrays for storing the underlying data:
  | [Int16_signed] | [Int16Array] |
  | [Int16_unsigned] | [Uint16Array] |
  | [Int32] | [Int32Array] |
- | [Int64] | Two [Int32Array]s |
+ | [Int64] | [Int32Array] (2 elements per value) |
  | [Int] | [Int32Array] |
  | [Nativeint] | [Int32Array] |
  | [Complex32] | [Float32Array] (2 elements per complex) |
@@ -145,7 +145,7 @@ OCaml exceptions are represented as:
 - {b With arguments}: a JavaScript array where index 1 is the exception identity and remaining indices contain the arguments
 
 For example, [Not_found] is just its identity object, while [Failure "oops"]
-becomes [[<Failure identity>, "oops"]].
+becomes [[0, <Failure identity>, "oops"]] (index 0 is the block tag).
 
 {b Note}: OCaml exceptions are not JavaScript [Error] objects. When an OCaml
 exception propagates to JavaScript code, it appears as an array, not an [Error].

--- a/manual/wasm_runtime.mld
+++ b/manual/wasm_runtime.mld
@@ -26,7 +26,7 @@ tag, of type [(ref i31)].
 (type $bytes (array (mut i8)))
 (type $float (struct (field f64)))
 (type $float_array (array (mut f64)))
-(type $js (struct (ref null any)))
+(type $js (struct (field anyref)))
 v}
 
 {2 Int32, Int64, and Nativeint}

--- a/toplevel/examples/lwt_toplevel/index.html
+++ b/toplevel/examples/lwt_toplevel/index.html
@@ -420,17 +420,24 @@
           useWasm = false;
         }
       }
-      function load_script(url){
+      function load_script(url, onerror){
         var fileref=document.createElement('script');
         fileref.setAttribute("type","text/javascript");
         fileref.setAttribute("src", prefix+(version===""?"":(version+"/"))+url);
+        if (onerror) fileref.onerror = onerror;
         document.getElementsByTagName("head")[0].appendChild(fileref);
       }
-      if (useWasm) {
-        load_script("toplevel_wasm.js");
-      } else {
+      function load_js_toplevel(){
         load_script("exported-unit.cmis.js");
         load_script(main);
+      }
+      if (useWasm) {
+        // The browser supports the Wasm features we need, but the Wasm
+        // toplevel may not have been built (e.g. wasm_of_ocaml unavailable).
+        // Fall back to the JavaScript toplevel if it fails to load.
+        load_script("toplevel_wasm.js", load_js_toplevel);
+      } else {
+        load_js_toplevel();
       }
 
     </script>


### PR DESCRIPTION
Bundles several independent fixes across the runtime libraries, the manual, and the toplevel demo.

## Library fixes

**`Deriving_Json`**
- Round-trips non-finite floats: the writer now emits `NaN`/`Infinity`/`-Infinity` (the spellings the reader accepts) instead of OCaml's `nan`/`inf`/`-inf`, which the reader rejected — so jsoo could not read back its own output. Adds a float round-trip regression test (nan compared specially since `nan <> nan`).
- `Deriving_Json_lexer.read_int64` reported "Int32 overflow" on overflow (copy-paste); now says "Int64 overflow".
- `.mli` now notes that `Json_nativeint` is unimplemented and raises.

**Lwt bindings**
- `Lwt_file` read functions fail the Lwt thread with an exception on a read error or abort, instead of hitting `assert false` (the `FileReader` fires `onloadend` with `readyState=DONE` but a null result). Uses `wakeup_later_exn` so a cancel-triggered abort stays a no-op.
- `Lwt_xmlHttpRequest` frame `content_xml` returns `None` for non-default response types (text/json/blob/arraybuffer/document) instead of raising `assert false` — the field is public and typed `unit -> _ option`.
- `Lwt_js_events.request_animation_frame` is now cancellable: built with `Lwt.task` + `cancelAnimationFrame` on cancel, so it composes with `Lwt.pick`/`choose` without leaving a stray frame callback.
- `Lwt_js_events.mousewheel`: dropped a leftover `console.log` fired on every event.

## Manual corrections
- **install**: dune >= 3.20 (`lang dune 3.20`) and ppxlib >= 0.33, matching `dune-project` (was 3.19 / 0.35).
- **ppx-deriving**: the `[@@deriving json]` functions are Buffer/lexbuf based (`Buffer.t -> t -> unit`, `lexbuf -> t`), not string based; show string round-tripping via `Deriving_Json.to_string`/`from_string`.
- **javascript-interop**: `runtime_value` lives in `Js.Unsafe`, so the sample is `Js.Unsafe.runtime_value`.
- **runtime-representation**: `Failure "oops"` is `[0, <identity>, "oops"]` (block tag at index 0); an Int64 bigarray is one `Int32Array` (2 elements per value).
- **wasm_runtime**: `$js` type is `(struct (field anyref))`, matching `runtime/wasm`.
- **linker**: negated conditions are `//If: !flag`, not `//Ifnot:` (per `annot_parser.mly`).

## Toplevel demo
The toplevel example (`toplevel/examples/lwt_toplevel/index.html`) selected the Wasm toplevel from browser feature detection alone (`WebAssembly.JSTag`), which can disagree with what the build produced. When `toplevel_wasm.js` is missing (e.g. `wasm_of_ocaml` not built/deployed), the page got stuck on "Loading …". An `onerror` handler on the Wasm script tag now falls back to the JavaScript toplevel. (Catches the artifact-missing case; not a `toplevel_wasm.js` that loads but later fails fetching its `.wasm` assets.)

`CHANGES.md` updated under `# dev` for the user-visible library fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)