### PR TITLE
lwt: add MutationObserver support to Lwt_js_events

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # dev
 
+## Features/Changes
+* Lib: add `Lwt_js_events.mutation`/`mutations` — wait for `MutationObserver`
+  mutation records as Lwt threads (#250)
+
 ## Bug fixes
 * Runtime/wasm: derive the wat-module name from the basename of the input
   path in `runtime/wasm/args.ml`, so dune 3.24's leading-`./` path-form

--- a/lib/lwt/lwt_js_events.ml
+++ b/lib/lwt/lwt_js_events.ml
@@ -395,6 +395,35 @@ let transitionrun ?use_capture ?passive elt =
 let transitioncancel ?use_capture ?passive elt =
   make_event Dom_html.Event.transitioncancel ?use_capture ?passive elt
 
+let mutation
+    ?attributes
+    ?child_list
+    ?character_data
+    ?subtree
+    ?attribute_old_value
+    ?character_data_old_value
+    ?attribute_filter
+    node =
+  let t, w = Lwt.task () in
+  let cancel o = o##disconnect in
+  let o =
+    MutationObserver.observe
+      ~node
+      ~f:(fun records observer ->
+        cancel observer;
+        Lwt.wakeup w records)
+      ?child_list
+      ?attributes
+      ?character_data
+      ?subtree
+      ?attribute_old_value
+      ?character_data_old_value
+      ?attribute_filter
+      ()
+  in
+  Lwt.on_cancel t (fun () -> cancel o);
+  t
+
 let clicks ?cancel_handler ?use_capture ?passive t =
   seq_loop click ?cancel_handler ?use_capture ?passive t
 
@@ -601,6 +630,32 @@ let transitionruns ?cancel_handler ?use_capture ?passive t =
 
 let transitioncancels ?cancel_handler ?use_capture ?passive t =
   seq_loop transitioncancel ?cancel_handler ?use_capture ?passive t
+
+let mutations
+    ?cancel_handler
+    ?attributes
+    ?child_list
+    ?character_data
+    ?subtree
+    ?attribute_old_value
+    ?character_data_old_value
+    ?attribute_filter
+    node
+    handler =
+  seq_loop
+    (fun ?use_capture:_ ?passive:_ () ->
+      mutation
+        ?attributes
+        ?child_list
+        ?character_data
+        ?subtree
+        ?attribute_old_value
+        ?character_data_old_value
+        ?attribute_filter
+        node)
+    ?cancel_handler
+    ()
+    handler
 
 let request_animation_frame () =
   let t, s = Lwt.task () in

--- a/lib/lwt/lwt_js_events.mli
+++ b/lib/lwt/lwt_js_events.mli
@@ -1155,6 +1155,45 @@ val transitioncancels :
   -> (Dom_html.transitionEvent Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
 
+(** {2 Mutation observers} *)
+
+val mutation :
+     ?attributes:bool
+  -> ?child_list:bool
+  -> ?character_data:bool
+  -> ?subtree:bool
+  -> ?attribute_old_value:bool
+  -> ?character_data_old_value:bool
+  -> ?attribute_filter:Js.js_string Js.t list
+  -> #Dom.node Js.t
+  -> MutationObserver.mutationRecord Js.t Js.js_array Js.t Lwt.t
+(** [mutation node] creates a Lwt thread that waits for the next batch of
+    mutations on [node], as reported by a [MutationObserver], and returns
+    the array of mutation records. The observer is disconnected once the
+    thread returns (or is cancelled with [Lwt.cancel]).
+
+    The optional parameters mirror the fields of [MutationObserverInit]; at
+    least one of [~child_list], [~attributes] or [~character_data] must be
+    set, otherwise the underlying [observe] call raises (as per the spec).
+    See {!MutationObserver.observe}. *)
+
+val mutations :
+     ?cancel_handler:bool
+  -> ?attributes:bool
+  -> ?child_list:bool
+  -> ?character_data:bool
+  -> ?subtree:bool
+  -> ?attribute_old_value:bool
+  -> ?character_data_old_value:bool
+  -> ?attribute_filter:Js.js_string Js.t list
+  -> #Dom.node Js.t
+  -> (MutationObserver.mutationRecord Js.t Js.js_array Js.t -> unit Lwt.t -> unit Lwt.t)
+  -> unit Lwt.t
+(** [mutations node handler] is the looping counterpart of {!mutation},
+    built on top of {!seq_loop}: it observes [node] and runs [handler] on
+    each batch of mutation records, then observes again. As with the other
+    loops, mutations happening while the handler runs are not reported. *)
+
 val request_animation_frame : unit -> unit Lwt.t
 (** Returns when a repaint of the window by the browser starts.
     (see JS method [window.requestAnimationFrame]) *)


### PR DESCRIPTION
Closes #250.

## Summary

Adds Lwt integration for `MutationObserver` to `Lwt_js_events`. The low-level `MutationObserver` binding already existed in `lib/js_of_ocaml/`, but there was no Lwt-friendly way to await mutations.

Two functions are added, following the existing `click`/`clicks`, `onresize`/`onresizes` naming convention:

- **`mutation`** — single-shot: returns an Lwt thread that resolves with the next batch of `MutationRecord`s observed on a node, then disconnects the observer. Cancellable with `Lwt.cancel` (which also disconnects).
- **`mutations`** — the looping counterpart, built on the existing `seq_loop` (same shape as `onresizes`), running a handler on each batch.

Both forward the `MutationObserverInit` options (`?attributes`, `?child_list`, `?character_data`, `?subtree`, `?attribute_old_value`, `?character_data_old_value`, `?attribute_filter`) to `MutationObserver.observe`.

## Notes

- No automated test: `MutationObserver` requires a real DOM, and the existing low-level binding has no tests either, so there is no harness to hook into. The doc comment notes the spec requirement that at least one of `child_list`/`attributes`/`character_data` must be set.
- `CHANGES.md` updated under `# dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)