### PR TITLE
lib: add Notification and Clipboard bindings

### DIFF
--- a/API-STATUS.md
+++ b/API-STATUS.md
@@ -110,7 +110,7 @@ This document lists standard JavaScript/Web APIs and their support status in js_
 | Pointer Events | Yes | Yes | `Dom_html` · Brr: `Brr.Ev.Pointer` |
 | Wheel Events | Yes | Yes | `Dom_html` · Brr: `Brr.Ev.Wheel` |
 | Drag and Drop Events | Yes | Yes | `Dom_html` · Brr: `Brr.Ev.Drag` |
-| Clipboard API | No | Yes | Brr: `Brr_io.Clipboard` |
+| Clipboard API | Yes | Yes | `Clipboard` · Brr: `Brr_io.Clipboard` |
 | Fullscreen API | Yes | Yes | `Dom_html` (`requestFullscreen` / `exitFullscreen`) · Brr: `Brr.El.request_fullscreen`, `Brr.Document.exit_fullscreen` |
 | Gamepad API | No | No | |
 | Pointer Lock API | Yes | Yes | `Dom_html` (`requestPointerLock`) · Brr: `Brr.El.request_pointer_lock` |
@@ -155,7 +155,7 @@ This document lists standard JavaScript/Web APIs and their support status in js_
 | Web Animations API | Yes | No | `Dom_html` (`animate`, `getAnimations`; `animation`, `animationEffect`, `keyframeEffect`, `computedKeyframe`, `animationTimeline`, `documentTimeline`, `optionalEffectTiming`, `computedEffectTiming`, `keyframeAnimationOptions`, `animationPlaybackEvent`) |
 | Web Components (Custom Elements, Shadow DOM) | Partial | No | `Dom_html` (Shadow DOM — `attachShadow`, `shadowRoot`, `assignedSlot`, `slot`); Custom Elements not bound |
 | Web Crypto API | Yes | Yes | `Crypto` · Brr: `Brr_webcrypto` |
-| Notifications API | No | Yes | Brr: `Brr_io.Notification` |
+| Notifications API | Yes | Yes | `Notification` · Brr: `Brr_io.Notification` |
 | Broadcast Channel API | No | Yes | Brr: `Brr_io.Message.Broadcast_channel` |
 | AbortController / AbortSignal | Yes | Yes | `Abort` · Brr: `Brr.Abort` |
 
@@ -172,11 +172,9 @@ other APIs depend on it.
 
 | API | Issue | In Brr | Why |
 |-----|-------|--------|-----|
