### PR TITLE
doc: document which opam package provides each module (#607)

### DIFF
--- a/lib/deriving_json/deriving_Json.mli
+++ b/lib/deriving_json/deriving_Json.mli
@@ -18,6 +18,10 @@
  *)
 
 (** Typesafe IO (based on the {i deriving} library).
+
+    {b This module is provided by the [js_of_ocaml.deriving] library, part of the
+    [js_of_ocaml] opam package.}
+
     @see <https://github.com/ocsigen/deriving> the source code of {i deriving}
     @see <http://code.google.com/p/deriving/> the documentation of the original {i deriving} library by Jeremy Yallop.
 *)

--- a/lib/js_of_ocaml/js_of_ocaml.ml
+++ b/lib/js_of_ocaml/js_of_ocaml.ml
@@ -17,6 +17,10 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *)
 
+(** Bindings to the browser and Node.js runtime.
+
+    {b This library is provided by the [js_of_ocaml] opam package.} *)
+
 module Abort = Abort
 module CSS = CSS
 module Console = Console

--- a/lib/lwt/js_of_ocaml_lwt.ml
+++ b/lib/lwt/js_of_ocaml_lwt.ml
@@ -17,6 +17,10 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *)
 
+(** Lwt support for Js_of_ocaml.
+
+    {b This library is provided by the [js_of_ocaml-lwt] opam package.} *)
+
 module XmlHttpRequest = struct
   include Js_of_ocaml.XmlHttpRequest
   include Lwt_xmlHttpRequest

--- a/lib/tyxml/js_of_ocaml_tyxml.ml
+++ b/lib/tyxml/js_of_ocaml_tyxml.ml
@@ -17,6 +17,10 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *)
 
+(** TyXML support for Js_of_ocaml.
+
+    {b This library is provided by the [js_of_ocaml-tyxml] opam package.} *)
+
 module Tyxml_js = Tyxml_js
 module Tyxml_cast = Tyxml_cast
 module Tyxml_cast_sigs = Tyxml_cast_sigs

--- a/manual/api-check/check_api.ml
+++ b/manual/api-check/check_api.ml
@@ -1,0 +1,105 @@
+(* Js_of_ocaml
+ * http://www.ocsigen.org/js_of_ocaml/
+ * Copyright (C) 2024 Ocsigen team
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+
+(* Completeness guard for [manual/api.mld]: every public module of every
+   documented library must be referenced from the API reference page.
+
+   Public modules are read from the source of truth rather than re-listed here,
+   so the check fails (printing the offending names) whenever someone adds a
+   public module without documenting which package provides it:
+
+   - [--wrapper FILE]: a library's main module file ([js_of_ocaml.ml],
+     [js_of_ocaml_lwt.ml], ...); its top-level [module X = ...] aliases are the
+     public modules.
+   - [--module NAME]: a public module of an unwrapped library (e.g. the
+     [js_of_ocaml.deriving] library, whose modules are top-level).
+   - [--skip NAME]: a public-but-undocumented module (e.g. a deprecated alias).
+
+   The program prints, one per line, every public module name that does not
+   appear in [api.mld]. A passing run prints nothing. *)
+
+let read_file path =
+  let ic = open_in_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_in ic)
+    (fun () -> really_input_string ic (in_channel_length ic))
+
+let is_ident_char c =
+  (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c = '_'
+
+(* Top-level [module Name ...] declarations of a wrapper file. *)
+let wrapper_modules path =
+  read_file path
+  |> String.split_on_char '\n'
+  |> List.filter_map (fun line ->
+      match String.index_opt line ' ' with
+      | Some i when String.sub line 0 i = "module" ->
+          let rest = String.sub line (i + 1) (String.length line - i - 1) in
+          let j = ref 0 in
+          while !j < String.length rest && is_ident_char rest.[!j] do
+            incr j
+          done;
+          if !j > 0 then Some (String.sub rest 0 !j) else None
+      | _ -> None)
+
+(* Whole-word occurrence of [name] in [haystack]. *)
+let mentions haystack name =
+  let nl = String.length name and hl = String.length haystack in
+  let rec loop i =
+    if i + nl > hl
+    then false
+    else if
+      String.sub haystack i nl = name
+      && (i = 0 || not (is_ident_char haystack.[i - 1]))
+      && (i + nl = hl || not (is_ident_char haystack.[i + nl]))
+    then true
+    else loop (i + 1)
+  in
+  loop 0
+
+let () =
+  let api = ref "" in
+  let wrappers = ref [] in
+  let modules = ref [] in
+  let skip = ref [] in
+  let rec parse = function
+    | "--api" :: f :: tl ->
+        api := f;
+        parse tl
+    | "--wrapper" :: f :: tl ->
+        wrappers := f :: !wrappers;
+        parse tl
+    | "--module" :: m :: tl ->
+        modules := m :: !modules;
+        parse tl
+    | "--skip" :: m :: tl ->
+        skip := m :: !skip;
+        parse tl
+    | [] -> ()
+    | x :: _ -> failwith ("check_api: unexpected argument " ^ x)
+  in
+  parse (List.tl (Array.to_list Sys.argv));
+  let api_text = read_file !api in
+  let all =
+    List.concat_map wrapper_modules (List.rev !wrappers) @ List.rev !modules
+    |> List.sort_uniq compare
+  in
+  List.iter
+    (fun m -> if not (List.mem m !skip || mentions api_text m) then print_endline m)
+    all

--- a/manual/api-check/dune
+++ b/manual/api-check/dune
@@ -1,0 +1,34 @@
+; Completeness guard for manual/api.mld: fails if a public module of a
+; documented library is missing from the API reference page.
+
+(executable
+ (name check_api)
+ (modules check_api))
+
+(rule
+ (action
+  (with-stdout-to
+   undocumented.actual
+   (run
+    ./check_api.exe
+    --api
+    %{dep:../api.mld}
+    --skip
+    Firebug
+    --wrapper
+    %{dep:../../lib/js_of_ocaml/js_of_ocaml.ml}
+    --wrapper
+    %{dep:../../lib/lwt/js_of_ocaml_lwt.ml}
+    --wrapper
+    %{dep:../../lib/tyxml/js_of_ocaml_tyxml.ml}
+    --wrapper
+    %{dep:../../toplevel/lib/js_of_ocaml_toplevel.ml}
+    --module
+    Deriving_Json
+    --module
+    Deriving_Json_lexer))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff undocumented.expected undocumented.actual)))

