### PR TITLE
lib: add Crypto bindings for the Web Crypto API

### DIFF
--- a/API-STATUS.md
+++ b/API-STATUS.md
@@ -154,7 +154,7 @@ This document lists standard JavaScript/Web APIs and their support status in js_
 | Performance API (now, mark, measure, entries) | Yes | Partial | `Performance` · Brr: `Brr.Performance` |
 | Web Animations API | Yes | No | `Dom_html` (`animate`, `getAnimations`; `animation`, `animationEffect`, `keyframeEffect`, `computedKeyframe`, `animationTimeline`, `documentTimeline`, `optionalEffectTiming`, `computedEffectTiming`, `keyframeAnimationOptions`, `animationPlaybackEvent`) |
 | Web Components (Custom Elements, Shadow DOM) | Partial | No | `Dom_html` (Shadow DOM — `attachShadow`, `shadowRoot`, `assignedSlot`, `slot`); Custom Elements not bound |
-| Web Crypto API | No | Yes | Brr: `Brr_webcrypto` |
+| Web Crypto API | Yes | Yes | `Crypto` · Brr: `Brr_webcrypto` |
 | Notifications API | No | Yes | Brr: `Brr_io.Notification` |
 | Broadcast Channel API | No | Yes | Brr: `Brr_io.Message.Broadcast_channel` |
 | AbortController / AbortSignal | Yes | Yes | `Abort` · Brr: `Brr.Abort` |
@@ -172,7 +172,6 @@ other APIs depend on it.
 
 | API | Issue | In Brr | Why |
 |-----|-------|--------|-----|
-| Web Crypto API | — | Yes | Required for authentication (JWT, PKCE), token generation, hashing. No safe workaround. |
 | Clipboard API | — | Yes | Copy/paste is a basic UX expectation. The older `document.execCommand` path is deprecated. |
 | Service Workers | — | Yes | Required for PWAs and offline-capable apps. Cache API depends on it. |
 | Cache API | — | Yes | Paired with Service Workers for offline support and network caching strategies. |
@@ -209,9 +208,8 @@ other APIs depend on it.
 
 ### Suggested implementation order
 
-1. **Web Crypto API** — security-critical, no safe workaround.
-2. **Clipboard API** — small surface, high user-facing value.
-3. **Service Workers + Cache API** — enables PWAs, the main class of apps jsoo
+1. **Clipboard API** — small surface, high user-facing value.
+2. **Service Workers + Cache API** — enables PWAs, the main class of apps jsoo
    cannot fully support today.
-4. **MessageChannel / Notifications / Broadcast Channel** — small APIs that fill
+3. **MessageChannel / Notifications / Broadcast Channel** — small APIs that fill
    out the remaining communication gaps.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@
   `to_algorithm`/`of_algorithm` conversions, typed `Key_type`/`Key_usage`/
   `Key_format` enums, and overloaded `generateKey`/`generateKey_pair`,
   `importKey`/`importKey_jwk` and `exportKey`/`exportKey_jwk` methods that
