### PR TITLE
Tests: fix md5/dump_sourcemap output under dune 3.24 (./-prefixed paths)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,10 @@
   path in `runtime/wasm/args.ml`, so dune 3.24's leading-`./` path-form
   representation (ocaml/dune#15156) keeps producing well-formed
   `module:path` lines for `wasmoo_link_wasm`.
+* Tests: pass file paths as literal arguments (with explicit `(deps ...)`)
+  instead of `%{dep:...}` in the `md5`/`md5_nat` and `dump_sourcemap` tests,
+  which echo the path verbatim, so dune 3.24's leading-`./` path form
+  (ocaml/dune#15156) no longer breaks their expected output (#2384)
 
 # 6.4.0 (2026-06-21) - Lille
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,9 +24,9 @@
   representation (ocaml/dune#15156) keeps producing well-formed
   `module:path` lines for `wasmoo_link_wasm`.
 * Tests: pass file paths as literal arguments (with explicit `(deps ...)`)
-  instead of `%{dep:...}` in the `md5`/`md5_nat` and `dump_sourcemap` tests,
-  which echo the path verbatim, so dune 3.24's leading-`./` path form
-  (ocaml/dune#15156) no longer breaks their expected output (#2384)
+  instead of `%{dep:...}` in the `md5`/`md5_nat`, `dump_sourcemap` and
+  `check-prim` tests, which echo the path verbatim, so dune 3.24's leading-`./`
+  path form (ocaml/dune#15156) no longer breaks their expected output (#2384)
 
 # 6.4.0 (2026-06-21) - Lille
 

--- a/compiler/tests-check-prim/dune.inc
+++ b/compiler/tests-check-prim/dune.inc
@@ -1,5 +1,6 @@
 (rule
  (targets main.4.14.output)
+ (deps main.bc)
  (mode
   (promote (until-clean)))
  (enabled_if (and (>= %{ocaml_version} 4.14)(< %{ocaml_version} 5.0)(not %{oxcaml_supported})))
@@ -11,10 +12,11 @@
     check-runtime
     +dynlink.js
     +toplevel.js
-    %{dep:main.bc}))))
+    main.bc))))
 
 (rule
  (targets unix-Win32.4.14.output)
+ (deps unix.bc)
  (mode
   (promote (until-clean)))
  (enabled_if (and (>= %{ocaml_version} 4.14)(< %{ocaml_version} 5.0)(= %{os_type} Win32)(not %{oxcaml_supported})))
@@ -26,10 +28,11 @@
     check-runtime
     +dynlink.js
     +toplevel.js
-    %{dep:unix.bc}))))
+    unix.bc))))
 
 (rule
  (targets unix-Unix.4.14.output)
+ (deps unix.bc)
  (mode
   (promote (until-clean)))
  (enabled_if (and (>= %{ocaml_version} 4.14)(< %{ocaml_version} 5.0)(= %{os_type} Unix)(not %{oxcaml_supported})))
@@ -41,10 +44,11 @@
     check-runtime
     +dynlink.js
     +toplevel.js
-    %{dep:unix.bc}))))
+    unix.bc))))
 
 (rule
  (targets main.5.4.output)
+ (deps main.bc)
  (mode
   (promote (until-clean)))
  (enabled_if (and (>= %{ocaml_version} 5.4)(< %{ocaml_version} 5.5)(not %{oxcaml_supported})))
@@ -56,10 +60,11 @@
     check-runtime
     +dynlink.js
     +toplevel.js
-    %{dep:main.bc}))))
+    main.bc))))
 
 (rule
  (targets unix-Win32.5.4.output)
+ (deps unix.bc)
  (mode
   (promote (until-clean)))
  (enabled_if (and (>= %{ocaml_version} 5.4)(< %{ocaml_version} 5.5)(= %{os_type} Win32)(not %{oxcaml_supported})))
@@ -71,10 +76,11 @@
     check-runtime
     +dynlink.js
     +toplevel.js
-    %{dep:unix.bc}))))
+    unix.bc))))
 
 (rule
  (targets unix-Unix.5.4.output)
+ (deps unix.bc)
  (mode
   (promote (until-clean)))
  (enabled_if (and (>= %{ocaml_version} 5.4)(< %{ocaml_version} 5.5)(= %{os_type} Unix)(not %{oxcaml_supported})))
@@ -86,10 +92,11 @@
     check-runtime
     +dynlink.js
     +toplevel.js
-    %{dep:unix.bc}))))
+    unix.bc))))
 
 (rule
  (targets main.5.2+ox.output)
+ (deps main.bc)
  (mode
   (promote (until-clean)))
  (enabled_if (and (>= %{ocaml_version} 5.2)(< %{ocaml_version} 5.3)%{oxcaml_supported}))
@@ -101,10 +108,11 @@
     check-runtime
     +dynlink.js
     +toplevel.js
-    %{dep:main.bc}))))
+    main.bc))))
 
 (rule
  (targets unix-Win32.5.2+ox.output)
+ (deps unix.bc)
  (mode
   (promote (until-clean)))
  (enabled_if (and (>= %{ocaml_version} 5.2)(< %{ocaml_version} 5.3)(= %{os_type} Win32)%{oxcaml_supported}))
@@ -116,10 +124,11 @@
     check-runtime
     +dynlink.js
     +toplevel.js
-    %{dep:unix.bc}))))
+    unix.bc))))
 
 (rule
  (targets unix-Unix.5.2+ox.output)
+ (deps unix.bc)
  (mode
   (promote (until-clean)))
  (enabled_if (and (>= %{ocaml_version} 5.2)(< %{ocaml_version} 5.3)(= %{os_type} Unix)%{oxcaml_supported}))
@@ -131,5 +140,5 @@
     check-runtime
     +dynlink.js
     +toplevel.js
-    %{dep:unix.bc}))))
+    unix.bc))))
 

