### PR TITLE
Runtime/wasm: fix path handling from dune variable in args.ml

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+# dev
+
+## Bug fixes
+* Runtime/wasm: derive the wat-module name from the basename of the input
+  path in `runtime/wasm/args.ml`, so dune 3.24's leading-`./` path-form
+  representation (ocaml/dune#15156) keeps producing well-formed
+  `module:path` lines for `wasmoo_link_wasm`.
+
 # 6.4.0 (2026-06-21) - Lille
 
 ## Features/Changes

--- a/runtime/wasm/args.ml
+++ b/runtime/wasm/args.ml
@@ -1,4 +1,7 @@
 let () =
   for i = 1 to Array.length Sys.argv - 1 do
-    Format.printf "%s:%s@." (Filename.chop_suffix Sys.argv.(i) ".wat") Sys.argv.(i)
+    Format.printf
+      "%s:%s@."
+      (Filename.chop_suffix (Filename.basename Sys.argv.(i)) ".wat")
+      Sys.argv.(i)
   done


### PR DESCRIPTION
Dune `deps` variables are expanded to paths. The representation of this has changed with https://github.com/ocaml/dune/pull/15156, causing the wasm_of_ocaml runtime build to fail on the pending dune 3.24: when `args.ml` is run with the `.wat` deps in the rule's own directory those arguments are now "./foo.wat" rather than "foo.wat", and `Filename.chop_suffix ".wat"` on them produces "./foo", which is not a valid wasm-link module name. By taking the basename of the path before chopping the suffix, we get a fix that works regardless of the path representation.

The breaking change showed up on the opam-repo revdep tests for the bending release of dune 3.24, like this:

```
#=== ERROR while compiling wasm_of_ocaml-compiler.6.1.0 =======================#
# context              2.5.1 | linux/x86_64 | ocaml-base-compiler.4.14.3 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/wasm_of_ocaml-compiler.6.1.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p wasm_of_ocaml-compiler -j 255 @install
# exit-code            1
# env-file             ~/.opam/log/wasm_of_ocaml-compiler-7-d90ad3.env
# output-file          ~/.opam/log/wasm_of_ocaml-compiler-7-d90ad3.out
### output ###
# (cd tools/version && /home/opam/.opam/4.14/bin/ocaml -I +compiler-libs /home/opam/.opam/4.14/.opam-switch/build/wasm_of_ocaml-compiler.6.1.0/_build/.dune/default/tools/version/dune.ml)
# fatal: not a git repository (or any parent up to mount point /)
# Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
# File "runtime/wasm/dune", lines 24-37, characters 0-328:
# 24 | (rule
# 25 |  (target runtime-cps.wasm)
# 26 |  (deps
# ....
# 35 |    --allowed-imports=bindings,Math,js,wasm:js-string,wasm:text-encoder,wasm:text-decoder
# 36 |    %{target}
# 37 |    %{read-lines:args})))
# (cd _build/default/runtime/wasm && ../../compiler/bin-wasm_of_ocaml/wasmoo_link_wasm.exe --binaryen=-g --binaryen-opt=-O3 --set=effects=cps --allowed-imports=bindings,Math,js,wasm:js-string,wasm:text-encoder,wasm:text-decoder ./runtime-cps.wasm ./array:./array.wat ./backtrace:./backtrace.wat ./bigarray:./bigarray.wat ./bigstring:./bigstring.wat ./blake2:./blake2.wat ./compare:./compare.wat ./custom:./custom.wat ./domain:./domain.wat ./dynlink:./dynlink.wat ./effect:./effect.wat ./fail:./fail.wat ./float:./float.wat ./fs:./fs.wat ./gc:./gc.wat ./hash:./hash.wat ./int32:./int32.wat ./int64:./int64.wat ./ints:./ints.wat ./io:./io.wat ./jslib:./jslib.wat ./jslib_js_of_ocaml:./jslib_js_of_ocaml.wat ./jsstring:./jsstring.wat ./lexing:./lexing.wat ./marshal:./marshal.wat ./md5:./md5.wat ./nat:./nat.wat ./obj:./obj.wat ./parsing:./parsing.wat ./printexc:./printexc.wat ./prng:./prng.wat ./runtime_events:./runtime_events.wat ./stdlib:./stdlib.wat ./str:./str.wat ./string:./string.wat ./sync:./sync.wat ./sys:./sys.wat ./toplevel:./toplevel.wat ./unix:./unix.wat ./weak:./weak.wat ./zstd:./zstd.wat)
```

See, e.g., https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/662e6a3427c777b88986bc9d015759eaaab0ea96/variant/compilers,4.14,dune.3.24.0,revdeps,wasm_of_ocaml-compiler.6.1.0