-| Clipboard API | — | Yes | Copy/paste is a basic UX expectation. The older `document.execCommand` path is deprecated. |
 | Service Workers | — | Yes | Required for PWAs and offline-capable apps. Cache API depends on it. |
 | Cache API | — | Yes | Paired with Service Workers for offline support and network caching strategies. |
 | MessageChannel / MessagePort | [#1464](https://github.com/ocsigen/js_of_ocaml/issues/1464) | Yes | Structured communication between Workers, iframes, and windows. Needed for non-trivial Worker usage. |
-| Notifications API | — | Yes | Common engagement feature in web apps. Small API surface. |
 
 ### Tier 2 — Medium
 
@@ -208,8 +206,7 @@ other APIs depend on it.
 
 ### Suggested implementation order
 
-1. **Clipboard API** — small surface, high user-facing value.
-2. **Service Workers + Cache API** — enables PWAs, the main class of apps jsoo
+1. **Service Workers + Cache API** — enables PWAs, the main class of apps jsoo
    cannot fully support today.
-3. **MessageChannel / Notifications / Broadcast Channel** — small APIs that fill
-   out the remaining communication gaps.
+2. **MessageChannel / Broadcast Channel** — small APIs that fill out the
+   remaining communication gaps.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
   `Key_format` enums, and overloaded `generateKey`/`generateKey_pair`,
   `importKey`/`importKey_jwk` and `exportKey`/`exportKey_jwk` methods that
   resolve the spec's union argument/return types (#2380)
+* Lib: add `Notification` and `Clipboard` — bindings to the Notifications API
+  and the (Promise-typed) async Clipboard API (#2390)
 * Lib: add `Lwt_js_events.mutation`/`mutations` — wait for `MutationObserver`
   mutation records as Lwt threads (#250)
 * Lib: remove `js_of_ocaml-lwt.logger` and the `lwt_log` dependency, as

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@
   `importKey`/`importKey_jwk` and `exportKey`/`exportKey_jwk` methods that
   resolve the spec's union argument/return types (#2380)
 * Lib: add `Notification` and `Clipboard` — bindings to the Notifications API
-  and the (Promise-typed) async Clipboard API (#2390)
+  and the (Promise-typed) async Clipboard API (#2379)
 * Lib: add `Lwt_js_events.mutation`/`mutations` — wait for `MutationObserver`
   mutation records as Lwt threads (#250)
 * Lib: remove `js_of_ocaml-lwt.logger` and the `lwt_log` dependency, as

--- a/lib/js_of_ocaml/clipboard.ml
+++ b/lib/js_of_ocaml/clipboard.ml
@@ -1,0 +1,49 @@
+(* Js_of_ocaml library
+ * http://www.ocsigen.org/js_of_ocaml/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+open! Import
+
+class type clipboardItem = object
+  method types : Js.js_string Js.t Js.js_array Js.t Js.readonly_prop
+
+  method presentationStyle : Js.js_string Js.t Js.readonly_prop
+
+  method getType : Js.js_string Js.t -> File.blob Js.t Promise.t Js.meth
+end
+
+let clipboardItem_global = Js.Unsafe.global##._ClipboardItem
+
+let clipboardItem : (Js.Unsafe.any -> clipboardItem Js.t) Js.constr = clipboardItem_global
+
+let item_supports (mime : Js.js_string Js.t) : bool Js.t =
+  clipboardItem_global##supports mime
+
+class type clipboard = object
+  method read : clipboardItem Js.t Js.js_array Js.t Promise.t Js.meth
+
+  method readText : Js.js_string Js.t Promise.t Js.meth
+
+  method write : clipboardItem Js.t Js.js_array Js.t -> unit Promise.t Js.meth
+
+  method writeText : Js.js_string Js.t -> unit Promise.t Js.meth
+end
+
+let navigator = Js.Unsafe.global##.navigator
+
+let clipboard () : clipboard Js.t = navigator##.clipboard
+
+let is_supported () = Js.Optdef.test navigator && Js.Optdef.test navigator##.clipboard

--- a/lib/js_of_ocaml/clipboard.mli
+++ b/lib/js_of_ocaml/clipboard.mli
@@ -1,0 +1,67 @@
+(* Js_of_ocaml library
+ * http://www.ocsigen.org/js_of_ocaml/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+
+(** Clipboard API.
+
+    A code example:
+    {[
+      if Clipboard.is_supported ()
+      then
+        ignore
+          (Promise.map
+             (fun () -> Console.console##log (Js.string "copied"))
+             ((Clipboard.clipboard ())##writeText (Js.string "Hello!")))
+    ]}
+
+    @see <https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API>
+    @see <https://w3c.github.io/clipboard-apis/> *)
+
+open Js
+
+class type clipboardItem = object
+  method types : js_string t js_array t readonly_prop
+
+  method presentationStyle : js_string t readonly_prop
+
+  method getType : js_string t -> File.blob t Promise.t meth
+end
+
+val clipboardItem : (Unsafe.any -> clipboardItem t) constr
+(** [new%js clipboardItem data] builds a clipboard item. [data] is a plain
+    JavaScript object whose keys are MIME types and whose values are the
+    associated {!File.blob}, string, or a promise resolving to either. *)
+
+val item_supports : js_string t -> bool t
+(** [item_supports mime] reports whether the given MIME type is supported by the
+    clipboard. Bound to the static [ClipboardItem.supports] method. *)
+
+class type clipboard = object
+  method read : clipboardItem t js_array t Promise.t meth
+
+  method readText : js_string t Promise.t meth
+
+  method write : clipboardItem t js_array t -> unit Promise.t meth
+
+  method writeText : js_string t -> unit Promise.t meth
+end
+
+val clipboard : unit -> clipboard t
+(** The [navigator.clipboard] object. *)
+
+val is_supported : unit -> bool
+(** Whether [navigator.clipboard] is available in the current environment. *)

--- a/lib/js_of_ocaml/js_of_ocaml.ml
+++ b/lib/js_of_ocaml/js_of_ocaml.ml
@@ -23,6 +23,7 @@
 
 module Abort = Abort
 module CSS = CSS
+module Clipboard = Clipboard
 module Console = Console
 module Crypto = Crypto
 module Dom = Dom
@@ -44,6 +45,7 @@ module Js_error = Js.Js_error
 module Json = Json
 module Jstable = Jstable
 module MutationObserver = MutationObserver
+module Notification = Notification
 module Performance = Performance
 module PerformanceObserver = PerformanceObserver
 module Promise = Promise

--- a/lib/js_of_ocaml/notification.ml
+++ b/lib/js_of_ocaml/notification.ml
@@ -22,6 +22,8 @@ class type notificationAction = object
 
   method title : Js.js_string Js.t Js.prop
 
+  method navigate : Js.js_string Js.t Js.prop
+
   method icon : Js.js_string Js.t Js.prop
 end
 

--- a/lib/js_of_ocaml/notification.ml
+++ b/lib/js_of_ocaml/notification.ml
@@ -1,0 +1,122 @@
+(* Js_of_ocaml library
+ * http://www.ocsigen.org/js_of_ocaml/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+open! Import
+
+class type notificationAction = object
+  method action : Js.js_string Js.t Js.prop
+
+  method title : Js.js_string Js.t Js.prop
+
+  method icon : Js.js_string Js.t Js.prop
+end
+
+class type notificationOptions = object
+  method dir : Js.js_string Js.t Js.writeonly_prop
+
+  method lang : Js.js_string Js.t Js.writeonly_prop
+
+  method body : Js.js_string Js.t Js.writeonly_prop
+
+  method navigate : Js.js_string Js.t Js.writeonly_prop
+
+  method tag : Js.js_string Js.t Js.writeonly_prop
+
+  method icon : Js.js_string Js.t Js.writeonly_prop
+
+  method image : Js.js_string Js.t Js.writeonly_prop
+
+  method badge : Js.js_string Js.t Js.writeonly_prop
+
+  method vibrate : int Js.js_array Js.t Js.writeonly_prop
+
+  method data : Js.Unsafe.any Js.writeonly_prop
+
+  method requireInteraction : bool Js.t Js.writeonly_prop
+
+  method silent : bool Js.t Js.opt Js.writeonly_prop
+
+  method renotify : bool Js.t Js.writeonly_prop
+
+  method timestamp : Js.number_t Js.writeonly_prop
+
+  method actions : notificationAction Js.t Js.js_array Js.t Js.writeonly_prop
+end
+
+let empty_options () : notificationOptions Js.t = Js.Unsafe.obj [||]
+
+class type notification = object ('self)
+  method title : Js.js_string Js.t Js.readonly_prop
+
+  method dir : Js.js_string Js.t Js.readonly_prop
+
+  method lang : Js.js_string Js.t Js.readonly_prop
+
+  method body : Js.js_string Js.t Js.readonly_prop
+
+  method navigate : Js.js_string Js.t Js.readonly_prop
+
+  method tag : Js.js_string Js.t Js.readonly_prop
+
+  method icon : Js.js_string Js.t Js.readonly_prop
+
+  method image : Js.js_string Js.t Js.readonly_prop
+
+  method badge : Js.js_string Js.t Js.readonly_prop
+
+  method vibrate : int Js.js_array Js.t Js.readonly_prop
+
+  method data : Js.Unsafe.any Js.readonly_prop
+
+  method requireInteraction : bool Js.t Js.readonly_prop
+
+  method silent : bool Js.t Js.opt Js.readonly_prop
+
+  method renotify : bool Js.t Js.readonly_prop
+
+  method timestamp : Js.number_t Js.readonly_prop
+
+  method actions : notificationAction Js.t Js.js_array Js.t Js.readonly_prop
+
+  method close : unit Js.meth
+
+  method onclick : ('self Js.t, 'self Dom.event Js.t) Dom.event_listener Js.writeonly_prop
+
+  method onclose : ('self Js.t, 'self Dom.event Js.t) Dom.event_listener Js.writeonly_prop
+
+  method onerror : ('self Js.t, 'self Dom.event Js.t) Dom.event_listener Js.writeonly_prop
+
+  method onshow : ('self Js.t, 'self Dom.event Js.t) Dom.event_listener Js.writeonly_prop
+end
+
+let notification_global = Js.Unsafe.global##._Notification
+
+let is_supported () = Js.Optdef.test notification_global
+
+let notification : (Js.js_string Js.t -> notification Js.t) Js.constr =
+  notification_global
+
+let notification_with_options :
+    (Js.js_string Js.t -> notificationOptions Js.t -> notification Js.t) Js.constr =
+  notification_global
+
+let permission () : Js.js_string Js.t = notification_global##.permission
+
+let max_actions () : int = notification_global##.maxActions
+
+let request_permission () : Js.js_string Js.t Promise.t =
+  Promise.of_any notification_global##requestPermission

--- a/lib/js_of_ocaml/notification.mli
+++ b/lib/js_of_ocaml/notification.mli
@@ -1,0 +1,150 @@
+(* Js_of_ocaml library
+ * http://www.ocsigen.org/js_of_ocaml/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+
+(** Notifications API.
+
+    A code example:
+    {[
+      if Notification.is_supported ()
+      then
+        Promise.map
+          (fun perm ->
+            if Js.to_string perm = "granted"
+            then
+              let options = Notification.empty_options () in
+              options##.body := Js.string "Hello from OCaml!";
+              ignore (new%js Notification.notification_with_options
+                        (Js.string "Title") options))
+          (Notification.request_permission ())
+    ]}
+
+    @see <https://developer.mozilla.org/en-US/docs/Web/API/Notifications_API>
+    @see <https://notifications.spec.whatwg.org/> *)
+
+open Js
+
+(** A single action shown alongside a (persistent) notification. Used both when
+    building {!notificationOptions} and when reading {!notification}'s
+    [actions]; the members are therefore read-write. *)
+class type notificationAction = object
+  method action : js_string t prop
+
+  method title : js_string t prop
+
+  method icon : js_string t prop
+end
+
+(** Initializer for {!class-type:notification}. All fields are optional; create
+    an empty record with {!empty_options} and populate the ones you need. *)
+class type notificationOptions = object
+  method dir : js_string t writeonly_prop
+  (** Text direction: ["auto"] (default), ["ltr"] or ["rtl"]. *)
+
+  method lang : js_string t writeonly_prop
+
+  method body : js_string t writeonly_prop
+
+  method navigate : js_string t writeonly_prop
+
+  method tag : js_string t writeonly_prop
+
+  method icon : js_string t writeonly_prop
+
+  method image : js_string t writeonly_prop
+
+  method badge : js_string t writeonly_prop
+
+  method vibrate : int js_array t writeonly_prop
+
+  method data : Unsafe.any writeonly_prop
+
+  method requireInteraction : bool t writeonly_prop
+
+  method silent : bool t opt writeonly_prop
+
+  method renotify : bool t writeonly_prop
+
+  method timestamp : number_t writeonly_prop
+
+  method actions : notificationAction t js_array t writeonly_prop
+end
+
+val empty_options : unit -> notificationOptions t
+
+class type notification = object ('self)
+  method title : js_string t readonly_prop
+
+  method dir : js_string t readonly_prop
+
+  method lang : js_string t readonly_prop
+
+  method body : js_string t readonly_prop
+
+  method navigate : js_string t readonly_prop
+
+  method tag : js_string t readonly_prop
+
+  method icon : js_string t readonly_prop
+
+  method image : js_string t readonly_prop
+
+  method badge : js_string t readonly_prop
+
+  method vibrate : int js_array t readonly_prop
+
+  method data : Unsafe.any readonly_prop
+
+  method requireInteraction : bool t readonly_prop
+
+  method silent : bool t opt readonly_prop
+
+  method renotify : bool t readonly_prop
+
+  method timestamp : number_t readonly_prop
+
+  method actions : notificationAction t js_array t readonly_prop
+
+  method close : unit meth
+
+  method onclick : ('self t, 'self Dom.event t) Dom.event_listener writeonly_prop
+
+  method onclose : ('self t, 'self Dom.event t) Dom.event_listener writeonly_prop
+
+  method onerror : ('self t, 'self Dom.event t) Dom.event_listener writeonly_prop
+
+  method onshow : ('self t, 'self Dom.event t) Dom.event_listener writeonly_prop
+end
+
+val notification : (js_string t -> notification t) constr
+
+val notification_with_options :
+  (js_string t -> notificationOptions t -> notification t) constr
+
+val permission : unit -> js_string t
+(** The current permission to display notifications: ["granted"], ["denied"] or
+    ["default"]. *)
+
+val max_actions : unit -> int
+(** The maximum number of actions supported by notifications on this device. *)
+
+val request_permission : unit -> js_string t Promise.t
+(** Request permission from the user to display notifications. The promise
+    resolves with the new permission value (see {!permission}). *)
+
+val is_supported : unit -> bool
+(** Whether the [Notification] global is available in the current environment. *)

--- a/lib/js_of_ocaml/notification.mli
+++ b/lib/js_of_ocaml/notification.mli
@@ -46,6 +46,8 @@ class type notificationAction = object
 
   method title : js_string t prop
 
+  method navigate : js_string t prop
+
   method icon : js_string t prop
 end
 

--- a/lib/tests/test_clipboard.ml
+++ b/lib/tests/test_clipboard.ml
@@ -1,0 +1,24 @@
+(* Js_of_ocaml
+ * http://www.ocsigen.org/js_of_ocaml/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+open Js_of_ocaml
+
+(* [navigator.clipboard] is not generally available (and requires a secure
+   context) in the test engines, so the suite only checks that the capability
+   probe returns a bool without throwing. *)
+
+let%expect_test "is_supported returns a bool" =
+  let (_ : bool) = Clipboard.is_supported () in
+  print_endline "PASSED";
+  [%expect {| PASSED |}]

--- a/lib/tests/test_notification.ml
+++ b/lib/tests/test_notification.ml
@@ -1,0 +1,38 @@
+(* Js_of_ocaml
+ * http://www.ocsigen.org/js_of_ocaml/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+open Js_of_ocaml
+
+(* The Notification API is not generally available in the test engines, so the
+   suite only exercises the parts that do not depend on the global being
+   present: building the options record and checking that the capability probe
+   returns without throwing. *)
+
+let%expect_test "options record can be populated" =
+  let o = Notification.empty_options () in
+  o##.body := Js.string "Hello";
+  o##.tag := Js.string "greeting";
+  o##.requireInteraction := Js._true;
+  (* The fields are write-only; read them back through an unsafe coercion to
+     check they were stored on the object. *)
+  print_endline (Js.to_string (Js.Unsafe.coerce o)##.body);
+  print_endline (Js.to_string (Js.Unsafe.coerce o)##.tag);
+  [%expect {|
+    Hello
+    greeting |}]
+
+let%expect_test "is_supported returns a bool" =
+  let (_ : bool) = Notification.is_supported () in
+  print_endline "PASSED";
+  [%expect {| PASSED |}]

--- a/manual/api.mld
+++ b/manual/api.mld
@@ -27,6 +27,7 @@ Browser APIs:
 {!modules:
 Js_of_ocaml.Abort
 Js_of_ocaml.CSS
+Js_of_ocaml.Clipboard
 Js_of_ocaml.Console
 Js_of_ocaml.Crypto
 Js_of_ocaml.Dom
@@ -42,6 +43,7 @@ Js_of_ocaml.IntersectionObserver
 Js_of_ocaml.Intl
 Js_of_ocaml.Json
 Js_of_ocaml.MutationObserver
+Js_of_ocaml.Notification
 Js_of_ocaml.Performance
 Js_of_ocaml.PerformanceObserver
 Js_of_ocaml.Promise


### PR DESCRIPTION
## Summary

Adds type-safe bindings to two standard Web APIs:

- **`Notification`** — the [Notifications API](https://notifications.spec.whatwg.org/): constructor (with/without options), the `permission` / `requestPermission` (Promise) / `maxActions` statics, all instance attributes (incl. `navigate`, `vibrate`, `actions` + a `notificationAction` class type), `close()`, and the `onclick`/`onshow`/`onclose`/`onerror` event-listener slots.
- **`Clipboard`** — the async [Clipboard API](https://w3c.github.io/clipboard-apis/): `navigator.clipboard` with Promise-typed `read`/`readText`/`write`/`writeText`, plus `clipboardItem` (with `getType`, `types`, `presentationStyle`) and the static `ClipboardItem.supports`.

Both modules follow the conventions of the existing Promise-based bindings (`Fetch`, `Geolocation`) and expose an `is_supported ()` capability probe.

## Verification

The bindings were checked member-by-member against the official WHATWG Notifications and W3C Clipboard IDL. Two deliberate, spec-conformant simplifications: `Clipboard.read` omits the optional `ClipboardUnsanitizedFormats` argument, and the `ClipboardItem` constructor omits the optional `ClipboardItemOptions` (both default to `{}`).

## Changes

- New: `lib/js_of_ocaml/{notification,clipboard}.{ml,mli}`
- Registered both modules in `js_of_ocaml.ml`
- Inline expect tests: `lib/tests/test_{notification,clipboard}.ml`
- `CHANGES.md` entry under `# dev`
- `API-STATUS.md`: both APIs moved to "Yes"; removed from the Tier 1 missing list

## Tests

`dune build lib/`, `dune build @fmt`, and `dune runtest lib/tests/` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)