--- a/compiler/tests-check-prim/gen_dune.ml
+++ b/compiler/tests-check-prim/gen_dune.ml
@@ -84,6 +84,7 @@ let rule bc ocaml_version os_type ocaml_variant =
   Printf.sprintf
     {|(rule
  (targets %s)
+ (deps %s)
  (mode
   (promote (until-clean)))
  (enabled_if %s)
@@ -95,9 +96,10 @@ let rule bc ocaml_version os_type ocaml_variant =
     check-runtime
     +dynlink.js
     +toplevel.js
-    %%{dep:%s}))))
+    %s))))
 |}
     target
+    bc
     enabled_if
     bc
 

--- a/compiler/tests-io/dune
+++ b/compiler/tests-io/dune
@@ -22,12 +22,13 @@
  (names md5)
  (modes js wasm)
  (deps
+  some-random-file
   (sandbox preserve_file_kind))
  (action
   (progn
-   (run node %{test} %{dep:some-random-file})
-   (run node %{test} %{dep:some-random-file} %{dep:some-random-file})
-   (run node %{test} -offset 2000 -length 4000 %{dep:some-random-file})
+   (run node %{test} some-random-file)
+   (run node %{test} some-random-file some-random-file)
+   (run node %{test} -offset 2000 -length 4000 some-random-file)
    (pipe-stdout
     (echo "tests")
     (run node %{test}))
@@ -42,11 +43,12 @@
  (names md5_nat)
  (modes
   (best exe))
+ (deps some-random-file)
  (action
   (progn
-   (run %{test} %{dep:some-random-file})
-   (run %{test} %{dep:some-random-file} %{dep:some-random-file})
-   (run %{test} -offset 2000 -length 4000 %{dep:some-random-file})
+   (run %{test} some-random-file)
+   (run %{test} some-random-file some-random-file)
+   (run %{test} -offset 2000 -length 4000 some-random-file)
    (pipe-stdout
     (echo "tests")
     (run %{test}))

--- a/compiler/tests-sourcemap/dune
+++ b/compiler/tests-sourcemap/dune
@@ -21,8 +21,9 @@
 (test
  (name dump_sourcemap)
  (modules dump_sourcemap)
+ (deps test.bc.js)
  (action
-  (run %{test} %{dep:test.bc.js}))
+  (run %{test} test.bc.js))
  (enabled_if
   (= %{profile} dev))
  (libraries js_of_ocaml-compiler))

--- a/tools/ci_setup-mainstream.ml
+++ b/tools/ci_setup-mainstream.ml
@@ -282,6 +282,27 @@ index fdf9926..d0ccf6a 100644
  let non_ascii = [%sedlex.regexp? Compl ascii]
  let ident_start_code_point = [%sedlex.regexp? 'a' .. 'z' | 'A' .. 'Z' | '_' | non_ascii]
  let ident_code_point = [%sedlex.regexp? ident_start_code_point | '0' .. '9' | '-']
+diff --git a/standalone/css_inliner.ml b/standalone/css_inliner.ml
+--- a/standalone/css_inliner.ml
++++ b/standalone/css_inliner.ml
+@@ -68,11 +68,15 @@
+     Buffer.add_string w mli_file;
+     Buffer.add_string w " end\n");
+   create_file alias_ml ~f:(fun w ->
+-    Buffer.add_string w ("include " ^ String.capitalize generated_name ^ "\n"));
++    Buffer.add_string
++      w
++      ("include " ^ String.capitalize (Filename.basename generated_name) ^ "\n"));
+   create_file alias_mli ~f:(fun w ->
+     Buffer.add_string
+       w
+-      ("include module type of " ^ String.capitalize generated_name ^ "\n"))
++      ("include module type of "
++       ^ String.capitalize (Filename.basename generated_name)
++       ^ "\n"))
+ ;;
+
+ let command =
 |}
     )
   ]

