### PR TITLE
lib: add Service Worker, MessageChannel and Cache API bindings

### DIFF
--- a/API-STATUS.md
+++ b/API-STATUS.md
@@ -45,7 +45,7 @@ This document lists standard JavaScript/Web APIs and their support status in js_
 |-----|------|-----|---------------------|
 | XMLHttpRequest | Yes | No | `XmlHttpRequest` |
 | Fetch API | Yes | Yes | `Fetch` · Brr: `Brr_io.Fetch` |
-| MessageChannel / MessagePort | No | Yes | [#1464](https://github.com/ocsigen/js_of_ocaml/issues/1464) · Brr: `Brr_io.Message` |
+| MessageChannel / MessagePort | Yes | Yes | `MessageChannel` · Brr: `Brr_io.Message` |
 | WebSocket | Yes | Yes | `WebSockets` · Brr: `Brr_io.Websocket` |
 | Server-Sent Events (EventSource) | Yes | No | `EventSource` |
 | Beacon API | No | No | |
@@ -56,14 +56,14 @@ This document lists standard JavaScript/Web APIs and their support status in js_
 |-----|------|-----|---------------------|
 | Web Storage (localStorage/sessionStorage) | Yes | Yes | `Dom_html` (storage) · Brr: `Brr_io.Storage` |
 | IndexedDB | No | No | |
-| Cache API | No | Yes | Brr: `Brr_io.Fetch.Cache` |
+| Cache API | Yes | Yes | `Cache` · Brr: `Brr_io.Fetch.Cache` |
 
 ## Workers
 
 | API | jsoo | Brr | jsoo Module / Notes |
 |-----|------|-----|---------------------|
 | Web Workers | Yes | Yes | `Worker` · Brr: `Brr_webworkers.Worker` |
-| Service Workers | No | Yes | Brr: `Brr_webworkers.Service_worker` |
+| Service Workers | Yes | Yes | `ServiceWorker` · Brr: `Brr_webworkers.Service_worker` |
 | Shared Workers | No | Yes | Brr: `Brr_webworkers.Worker.Shared` |
 
 ## File & Binary Data
@@ -170,11 +170,11 @@ other APIs depend on it.
 
 ### Tier 1 — High
 
-| API | Issue | In Brr | Why |
-|-----|-------|--------|-----|
-| Service Workers | — | Yes | Required for PWAs and offline-capable apps. Cache API depends on it. |
-| Cache API | — | Yes | Paired with Service Workers for offline support and network caching strategies. |
-| MessageChannel / MessagePort | [#1464](https://github.com/ocsigen/js_of_ocaml/issues/1464) | Yes | Structured communication between Workers, iframes, and windows. Needed for non-trivial Worker usage. |
+All previously Tier 1 APIs are now implemented: **Web Crypto** (`Crypto`),
+**Clipboard** (`Clipboard`), **Notifications** (`Notification`), **Service
+Workers** (`ServiceWorker`), the **Cache API** (`Cache`) and **MessageChannel /
+MessagePort** (`MessageChannel`) — together enabling PWAs and structured
+Worker/iframe/window communication.
 
 ### Tier 2 — Medium
 
@@ -206,7 +206,5 @@ other APIs depend on it.
 
 ### Suggested implementation order
 
-1. **Service Workers + Cache API** — enables PWAs, the main class of apps jsoo
-   cannot fully support today.
-2. **MessageChannel / Broadcast Channel** — small APIs that fill out the
+1. **Broadcast Channel** — small API that fills out the
    remaining communication gaps.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@
   and the (Promise-typed) async Clipboard API (#2379)
 * Lib: add bindings for the Service Worker API (`ServiceWorker`),
   channel messaging (`MessageChannel`, `MessagePort`, `MessageEvent`) and the
-  Cache API (`Cache`) (#NNNN)
+  Cache API (`Cache`) (#2381)
 * Lib: add `Lwt_js_events.mutation`/`mutations` — wait for `MutationObserver`
   mutation records as Lwt threads (#250)
 * Lib: remove `js_of_ocaml-lwt.logger` and the `lwt_log` dependency, as

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,9 @@
   resolve the spec's union argument/return types (#2380)
 * Lib: add `Notification` and `Clipboard` — bindings to the Notifications API
   and the (Promise-typed) async Clipboard API (#2379)
+* Lib: add bindings for the Service Worker API (`ServiceWorker`),
+  channel messaging (`MessageChannel`, `MessagePort`, `MessageEvent`) and the
+  Cache API (`Cache`) (#NNNN)
 * Lib: add `Lwt_js_events.mutation`/`mutations` — wait for `MutationObserver`
   mutation records as Lwt threads (#250)
 * Lib: remove `js_of_ocaml-lwt.logger` and the `lwt_log` dependency, as

--- a/lib/js_of_ocaml/cache.ml
+++ b/lib/js_of_ocaml/cache.ml
@@ -28,6 +28,14 @@ end
 
 let empty_query_options () : queryOptions Js.t = Js.Unsafe.obj [||]
 
+class type multiQueryOptions = object
+  inherit queryOptions
+
+  method cacheName : Js.js_string Js.t Js.writeonly_prop
+end
+
+let empty_multi_query_options () : multiQueryOptions Js.t = Js.Unsafe.obj [||]
+
 class type cache = object
   method match_ : Fetch.request Js.t -> Fetch.response Js.t Js.optdef Promise.t Js.meth
 
@@ -77,6 +85,11 @@ class type cacheStorage = object
   method match_ : Fetch.request Js.t -> Fetch.response Js.t Js.optdef Promise.t Js.meth
 
   method match_url : Js.js_string Js.t -> Fetch.response Js.t Js.optdef Promise.t Js.meth
+
+  method match_withOptions :
+       Fetch.request Js.t
+    -> multiQueryOptions Js.t
+    -> Fetch.response Js.t Js.optdef Promise.t Js.meth
 
   method has : Js.js_string Js.t -> bool Js.t Promise.t Js.meth
 

--- a/lib/js_of_ocaml/cache.ml
+++ b/lib/js_of_ocaml/cache.ml
@@ -1,0 +1,92 @@
+(* Js_of_ocaml library
+ * http://www.ocsigen.org/js_of_ocaml/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+
+open! Import
+
+class type queryOptions = object
+  method ignoreSearch : bool Js.t Js.writeonly_prop
+
+  method ignoreMethod : bool Js.t Js.writeonly_prop
+
+  method ignoreVary : bool Js.t Js.writeonly_prop
+end
+
+let empty_query_options () : queryOptions Js.t = Js.Unsafe.obj [||]
+
+class type cache = object
+  method match_ : Fetch.request Js.t -> Fetch.response Js.t Js.optdef Promise.t Js.meth
+
+  method match_url : Js.js_string Js.t -> Fetch.response Js.t Js.optdef Promise.t Js.meth
+
+  method match_withOptions :
+       Fetch.request Js.t
+    -> queryOptions Js.t
+    -> Fetch.response Js.t Js.optdef Promise.t Js.meth
+
+  method matchAll : Fetch.response Js.t Js.js_array Js.t Promise.t Js.meth
+
+  method matchAll_request :
+    Fetch.request Js.t -> Fetch.response Js.t Js.js_array Js.t Promise.t Js.meth
+
+  method matchAll_withOptions :
+       Fetch.request Js.t
+    -> queryOptions Js.t
+    -> Fetch.response Js.t Js.js_array Js.t Promise.t Js.meth
+
+  method add : Fetch.request Js.t -> unit Promise.t Js.meth
+
+  method add_url : Js.js_string Js.t -> unit Promise.t Js.meth
+
+  method addAll : Fetch.request Js.t Js.js_array Js.t -> unit Promise.t Js.meth
+
+  method addAll_url : Js.js_string Js.t Js.js_array Js.t -> unit Promise.t Js.meth
+
+  method put : Fetch.request Js.t -> Fetch.response Js.t -> unit Promise.t Js.meth
+
+  method put_url : Js.js_string Js.t -> Fetch.response Js.t -> unit Promise.t Js.meth
+
+  method delete : Fetch.request Js.t -> bool Js.t Promise.t Js.meth
+
+  method delete_url : Js.js_string Js.t -> bool Js.t Promise.t Js.meth
+
+  method delete_withOptions :
+    Fetch.request Js.t -> queryOptions Js.t -> bool Js.t Promise.t Js.meth
+
+  method keys : Fetch.request Js.t Js.js_array Js.t Promise.t Js.meth
+
+  method keys_request :
+    Fetch.request Js.t -> Fetch.request Js.t Js.js_array Js.t Promise.t Js.meth
+end
+
+class type cacheStorage = object
+  method match_ : Fetch.request Js.t -> Fetch.response Js.t Js.optdef Promise.t Js.meth
+
+  method match_url : Js.js_string Js.t -> Fetch.response Js.t Js.optdef Promise.t Js.meth
+
+  method has : Js.js_string Js.t -> bool Js.t Promise.t Js.meth
+
+  method open_ : Js.js_string Js.t -> cache Js.t Promise.t Js.meth
+
+  method delete : Js.js_string Js.t -> bool Js.t Promise.t Js.meth
+
+  method keys : Js.js_string Js.t Js.js_array Js.t Promise.t Js.meth
+end
+
+let caches () : cacheStorage Js.t = Js.Unsafe.global##.caches
+
+let is_supported () = Js.Optdef.test Js.Unsafe.global##.caches

--- a/lib/js_of_ocaml/cache.mli
+++ b/lib/js_of_ocaml/cache.mli
@@ -40,6 +40,17 @@ end
 
 val empty_query_options : unit -> queryOptions t
 
+(** Like {!class-type:queryOptions} but with a [cacheName] to restrict
+    {!class-type:cacheStorage}[##match_withOptions] to a single named cache.
+    Create an empty record with {!empty_multi_query_options}. *)
+class type multiQueryOptions = object
+  inherit queryOptions
+
+  method cacheName : js_string t writeonly_prop
+end
+
+val empty_multi_query_options : unit -> multiQueryOptions t
+
 (** A single named {!Cache} instance, obtained from {!class-type:cacheStorage}.
 
     The methods come in two flavours: the [_url] variants take the request as a
@@ -92,6 +103,9 @@ class type cacheStorage = object
   method match_ : Fetch.request t -> Fetch.response t optdef Promise.t meth
 
   method match_url : js_string t -> Fetch.response t optdef Promise.t meth
+
+  method match_withOptions :
+    Fetch.request t -> multiQueryOptions t -> Fetch.response t optdef Promise.t meth
 
   method has : js_string t -> bool t Promise.t meth
 

--- a/lib/js_of_ocaml/cache.mli
+++ b/lib/js_of_ocaml/cache.mli
@@ -1,0 +1,112 @@
+(* Js_of_ocaml library
+ * http://www.ocsigen.org/js_of_ocaml/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+
+(** Cache API: persistent storage of {!Fetch} [Request]/[Response] pairs.
+
+    Available from {!Dom_html.window} and from {!ServiceWorker} contexts; the
+    Cache API requires a secure context. The methods are Promise-typed — see
+    {!Promise}.
+
+    @see <https://developer.mozilla.org/en-US/docs/Web/API/Cache>
+    @see <https://developer.mozilla.org/en-US/docs/Web/API/CacheStorage>
+    @see <https://w3c.github.io/ServiceWorker/#cache-interface> *)
+
+open Js
+
+(** Options controlling how a request is matched against cached entries.
+    Create an empty record with {!empty_query_options}. *)
+class type queryOptions = object
+  method ignoreSearch : bool t writeonly_prop
+
+  method ignoreMethod : bool t writeonly_prop
+
+  method ignoreVary : bool t writeonly_prop
+end
+
+val empty_query_options : unit -> queryOptions t
+
+(** A single named {!Cache} instance, obtained from {!class-type:cacheStorage}.
+
+    The methods come in two flavours: the [_url] variants take the request as a
+    URL string, while the others take a {!Fetch.request}. *)
+class type cache = object
+  method match_ : Fetch.request t -> Fetch.response t optdef Promise.t meth
+
+  method match_url : js_string t -> Fetch.response t optdef Promise.t meth
+
+  method match_withOptions :
+    Fetch.request t -> queryOptions t -> Fetch.response t optdef Promise.t meth
+
+  method matchAll : Fetch.response t js_array t Promise.t meth
+
+  method matchAll_request : Fetch.request t -> Fetch.response t js_array t Promise.t meth
+
+  method matchAll_withOptions :
+    Fetch.request t -> queryOptions t -> Fetch.response t js_array t Promise.t meth
+
+  method add : Fetch.request t -> unit Promise.t meth
+  (** [cache##add req] fetches [req] and stores the resulting response. The
+      promise rejects if the response does not have an ok status. *)
+
+  method add_url : js_string t -> unit Promise.t meth
+
+  method addAll : Fetch.request t js_array t -> unit Promise.t meth
+
+  method addAll_url : js_string t js_array t -> unit Promise.t meth
+
+  method put : Fetch.request t -> Fetch.response t -> unit Promise.t meth
+
+  method put_url : js_string t -> Fetch.response t -> unit Promise.t meth
+
+  method delete : Fetch.request t -> bool t Promise.t meth
+  (** [cache##delete req] resolves with [true] if a matching entry was found
+      and removed, [false] otherwise. *)
+
+  method delete_url : js_string t -> bool t Promise.t meth
+
+  method delete_withOptions : Fetch.request t -> queryOptions t -> bool t Promise.t meth
+
+  method keys : Fetch.request t js_array t Promise.t meth
+
+  method keys_request : Fetch.request t -> Fetch.request t js_array t Promise.t meth
+end
+
+(** The set of named {!Cache}s for the current origin, exposed as the global
+    [caches] (see {!caches}). *)
+class type cacheStorage = object
+  method match_ : Fetch.request t -> Fetch.response t optdef Promise.t meth
+
+  method match_url : js_string t -> Fetch.response t optdef Promise.t meth
+
+  method has : js_string t -> bool t Promise.t meth
+
+  method open_ : js_string t -> cache t Promise.t meth
+  (** [caches##open_ name] resolves with the {!class-type:cache} named [name],
+      creating it if it does not yet exist. *)
+
+  method delete : js_string t -> bool t Promise.t meth
+
+  method keys : js_string t js_array t Promise.t meth
+end
+
+val caches : unit -> cacheStorage t
+(** The [caches] global ([CacheStorage]) for the current origin. Guard with
+    {!is_supported} in environments where the Cache API may be missing. *)
+
+val is_supported : unit -> bool
+(** Whether the [caches] global is available in the current environment. *)

--- a/lib/js_of_ocaml/js_of_ocaml.ml
+++ b/lib/js_of_ocaml/js_of_ocaml.ml
@@ -23,6 +23,7 @@
 
 module Abort = Abort
 module CSS = CSS
+module Cache = Cache
 module Clipboard = Clipboard
 module Console = Console
 module Crypto = Crypto
@@ -44,6 +45,7 @@ module Js = Js
 module Js_error = Js.Js_error
 module Json = Json
 module Jstable = Jstable
+module MessageChannel = MessageChannel
 module MutationObserver = MutationObserver
 module Notification = Notification
 module Performance = Performance
@@ -51,6 +53,7 @@ module PerformanceObserver = PerformanceObserver
 module Promise = Promise
 module ResizeObserver = ResizeObserver
 module Regexp = Regexp
+module ServiceWorker = ServiceWorker
 module Sys_js = Sys_js
 module Typed_array = Typed_array
 module Url = Url

--- a/lib/js_of_ocaml/messageChannel.ml
+++ b/lib/js_of_ocaml/messageChannel.ml
@@ -1,0 +1,83 @@
+(* Js_of_ocaml library
+ * http://www.ocsigen.org/js_of_ocaml/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+
+open! Import
+
+class type ['a] messageEvent = object
+  inherit Dom_html.event
+
+  method data : 'a Js.readonly_prop
+
+  method origin : Js.js_string Js.t Js.readonly_prop
+
+  method lastEventId : Js.js_string Js.t Js.readonly_prop
+
+  method source : Js.Unsafe.any Js.opt Js.readonly_prop
+
+  method ports : messagePort Js.t Js.js_array Js.t Js.readonly_prop
+end
+
+and messagePort = object ('self)
+  inherit Dom_html.eventTarget
+
+  method postMessage : 'a. 'a -> unit Js.meth
+
+  method postMessage_withTransfer :
+    'a. 'a -> Js.Unsafe.any Js.js_array Js.t -> unit Js.meth
+
+  method start : unit Js.meth
+
+  method close : unit Js.meth
+
+  method onmessage :
+    ('self Js.t, Js.Unsafe.any messageEvent Js.t) Dom.event_listener Js.writeonly_prop
+
+  method onmessageerror :
+    ('self Js.t, Js.Unsafe.any messageEvent Js.t) Dom.event_listener Js.writeonly_prop
+end
+
+class type messageChannel = object
+  method port1 : messagePort Js.t Js.readonly_prop
+
+  method port2 : messagePort Js.t Js.readonly_prop
+end
+
+let messageChannel : messageChannel Js.t Js.constr = Js.Unsafe.global##._MessageChannel
+
+class type messageEventInit = object
+  method data : Js.Unsafe.any Js.writeonly_prop
+
+  method origin : Js.js_string Js.t Js.writeonly_prop
+
+  method lastEventId : Js.js_string Js.t Js.writeonly_prop
+
+  method source : Js.Unsafe.any Js.writeonly_prop
+
+  method ports : messagePort Js.t Js.js_array Js.t Js.writeonly_prop
+end
+
+let empty_message_event_init () : messageEventInit Js.t = Js.Unsafe.obj [||]
+
+let messageEvent : (Js.js_string Js.t -> 'a messageEvent Js.t) Js.constr =
+  Js.Unsafe.global##._MessageEvent
+
+let messageEvent_with_init :
+    (Js.js_string Js.t -> messageEventInit Js.t -> 'a messageEvent Js.t) Js.constr =
+  Js.Unsafe.global##._MessageEvent
+
+let is_supported () = Js.Optdef.test Js.Unsafe.global##._MessageChannel

--- a/lib/js_of_ocaml/messageChannel.ml
+++ b/lib/js_of_ocaml/messageChannel.ml
@@ -49,6 +49,8 @@ and messagePort = object ('self)
 
   method onmessageerror :
     ('self Js.t, Js.Unsafe.any messageEvent Js.t) Dom.event_listener Js.writeonly_prop
+
+  method onclose : ('self Js.t, 'self Dom.event Js.t) Dom.event_listener Js.writeonly_prop
 end
 
 class type messageChannel = object

--- a/lib/js_of_ocaml/messageChannel.mli
+++ b/lib/js_of_ocaml/messageChannel.mli
@@ -67,6 +67,8 @@ and messagePort = object ('self)
 
   method onmessageerror :
     ('self t, Unsafe.any messageEvent t) Dom.event_listener writeonly_prop
+
+  method onclose : ('self t, 'self Dom.event t) Dom.event_listener writeonly_prop
 end
 
 class type messageChannel = object

--- a/lib/js_of_ocaml/messageChannel.mli
+++ b/lib/js_of_ocaml/messageChannel.mli
@@ -1,0 +1,108 @@
+(* Js_of_ocaml library
+ * http://www.ocsigen.org/js_of_ocaml/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+
+(** Channel messaging: [MessageChannel], [MessagePort] and [MessageEvent].
+
+    @see <https://developer.mozilla.org/en-US/docs/Web/API/MessageChannel>
+    @see <https://developer.mozilla.org/en-US/docs/Web/API/MessagePort>
+    @see <https://developer.mozilla.org/en-US/docs/Web/API/MessageEvent>
+    @see <https://html.spec.whatwg.org/multipage/web-messaging.html> *)
+
+open Js
+
+(** A message delivered to a [message] / [messageerror] listener (also used by
+    {!Worker}, {!ServiceWorker} and [postMessage] on a {!class-type:messagePort}).
+    The type parameter ['a] is the type of the [data] payload. *)
+class type ['a] messageEvent = object
+  inherit Dom_html.event
+
+  method data : 'a readonly_prop
+
+  method origin : js_string t readonly_prop
+
+  method lastEventId : js_string t readonly_prop
+
+  method source : Unsafe.any opt readonly_prop
+  (** The [source] of a message event is a [MessageEventSource], i.e. one of a
+      [WindowProxy], a {!class-type:messagePort} or a
+      {!ServiceWorker.serviceWorker}; [null] when there is none. *)
+
+  method ports : messagePort t js_array t readonly_prop
+end
+
+(** One of the two endpoints of a {!class-type:messageChannel}. Messages posted
+    on one port are delivered to the [message] listener of the other. *)
+and messagePort = object ('self)
+  inherit Dom_html.eventTarget
+
+  method postMessage : 'a. 'a -> unit meth
+
+  method postMessage_withTransfer : 'a. 'a -> Unsafe.any js_array t -> unit meth
+  (** [port##postMessage_withTransfer msg transfer] posts [msg], transferring
+      ownership of the {{:https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Transferable_objects}
+      transferable objects} in [transfer] (e.g. [ArrayBuffer]s or other
+      {!class-type:messagePort}s) to the receiving context. *)
+
+  method start : unit meth
+
+  method close : unit meth
+
+  method onmessage :
+    ('self t, Unsafe.any messageEvent t) Dom.event_listener writeonly_prop
+
+  method onmessageerror :
+    ('self t, Unsafe.any messageEvent t) Dom.event_listener writeonly_prop
+end
+
+class type messageChannel = object
+  method port1 : messagePort t readonly_prop
+
+  method port2 : messagePort t readonly_prop
+end
+
+val messageChannel : messageChannel t constr
+
+(** {2 MessageEvent constructor} *)
+
+(** Initializer for {!messageEvent}. All fields are optional; create an empty
+    record with {!empty_message_event_init} and populate the ones you need.
+    The [data] payload is injected as {!Js.Unsafe.any}; the resulting event is
+    read back at whatever type the caller annotates {!messageEvent_with_init}
+    with. *)
+class type messageEventInit = object
+  method data : Unsafe.any writeonly_prop
+
+  method origin : js_string t writeonly_prop
+
+  method lastEventId : js_string t writeonly_prop
+
+  method source : Unsafe.any writeonly_prop
+
+  method ports : messagePort t js_array t writeonly_prop
+end
+
+val empty_message_event_init : unit -> messageEventInit t
+
+val messageEvent : (js_string t -> 'a messageEvent t) constr
+
+val messageEvent_with_init :
+  (js_string t -> messageEventInit t -> 'a messageEvent t) constr
+
+val is_supported : unit -> bool
+(** Whether the [MessageChannel] global is available in the current
+    environment. *)

--- a/lib/js_of_ocaml/serviceWorker.ml
+++ b/lib/js_of_ocaml/serviceWorker.ml
@@ -1,0 +1,201 @@
+(* Js_of_ocaml library
+ * http://www.ocsigen.org/js_of_ocaml/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+
+open! Import
+
+class type serviceWorker = object ('self)
+  inherit Dom_html.eventTarget
+
+  method scriptURL : Js.js_string Js.t Js.readonly_prop
+
+  method state : Js.js_string Js.t Js.readonly_prop
+
+  method postMessage : 'a. 'a -> unit Js.meth
+
+  method postMessage_withTransfer :
+    'a. 'a -> Js.Unsafe.any Js.js_array Js.t -> unit Js.meth
+
+  method onstatechange :
+    ('self Js.t, 'self Dom.event Js.t) Dom.event_listener Js.writeonly_prop
+
+  method onerror :
+    ('self Js.t, Worker.errorEvent Js.t) Dom.event_listener Js.writeonly_prop
+end
+
+class type registrationOptions = object
+  method scope : Js.js_string Js.t Js.writeonly_prop
+
+  method _type : Js.js_string Js.t Js.writeonly_prop
+
+  method updateViaCache : Js.js_string Js.t Js.writeonly_prop
+end
+
+let empty_registration_options () : registrationOptions Js.t = Js.Unsafe.obj [||]
+
+class type serviceWorkerRegistration = object ('self)
+  inherit Dom_html.eventTarget
+
+  method installing : serviceWorker Js.t Js.opt Js.readonly_prop
+
+  method waiting : serviceWorker Js.t Js.opt Js.readonly_prop
+
+  method active : serviceWorker Js.t Js.opt Js.readonly_prop
+
+  method scope : Js.js_string Js.t Js.readonly_prop
+
+  method updateViaCache : Js.js_string Js.t Js.readonly_prop
+
+  method update : unit Promise.t Js.meth
+
+  method unregister : bool Js.t Promise.t Js.meth
+
+  method onupdatefound :
+    ('self Js.t, 'self Dom.event Js.t) Dom.event_listener Js.writeonly_prop
+end
+
+class type serviceWorkerContainer = object ('self)
+  inherit Dom_html.eventTarget
+
+  method controller : serviceWorker Js.t Js.opt Js.readonly_prop
+
+  method ready : serviceWorkerRegistration Js.t Promise.t Js.readonly_prop
+
+  method register : Js.js_string Js.t -> serviceWorkerRegistration Js.t Promise.t Js.meth
+
+  method register_withOptions :
+       Js.js_string Js.t
+    -> registrationOptions Js.t
+    -> serviceWorkerRegistration Js.t Promise.t Js.meth
+
+  method getRegistration : serviceWorkerRegistration Js.t Js.optdef Promise.t Js.meth
+
+  method getRegistration_withUrl :
+    Js.js_string Js.t -> serviceWorkerRegistration Js.t Js.optdef Promise.t Js.meth
+
+  method getRegistrations :
+    serviceWorkerRegistration Js.t Js.js_array Js.t Promise.t Js.meth
+
+  method startMessages : unit Js.meth
+
+  method oncontrollerchange :
+    ('self Js.t, 'self Dom.event Js.t) Dom.event_listener Js.writeonly_prop
+
+  method onmessage :
+    ('self Js.t, Js.Unsafe.any MessageChannel.messageEvent Js.t) Dom.event_listener
+    Js.writeonly_prop
+end
+
+let container () : serviceWorkerContainer Js.t Js.optdef =
+  Js.Optdef.case
+    Js.Unsafe.global##.navigator
+    (fun () -> Js.undefined)
+    (fun nav -> nav##.serviceWorker)
+
+let is_supported () = Js.Optdef.test (container ())
+
+class type extendableEvent = object
+  inherit Dom_html.event
+
+  method waitUntil : 'a. 'a Promise.t -> unit Js.meth
+end
+
+class type fetchEvent = object
+  inherit extendableEvent
+
+  method request : Fetch.request Js.t Js.readonly_prop
+
+  method clientId : Js.js_string Js.t Js.readonly_prop
+
+  method resultingClientId : Js.js_string Js.t Js.readonly_prop
+
+  method preloadResponse : Js.Unsafe.any Promise.t Js.readonly_prop
+
+  method respondWith : Fetch.response Js.t Promise.t -> unit Js.meth
+end
+
+class type client = object
+  method id : Js.js_string Js.t Js.readonly_prop
+
+  method url : Js.js_string Js.t Js.readonly_prop
+
+  method _type : Js.js_string Js.t Js.readonly_prop
+
+  method postMessage : 'a. 'a -> unit Js.meth
+
+  method postMessage_withTransfer :
+    'a. 'a -> Js.Unsafe.any Js.js_array Js.t -> unit Js.meth
+end
+
+class type windowClient = object
+  inherit client
+
+  method focused : bool Js.t Js.readonly_prop
+
+  method visibilityState : Js.js_string Js.t Js.readonly_prop
+
+  method focus : windowClient Js.t Promise.t Js.meth
+
+  method navigate : Js.js_string Js.t -> windowClient Js.t Js.opt Promise.t Js.meth
+end
+
+class type clientsQueryOptions = object
+  method includeUncontrolled : bool Js.t Js.writeonly_prop
+
+  method _type : Js.js_string Js.t Js.writeonly_prop
+end
+
+let empty_clients_query_options () : clientsQueryOptions Js.t = Js.Unsafe.obj [||]
+
+class type clients = object
+  method get : Js.js_string Js.t -> client Js.t Js.optdef Promise.t Js.meth
+
+  method matchAll : client Js.t Js.js_array Js.t Promise.t Js.meth
+
+  method matchAll_withOptions :
+    clientsQueryOptions Js.t -> client Js.t Js.js_array Js.t Promise.t Js.meth
+
+  method openWindow : Js.js_string Js.t -> windowClient Js.t Js.opt Promise.t Js.meth
+
+  method claim : unit Promise.t Js.meth
+end
+
+class type serviceWorkerGlobalScope = object ('self)
+  inherit Dom_html.eventTarget
+
+  method clients : clients Js.t Js.readonly_prop
+
+  method registration : serviceWorkerRegistration Js.t Js.readonly_prop
+
+  method serviceWorker : serviceWorker Js.t Js.readonly_prop
+
+  method skipWaiting : unit Promise.t Js.meth
+
+  method oninstall :
+    ('self Js.t, extendableEvent Js.t) Dom.event_listener Js.writeonly_prop
+
+  method onactivate :
+    ('self Js.t, extendableEvent Js.t) Dom.event_listener Js.writeonly_prop
+
+  method onfetch : ('self Js.t, fetchEvent Js.t) Dom.event_listener Js.writeonly_prop
+
+  method onmessage :
+    ('self Js.t, Js.Unsafe.any MessageChannel.messageEvent Js.t) Dom.event_listener
+    Js.writeonly_prop
+end
+
+let global () : serviceWorkerGlobalScope Js.t = Js.Unsafe.global

--- a/lib/js_of_ocaml/serviceWorker.ml
+++ b/lib/js_of_ocaml/serviceWorker.ml
@@ -44,6 +44,22 @@ end
 
 let empty_registration_options () : registrationOptions Js.t = Js.Unsafe.obj [||]
 
+class type navigationPreloadState = object
+  method enabled : bool Js.t Js.readonly_prop
+
+  method headerValue : Js.js_string Js.t Js.optdef Js.readonly_prop
+end
+
+class type navigationPreloadManager = object
+  method enable : unit Promise.t Js.meth
+
+  method disable : unit Promise.t Js.meth
+
+  method setHeaderValue : Js.js_string Js.t -> unit Promise.t Js.meth
+
+  method getState : navigationPreloadState Js.t Promise.t Js.meth
+end
+
 class type serviceWorkerRegistration = object ('self)
   inherit Dom_html.eventTarget
 
@@ -52,6 +68,8 @@ class type serviceWorkerRegistration = object ('self)
   method waiting : serviceWorker Js.t Js.opt Js.readonly_prop
 
   method active : serviceWorker Js.t Js.opt Js.readonly_prop
+
+  method navigationPreload : navigationPreloadManager Js.t Js.readonly_prop
 
   method scope : Js.js_string Js.t Js.readonly_prop
 

--- a/lib/js_of_ocaml/serviceWorker.ml
+++ b/lib/js_of_ocaml/serviceWorker.ml
@@ -151,6 +151,20 @@ class type fetchEvent = object
   method respondWith : Fetch.response Js.t Promise.t -> unit Js.meth
 end
 
+class type ['a] extendableMessageEvent = object
+  inherit extendableEvent
+
+  method data : 'a Js.readonly_prop
+
+  method origin : Js.js_string Js.t Js.readonly_prop
+
+  method lastEventId : Js.js_string Js.t Js.readonly_prop
+
+  method source : Js.Unsafe.any Js.opt Js.readonly_prop
+
+  method ports : MessageChannel.messagePort Js.t Js.js_array Js.t Js.readonly_prop
+end
+
 class type client = object
   method id : Js.js_string Js.t Js.readonly_prop
 
@@ -221,11 +235,11 @@ class type serviceWorkerGlobalScope = object ('self)
   method onfetch : ('self Js.t, fetchEvent Js.t) Dom.event_listener Js.writeonly_prop
 
   method onmessage :
-    ('self Js.t, Js.Unsafe.any MessageChannel.messageEvent Js.t) Dom.event_listener
+    ('self Js.t, Js.Unsafe.any extendableMessageEvent Js.t) Dom.event_listener
     Js.writeonly_prop
 
   method onmessageerror :
-    ('self Js.t, Js.Unsafe.any MessageChannel.messageEvent Js.t) Dom.event_listener
+    ('self Js.t, Js.Unsafe.any extendableMessageEvent Js.t) Dom.event_listener
     Js.writeonly_prop
 end
 

--- a/lib/js_of_ocaml/serviceWorker.ml
+++ b/lib/js_of_ocaml/serviceWorker.ml
@@ -32,9 +32,6 @@ class type serviceWorker = object ('self)
 
   method onstatechange :
     ('self Js.t, 'self Dom.event Js.t) Dom.event_listener Js.writeonly_prop
-
-  method onerror :
-    ('self Js.t, Worker.errorEvent Js.t) Dom.event_listener Js.writeonly_prop
 end
 
 class type registrationOptions = object
@@ -60,7 +57,7 @@ class type serviceWorkerRegistration = object ('self)
 
   method updateViaCache : Js.js_string Js.t Js.readonly_prop
 
-  method update : unit Promise.t Js.meth
+  method update : serviceWorkerRegistration Js.t Promise.t Js.meth
 
   method unregister : bool Js.t Promise.t Js.meth
 
@@ -98,6 +95,10 @@ class type serviceWorkerContainer = object ('self)
   method onmessage :
     ('self Js.t, Js.Unsafe.any MessageChannel.messageEvent Js.t) Dom.event_listener
     Js.writeonly_prop
+
+  method onmessageerror :
+    ('self Js.t, Js.Unsafe.any MessageChannel.messageEvent Js.t) Dom.event_listener
+    Js.writeonly_prop
 end
 
 let container () : serviceWorkerContainer Js.t Js.optdef =
@@ -123,7 +124,11 @@ class type fetchEvent = object
 
   method resultingClientId : Js.js_string Js.t Js.readonly_prop
 
+  method replacesClientId : Js.js_string Js.t Js.readonly_prop
+
   method preloadResponse : Js.Unsafe.any Promise.t Js.readonly_prop
+
+  method handled : unit Promise.t Js.readonly_prop
 
   method respondWith : Fetch.response Js.t Promise.t -> unit Js.meth
 end
@@ -134,6 +139,8 @@ class type client = object
   method url : Js.js_string Js.t Js.readonly_prop
 
   method _type : Js.js_string Js.t Js.readonly_prop
+
+  method frameType : Js.js_string Js.t Js.readonly_prop
 
   method postMessage : 'a. 'a -> unit Js.meth
 
@@ -147,6 +154,8 @@ class type windowClient = object
   method focused : bool Js.t Js.readonly_prop
 
   method visibilityState : Js.js_string Js.t Js.readonly_prop
+
+  method ancestorOrigins : Js.js_string Js.t Js.js_array Js.t Js.readonly_prop
 
   method focus : windowClient Js.t Promise.t Js.meth
 
@@ -194,6 +203,10 @@ class type serviceWorkerGlobalScope = object ('self)
   method onfetch : ('self Js.t, fetchEvent Js.t) Dom.event_listener Js.writeonly_prop
 
   method onmessage :
+    ('self Js.t, Js.Unsafe.any MessageChannel.messageEvent Js.t) Dom.event_listener
+    Js.writeonly_prop
+
+  method onmessageerror :
     ('self Js.t, Js.Unsafe.any MessageChannel.messageEvent Js.t) Dom.event_listener
     Js.writeonly_prop
 end

--- a/lib/js_of_ocaml/serviceWorker.mli
+++ b/lib/js_of_ocaml/serviceWorker.mli
@@ -1,0 +1,235 @@
+(* Js_of_ocaml library
+ * http://www.ocsigen.org/js_of_ocaml/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+
+(** Service Workers.
+
+    This module covers both sides of the API: the page-facing registration API
+    ({!container}, {!class-type:serviceWorkerContainer},
+    {!class-type:serviceWorkerRegistration}, {!class-type:serviceWorker}) and
+    the worker-side global scope ({!global},
+    {!class-type:serviceWorkerGlobalScope} and its events). The Cache API used
+    inside a worker lives in {!Cache}.
+
+    Service Workers require a secure context. The Promise-typed members use
+    {!Promise}.
+
+    @see <https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API>
+    @see <https://w3c.github.io/ServiceWorker/> *)
+
+open Js
+
+(** A service worker, as seen from a controlled page. Inherits [EventTarget]. *)
+class type serviceWorker = object ('self)
+  inherit Dom_html.eventTarget
+
+  method scriptURL : js_string t readonly_prop
+
+  method state : js_string t readonly_prop
+  (** One of ["parsed"], ["installing"], ["installed"], ["activating"],
+      ["activated"] or ["redundant"]. *)
+
+  method postMessage : 'a. 'a -> unit meth
+
+  method postMessage_withTransfer : 'a. 'a -> Unsafe.any js_array t -> unit meth
+
+  method onstatechange : ('self t, 'self Dom.event t) Dom.event_listener writeonly_prop
+
+  method onerror : ('self t, Worker.errorEvent t) Dom.event_listener writeonly_prop
+end
+
+(** Options for {!class-type:serviceWorkerContainer}[##register_withOptions].
+    Create an empty record with {!empty_registration_options}. *)
+class type registrationOptions = object
+  method scope : js_string t writeonly_prop
+
+  method _type : js_string t writeonly_prop
+  (** Either ["classic"] (default) or ["module"]. *)
+
+  method updateViaCache : js_string t writeonly_prop
+  (** Either ["imports"] (default), ["all"] or ["none"]. *)
+end
+
+val empty_registration_options : unit -> registrationOptions t
+
+(** A registration of a service worker against a scope. Inherits [EventTarget]. *)
+class type serviceWorkerRegistration = object ('self)
+  inherit Dom_html.eventTarget
+
+  method installing : serviceWorker t opt readonly_prop
+
+  method waiting : serviceWorker t opt readonly_prop
+
+  method active : serviceWorker t opt readonly_prop
+
+  method scope : js_string t readonly_prop
+
+  method updateViaCache : js_string t readonly_prop
+
+  method update : unit Promise.t meth
+
+  method unregister : bool t Promise.t meth
+  (** Resolves with [true] if the registration was found and unregistered. *)
+
+  method onupdatefound : ('self t, 'self Dom.event t) Dom.event_listener writeonly_prop
+end
+
+(** The page-facing entry point, exposed as [navigator.serviceWorker]
+    (see {!container}). Inherits [EventTarget]. *)
+class type serviceWorkerContainer = object ('self)
+  inherit Dom_html.eventTarget
+
+  method controller : serviceWorker t opt readonly_prop
+
+  method ready : serviceWorkerRegistration t Promise.t readonly_prop
+
+  method register : js_string t -> serviceWorkerRegistration t Promise.t meth
+
+  method register_withOptions :
+    js_string t -> registrationOptions t -> serviceWorkerRegistration t Promise.t meth
+
+  method getRegistration : serviceWorkerRegistration t optdef Promise.t meth
+
+  method getRegistration_withUrl :
+    js_string t -> serviceWorkerRegistration t optdef Promise.t meth
+
+  method getRegistrations : serviceWorkerRegistration t js_array t Promise.t meth
+
+  method startMessages : unit meth
+
+  method oncontrollerchange :
+    ('self t, 'self Dom.event t) Dom.event_listener writeonly_prop
+
+  method onmessage :
+    ('self t, Unsafe.any MessageChannel.messageEvent t) Dom.event_listener writeonly_prop
+end
+
+val container : unit -> serviceWorkerContainer t optdef
+(** [navigator.serviceWorker], or [undefined] when service workers are not
+    supported (including non-secure contexts). *)
+
+val is_supported : unit -> bool
+(** Whether [navigator.serviceWorker] is available in the current environment. *)
+
+(** {1 Service worker global scope}
+
+    The following bindings are meant to be used from {e inside} a service worker
+    (see {!global}); they are not available on a controlled page. *)
+
+(** Base class of events that may extend the service worker's lifetime via
+    [waitUntil]. *)
+class type extendableEvent = object
+  inherit Dom_html.event
+
+  method waitUntil : 'a. 'a Promise.t -> unit meth
+end
+
+(** The event passed to the worker's [fetch] handler. *)
+class type fetchEvent = object
+  inherit extendableEvent
+
+  method request : Fetch.request t readonly_prop
+
+  method clientId : js_string t readonly_prop
+
+  method resultingClientId : js_string t readonly_prop
+
+  method preloadResponse : Unsafe.any Promise.t readonly_prop
+
+  method respondWith : Fetch.response t Promise.t -> unit meth
+  (** [event##respondWith p] provides the response (as a promise) for the
+      intercepted request. *)
+end
+
+(** A client (a [Window], worker or shared worker) controlled by the worker. *)
+class type client = object
+  method id : js_string t readonly_prop
+
+  method url : js_string t readonly_prop
+
+  method _type : js_string t readonly_prop
+  (** One of ["window"], ["worker"], ["sharedworker"] or ["all"]. *)
+
+  method postMessage : 'a. 'a -> unit meth
+
+  method postMessage_withTransfer : 'a. 'a -> Unsafe.any js_array t -> unit meth
+end
+
+(** A {!class-type:client} that is a top-level browsing context (a window/tab). *)
+class type windowClient = object
+  inherit client
+
+  method focused : bool t readonly_prop
+
+  method visibilityState : js_string t readonly_prop
+
+  method focus : windowClient t Promise.t meth
+
+  method navigate : js_string t -> windowClient t opt Promise.t meth
+end
+
+(** Options for [clients##matchAll_withOptions].
+    Create an empty record with {!empty_clients_query_options}. *)
+class type clientsQueryOptions = object
+  method includeUncontrolled : bool t writeonly_prop
+
+  method _type : js_string t writeonly_prop
+end
+
+val empty_clients_query_options : unit -> clientsQueryOptions t
+
+(** The worker's [clients] object, used to enumerate and message controlled
+    clients. *)
+class type clients = object
+  method get : js_string t -> client t optdef Promise.t meth
+
+  method matchAll : client t js_array t Promise.t meth
+
+  method matchAll_withOptions :
+    clientsQueryOptions t -> client t js_array t Promise.t meth
+
+  method openWindow : js_string t -> windowClient t opt Promise.t meth
+
+  method claim : unit Promise.t meth
+end
+
+(** The global scope of a running service worker (its [self]). Inherits
+    [EventTarget]. *)
+class type serviceWorkerGlobalScope = object ('self)
+  inherit Dom_html.eventTarget
+
+  method clients : clients t readonly_prop
+
+  method registration : serviceWorkerRegistration t readonly_prop
+
+  method serviceWorker : serviceWorker t readonly_prop
+
+  method skipWaiting : unit Promise.t meth
+
+  method oninstall : ('self t, extendableEvent t) Dom.event_listener writeonly_prop
+
+  method onactivate : ('self t, extendableEvent t) Dom.event_listener writeonly_prop
+
+  method onfetch : ('self t, fetchEvent t) Dom.event_listener writeonly_prop
+
+  method onmessage :
+    ('self t, Unsafe.any MessageChannel.messageEvent t) Dom.event_listener writeonly_prop
+end
+
+val global : unit -> serviceWorkerGlobalScope t
+(** The service worker's global scope. Only meaningful when the current code is
+    actually running as a service worker. *)

--- a/lib/js_of_ocaml/serviceWorker.mli
+++ b/lib/js_of_ocaml/serviceWorker.mli
@@ -190,6 +190,28 @@ class type fetchEvent = object
       intercepted request. *)
 end
 
+(** The event delivered to the worker's [message] / [messageerror] handlers.
+    Unlike a plain {!MessageChannel.messageEvent} it extends
+    {!class-type:extendableEvent}, so the handler can call [waitUntil] to keep
+    the worker alive until asynchronous processing of the message finishes. The
+    type parameter ['a] is the type of the [data] payload. *)
+class type ['a] extendableMessageEvent = object
+  inherit extendableEvent
+
+  method data : 'a readonly_prop
+
+  method origin : js_string t readonly_prop
+
+  method lastEventId : js_string t readonly_prop
+
+  method source : Unsafe.any opt readonly_prop
+  (** The message source: a {!class-type:client}, a
+      {!class-type:serviceWorker} or a {!MessageChannel.messagePort}; [null]
+      when there is none. *)
+
+  method ports : MessageChannel.messagePort t js_array t readonly_prop
+end
+
 (** A client (a [Window], worker or shared worker) controlled by the worker. *)
 class type client = object
   method id : js_string t readonly_prop
@@ -267,10 +289,10 @@ class type serviceWorkerGlobalScope = object ('self)
   method onfetch : ('self t, fetchEvent t) Dom.event_listener writeonly_prop
 
   method onmessage :
-    ('self t, Unsafe.any MessageChannel.messageEvent t) Dom.event_listener writeonly_prop
+    ('self t, Unsafe.any extendableMessageEvent t) Dom.event_listener writeonly_prop
 
   method onmessageerror :
-    ('self t, Unsafe.any MessageChannel.messageEvent t) Dom.event_listener writeonly_prop
+    ('self t, Unsafe.any extendableMessageEvent t) Dom.event_listener writeonly_prop
 end
 
 val global : unit -> serviceWorkerGlobalScope t

--- a/lib/js_of_ocaml/serviceWorker.mli
+++ b/lib/js_of_ocaml/serviceWorker.mli
@@ -64,6 +64,30 @@ end
 
 val empty_registration_options : unit -> registrationOptions t
 
+(** The state of a registration's navigation preload, as resolved by
+    {!class-type:navigationPreloadManager}[##getState]. *)
+class type navigationPreloadState = object
+  method enabled : bool t readonly_prop
+
+  method headerValue : js_string t optdef readonly_prop
+  (** The [Service-Worker-Navigation-Preload] header value; [undefined] when
+      not set. *)
+end
+
+(** Manages navigation preloading for a {!class-type:serviceWorkerRegistration},
+    exposed as its [navigationPreload]. *)
+class type navigationPreloadManager = object
+  method enable : unit Promise.t meth
+
+  method disable : unit Promise.t meth
+
+  method setHeaderValue : js_string t -> unit Promise.t meth
+  (** Sets the value sent in the [Service-Worker-Navigation-Preload] request
+      header for preload requests. *)
+
+  method getState : navigationPreloadState t Promise.t meth
+end
+
 (** A registration of a service worker against a scope. Inherits [EventTarget]. *)
 class type serviceWorkerRegistration = object ('self)
   inherit Dom_html.eventTarget
@@ -73,6 +97,8 @@ class type serviceWorkerRegistration = object ('self)
   method waiting : serviceWorker t opt readonly_prop
 
   method active : serviceWorker t opt readonly_prop
+
+  method navigationPreload : navigationPreloadManager t readonly_prop
 
   method scope : js_string t readonly_prop
 

--- a/lib/js_of_ocaml/serviceWorker.mli
+++ b/lib/js_of_ocaml/serviceWorker.mli
@@ -48,8 +48,6 @@ class type serviceWorker = object ('self)
   method postMessage_withTransfer : 'a. 'a -> Unsafe.any js_array t -> unit meth
 
   method onstatechange : ('self t, 'self Dom.event t) Dom.event_listener writeonly_prop
-
-  method onerror : ('self t, Worker.errorEvent t) Dom.event_listener writeonly_prop
 end
 
 (** Options for {!class-type:serviceWorkerContainer}[##register_withOptions].
@@ -80,7 +78,9 @@ class type serviceWorkerRegistration = object ('self)
 
   method updateViaCache : js_string t readonly_prop
 
-  method update : unit Promise.t meth
+  method update : serviceWorkerRegistration t Promise.t meth
+  (** Triggers a soft update of the registration; resolves with the
+      registration object. *)
 
   method unregister : bool t Promise.t meth
   (** Resolves with [true] if the registration was found and unregistered. *)
@@ -116,6 +116,9 @@ class type serviceWorkerContainer = object ('self)
 
   method onmessage :
     ('self t, Unsafe.any MessageChannel.messageEvent t) Dom.event_listener writeonly_prop
+
+  method onmessageerror :
+    ('self t, Unsafe.any MessageChannel.messageEvent t) Dom.event_listener writeonly_prop
 end
 
 val container : unit -> serviceWorkerContainer t optdef
@@ -148,7 +151,13 @@ class type fetchEvent = object
 
   method resultingClientId : js_string t readonly_prop
 
+  method replacesClientId : js_string t readonly_prop
+
   method preloadResponse : Unsafe.any Promise.t readonly_prop
+
+  method handled : unit Promise.t readonly_prop
+  (** Resolves once the request has been handled (whether or not
+      [respondWith] was called). *)
 
   method respondWith : Fetch.response t Promise.t -> unit meth
   (** [event##respondWith p] provides the response (as a promise) for the
@@ -162,7 +171,10 @@ class type client = object
   method url : js_string t readonly_prop
 
   method _type : js_string t readonly_prop
-  (** One of ["window"], ["worker"], ["sharedworker"] or ["all"]. *)
+  (** One of ["window"], ["worker"] or ["sharedworker"]. *)
+
+  method frameType : js_string t readonly_prop
+  (** One of ["auxiliary"], ["top-level"], ["nested"] or ["none"]. *)
 
   method postMessage : 'a. 'a -> unit meth
 
@@ -176,6 +188,8 @@ class type windowClient = object
   method focused : bool t readonly_prop
 
   method visibilityState : js_string t readonly_prop
+
+  method ancestorOrigins : js_string t js_array t readonly_prop
 
   method focus : windowClient t Promise.t meth
 
@@ -227,6 +241,9 @@ class type serviceWorkerGlobalScope = object ('self)
   method onfetch : ('self t, fetchEvent t) Dom.event_listener writeonly_prop
 
   method onmessage :
+    ('self t, Unsafe.any MessageChannel.messageEvent t) Dom.event_listener writeonly_prop
+
+  method onmessageerror :
     ('self t, Unsafe.any MessageChannel.messageEvent t) Dom.event_listener writeonly_prop
 end
 

--- a/lib/tests/test_message_channel.ml
+++ b/lib/tests/test_message_channel.ml
@@ -1,0 +1,67 @@
+(* Js_of_ocaml
+ * http://www.ocsigen.org/js_of_ocaml/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+open Js_of_ocaml
+
+(* [MessageChannel]/[MessagePort]/[MessageEvent] are not available under
+   QuickJS, so the whole suite is gated with [@when not quickjs]. *)
+
+let is_message_port any =
+  Js.instanceof
+    (Js.Unsafe.coerce any : _ Js.t)
+    (Js.Unsafe.global##._MessagePort : _ Js.constr)
+
+let%expect_test ("is_supported" [@when not quickjs]) =
+  print_endline (if MessageChannel.is_supported () then "PASSED" else "FAILED");
+  [%expect {| PASSED |}]
+
+let%expect_test ("channel exposes two distinct MessagePorts" [@when not quickjs]) =
+  let chan = new%js MessageChannel.messageChannel in
+  print_endline (string_of_bool (is_message_port chan##.port1));
+  print_endline (string_of_bool (is_message_port chan##.port2));
+  print_endline (string_of_bool (chan##.port1 != chan##.port2));
+  [%expect {|
+    true
+    true
+    true
+    |}]
+
+let%expect_test ("ports expose the messaging methods" [@when not quickjs]) =
+  let chan = new%js MessageChannel.messageChannel in
+  let port = chan##.port1 in
+  (* [start] then [postMessage] must not raise on an open port. *)
+  port##start;
+  port##postMessage (Js.string "ping");
+  port##close;
+  print_endline "PASSED";
+  [%expect {| PASSED |}]
+
+let%expect_test ("MessageEvent constructor carries its data" [@when not quickjs]) =
+  let init = MessageChannel.empty_message_event_init () in
+  init##.data := Js.Unsafe.inject (Js.string "payload");
+  init##.origin := Js.string "https://example.invalid";
+  init##.lastEventId := Js.string "42";
+  let ev = new%js MessageChannel.messageEvent_with_init (Js.string "message") init in
+  print_endline (Js.to_string ev##._type);
+  print_endline (Js.to_string (Js.Unsafe.coerce ev##.data));
+  print_endline (Js.to_string ev##.origin);
+  print_endline (Js.to_string ev##.lastEventId);
+  print_endline (string_of_int ev##.ports##.length);
+  [%expect {|
+    message
+    payload
+    https://example.invalid
+    42
+    0
+    |}]

--- a/manual/api.mld
+++ b/manual/api.mld
@@ -27,6 +27,7 @@ Browser APIs:
 {!modules:
 Js_of_ocaml.Abort
 Js_of_ocaml.CSS
+Js_of_ocaml.Cache
 Js_of_ocaml.Clipboard
 Js_of_ocaml.Console
 Js_of_ocaml.Crypto
@@ -42,6 +43,7 @@ Js_of_ocaml.Geolocation
 Js_of_ocaml.IntersectionObserver
 Js_of_ocaml.Intl
 Js_of_ocaml.Json
+Js_of_ocaml.MessageChannel
 Js_of_ocaml.MutationObserver
 Js_of_ocaml.Notification
 Js_of_ocaml.Performance
@@ -49,6 +51,7 @@ Js_of_ocaml.PerformanceObserver
 Js_of_ocaml.Promise
 Js_of_ocaml.Regexp
 Js_of_ocaml.ResizeObserver
+Js_of_ocaml.ServiceWorker
 Js_of_ocaml.Url
 Js_of_ocaml.WebGL
 Js_of_ocaml.WebSockets


### PR DESCRIPTION
## Summary

Add bindings for three related browser APIs:

- **Service Worker API** (`ServiceWorker`) — both sides: the page-facing
  registration API (`serviceWorkerContainer`, `serviceWorkerRegistration`,
  `serviceWorker`) and the worker-side global scope
  (`serviceWorkerGlobalScope`, `clients`/`client`/`windowClient`,
  `extendableEvent`/`fetchEvent`), plus `navigationPreloadManager`.
- **Channel messaging** (`MessageChannel`) — `MessageChannel`, `MessagePort`
  and `MessageEvent` (with its init dict and constructors).
- **Cache API** (`Cache`) — `Cache` and `CacheStorage` (the `caches` global),
  with `_url` string variants for `RequestInfo` arguments.

All Promise-typed members use `Js_of_ocaml.Promise`. The bindings were checked
against the W3C Service Workers spec and the WHATWG HTML web-messaging section.

Closes #1464.

## Test plan

- `lib/tests/test_message_channel.ml` inline expect test
- `manual/api.mld` updated (the `api-check` completeness guard passes)
- `CHANGES.md` and `API-STATUS.md` updated
- `dune build lib/js_of_ocaml` and `dune runtest manual/api-check lib/tests` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