--- a/manual/api.mld
+++ b/manual/api.mld
@@ -1,37 +1,51 @@
 {0 API reference}
 
-The Js_of_ocaml distribution is made of several packages. This page gathers the
-public modules of each; see the {{!page-"index"}documentation home} for the
-manual.
+The Js_of_ocaml distribution ships several opam packages, each providing one or
+more libraries. This page lists the public modules of every package; see the
+{{!page-"index"}documentation home} for the manual.
 
-{1 Js_of_ocaml — the base library}
+The top-level module of each library also states, in its own documentation,
+which opam package provides it.
+
+{1 [js_of_ocaml] — the base library}
+
+Provided by the [js_of_ocaml] opam package (library [js_of_ocaml]).
 
 Core runtime and JavaScript values:
 
 {!modules:
 Js_of_ocaml.Js
+Js_of_ocaml.Js_error
 Js_of_ocaml.Jstable
 Js_of_ocaml.Sys_js
 Js_of_ocaml.Typed_array
+Js_of_ocaml.Effect_js
 }
 
 Browser APIs:
 
 {!modules:
+Js_of_ocaml.Abort
 Js_of_ocaml.CSS
+Js_of_ocaml.Console
 Js_of_ocaml.Dom
 Js_of_ocaml.Dom_events
 Js_of_ocaml.Dom_html
 Js_of_ocaml.Dom_svg
 Js_of_ocaml.EventSource
+Js_of_ocaml.Fetch
 Js_of_ocaml.File
-Js_of_ocaml.Firebug
 Js_of_ocaml.Form
 Js_of_ocaml.Geolocation
+Js_of_ocaml.IntersectionObserver
 Js_of_ocaml.Intl
 Js_of_ocaml.Json
 Js_of_ocaml.MutationObserver
+Js_of_ocaml.Performance
+Js_of_ocaml.PerformanceObserver
+Js_of_ocaml.Promise
 Js_of_ocaml.Regexp
+Js_of_ocaml.ResizeObserver
 Js_of_ocaml.Url
 Js_of_ocaml.WebGL
 Js_of_ocaml.WebSockets
@@ -39,26 +53,43 @@ Js_of_ocaml.Worker
 Js_of_ocaml.XmlHttpRequest
 }
 