--- a/tools/ci_setup-oxcaml.ml
+++ b/tools/ci_setup-oxcaml.ml
@@ -266,6 +266,31 @@ index 059d011..b40264e 100644
  module Zarith_version = Zarith_version
 |zs}
     )
+  ; ( "ppx_css"
+    , {|
+diff --git a/standalone/css_inliner.ml b/standalone/css_inliner.ml
+--- a/standalone/css_inliner.ml
++++ b/standalone/css_inliner.ml
+@@ -68,11 +68,15 @@
+     Buffer.add_string w mli_file;
+     Buffer.add_string w " end\n");
+   create_file alias_ml ~f:(fun w ->
+-    Buffer.add_string w ("include " ^ String.capitalize generated_name ^ "\n"));
++    Buffer.add_string
++      w
++      ("include " ^ String.capitalize (Filename.basename generated_name) ^ "\n"));
+   create_file alias_mli ~f:(fun w ->
+     Buffer.add_string
+       w
+-      ("include module type of " ^ String.capitalize generated_name ^ "\n"))
++      ("include module type of "
++       ^ String.capitalize (Filename.basename generated_name)
++       ^ "\n"))
+ ;;
+
+ let command =
+|}
+    )
   ]
 
 let removes =


### PR DESCRIPTION
## Problem

CI on `master` fails (`js_of_ocaml`, `wasm_of_ocaml`, `quickjs` jobs) because **dune 3.24** changed `%{dep:file}` argument expansion to a leading-`./` path form (ocaml/dune#15156): `some-random-file` → `./some-random-file`.

Three tests pass such a dep as an argument to a program that prints the path **verbatim**, so their expected-output diffs fail:

- `compiler/tests-io` — `md5` (js+wasm) and `md5_nat` (native): `… some-random-file` → `… ./some-random-file`
- `compiler/tests-sourcemap` — `dump_sourcemap`: `sourcemap for test.bc.js` → `sourcemap for ./test.bc.js`

## Fix

Pass the filenames as **literal arguments** (emitted verbatim by every dune version) and declare them via explicit `(deps ...)`, instead of `%{dep:...}`. This keeps the tests passing across the supported dune range (`>= 3.20`) — simply promoting the `./` output would break contributors on dune 3.20–3.23.

Expected `.expected` files are unchanged. Sibling to the existing dune-3.24 runtime fix already in `CHANGES.md`.

## Verification

Reproduced and verified locally with **dune 3.24.0** (the version CI installs):

- Unfixed → reproduces the `./`-prefixed diff failure.
- Fixed → `@compiler/tests-io/runtest` (md5 + md5_nat, all modes) and `@compiler/tests-sourcemap/runtest` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)