### PR TITLE
Tyxml: keep the first of repeated attributes (fix #968)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,11 @@
 * Lib: remove `js_of_ocaml-lwt.logger` and the `lwt_log` dependency, as
   upstream `lwt_log` is deprecated (#2378)
 
+## Bug fixes
+* Tyxml: when the same attribute (e.g. multiple `a_class`) is given several
+  times, keep the first one and ignore the rest, matching browser semantics,
+  instead of letting the last one silently overwrite the others (#968)
+
 # 6.4.1 (2026-06-30) - Lille
 
 ## Bug fixes

--- a/lib/tyxml/tyxml_js.ml
+++ b/lib/tyxml/tyxml_js.ml
@@ -194,38 +194,51 @@ module Xml = struct
     | None -> ()
 
   let attach_attribs node l =
+    (* When the same attribute name appears several times (e.g. multiple
+       [a_class]), a browser keeps the first occurrence and ignores the rest.
+       Reproduce that here: without it, each occurrence would subscribe its own
+       [React.S.map], leaving several live signals writing to the same name.
+       They would then fight over time — the attribute alternating between their
+       values on each update, and vanishing whenever any signal yields [None] —
+       not merely the last one silently winning. Keeping only the first
+       occurrence leaves a single writer per name. See #968. *)
+    let seen = Jstable.create () in
     List.iter
       (fun (n', att) ->
         let n = Js.string n' in
-        match att with
-        | Attr a ->
-            let (keepme : unit React.S.t) =
-              React.S.map
-                (function
-                  | Some v -> (
-                      ignore (node##setAttribute n v);
-                      match n' with
-                      | "style" -> node##.style##.cssText := v
-                      | _ ->
-                          iter_prop_protected node n (fun name ->
-                              Js.Unsafe.set node name v))
-                  | None -> (
-                      ignore (node##removeAttribute n);
-                      match n' with
-                      | "style" -> node##.style##.cssText := Js.string ""
-                      | _ ->
-                          iter_prop_protected node n (fun name ->
-                              Js.Unsafe.set node name Js.null)))
-                a
-            in
-            retain (node :> Dom.node Js.t) ~keepme
-        | Event h -> Js.Unsafe.set node n (Js.wrap_callback (fun ev -> Js.bool (h ev)))
-        | MouseEvent h ->
-            Js.Unsafe.set node n (Js.wrap_callback (fun ev -> Js.bool (h ev)))
-        | KeyboardEvent h ->
-            Js.Unsafe.set node n (Js.wrap_callback (fun ev -> Js.bool (h ev)))
-        | TouchEvent h ->
-            Js.Unsafe.set node n (Js.wrap_callback (fun ev -> Js.bool (h ev))))
+        if Js.Optdef.test (Jstable.find seen n)
+        then () (* already set by an earlier attribute of the same name *)
+        else (
+          Jstable.add seen n ();
+          match att with
+          | Attr a ->
+              let (keepme : unit React.S.t) =
+                React.S.map
+                  (function
+                    | Some v -> (
+                        ignore (node##setAttribute n v);
+                        match n' with
+                        | "style" -> node##.style##.cssText := v
+                        | _ ->
+                            iter_prop_protected node n (fun name ->
+                                Js.Unsafe.set node name v))
+                    | None -> (
+                        ignore (node##removeAttribute n);
+                        match n' with
+                        | "style" -> node##.style##.cssText := Js.string ""
+                        | _ ->
+                            iter_prop_protected node n (fun name ->
+                                Js.Unsafe.set node name Js.null)))
+                  a
+              in
+              retain (node :> Dom.node Js.t) ~keepme
+          | Event h -> Js.Unsafe.set node n (Js.wrap_callback (fun ev -> Js.bool (h ev)))
+          | MouseEvent h ->
+              Js.Unsafe.set node n (Js.wrap_callback (fun ev -> Js.bool (h ev)))
+          | KeyboardEvent h ->
+              Js.Unsafe.set node n (Js.wrap_callback (fun ev -> Js.bool (h ev)))
+          | TouchEvent h ->
+              Js.Unsafe.set node n (Js.wrap_callback (fun ev -> Js.bool (h ev)))))
       l
 
   let leaf ?(a = []) name =


### PR DESCRIPTION
### Problem

When the same attribute is passed several times to a `Tyxml_js` element — most commonly multiple `a_class` — the attributes are reactive (`React.S.t`), and each occurrence was wired up with its own `React.S.map`. That left several live signals writing to the same attribute name, which is worse than a one-shot overwrite:

```ocaml
Tyxml_js.Html.(div ~a:[ a_class [ "a" ]; a_class [ "b" ] ] [])
```

- **Alternation:** whenever any of the signals fires, its callback calls `setAttribute` with *its* current value, so the attribute flips between the values on every update.
- **Disappearance:** if any signal yields `None`, its callback calls `removeAttribute`, wiping the attribute even though another signal still holds a value.

With static values this merely looks like "the last one silently wins"; with reactive values it becomes visible flicker and dropped attributes over time.

### Fix

Follow browser semantics: when a name appears more than once, **keep the first occurrence and ignore the rest**, exactly as a browser parses `<div class="a" class="b">` (→ `class="a"`). Only the first occurrence's signal is ever subscribed, so there is exactly one live writer per name — no alternation, no spurious removal.

The deduplication is folded into the existing `attach_attribs` loop — a `Jstable` set records each name as it is applied and repeated names are skipped, so there is no intermediate list and the existing `Js.string` conversion is reused.

### Notes

- Order is otherwise preserved.
- This is a behavior change for code that relied on the previous last-wins accident; the new behavior matches the DOM.