-{1 Js_of_ocaml-lwt — Lwt support}
+The same opam package also provides the [js_of_ocaml.deriving] library — the
+runtime used by the code that [[@@deriving json]] generates:
+
+{!modules:
+Deriving_Json
+Deriving_Json_lexer
+}
+
+{1 [js_of_ocaml-lwt] — Lwt support}
+
+Provided by the [js_of_ocaml-lwt] opam package (library [js_of_ocaml-lwt]).
 
 - {!Js_of_ocaml_lwt.Lwt_js} — sleeping and yielding
 - {!Js_of_ocaml_lwt.Lwt_js_events} — DOM events as Lwt threads
 - {!Js_of_ocaml_lwt.XmlHttpRequest} — XMLHttpRequest with Lwt
 - {!Js_of_ocaml_lwt.Jsonp} — JSONP requests
 - {!Js_of_ocaml_lwt.File} — reading files with Lwt
+- {!Js_of_ocaml_lwt.Promise} — bridge between Lwt threads and JS promises
 
-{1 Js_of_ocaml-ppx_deriving_json — JSON derivation}
+{1 [js_of_ocaml-ppx_deriving_json] — JSON derivation syntax}
 
-{!modules:
-Deriving_Json
-}
+Provided by the [js_of_ocaml-ppx_deriving_json] opam package. This is the PPX
+that derives JSON serializers ([[@@deriving json]]); the generated code relies
+on the {!Deriving_Json} runtime from the [js_of_ocaml] package above. See
+{{!page-"ppx-deriving"}the manual} for usage.
 
-{1 Js_of_ocaml-tyxml — TyXML support}
+{1 [js_of_ocaml-tyxml] — TyXML support}
+
+Provided by the [js_of_ocaml-tyxml] opam package (library [js_of_ocaml-tyxml]).
 
 - {!Js_of_ocaml_tyxml.Tyxml_js} — build and manipulate DOM trees with TyXML
 - {!Js_of_ocaml_tyxml.Tyxml_cast} — cast between TyXML and Dom nodes
 - {!Js_of_ocaml_tyxml.Tyxml_cast_sigs} — signatures for the casts
 
-{1 Js_of_ocaml-toplevel — toplevel and Dynlink}
+{1 [js_of_ocaml-toplevel] — toplevel and Dynlink}
+
+Provided by the [js_of_ocaml-toplevel] opam package (library
+[js_of_ocaml-toplevel]).
 
 - {!Js_of_ocaml_toplevel.JsooTop} — run an OCaml toplevel in the browser

--- a/toplevel/lib/js_of_ocaml_toplevel.ml
+++ b/toplevel/lib/js_of_ocaml_toplevel.ml
@@ -17,4 +17,8 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *)
 
+(** Run an OCaml toplevel in the browser.
+
+    {b This library is provided by the [js_of_ocaml-toplevel] opam package.} *)
+
 module JsooTop = Js_of_ocaml_toplevel_common.JsooTop


### PR DESCRIPTION
Closes #607.

After the opam package split there was no in-tree mapping from the `js_of_ocaml-*` opam packages to the OCaml modules they provide — the only way to guess was `opam search`. This addresses it from both ends.

## Complete & correct the central listing (`manual/api.mld`)
- Added the public modules it was missing: `Abort`, `Console`, `Effect_js`, `Fetch`, `IntersectionObserver`, `Performance`, `PerformanceObserver`, `Promise`, `ResizeObserver`, `Js_error`, `Deriving_Json_lexer`, and `Js_of_ocaml_lwt.Promise`.
- **Fixed a mis-attribution**: `Deriving_Json` was listed under `js_of_ocaml-ppx_deriving_json`, but it is the `js_of_ocaml.deriving` library shipped in the **`js_of_ocaml`** opam package. It is now under the correct package, and the ppx package is described as the PPX that *uses* that runtime.
- Each package section states its opam package and library explicitly.

## Per-module package note
Each library's top-level module now carries a one-line note in its own documentation, so a reader landing directly on a module page sees the package:

> *This library is provided by the `js_of_ocaml-lwt` opam package.*

Added to `Js_of_ocaml`, `Js_of_ocaml_lwt`, `Js_of_ocaml_tyxml`, `Js_of_ocaml_toplevel`, and `Deriving_Json` (which is unwrapped).

## Drift guard (`manual/api-check/`)
A small `runtest` check reads each library's public modules from the source of truth (the wrapper `.ml` files + the unwrapped deriving modules) and fails — naming the offenders — if any is missing from `api.mld`. This is what keeps the mapping from silently rotting as new modules are added (which is how `api.mld` had already fallen behind).

## Verification
- All affected libraries compile.
- `dune build @doc --force`: exit 0, **zero warnings** — every `api.mld` reference resolves; confirmed the new modules render on the API page and each note renders on its module page.
- The guard passes, and was confirmed to fail correctly when a known module is omitted.

No `CHANGES.md` entry: documentation + a test-only guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)