-  resolve the spec's union argument/return types (#NNNN)
+  resolve the spec's union argument/return types (#2380)
 * Lib: add `Lwt_js_events.mutation`/`mutations` — wait for `MutationObserver`
   mutation records as Lwt threads (#250)
 * Lib: remove `js_of_ocaml-lwt.logger` and the `lwt_log` dependency, as

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,13 @@
 # dev
 
 ## Features/Changes
+* Lib: add `Crypto` — bindings to the Web Crypto API (`crypto`,
+  `getRandomValues`, `randomUUID`, and the Promise-typed `SubtleCrypto`), with a
+  typed `params` variant (one constructor per algorithm) and
+  `to_algorithm`/`of_algorithm` conversions, typed `Key_type`/`Key_usage`/
+  `Key_format` enums, and overloaded `generateKey`/`generateKey_pair`,
+  `importKey`/`importKey_jwk` and `exportKey`/`exportKey_jwk` methods that
+  resolve the spec's union argument/return types (#NNNN)
 * Lib: add `Lwt_js_events.mutation`/`mutations` — wait for `MutationObserver`
   mutation records as Lwt threads (#250)
 * Lib: remove `js_of_ocaml-lwt.logger` and the `lwt_log` dependency, as

--- a/lib/js_of_ocaml/crypto.ml
+++ b/lib/js_of_ocaml/crypto.ml
@@ -1,0 +1,445 @@
+(* Js_of_ocaml library
+ * http://www.ocsigen.org/js_of_ocaml/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+open! Import
+
+type algorithm = Js.Unsafe.any
+
+let algorithm (s : Js.js_string Js.t) : algorithm = Js.Unsafe.inject s
+
+let algorithm_obj (o : < .. > Js.t) : algorithm = Js.Unsafe.inject o
+
+type bufferSource = Js.Unsafe.any
+
+let buffer_source_of_array_buffer (b : Typed_array.arrayBuffer Js.t) : bufferSource =
+  Js.Unsafe.inject b
+
+let buffer_source_of_array_buffer_view (v : #Typed_array.arrayBufferView Js.t) :
+    bufferSource =
+  Js.Unsafe.inject v
+
+module Key_type = struct
+  type t =
+    | Public
+    | Private
+    | Secret
+
+  let to_js = function
+    | Public -> Js.string "public"
+    | Private -> Js.string "private"
+    | Secret -> Js.string "secret"
+
+  let of_js s =
+    match Js.to_string s with
+    | "public" -> Public
+    | "private" -> Private
+    | "secret" -> Secret
+    | other -> invalid_arg ("Crypto.Key_type.of_js: " ^ other)
+end
+
+module Key_usage = struct
+  type t =
+    | Encrypt
+    | Decrypt
+    | Sign
+    | Verify
+    | Derive_key
+    | Derive_bits
+    | Wrap_key
+    | Unwrap_key
+
+  let to_js = function
+    | Encrypt -> Js.string "encrypt"
+    | Decrypt -> Js.string "decrypt"
+    | Sign -> Js.string "sign"
+    | Verify -> Js.string "verify"
+    | Derive_key -> Js.string "deriveKey"
+    | Derive_bits -> Js.string "deriveBits"
+    | Wrap_key -> Js.string "wrapKey"
+    | Unwrap_key -> Js.string "unwrapKey"
+
+  let of_js s =
+    match Js.to_string s with
+    | "encrypt" -> Encrypt
+    | "decrypt" -> Decrypt
+    | "sign" -> Sign
+    | "verify" -> Verify
+    | "deriveKey" -> Derive_key
+    | "deriveBits" -> Derive_bits
+    | "wrapKey" -> Wrap_key
+    | "unwrapKey" -> Unwrap_key
+    | other -> invalid_arg ("Crypto.Key_usage.of_js: " ^ other)
+
+  let list_to_js l = Js.array (Array.of_list (List.map to_js l))
+
+  let list_of_js a = List.map of_js (Array.to_list (Js.to_array a))
+end
+
+module Key_format = struct
+  type t =
+    | Raw
+    | Spki
+    | Pkcs8
+    | Jwk
+
+  let to_js = function
+    | Raw -> Js.string "raw"
+    | Spki -> Js.string "spki"
+    | Pkcs8 -> Js.string "pkcs8"
+    | Jwk -> Js.string "jwk"
+
+  let of_js s =
+    match Js.to_string s with
+    | "raw" -> Raw
+    | "spki" -> Spki
+    | "pkcs8" -> Pkcs8
+    | "jwk" -> Jwk
+    | other -> invalid_arg ("Crypto.Key_format.of_js: " ^ other)
+end
+
+class type cryptoKey = object
+  method _type : Js.js_string Js.t Js.readonly_prop
+
+  method extractable : bool Js.t Js.readonly_prop
+
+  method algorithm : algorithm Js.readonly_prop
+
+  method usages : Js.js_string Js.t Js.js_array Js.t Js.readonly_prop
+end
+
+class type cryptoKeyPair = object
+  method publicKey : cryptoKey Js.t Js.readonly_prop
+
+  method privateKey : cryptoKey Js.t Js.readonly_prop
+end
+
+type jsonWebKey = Js.Unsafe.any
+
+type params =
+  | RSASSA_PKCS1_v1_5
+  | RSA_PSS of { salt_length : int }
+  | RSA_OAEP of { label : bufferSource option }
+  | ECDSA of { hash : algorithm }
+  | ECDH of { public : cryptoKey Js.t }
+  | AES_CTR of
+      { counter : bufferSource
+      ; length : int
+      }
+  | AES_CBC of { iv : bufferSource }
+  | AES_GCM of
+      { iv : bufferSource
+      ; additional_data : bufferSource option
+      ; tag_length : int option
+      }
+  | AES_KW
+  | HMAC
+  | HKDF of
+      { hash : algorithm
+      ; salt : bufferSource
+      ; info : bufferSource
+      }
+  | PBKDF2 of
+      { hash : algorithm
+      ; salt : bufferSource
+      ; iterations : int
+      }
+  | RSA_keygen of
+      { name : Js.js_string Js.t
+      ; modulus_length : int
+      ; public_exponent : Typed_array.uint8Array Js.t
+      ; hash : algorithm
+      }
+  | RSA_import of
+      { name : Js.js_string Js.t
+      ; hash : algorithm
+      }
+  | EC_keygen of
+      { name : Js.js_string Js.t
+      ; named_curve : Js.js_string Js.t
+      }
+  | AES_keygen of
+      { name : Js.js_string Js.t
+      ; length : int
+      }
+  | HMAC_keygen of
+      { hash : algorithm
+      ; length : int option
+      }
+  | SHA_1
+  | SHA_256
+  | SHA_384
+  | SHA_512
+  | Other of Js.js_string Js.t
+
+let to_algorithm (p : params) : algorithm =
+  let str s : Js.Unsafe.any = Js.Unsafe.inject (Js.string s) in
+  let i n : Js.Unsafe.any = Js.Unsafe.inject (n : int) in
+  let obj l : algorithm = Js.Unsafe.inject (Js.Unsafe.obj (Array.of_list l)) in
+  let opt name f = function
+    | None -> []
+    | Some v -> [ name, f v ]
+  in
+  match p with
+  | SHA_1 -> algorithm (Js.string "SHA-1")
+  | SHA_256 -> algorithm (Js.string "SHA-256")
+  | SHA_384 -> algorithm (Js.string "SHA-384")
+  | SHA_512 -> algorithm (Js.string "SHA-512")
+  | AES_KW -> algorithm (Js.string "AES-KW")
+  | HMAC -> algorithm (Js.string "HMAC")
+  | RSASSA_PKCS1_v1_5 -> algorithm (Js.string "RSASSA-PKCS1-v1_5")
+  | Other name -> algorithm name
+  | RSA_PSS { salt_length } -> obj [ "name", str "RSA-PSS"; "saltLength", i salt_length ]
+  | RSA_OAEP { label } -> obj (("name", str "RSA-OAEP") :: opt "label" (fun b -> b) label)
+  | ECDSA { hash } -> obj [ "name", str "ECDSA"; "hash", hash ]
+  | ECDH { public } -> obj [ "name", str "ECDH"; "public", Js.Unsafe.inject public ]
+  | AES_CTR { counter; length } ->
+      obj [ "name", str "AES-CTR"; "counter", counter; "length", i length ]
+  | AES_CBC { iv } -> obj [ "name", str "AES-CBC"; "iv", iv ]
+  | AES_GCM { iv; additional_data; tag_length } ->
+      obj
+        ([ "name", str "AES-GCM"; "iv", iv ]
+        @ opt "additionalData" (fun b -> b) additional_data
+        @ opt "tagLength" i tag_length)
+  | HKDF { hash; salt; info } ->
+      obj [ "name", str "HKDF"; "hash", hash; "salt", salt; "info", info ]
+  | PBKDF2 { hash; salt; iterations } ->
+      obj [ "name", str "PBKDF2"; "hash", hash; "salt", salt; "iterations", i iterations ]
+  | RSA_keygen { name; modulus_length; public_exponent; hash } ->
+      obj
+        [ "name", Js.Unsafe.inject name
+        ; "modulusLength", i modulus_length
+        ; "publicExponent", Js.Unsafe.inject public_exponent
+        ; "hash", hash
+        ]
+  | RSA_import { name; hash } -> obj [ "name", Js.Unsafe.inject name; "hash", hash ]
+  | EC_keygen { name; named_curve } ->
+      obj [ "name", Js.Unsafe.inject name; "namedCurve", Js.Unsafe.inject named_curve ]
+  | AES_keygen { name; length } ->
+      obj [ "name", Js.Unsafe.inject name; "length", i length ]
+  | HMAC_keygen { hash; length } ->
+      obj (("name", str "HMAC") :: ("hash", hash) :: opt "length" i length)
+
+let of_algorithm (a : algorithm) : params =
+  let name_only s =
+    match s with
+    | "SHA-1" -> SHA_1
+    | "SHA-256" -> SHA_256
+    | "SHA-384" -> SHA_384
+    | "SHA-512" -> SHA_512
+    | "AES-KW" -> AES_KW
+    | "HMAC" -> HMAC
+    | "RSASSA-PKCS1-v1_5" -> RSASSA_PKCS1_v1_5
+    | _ -> Other (Js.string s)
+  in
+  if String.equal (Js.to_string (Js.typeof a)) "string"
+  then name_only (Js.to_string (Js.Unsafe.coerce a : Js.js_string Js.t))
+  else begin
+    let o : < .. > Js.t = Js.Unsafe.coerce a in
+    let field k = Js.Unsafe.get o (Js.string k) in
+    let has k = Js.Optdef.test (field k : 'a Js.Optdef.t) in
+    let str k : Js.js_string Js.t = field k in
+    let int_ k : int = field k in
+    let alg k : algorithm = field k in
+    let buf k : bufferSource = field k in
+    let opt_buf k = if has k then Some (buf k) else None in
+    let opt_int k = if has k then Some (int_ k) else None in
+    let rsa_keygen () =
+      RSA_keygen
+        { name = str "name"
+        ; modulus_length = int_ "modulusLength"
+        ; public_exponent = field "publicExponent"
+        ; hash = alg "hash"
+        }
+    in
+    let ec_keygen () = EC_keygen { name = str "name"; named_curve = str "namedCurve" } in
+    let aes_keygen () = AES_keygen { name = str "name"; length = int_ "length" } in
+    let rsa_import () = RSA_import { name = str "name"; hash = alg "hash" } in
+    match Js.to_string (str "name") with
+    | "SHA-1" -> SHA_1
+    | "SHA-256" -> SHA_256
+    | "SHA-384" -> SHA_384
+    | "SHA-512" -> SHA_512
+    | "RSASSA-PKCS1-v1_5" ->
+        if has "modulusLength"
+        then rsa_keygen ()
+        else if has "hash"
+        then rsa_import ()
+        else RSASSA_PKCS1_v1_5
+    | "RSA-PSS" ->
+        if has "modulusLength"
+        then rsa_keygen ()
+        else if has "saltLength"
+        then RSA_PSS { salt_length = int_ "saltLength" }
+        else if has "hash"
+        then rsa_import ()
+        else Other (str "name")
+    | "RSA-OAEP" ->
+        if has "modulusLength"
+        then rsa_keygen ()
+        else if has "hash"
+        then rsa_import ()
+        else RSA_OAEP { label = opt_buf "label" }
+    | "ECDSA" -> if has "namedCurve" then ec_keygen () else ECDSA { hash = alg "hash" }
+    | "ECDH" ->
+        if has "namedCurve" then ec_keygen () else ECDH { public = field "public" }
+    | "AES-CTR" ->
+        if has "counter"
+        then AES_CTR { counter = buf "counter"; length = int_ "length" }
+        else if has "length"
+        then aes_keygen ()
+        else Other (str "name")
+    | "AES-CBC" ->
+        if has "iv"
+        then AES_CBC { iv = buf "iv" }
+        else if has "length"
+        then aes_keygen ()
+        else Other (str "name")
+    | "AES-GCM" ->
+        if has "iv"
+        then
+          AES_GCM
+            { iv = buf "iv"
+            ; additional_data = opt_buf "additionalData"
+            ; tag_length = opt_int "tagLength"
+            }
+        else if has "length"
+        then aes_keygen ()
+        else Other (str "name")
+    | "AES-KW" -> if has "length" then aes_keygen () else AES_KW
+    | "HMAC" ->
+        if has "hash"
+        then HMAC_keygen { hash = alg "hash"; length = opt_int "length" }
+        else HMAC
+    | "HKDF" -> HKDF { hash = alg "hash"; salt = buf "salt"; info = buf "info" }
+    | "PBKDF2" ->
+        PBKDF2 { hash = alg "hash"; salt = buf "salt"; iterations = int_ "iterations" }
+    | _ -> Other (str "name")
+  end
+
+class type subtleCrypto = object
+  method encrypt :
+       algorithm
+    -> cryptoKey Js.t
+    -> bufferSource
+    -> Typed_array.arrayBuffer Js.t Promise.t Js.meth
+
+  method decrypt :
+       algorithm
+    -> cryptoKey Js.t
+    -> bufferSource
+    -> Typed_array.arrayBuffer Js.t Promise.t Js.meth
+
+  method sign :
+       algorithm
+    -> cryptoKey Js.t
+    -> bufferSource
+    -> Typed_array.arrayBuffer Js.t Promise.t Js.meth
+
+  method verify :
+       algorithm
+    -> cryptoKey Js.t
+    -> bufferSource
+    -> bufferSource
+    -> bool Js.t Promise.t Js.meth
+
+  method digest :
+    algorithm -> bufferSource -> Typed_array.arrayBuffer Js.t Promise.t Js.meth
+
+  method generateKey :
+       algorithm
+    -> bool Js.t
+    -> Js.js_string Js.t Js.js_array Js.t
+    -> cryptoKey Js.t Promise.t Js.meth
+
+  method generateKey_pair :
+       algorithm
+    -> bool Js.t
+    -> Js.js_string Js.t Js.js_array Js.t
+    -> cryptoKeyPair Js.t Promise.t Js.meth
+
+  method deriveKey :
+       algorithm
+    -> cryptoKey Js.t
+    -> algorithm
+    -> bool Js.t
+    -> Js.js_string Js.t Js.js_array Js.t
+    -> cryptoKey Js.t Promise.t Js.meth
+
+  method deriveBits :
+    algorithm -> cryptoKey Js.t -> Typed_array.arrayBuffer Js.t Promise.t Js.meth
+
+  method deriveBits_length :
+    algorithm -> cryptoKey Js.t -> int -> Typed_array.arrayBuffer Js.t Promise.t Js.meth
+
+  method importKey :
+       Js.js_string Js.t
+    -> bufferSource
+    -> algorithm
+    -> bool Js.t
+    -> Js.js_string Js.t Js.js_array Js.t
+    -> cryptoKey Js.t Promise.t Js.meth
+
+  method importKey_jwk :
+       Js.js_string Js.t
+    -> jsonWebKey
+    -> algorithm
+    -> bool Js.t
+    -> Js.js_string Js.t Js.js_array Js.t
+    -> cryptoKey Js.t Promise.t Js.meth
+
+  method exportKey :
+    Js.js_string Js.t -> cryptoKey Js.t -> Typed_array.arrayBuffer Js.t Promise.t Js.meth
+
+  method exportKey_jwk :
+    Js.js_string Js.t -> cryptoKey Js.t -> jsonWebKey Promise.t Js.meth
+
+  method wrapKey :
+       Js.js_string Js.t
+    -> cryptoKey Js.t
+    -> cryptoKey Js.t
+    -> algorithm
+    -> Typed_array.arrayBuffer Js.t Promise.t Js.meth
+
+  method unwrapKey :
+       Js.js_string Js.t
+    -> bufferSource
+    -> cryptoKey Js.t
+    -> algorithm
+    -> algorithm
+    -> bool Js.t
+    -> Js.js_string Js.t Js.js_array Js.t
+    -> cryptoKey Js.t Promise.t Js.meth
+end
+
+class type crypto = object
+  method subtle : subtleCrypto Js.t Js.readonly_prop
+
+  method getRandomValues :
+    'a 'b 'c.
+       ('a, 'b, 'c) Typed_array.typedArray Js.t
+    -> ('a, 'b, 'c) Typed_array.typedArray Js.t Js.meth
+
+  method randomUUID : Js.js_string Js.t Js.meth
+end
+
+let crypto_global = Js.Unsafe.global##.crypto
+
+let is_supported () = Js.Optdef.test crypto_global
+
+let crypto () : crypto Js.t = crypto_global
+
+let subtle () : subtleCrypto Js.t = crypto_global##.subtle

--- a/lib/js_of_ocaml/crypto.mli
+++ b/lib/js_of_ocaml/crypto.mli
@@ -1,0 +1,316 @@
+(* Js_of_ocaml library
+ * http://www.ocsigen.org/js_of_ocaml/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+
+(** Web Crypto API.
+
+    A code example:
+    {[
+      let hash data =
+        Promise.map
+          (fun buf -> buf)
+          ((Crypto.subtle ())##digest
+             (Crypto.algorithm (Js.string "SHA-256"))
+             (Crypto.buffer_source_of_array_buffer_view data))
+    ]}
+
+    Most of {!SubtleCrypto} is exposed as object methods, mirroring the
+    JavaScript surface: obtain the [subtle] object with {!subtle} and call its
+    methods with [##].
+
+    @see <https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API>
+    @see <https://w3c.github.io/webcrypto/> *)
+
+open Js
+
+(** {1 Common types} *)
+
+type algorithm
+(** An [AlgorithmIdentifier]: either a bare name (e.g. ["SHA-256"]) or a
+    parameter object (e.g. [{name: "AES-GCM"; iv: ...}]). Build one with
+    {!algorithm} or {!algorithm_obj}. *)
+
+val algorithm : js_string t -> algorithm
+(** [algorithm name] is the bare-name form of an algorithm identifier, such as
+    [algorithm (Js.string "SHA-256")]. *)
+
+val algorithm_obj : < .. > t -> algorithm
+(** [algorithm_obj o] uses an arbitrary parameter object as an algorithm
+    identifier. Build [o] with {!Js.Unsafe.obj} or the [object%js] syntax. *)
+
+type bufferSource
+(** A [BufferSource]: an [ArrayBuffer] or any [ArrayBufferView] (typed array or
+    [DataView]). Build one with {!buffer_source_of_array_buffer} or
+    {!buffer_source_of_array_buffer_view}. *)
+
+val buffer_source_of_array_buffer : Typed_array.arrayBuffer t -> bufferSource
+
+val buffer_source_of_array_buffer_view : #Typed_array.arrayBufferView t -> bufferSource
+
+(** {1 Key types, usages and formats} *)
+
+(** The [KeyType] of a {!cryptoKey}. *)
+module Key_type : sig
+  type t =
+    | Public
+    | Private
+    | Secret
+
+  val to_js : t -> Js.js_string Js.t
+
+  val of_js : Js.js_string Js.t -> t
+  (** @raise Invalid_argument on an unrecognised string. *)
+end
+
+(** A [KeyUsage]: an operation a {!cryptoKey} may be used for. *)
+module Key_usage : sig
+  type t =
+    | Encrypt
+    | Decrypt
+    | Sign
+    | Verify
+    | Derive_key
+    | Derive_bits
+    | Wrap_key
+    | Unwrap_key
+
+  val to_js : t -> Js.js_string Js.t
+
+  val of_js : Js.js_string Js.t -> t
+  (** @raise Invalid_argument on an unrecognised string. *)
+
+  val list_to_js : t list -> Js.js_string Js.t Js.js_array Js.t
+
+  val list_of_js : Js.js_string Js.t Js.js_array Js.t -> t list
+end
+
+(** A [KeyFormat] for importing and exporting keys. *)
+module Key_format : sig
+  type t =
+    | Raw
+    | Spki
+    | Pkcs8
+    | Jwk
+
+  val to_js : t -> Js.js_string Js.t
+
+  val of_js : Js.js_string Js.t -> t
+  (** @raise Invalid_argument on an unrecognised string. *)
+end
+
+(** {1 Keys} *)
+
+class type cryptoKey = object
+  method _type : js_string t readonly_prop
+  (** The key type: ["secret"], ["private"] or ["public"]. *)
+
+  method extractable : bool t readonly_prop
+
+  method algorithm : algorithm readonly_prop
+  (** The algorithm the key is for; pass to {!of_algorithm} to inspect it. *)
+
+  method usages : js_string t js_array t readonly_prop
+end
+
+class type cryptoKeyPair = object
+  method publicKey : cryptoKey t readonly_prop
+
+  method privateKey : cryptoKey t readonly_prop
+end
+
+type jsonWebKey = Unsafe.any
+(** A key in [JsonWebKey] form (RFC 7517): a plain JSON object whose members
+    carry the key material (e.g. [kty], [n], [e] for RSA; [crv], [x], [y] for
+    EC). Exposed as {!Js.Unsafe.any}: read its members with {!Js.Unsafe.get},
+    build one with {!Js.Unsafe.obj}, and serialise/parse with the [JSON] global. *)
+
+(** {1 Typed algorithm parameters} *)
+
+(** A typed view of an {!algorithm} identifier, with one constructor per
+    WebCrypto algorithm-parameter dictionary. The nullary constructors map to a
+    bare name string; the others map to a parameter object. [hash] fields are
+    themselves {!algorithm} values (usually a digest name such as
+    {!to_algorithm} of {!SHA_256}). *)
+type params =
+  | RSASSA_PKCS1_v1_5  (** Sign/verify; parameters are just the name. *)
+  | RSA_PSS of { salt_length : int }
+  | RSA_OAEP of { label : bufferSource option }
+  | ECDSA of { hash : algorithm }
+  | ECDH of { public : cryptoKey t }
+  | AES_CTR of
+      { counter : bufferSource
+      ; length : int
+      }
+  | AES_CBC of { iv : bufferSource }
+  | AES_GCM of
+      { iv : bufferSource
+      ; additional_data : bufferSource option
+      ; tag_length : int option
+      }
+  | AES_KW  (** Key-wrapping; parameters are just the name. *)
+  | HMAC  (** Sign/verify; parameters are just the name. *)
+  | HKDF of
+      { hash : algorithm
+      ; salt : bufferSource
+      ; info : bufferSource
+      }
+  | PBKDF2 of
+      { hash : algorithm
+      ; salt : bufferSource
+      ; iterations : int
+      }
+  | RSA_keygen of
+      { name : js_string t  (** ["RSASSA-PKCS1-v1_5"], ["RSA-PSS"] or ["RSA-OAEP"]. *)
+      ; modulus_length : int
+      ; public_exponent : Typed_array.uint8Array t
+      ; hash : algorithm
+      }  (** [RsaHashedKeyGenParams] for {!subtleCrypto.generateKey}. *)
+  | RSA_import of
+      { name : js_string t  (** ["RSASSA-PKCS1-v1_5"], ["RSA-PSS"] or ["RSA-OAEP"]. *)
+      ; hash : algorithm
+      }  (** [RsaHashedImportParams] for {!subtleCrypto.importKey}. *)
+  | EC_keygen of
+      { name : js_string t  (** ["ECDSA"] or ["ECDH"]. *)
+      ; named_curve : js_string t
+      }  (** [EcKeyGenParams]. *)
+  | AES_keygen of
+      { name : js_string t  (** ["AES-CTR"], ["AES-CBC"], ["AES-GCM"] or ["AES-KW"]. *)
+      ; length : int
+      }  (** [AesKeyGenParams]. *)
+  | HMAC_keygen of
+      { hash : algorithm
+      ; length : int option
+      }  (** [HmacKeyGenParams]. *)
+  | SHA_1
+  | SHA_256
+  | SHA_384
+  | SHA_512
+  | Other of js_string t  (** An algorithm whose name is not recognised. *)
+
+val to_algorithm : params -> algorithm
+(** Build a JS [AlgorithmIdentifier] from typed {!params}. *)
+
+val of_algorithm : algorithm -> params
+(** Recover typed {!params} from a JS [AlgorithmIdentifier] by dispatching on its
+    [name]. Key-generation and import parameter objects are told apart from
+    same-named operation parameters by which fields are present (e.g.
+    [modulusLength] vs [hash] for RSA, [namedCurve] for EC, [iv]/[counter] vs
+    [length] for AES). An unrecognised name maps to {!Other}. *)
+
+(** {1 SubtleCrypto} *)
+
+class type subtleCrypto = object
+  method encrypt :
+    algorithm -> cryptoKey t -> bufferSource -> Typed_array.arrayBuffer t Promise.t meth
+
+  method decrypt :
+    algorithm -> cryptoKey t -> bufferSource -> Typed_array.arrayBuffer t Promise.t meth
+
+  method sign :
+    algorithm -> cryptoKey t -> bufferSource -> Typed_array.arrayBuffer t Promise.t meth
+
+  method verify :
+    algorithm -> cryptoKey t -> bufferSource -> bufferSource -> bool t Promise.t meth
+
+  method digest : algorithm -> bufferSource -> Typed_array.arrayBuffer t Promise.t meth
+
+  method generateKey :
+    algorithm -> bool t -> js_string t js_array t -> cryptoKey t Promise.t meth
+  (** Generate a single key (AES, HMAC, …). *)
+
+  method generateKey_pair :
+    algorithm -> bool t -> js_string t js_array t -> cryptoKeyPair t Promise.t meth
+  (** Generate a key pair (RSA, EC, …). *)
+
+  method deriveKey :
+       algorithm
+    -> cryptoKey t
+    -> algorithm
+    -> bool t
+    -> js_string t js_array t
+    -> cryptoKey t Promise.t meth
+
+  method deriveBits : algorithm -> cryptoKey t -> Typed_array.arrayBuffer t Promise.t meth
+  (** Derive bits using the algorithm's default length. *)
+
+  method deriveBits_length :
+    algorithm -> cryptoKey t -> int -> Typed_array.arrayBuffer t Promise.t meth
+  (** [deriveBits_length algorithm baseKey length] derives [length] bits. *)
+
+  method importKey :
+       js_string t
+    -> bufferSource
+    -> algorithm
+    -> bool t
+    -> js_string t js_array t
+    -> cryptoKey t Promise.t meth
+  (** Import a key from raw bytes (the [raw], [spki] and [pkcs8] formats). *)
+
+  method importKey_jwk :
+       js_string t
+    -> jsonWebKey
+    -> algorithm
+    -> bool t
+    -> js_string t js_array t
+    -> cryptoKey t Promise.t meth
+  (** Import a key from a {!jsonWebKey} (the [jwk] format). *)
+
+  method exportKey :
+    js_string t -> cryptoKey t -> Typed_array.arrayBuffer t Promise.t meth
+  (** Export to raw bytes (the [raw], [spki] and [pkcs8] formats). *)
+
+  method exportKey_jwk : js_string t -> cryptoKey t -> jsonWebKey Promise.t meth
+  (** Export to a {!jsonWebKey} (the [jwk] format). *)
+
+  method wrapKey :
+       js_string t
+    -> cryptoKey t
+    -> cryptoKey t
+    -> algorithm
+    -> Typed_array.arrayBuffer t Promise.t meth
+
+  method unwrapKey :
+       js_string t
+    -> bufferSource
+    -> cryptoKey t
+    -> algorithm
+    -> algorithm
+    -> bool t
+    -> js_string t js_array t
+    -> cryptoKey t Promise.t meth
+end
+
+(** {1 Crypto} *)
+
+class type crypto = object
+  method subtle : subtleCrypto t readonly_prop
+
+  method getRandomValues :
+    'a 'b 'c.
+    ('a, 'b, 'c) Typed_array.typedArray t -> ('a, 'b, 'c) Typed_array.typedArray t meth
+
+  method randomUUID : js_string t meth
+end
+
+val crypto : unit -> crypto t
+(** The [crypto] global ([globalThis.crypto]). *)
+
+val subtle : unit -> subtleCrypto t
+(** [(crypto ())##.subtle]. Only available in a secure context. *)
+
+val is_supported : unit -> bool
+(** Whether the [crypto] global is available in the current environment. *)

--- a/lib/js_of_ocaml/js_of_ocaml.ml
+++ b/lib/js_of_ocaml/js_of_ocaml.ml
@@ -24,6 +24,7 @@
 module Abort = Abort
 module CSS = CSS
 module Console = Console
+module Crypto = Crypto
 module Dom = Dom
 module Dom_events = Dom_events
 module Dom_html = Dom_html

--- a/lib/tests/test_crypto.ml
+++ b/lib/tests/test_crypto.ml
@@ -1,0 +1,167 @@
+(* Js_of_ocaml
+ * http://www.ocsigen.org/js_of_ocaml/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+open Js_of_ocaml
+
+let is_promise any =
+  Js.instanceof
+    (Js.Unsafe.coerce any : _ Js.t)
+    (Js.Unsafe.global##._Promise : _ Js.constr)
+
+let%expect_test "is_supported returns a bool" =
+  let (_ : bool) = Crypto.is_supported () in
+  print_endline "PASSED";
+  [%expect {| PASSED |}]
+
+let%expect_test "algorithm params round-trip through JS objects" =
+  let describe (p : Crypto.params) =
+    match p with
+    | Crypto.SHA_256 -> "SHA-256"
+    | Crypto.RSASSA_PKCS1_v1_5 -> "RSASSA-PKCS1-v1_5"
+    | Crypto.AES_GCM { tag_length; _ } ->
+        Printf.sprintf
+          "AES-GCM tag=%s"
+          (match tag_length with
+          | Some t -> string_of_int t
+          | None -> "none")
+    | Crypto.PBKDF2 { iterations; _ } -> Printf.sprintf "PBKDF2 iter=%d" iterations
+    | Crypto.RSA_keygen { name; modulus_length; _ } ->
+        Printf.sprintf "RSA-keygen %s mod=%d" (Js.to_string name) modulus_length
+    | Crypto.RSA_import { name; hash } ->
+        Printf.sprintf
+          "RSA-import %s hash=%s"
+          (Js.to_string name)
+          (match Crypto.of_algorithm hash with
+          | Crypto.SHA_256 -> "SHA-256"
+          | _ -> "?")
+    | Crypto.AES_keygen { name; length } ->
+        Printf.sprintf "AES-keygen %s len=%d" (Js.to_string name) length
+    | Crypto.ECDSA { hash } ->
+        Printf.sprintf
+          "ECDSA hash=%s"
+          (match Crypto.of_algorithm hash with
+          | Crypto.SHA_384 -> "SHA-384"
+          | _ -> "?")
+    | Crypto.Other s -> "Other " ^ Js.to_string s
+    | _ -> "other"
+  in
+  let rt p = print_endline (describe (Crypto.of_algorithm (Crypto.to_algorithm p))) in
+  let buf () =
+    Crypto.buffer_source_of_array_buffer_view (new%js Typed_array.uint8Array 12)
+  in
+  rt Crypto.SHA_256;
+  rt Crypto.RSASSA_PKCS1_v1_5;
+  rt (Crypto.AES_GCM { iv = buf (); additional_data = None; tag_length = Some 128 });
+  rt
+    (Crypto.PBKDF2
+       { hash = Crypto.to_algorithm Crypto.SHA_256; salt = buf (); iterations = 100_000 });
+  rt
+    (Crypto.RSA_keygen
+       { name = Js.string "RSA-OAEP"
+       ; modulus_length = 2048
+       ; public_exponent = new%js Typed_array.uint8Array 3
+       ; hash = Crypto.to_algorithm Crypto.SHA_256
+       });
+  (* Same name "AES-GCM" but a key-generation shape: disambiguated by fields. *)
+  rt (Crypto.AES_keygen { name = Js.string "AES-GCM"; length = 256 });
+  rt (Crypto.ECDSA { hash = Crypto.to_algorithm Crypto.SHA_384 });
+  (* RSA import params {name, hash}: distinct from the keygen and operation
+     shapes of the same name, no longer lossy. *)
+  rt
+    (Crypto.RSA_import
+       { name = Js.string "RSASSA-PKCS1-v1_5"; hash = Crypto.to_algorithm Crypto.SHA_256 });
+  [%expect
+    {|
+    SHA-256
+    RSASSA-PKCS1-v1_5
+    AES-GCM tag=128
+    PBKDF2 iter=100000
+    RSA-keygen RSA-OAEP mod=2048
+    AES-keygen AES-GCM len=256
+    ECDSA hash=SHA-384
+    RSA-import RSASSA-PKCS1-v1_5 hash=SHA-256 |}]
+
+let%expect_test "key enums round-trip" =
+  let usages =
+    [ Crypto.Key_usage.Encrypt
+    ; Crypto.Key_usage.Derive_bits
+    ; Crypto.Key_usage.Unwrap_key
+    ]
+  in
+  let back = Crypto.Key_usage.list_of_js (Crypto.Key_usage.list_to_js usages) in
+  List.iter (fun u -> print_string (Js.to_string (Crypto.Key_usage.to_js u) ^ " ")) back;
+  print_newline ();
+  print_endline (Js.to_string (Crypto.Key_type.to_js Crypto.Key_type.Private));
+  print_endline (Js.to_string (Crypto.Key_format.to_js Crypto.Key_format.Pkcs8));
+  print_endline
+    (match Crypto.Key_usage.of_js (Js.string "deriveKey") with
+    | Crypto.Key_usage.Derive_key -> "ok"
+    | _ -> "bad");
+  [%expect {|
+    encrypt deriveBits unwrapKey
+    private
+    pkcs8
+    ok |}]
+
+(* [crypto] is not available under QuickJS, so the functional tests are gated. *)
+
+let%expect_test ("getRandomValues fills the array in place" [@when not quickjs]) =
+  let a = new%js Typed_array.uint8Array 16 in
+  let b = (Crypto.crypto ())##getRandomValues a in
+  (* The same object is returned, and it keeps its length. *)
+  print_endline (string_of_bool (a == b));
+  print_endline (string_of_int b##.length);
+  [%expect {|
+    true
+    16 |}]
+
+let%expect_test ("randomUUID has the canonical shape" [@when not quickjs]) =
+  let uuid = Js.to_string (Crypto.crypto ())##randomUUID in
+  print_endline (string_of_int (String.length uuid));
+  print_endline
+    (string_of_bool
+       (Char.equal uuid.[8] '-'
+       && Char.equal uuid.[13] '-'
+       && Char.equal uuid.[18] '-'
+       && Char.equal uuid.[23] '-'));
+  [%expect {|
+    36
+    true |}]
+
+let%expect_test ("digest returns a promise" [@when not quickjs]) =
+  let data = new%js Typed_array.uint8Array 3 in
+  Typed_array.set data 0 1;
+  Typed_array.set data 1 2;
+  Typed_array.set data 2 3;
+  let p =
+    (Crypto.subtle ())##digest
+      (Crypto.algorithm (Js.string "SHA-256"))
+      (Crypto.buffer_source_of_array_buffer_view data)
+  in
+  (* The result settles asynchronously, so we can only assert synchronously that
+     a promise was returned. *)
+  print_endline (string_of_bool (is_promise (Promise.to_any p)));
+  [%expect {| true |}]
+
+let%expect_test ("generateKey builds and returns a promise" [@when not quickjs]) =
+  (* AES yields a single key; the method picks the result type. *)
+  let p : Crypto.cryptoKey Js.t Promise.t =
+    (Crypto.subtle ())##generateKey
+      (Crypto.to_algorithm
+         (Crypto.AES_keygen { name = Js.string "AES-GCM"; length = 256 }))
+      Js._true
+      (Crypto.Key_usage.list_to_js [ Crypto.Key_usage.Encrypt; Crypto.Key_usage.Decrypt ])
+  in
+  print_endline (string_of_bool (is_promise (Promise.to_any p)));
+  [%expect {| true |}]

--- a/manual/api.mld
+++ b/manual/api.mld
@@ -28,6 +28,7 @@ Browser APIs:
 Js_of_ocaml.Abort
 Js_of_ocaml.CSS
 Js_of_ocaml.Console
+Js_of_ocaml.Crypto
 Js_of_ocaml.Dom
 Js_of_ocaml.Dom_events
 Js_of_ocaml.Dom_html


### PR DESCRIPTION
## Summary

Add `Js_of_ocaml.Crypto` — bindings to the [Web Crypto API](https://www.w3.org/TR/WebCryptoAPI/):

- `crypto` global with `getRandomValues` and `randomUUID`
- the Promise-typed `SubtleCrypto` interface
- an abstract `algorithm` type with a typed `params` variant (one constructor per
  algorithm parameter dictionary) plus `to_algorithm`/`of_algorithm` conversions
- typed `Key_type` / `Key_usage` / `Key_format` enums
- the spec's union-shaped operations exposed as overloaded methods —
  `generateKey`/`generateKey_pair`, `importKey`/`importKey_jwk`,
  `exportKey`/`exportKey_jwk` — so callers get typed results without runtime
  projection

Bindings were verified against the W3C WebCrypto spec.

## Test plan

- Inline `ppx_expect` tests in `lib/tests/test_crypto.ml`
- `CHANGES.md` entry and `API-STATUS.md` update included

🤖 Generated with [Claude Code](https://claude.com/claude-code)
