### PR TITLE
Doc: check documentation examples (#1020)

### DIFF
--- a/.github/workflows/wax.yml
+++ b/.github/workflows/wax.yml
@@ -31,7 +31,9 @@ jobs:
           ocaml-compiler: "5.4.0"
 
       - name: Install wax
-        run: opam pin add --yes wax https://github.com/vouillon/wax.git
+        run: |
+          opam pin add --yes wax-lib https://github.com/vouillon/wax.git
+          opam pin add --yes wax https://github.com/vouillon/wax.git
 
       - name: Convert Wasm runtime files to wax
         run: opam exec -- ./tools/wat2wax.sh

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -101,6 +101,14 @@
   `taggedEvent` variant, `CoerceTo.mouseScrollEvent` and
   `Event._DOMMouseScroll` (#2350)
 
+## Documentation
+* Doc: check documentation examples. An `{@ocaml[ … ]}` code block in an `.mli`
+  doc-comment or an `.mld` manual page is type-checked against the library by
+  `dune build @runtest`, so examples that no longer match the API fail the build.
+  The `{@ocaml parse[ … ]}` and `{@ocaml skip[ … ]}` markers opt out of typing
+  (parse-only) and of checking entirely; plain `{[ … ]}` blocks are never
+  checked. See `manual/examples-check/` (#1020)
+
 ## Bug fixes
 * Compiler: don't rewrite `x = e + x` into `x += e` for `+` (not
   commutative on strings), which reversed `Filename.concat` operands and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,14 @@ opam install odoc yojson ocp-indent graphics higlo
 
 Run `make tests`.
 
+### Documentation examples
+
+Code examples in `.mli` doc-comments and the `manual/` pages are checked by the
+test suite: an `{@ocaml[ ... ]}` block is type-checked against the real API, so
+examples cannot silently drift out of sync. Mark an illustrative snippet that is
+not meant to compile with `{@ocaml parse[ ... ]}` (syntax-checked only) or
+`{@ocaml skip[ ... ]}` (ignored). See `manual/examples-check/` for details.
+
 ## Library binding conventions
 
 When adding new bindings under `lib/js_of_ocaml/`, follow these rules so

--- a/lib/js_of_ocaml/clipboard.mli
+++ b/lib/js_of_ocaml/clipboard.mli
@@ -19,7 +19,7 @@
 (** Clipboard API.
 
     A code example:
-    {[
+    {@ocaml[
       if Clipboard.is_supported ()
       then
         ignore

--- a/lib/js_of_ocaml/crypto.mli
+++ b/lib/js_of_ocaml/crypto.mli
@@ -19,7 +19,7 @@
 (** Web Crypto API.
 
     A code example:
-    {[
+    {@ocaml[
       let hash data =
         Promise.map
           (fun buf -> buf)

--- a/lib/js_of_ocaml/dom_html.mli
+++ b/lib/js_of_ocaml/dom_html.mli
@@ -3207,10 +3207,10 @@ val getElementById_coerce : string -> (element t -> 'a opt) -> 'a option
     It returns [None] if there are no such element or if the [coerce] function
     returns [Js.none].
     Typical usage is the following:
-    {[
+    {@ocaml[
       match Dom_html.getElementById_coerce "myinput" Dom_html.CoerceTo.input with
-      | None -> ..
-      | Some input -> ..
+      | None -> ()
+      | Some input -> ignore input
     ]}
 *)
 

--- a/lib/js_of_ocaml/geolocation.mli
+++ b/lib/js_of_ocaml/geolocation.mli
@@ -20,7 +20,7 @@
 (** Geolocation API
 
   A code example:
-  {[
+  {@ocaml[
   if (Geolocation.is_supported()) then
     let geo = Geolocation.geolocation in
     let options = Geolocation.empty_position_options() in
@@ -28,7 +28,7 @@
     let f_success pos =
       let coords = pos##.coords in
       let latitude = coords##.latitude in
-      Console.console##debug latitude ;
+      Console.console##debug latitude
     in
     let f_error err =
       let code = err##.code in

--- a/lib/js_of_ocaml/intl.mli
+++ b/lib/js_of_ocaml/intl.mli
@@ -20,7 +20,7 @@
 (** Internationalization API
 
     A code example:
-{@ocaml parse[
+{@ocaml[
 
 open Js;;
 
@@ -42,12 +42,8 @@ then (
 
     (* Note: the exact output may be browser-dependent *)
     let letterSort lang letters =
-      letters##sort
-        (wrap_callback (fun a b ->
-             let collator =
-               new%js Intl.collator_constr (def (array [| lang |])) undefined
-             in
-             collator##.compare a b));
+      let collator = new%js Intl.collator_constr (def (array [| lang |])) undefined in
+      ignore (letters##sort (wrap_callback (fun a b -> collator##.compare a b)));
       letters
     in
     let a = jas [| "a"; "z"; "ä" |] in

--- a/lib/js_of_ocaml/intl.mli
+++ b/lib/js_of_ocaml/intl.mli
@@ -20,7 +20,7 @@
 (** Internationalization API
 
     A code example:
-{[
+{@ocaml parse[
 
 open Js;;
 

--- a/lib/js_of_ocaml/js.mli
+++ b/lib/js_of_ocaml/js.mli
@@ -25,6 +25,13 @@
     objects.
 *)
 
+(* Setup for the checked examples in this file (not rendered by odoc): the
+   examples below read as if written inside this module, i.e. with [open Js].
+{@ocaml prelude[
+open Js_of_ocaml.Js
+let id = string "my-id"
+]} *)
+
 (** {2 Dealing with [null] and [undefined] values.} *)
 
 type +'a opt
@@ -855,7 +862,7 @@ val coerce_opt : 'a Opt.t -> ('a -> 'b Opt.t) -> ('a -> 'b) -> 'b
       If [v] is [null] or the coercion returns [null], function [f] is
       called.
       Typical usage is the following:
-      {@ocaml parse[Js.coerce_opt (Dom_html.document##getElementById id)
+      {@ocaml[Js.coerce_opt (Dom_html.document##getElementById id)
       Dom_html.CoerceTo.div (fun _ -> assert false)]} *)
 
 (** {2 Type checking operators.} *)
@@ -883,7 +890,7 @@ val export : string -> 'a -> unit
 
 val export_all : 'a t -> unit
 (** [export_all obj] export every key of [obj] object.
-{@ocaml parse[
+{@ocaml[
 export_all
   object%js
     method add x y = x +. y

--- a/lib/js_of_ocaml/js.mli
+++ b/lib/js_of_ocaml/js.mli
@@ -855,7 +855,7 @@ val coerce_opt : 'a Opt.t -> ('a -> 'b Opt.t) -> ('a -> 'b) -> 'b
       If [v] is [null] or the coercion returns [null], function [f] is
       called.
       Typical usage is the following:
-      {[Js.coerce_opt (Dom_html.document##getElementById id)
+      {@ocaml parse[Js.coerce_opt (Dom_html.document##getElementById id)
       Dom_html.CoerceTo.div (fun _ -> assert false)]} *)
 
 (** {2 Type checking operators.} *)
@@ -883,7 +883,7 @@ val export : string -> 'a -> unit
 
 val export_all : 'a t -> unit
 (** [export_all obj] export every key of [obj] object.
-{[
+{@ocaml parse[
 export_all
   object%js
     method add x y = x +. y

--- a/lib/js_of_ocaml/mutationObserver.mli
+++ b/lib/js_of_ocaml/mutationObserver.mli
@@ -20,7 +20,7 @@
 (** MutationObserver API
 
   A code example:
-  {[
+  {@ocaml[
     if (MutationObserver.is_supported()) then
       let doc = Dom_html.document in
       let target =
@@ -32,9 +32,10 @@
         Console.console##debug records ;
         Console.console##debug observer
       in
-      MutationObserver.observe ~node ~f
-        ~attributes:true ~child_list:true ~character_data:true
-        ()
+      ignore
+        (MutationObserver.observe ~node ~f
+           ~attributes:true ~child_list:true ~character_data:true
+           ())
   ]}
 
   @see <https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver> for API documentation.

--- a/lib/js_of_ocaml/notification.mli
+++ b/lib/js_of_ocaml/notification.mli
@@ -19,18 +19,19 @@
 (** Notifications API.
 
     A code example:
-    {[
+    {@ocaml[
       if Notification.is_supported ()
       then
-        Promise.map
-          (fun perm ->
-            if Js.to_string perm = "granted"
-            then
-              let options = Notification.empty_options () in
-              options##.body := Js.string "Hello from OCaml!";
-              ignore (new%js Notification.notification_with_options
-                        (Js.string "Title") options))
-          (Notification.request_permission ())
+        ignore
+          (Promise.map
+             (fun perm ->
+               if Js.to_string perm = "granted"
+               then
+                 let options = Notification.empty_options () in
+                 options##.body := Js.string "Hello from OCaml!";
+                 ignore (new%js Notification.notification_with_options
+                           (Js.string "Title") options))
+             (Notification.request_permission ()))
     ]}
 
     @see <https://developer.mozilla.org/en-US/docs/Web/API/Notifications_API>

--- a/lib/js_of_ocaml/performance.mli
+++ b/lib/js_of_ocaml/performance.mli
@@ -16,15 +16,26 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *)
 
+(* Setup for the checked example below (not rendered by odoc): [do_something]
+   stands in for the work being measured.
+{@ocaml prelude[
+let do_something () = ()
+]} *)
+
 (** Performance API
 
     A code example:
-    {@ocaml parse[
+    {@ocaml[
       let perf = Performance.performance in
-      perf##mark (Js.string "start");
+      ignore (perf##mark (Js.string "start"));
       do_something ();
-      perf##mark (Js.string "end");
-      let _ = perf##measure (Js.string "elapsed") (Js.string "start") (Js.string "end") in
+      ignore (perf##mark (Js.string "end"));
+      let _ =
+        perf##measure
+          (Js.string "elapsed")
+          (Js.def (Js.string "start"))
+          (Js.def (Js.string "end"))
+      in
       let entries = perf##getEntriesByType (Js.string "measure") in
       Js.array_get entries 0 |> ignore
     ]}

--- a/lib/js_of_ocaml/performance.mli
+++ b/lib/js_of_ocaml/performance.mli
@@ -19,7 +19,7 @@
 (** Performance API
 
     A code example:
-    {[
+    {@ocaml parse[
       let perf = Performance.performance in
       perf##mark (Js.string "start");
       do_something ();

--- a/lib/js_of_ocaml/performanceObserver.mli
+++ b/lib/js_of_ocaml/performanceObserver.mli
@@ -20,7 +20,7 @@
 (** PerformanceObserver API
 
     A code example:
-    {[
+    {@ocaml[
       if (PerformanceObserver.is_supported()) then
         let entry_types = [ "measure" ] in
         let f entries observer =
@@ -28,8 +28,7 @@
           Console.console##debug entries ;
           Console.console##debug observer
         in
-        PerformanceObserver.observe ~entry_types ~f
-        ()
+        ignore (PerformanceObserver.observe ~entry_types ~f)
    ]}
 
    @see <https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserver> for API documentation.

--- a/lib/js_of_ocaml/resizeObserver.mli
+++ b/lib/js_of_ocaml/resizeObserver.mli
@@ -20,7 +20,7 @@
 (** ResizeObserver API
 
     A code example:
-    {[
+    {@ocaml[
       if (ResizeObserver.is_supported ()) then
         let doc = Dom_html.document in
         let target =
@@ -32,9 +32,10 @@
           Console.console##debug entries;
           Console.console##debug observer
         in
-        ResizeObserver.observe ~node ~f
-          ~box:(Js.string "content-box")
-          ()
+        ignore
+          (ResizeObserver.observe ~node ~f
+             ~box:(Js.string "content-box")
+             ())
     ]}
 
     @see <https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver> for API documentation

--- a/lib/lwt/lwt_js_events.mli
+++ b/lib/lwt/lwt_js_events.mli
@@ -42,8 +42,9 @@ open Js_of_ocaml
 
    Defining a thread that waits for ESC key on an element:
 
-   {[let rec esc elt =
-      let%lwt ev = keydown elt in
+   {@ocaml[let rec esc elt =
+      let open Lwt.Syntax in
+      let* ev = keydown elt in
       if ev##.keyCode = 27
       then Lwt.return ev
       else esc elt]}

--- a/lib/tyxml/tyxml_js.mli
+++ b/lib/tyxml/tyxml_js.mli
@@ -19,7 +19,7 @@
 
 (** Tyxml interface.
     Example of use for HTML:
-    {[
+    {@ocaml[
      module T = Tyxml_js.Html
      let html = T.(
        div ~a:[a_class ["several"; "css"; "class"]; a_id "id-of-div"] [

--- a/manual/contribute.mld
+++ b/manual/contribute.mld
@@ -50,6 +50,14 @@ make fmt-js
 make lint-js
 v}
 
+{1:documentation Documentation}
+
+Code examples in the [.mli] doc-comments and the [manual/] pages are checked by
+the test suite: OCaml code blocks are type-checked against the real API, so
+examples cannot silently drift out of sync. An illustrative snippet that is not
+meant to compile can be marked to be only syntax-checked, or skipped entirely.
+See [manual/examples-check/] for the markers.
+
 {1:testing Testing}
 
 {v

--- a/manual/errors.mld
+++ b/manual/errors.mld
@@ -97,7 +97,7 @@ so attaching one to an OCaml exception preserves the stack trace for debugging.
 Use {{!Js_of_ocaml.Js.Js_error.attach_js_backtrace}Js_error.attach_js_backtrace} to attach a JavaScript stack trace
 to an OCaml exception:
 
-{@ocaml[
+{@ocaml parse[
 let process data =
   try
     do_something data

--- a/manual/examples-check/README.md
+++ b/manual/examples-check/README.md
@@ -90,12 +90,16 @@ Checked blocks need their opens in scope. Two styles, chosen per source file in
 
 ## Current coverage
 
-The whole manual (`manual/*.mld`) — every page that has `{@ocaml[ … ]}` blocks
-is wired in. The API `.mli` doc-comments are not wired in yet.
+- The whole manual (`manual/*.mld`) — every page that has `{@ocaml[ … ]}` blocks
+  is wired in.
+- The whole `js_of_ocaml` library interface — `examples_lib` globs every
+  `lib/js_of_ocaml/*.mli`, so any tagged block (now or in future) is checked.
+  Blocks that were plain `{[ … ]}` are left unchecked; the checkable ones are
+  tagged.
 
-Pages using the base `js_of_ocaml` library share one type unit and one parse
-unit. `manual/ppx-deriving.mld` has its own unit built with the
-`ppx_deriving_json` preprocessor and `js_of_ocaml.deriving` runtime.
+Pages/files using the base `js_of_ocaml` library share type and parse units.
+`manual/ppx-deriving.mld` has its own unit built with the `ppx_deriving_json`
+preprocessor and `js_of_ocaml.deriving` runtime.
 
 ## Adding files to the check
 

--- a/manual/examples-check/README.md
+++ b/manual/examples-check/README.md
@@ -96,6 +96,8 @@ Checked blocks need their opens in scope. Two styles, chosen per source file in
   `lib/js_of_ocaml/*.mli`, so any tagged block (now or in future) is checked.
   Blocks that were plain `{[ … ]}` are left unchecked; the checkable ones are
   tagged.
+- `js_of_ocaml-tyxml` (`examples_tyxml`) and `js_of_ocaml-lwt` (`examples_lwt`),
+  each in its own unit with the right library and ppx (`lwt_ppx` for `let%lwt`).
 
 Pages/files using the base `js_of_ocaml` library share type and parse units.
 `manual/ppx-deriving.mld` has its own unit built with the `ppx_deriving_json`

--- a/manual/examples-check/README.md
+++ b/manual/examples-check/README.md
@@ -1,0 +1,106 @@
+# Checked documentation examples
+
+This directory checks the code examples embedded in the js_of_ocaml
+documentation — both the API doc-comments (`.mli`) and the manual pages
+(`.mld`) — so an example that drifts out of sync with the API breaks the build
+instead of silently rotting (see issue #1020).
+
+## The convention: checked by default, opt out with a marker
+
+An `{@ocaml[ … ]}` code block is **type-checked by default**. Two metadata
+markers on the block opt out:
+
+| Block | Meaning |
+|---|---|
+| `{@ocaml[ … ]}` | **type-checked** (compiled against the real library) |
+| `{@ocaml parse[ … ]}` | **parse-only** — syntax-checked, not type-checked |
+| `{@ocaml skip[ … ]}` | **ignored** — not even parsed |
+| `{@ocaml prelude[ … ]}` | **setup** prepended to the type unit (see below) |
+| `{[ … ]}` | never checked (carries no metadata) |
+
+- Use **`parse`** for an example that references hypothetical/undefined
+  identifiers or placeholder types (`type1`, a free `obj`, …) but should still be
+  valid OCaml. It catches syntax rot without demanding a self-contained program.
+- Use **`skip`** for pseudo-code, elisions (`…`), toplevel/REPL transcripts, or
+  fragments that are not OCaml at all.
+
+## Preludes: type-check more without cluttering the docs
+
+A `{@ocaml prelude[ … ]}` block is prepended, at top level, to the type unit,
+so the checked examples can refer to whatever it binds (a shared `open`, a helper
+value, a placeholder type). This lets an example that would otherwise be
+`parse`-only become fully type-checked without spelling out the setup in every
+snippet.
+
+In an `.mli`, put the prelude in a **plain `(* … *)` comment** (not a `(** … *)`
+doc-comment): odoc does not render plain comments, so the setup stays out of the
+published documentation, while this checker still reads the raw text, e.g.
+
+```
+(* Shared setup for the checked examples in this file — not rendered by odoc.
+{@ocaml prelude[
+open Js_of_ocaml
+let element = Dom_html.document##.documentElement
+]} *)
+```
+
+lets the file's examples use `element` (and drop a repeated `open`) without
+that boilerplate appearing in the rendered docs. (`.mld` pages have no
+invisible-comment syntax, so a prelude there would render; prefer an injected
+`--open` or a self-contained example on manual pages.) No `.mli` is wired into
+the check today; this is available for when one is.
+
+All of these render **identically** — odoc emits `<pre class="language-ocaml">`
+and strips the metadata — so readers never see the marker; it only tells this
+checker what to do.
+
+## How it works
+
+`extract_examples` pulls the blocks of a chosen tier out of the listed files and
+emits one module per block, with a `# line` directive back to the source:
+
+- **type tier** → compiled against `js_of_ocaml` (+ `js_of_ocaml-ppx`, so
+  `##`/`##.`/`object%js` work) as a **library**. Building the `.cma` type-checks
+  every module but skips the final link, so an example that declares or uses a
+  JS-only `external` still checks. The examples are **never executed** (their
+  top-level side effects touch the DOM, which only exists in a browser).
+- **parse tier** → `ocamlc -stop-after parsing` (no ppx, no injected opens —
+  `##`/`%js` parse as plain OCaml and names are never resolved). Undefined
+  identifiers are fine; a real syntax error fails. (Opens are not injected here
+  because an `open` before a bare-expression block is itself a syntax error.)
+
+A failure is reported at the original source line, e.g.:
+
+```
+File "../javascript-interop.mld", line 493, characters 12-16:
+Error: The value args has type Js.Unsafe.any_js_array = Js.Unsafe.top Js.t
+       but an expression was expected of type < .. > Js.t
+```
+
+## Self-contained vs. injected opens
+
+Checked blocks need their opens in scope. Two styles, chosen per source file in
+[`dune`](dune):
+
+- **`.mli` API examples are self-contained** — the block includes its own
+  `open Js_of_ocaml`, so the rendered example is copy-pasteable.
+- **`.mld` manual pages get their ambient opens injected** (`--open
+  Js_of_ocaml`), because a page assumes them throughout; repeating the `open` in
+  every small block would be noise.
+
+## Current coverage
+
+The whole manual (`manual/*.mld`) — every page that has `{@ocaml[ … ]}` blocks
+is wired in. The API `.mli` doc-comments are not wired in yet.
+
+Pages using the base `js_of_ocaml` library share one type unit and one parse
+unit. `manual/ppx-deriving.mld` has its own unit built with the
+`ppx_deriving_json` preprocessor and `js_of_ocaml.deriving` runtime.
+
+## Adding files to the check
+
+Add the `.mli`/`.mld` to the `extract_examples` invocations in [`dune`](dune)
+(both the type-tier and, if the page has `parse` blocks, the parse-tier rule).
+Files needing a different library or ppx (e.g. the deriving page) get their own
+generated unit built against that library, following the `examples_deriving`
+example.

--- a/manual/examples-check/dune
+++ b/manual/examples-check/dune
@@ -15,28 +15,18 @@
 ; every module but skips the final link, so an example that declares/uses an
 ; `external` primitive that only exists in JS still checks.
 
-; Manual examples, from the .mld pages that use the base `js_of_ocaml` library.
-; The pages read with `open Js_of_ocaml` assumed throughout, so we inject it
-; (--open) rather than repeat it in every small block; the rendered blocks stay
-; clean and are checked as-is. The same file list feeds the parse tier below
-; (pages with only parse-only blocks, e.g. lwt.mld, contribute nothing here).
+; Manual examples: every manual/*.mld page. The pages read with `open Js_of_ocaml`
+; assumed throughout, so we inject it (--open) rather than repeat it in every
+; small block; the rendered blocks stay clean and are checked as-is. The same
+; glob feeds the parse tier below (pages with only parse-only blocks, e.g.
+; lwt.mld, and pages with no blocks contribute nothing here).
 
 (rule
  (target examples_manual.ml)
  (deps
   extract_examples.exe
   (:mlds
-   ../build-toplevel.mld
-   ../debug.mld
-   ../errors.mld
-   ../javascript-interop.mld
-   ../linker.mld
-   ../lwt.mld
-   ../ppx.mld
-   ../quickstart.mld
-   ../rev-bindings.mld
-   ../runtime-representation.mld
-   ../tailcall.mld))
+   (glob_files ../*.mld)))
  (action
   (with-stdout-to
    %{target}
@@ -46,37 +36,15 @@
  (name examples_manual)
  (modules examples_manual)
  (modes byte)
- ; dynlink / wasm_of_ocaml-compiler.dynlink / js_of_ocaml-toplevel.worker:
- ; the build-toplevel page's Dynlink.loadfile, Wasm_of_ocaml_compiler_dynlink
- ; and Js_of_ocaml_toplevel_worker examples.
+ ; dynlink / wasm_of_ocaml-compiler.dynlink / js_of_ocaml-toplevel.worker: the
+ ; build-toplevel page's loadfile and worker examples. js_of_ocaml.deriving +
+ ; the ppx_deriving_json preprocessor: the ppx-deriving page.
  (libraries
   js_of_ocaml
+  js_of_ocaml.deriving
   dynlink
   wasm_of_ocaml-compiler.dynlink
   js_of_ocaml-toplevel.worker)
- (flags
-  (:standard -w -a))
- (preprocess
-  (pps js_of_ocaml-ppx)))
-
-; Deriving examples (ppx-deriving.mld) need the ppx_deriving_json preprocessor
-; and its runtime, so they get their own unit.
-
-(rule
- (target examples_deriving.ml)
- (deps
-  extract_examples.exe
-  (:mld ../ppx-deriving.mld))
- (action
-  (with-stdout-to
-   %{target}
-   (run ./extract_examples.exe --open Js_of_ocaml %{mld}))))
-
-(library
- (name examples_deriving)
- (modules examples_deriving)
- (modes byte)
- (libraries js_of_ocaml js_of_ocaml.deriving)
  (flags
   (:standard -w -a))
  (preprocess
@@ -167,17 +135,7 @@
  (deps
   extract_examples.exe
   (:mlds
-   ../build-toplevel.mld
-   ../debug.mld
-   ../errors.mld
-   ../javascript-interop.mld
-   ../linker.mld
-   ../lwt.mld
-   ../ppx.mld
-   ../quickstart.mld
-   ../rev-bindings.mld
-   ../runtime-representation.mld
-   ../tailcall.mld))
+   (glob_files ../*.mld)))
  (action
   (with-stdout-to
    %{target}
@@ -208,7 +166,6 @@
   (= %{os_type} Unix))
  (deps
   examples_manual.cma
-  examples_deriving.cma
   examples_lib.cma
   examples_tyxml.cma
   examples_lwt.cma)

--- a/manual/examples-check/dune
+++ b/manual/examples-check/dune
@@ -1,0 +1,135 @@
+; Checks the documentation examples. An {@ocaml[ ... ]} code block in a
+; js_of_ocaml .mli doc-comment or .mld manual page is type-checked by default, so
+; an example that no longer matches the API breaks `dune build @runtest`. The
+; {@ocaml parse[ ... ]} and {@ocaml skip[ ... ]} markers opt out of type-checking
+; (parse-only) and of checking entirely; plain {[ ... ]} blocks are never checked.
+; See extract_examples.ml and README.md.
+
+(executable
+ (name extract_examples)
+ (modules extract_examples))
+
+; --- Type-checked blocks ---------------------------------------------------
+
+; Each type unit is a library (not an executable): building the .cma type-checks
+; every module but skips the final link, so an example that declares/uses an
+; `external` primitive that only exists in JS still checks.
+
+; Manual examples, from the .mld pages that use the base `js_of_ocaml` library.
+; The pages read with `open Js_of_ocaml` assumed throughout, so we inject it
+; (--open) rather than repeat it in every small block; the rendered blocks stay
+; clean and are checked as-is. The same file list feeds the parse tier below
+; (pages with only parse-only blocks, e.g. lwt.mld, contribute nothing here).
+
+(rule
+ (target examples_manual.ml)
+ (deps
+  extract_examples.exe
+  (:mlds
+   ../build-toplevel.mld
+   ../debug.mld
+   ../errors.mld
+   ../javascript-interop.mld
+   ../linker.mld
+   ../lwt.mld
+   ../ppx.mld
+   ../quickstart.mld
+   ../rev-bindings.mld
+   ../runtime-representation.mld
+   ../tailcall.mld))
+ (action
+  (with-stdout-to
+   %{target}
+   (run ./extract_examples.exe --open Js_of_ocaml %{mlds}))))
+
+(library
+ (name examples_manual)
+ (modules examples_manual)
+ (modes byte)
+ ; dynlink / wasm_of_ocaml-compiler.dynlink / js_of_ocaml-toplevel.worker:
+ ; the build-toplevel page's Dynlink.loadfile, Wasm_of_ocaml_compiler_dynlink
+ ; and Js_of_ocaml_toplevel_worker examples.
+ (libraries
+  js_of_ocaml
+  dynlink
+  wasm_of_ocaml-compiler.dynlink
+  js_of_ocaml-toplevel.worker)
+ (flags
+  (:standard -w -a))
+ (preprocess
+  (pps js_of_ocaml-ppx)))
+
+; Deriving examples (ppx-deriving.mld) need the ppx_deriving_json preprocessor
+; and its runtime, so they get their own unit.
+
+(rule
+ (target examples_deriving.ml)
+ (deps
+  extract_examples.exe
+  (:mld ../ppx-deriving.mld))
+ (action
+  (with-stdout-to
+   %{target}
+   (run ./extract_examples.exe --open Js_of_ocaml %{mld}))))
+
+(library
+ (name examples_deriving)
+ (modules examples_deriving)
+ (modes byte)
+ (libraries js_of_ocaml js_of_ocaml.deriving)
+ (flags
+  (:standard -w -a))
+ (preprocess
+  (pps js_of_ocaml-ppx js_of_ocaml-ppx_deriving_json)))
+
+; --- Parse-only blocks -----------------------------------------------------
+
+; The {@ocaml parse[ ... ]} blocks of the same pages: syntax-checked only (they
+; reference hypothetical identifiers or placeholder types). No ppx and no --open:
+; `##`/`object%js` parse as plain OCaml, names are never resolved, and injecting
+; an `open` before a bare-expression block would itself be a syntax error.
+
+(rule
+ (target examples_manual_parse.ml)
+ (deps
+  extract_examples.exe
+  (:mlds
+   ../build-toplevel.mld
+   ../debug.mld
+   ../errors.mld
+   ../javascript-interop.mld
+   ../linker.mld
+   ../lwt.mld
+   ../ppx.mld
+   ../quickstart.mld
+   ../rev-bindings.mld
+   ../runtime-representation.mld
+   ../tailcall.mld))
+ (action
+  (with-stdout-to
+   %{target}
+   (run ./extract_examples.exe --select parse %{mlds}))))
+
+; --- Run the checks under @runtest -----------------------------------------
+
+; Type tier: build the archives (type-checking) — never executed.
+
+(rule
+ (alias runtest)
+ (deps examples_manual.cma examples_deriving.cma)
+ (action (progn)))
+
+; Parse tier: stop after parsing, so undefined identifiers are allowed but a
+; genuine syntax error fails.
+
+(rule
+ (alias runtest)
+ (deps examples_manual_parse.ml)
+ (action
+  (run
+   %{ocaml_bin}/ocamlc
+   -stop-after
+   parsing
+   -w
+   -a
+   examples_manual_parse.ml)))

--- a/manual/examples-check/dune
+++ b/manual/examples-check/dune
@@ -106,6 +106,55 @@
  (preprocess
   (pps js_of_ocaml-ppx)))
 
+; js_of_ocaml-tyxml examples (the functional Tyxml_js.Html API).
+
+(rule
+ (target examples_tyxml.ml)
+ (deps
+  extract_examples.exe
+  (:mlis
+   (glob_files ../../lib/tyxml/*.mli)))
+ (action
+  (with-stdout-to
+   %{target}
+   (run ./extract_examples.exe --open Js_of_ocaml_tyxml %{mlis}))))
+
+(library
+ (name examples_tyxml)
+ (modules examples_tyxml)
+ (modes byte)
+ (libraries js_of_ocaml-tyxml)
+ (flags
+  (:standard -w -a))
+ (preprocess
+  (pps js_of_ocaml-ppx)))
+
+; js_of_ocaml-lwt examples: need the js ppx (##.), with Lwt_js_events opened so
+; the event functions resolve unqualified. The examples use Lwt.Syntax (let*)
+; rather than lwt_ppx's let%lwt, so no lwt_ppx is required (it is unavailable on
+; some environments, e.g. OxCaml).
+
+(rule
+ (target examples_lwt.ml)
+ (deps
+  extract_examples.exe
+  (:mlis
+   (glob_files ../../lib/lwt/*.mli)))
+ (action
+  (with-stdout-to
+   %{target}
+   (run ./extract_examples.exe --open Js_of_ocaml_lwt.Lwt_js_events %{mlis}))))
+
+(library
+ (name examples_lwt)
+ (modules examples_lwt)
+ (modes byte)
+ (libraries js_of_ocaml js_of_ocaml-lwt lwt)
+ (flags
+  (:standard -w -a))
+ (preprocess
+  (pps js_of_ocaml-ppx)))
+
 ; --- Parse-only blocks -----------------------------------------------------
 
 ; The {@ocaml parse[ ... ]} blocks of the same pages: syntax-checked only (they
@@ -147,11 +196,22 @@
 
 ; --- Run the checks under @runtest -----------------------------------------
 
+; The check only runs on Unix: the parse tier invokes ocamlc through
+; %{ocaml_bin}, which resolves to a bare `ocamlc` (no `.exe`) on Windows, and
+; the check adds no coverage that the Unix jobs don't already provide.
+
 ; Type tier: build the archives (type-checking) — never executed.
 
 (rule
  (alias runtest)
- (deps examples_manual.cma examples_deriving.cma examples_lib.cma)
+ (enabled_if
+  (= %{os_type} Unix))
+ (deps
+  examples_manual.cma
+  examples_deriving.cma
+  examples_lib.cma
+  examples_tyxml.cma
+  examples_lwt.cma)
  (action (progn)))
 
 ; Parse tier: stop after parsing, so undefined identifiers are allowed but a
@@ -159,6 +219,8 @@
 
 (rule
  (alias runtest)
+ (enabled_if
+  (= %{os_type} Unix))
  (deps examples_manual_parse.ml)
  (action
   (run
@@ -171,6 +233,8 @@
 
 (rule
  (alias runtest)
+ (enabled_if
+  (= %{os_type} Unix))
  (deps examples_lib_parse.ml)
  (action
   (run %{ocaml_bin}/ocamlc -stop-after parsing -w -a examples_lib_parse.ml)))

--- a/manual/examples-check/dune
+++ b/manual/examples-check/dune
@@ -82,6 +82,30 @@
  (preprocess
   (pps js_of_ocaml-ppx js_of_ocaml-ppx_deriving_json)))
 
+; API examples, from the js_of_ocaml library .mli doc-comments. `open Js_of_ocaml`
+; is injected (the examples reference Js, Dom_html, Intl, Console, ... unqualified).
+
+(rule
+ (target examples_lib.ml)
+ (deps
+  extract_examples.exe
+  (:mlis
+   (glob_files ../../lib/js_of_ocaml/*.mli)))
+ (action
+  (with-stdout-to
+   %{target}
+   (run ./extract_examples.exe --open Js_of_ocaml %{mlis}))))
+
+(library
+ (name examples_lib)
+ (modules examples_lib)
+ (modes byte)
+ (libraries js_of_ocaml)
+ (flags
+  (:standard -w -a))
+ (preprocess
+  (pps js_of_ocaml-ppx)))
+
 ; --- Parse-only blocks -----------------------------------------------------
 
 ; The {@ocaml parse[ ... ]} blocks of the same pages: syntax-checked only (they
@@ -110,13 +134,24 @@
    %{target}
    (run ./extract_examples.exe --select parse %{mlds}))))
 
+(rule
+ (target examples_lib_parse.ml)
+ (deps
+  extract_examples.exe
+  (:mlis
+   (glob_files ../../lib/js_of_ocaml/*.mli)))
+ (action
+  (with-stdout-to
+   %{target}
+   (run ./extract_examples.exe --select parse %{mlis}))))
+
 ; --- Run the checks under @runtest -----------------------------------------
 
 ; Type tier: build the archives (type-checking) — never executed.
 
 (rule
  (alias runtest)
- (deps examples_manual.cma examples_deriving.cma)
+ (deps examples_manual.cma examples_deriving.cma examples_lib.cma)
  (action (progn)))
 
 ; Parse tier: stop after parsing, so undefined identifiers are allowed but a
@@ -133,3 +168,9 @@
    -w
    -a
    examples_manual_parse.ml)))
+
+(rule
+ (alias runtest)
+ (deps examples_lib_parse.ml)
+ (action
+  (run %{ocaml_bin}/ocamlc -stop-after parsing -w -a examples_lib_parse.ml)))

--- a/manual/examples-check/extract_examples.ml
+++ b/manual/examples-check/extract_examples.ml
@@ -1,0 +1,215 @@
+(* Js_of_ocaml
+ * http://www.ocsigen.org/js_of_ocaml/
+ * Copyright (C) 2024 Ocsigen team
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+
+(* Extract documentation examples so the build can check them.
+
+   In the [.mli] doc-comments and the [.mld] manual pages, an [{@ocaml[ ... ]}]
+   code block is *type-checked by default*. Two metadata markers opt out:
+
+   - [{@ocaml skip[ ... ]}]    : ignored entirely (not even parsed) — for
+     pseudo-code, elisions ([... ]) and toplevel-style snippets.
+   - [{@ocaml parse[ ... ]}]   : only parsed (syntax-checked), not type-checked —
+     for examples that reference hypothetical/undefined identifiers or placeholder
+     types but should still be valid OCaml.
+   - [{@ocaml prelude[ ... ]}] : shared setup (opens, helper bindings) prepended
+     at top level to the type unit so the other examples can refer to it. Put it
+     in a plain [(* ... *)] comment in an [.mli] to keep it out of the rendered
+     documentation (odoc renders only [(** ... *)] doc-comments).
+
+   A plain [{[ ... ]}] block carries no metadata and is always highlight-only
+   (never checked). Use it for fragments you do not want checked at all.
+
+   Each checked block must be a sequence of OCaml structure items (what you would
+   paste into a [.ml] file), so it can be wrapped verbatim in its own module. A
+   bare expression should be written as [let () = ignore (...)].
+
+   Usage:
+     extract_examples [--open MODULE]... [--select type|parse] FILE...
+
+   [--select type] (the default) emits the type-checked blocks; [--select parse]
+   emits the parse-only blocks. Files may be [.mli] or [.mld]. The generated
+   modules carry a [# line] directive pointing back at the original file, so an
+   error is reported at the real source line. *)
+
+let read_file path =
+  let ic = open_in_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_in ic)
+    (fun () ->
+      let n = in_channel_length ic in
+      let s = Bytes.create n in
+      really_input ic s 0 n;
+      Bytes.to_string s)
+
+(* Module-name-safe identifier derived from a file's basename. *)
+let ident_of_basename base =
+  let b = Bytes.of_string base in
+  for i = 0 to Bytes.length b - 1 do
+    match Bytes.get b i with
+    | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' -> ()
+    | _ -> Bytes.set b i '_'
+  done;
+  String.capitalize_ascii (Bytes.to_string b)
+
+let opening = "{@ocaml"
+
+let closing = "]}"
+
+type tier =
+  | Type (* type-checked (the default) *)
+  | Parse (* parse-only: [parse] metadata *)
+  | Skip (* ignored: [skip] metadata *)
+  | Prelude (* setup prepended to the type unit: [prelude] metadata *)
+
+let contains ~sub s =
+  let ls = String.length s and lsub = String.length sub in
+  let rec loop i =
+    if i + lsub > ls then false else String.sub s i lsub = sub || loop (i + 1)
+  in
+  loop 0
+
+(* The tier is read from the [{@ocaml <meta>[] metadata: [skip]/[parse]/[prelude]
+   opt out of (respectively) all checking, typing, and being a standalone module;
+   anything else (including no metadata) is type-checked. A [prelude] block holds
+   shared setup (opens, helper bindings) that is prepended to the type unit so the
+   other examples can refer to it; place it in a plain [(* ... *)] comment in an
+   [.mli] to keep it out of the rendered documentation. *)
+let tier_of_meta meta =
+  if contains ~sub:"skip" meta
+  then Skip
+  else if contains ~sub:"prelude" meta
+  then Prelude
+  else if contains ~sub:"parse" meta
+  then Parse
+  else Type
+
+(* Find the [{@ocaml ...[ ... ]}] code blocks in [s]. Returns (tier, line, code)
+   triples where [line] is the 1-based line of the first character of [code].
+   Plain [{[ ... ]}] blocks carry no [{@ocaml] marker and are never returned. *)
+let blocks s =
+  let len = String.length s in
+  let found = ref [] in
+  let line_of pos =
+    let n = ref 1 in
+    for i = 0 to pos - 1 do
+      if s.[i] = '\n' then incr n
+    done;
+    !n
+  in
+  (* naive substring search for [opening] starting at [i] *)
+  let rec at i =
+    if i + String.length opening > len
+    then None
+    else if String.sub s i (String.length opening) = opening
+    then Some i
+    else at (i + 1)
+  in
+  let rec find_close j =
+    if j + String.length closing > len
+    then None
+    else if String.sub s j (String.length closing) = closing
+    then Some j
+    else find_close (j + 1)
+  in
+  let rec search from =
+    match at from with
+    | None -> ()
+    | Some i -> (
+        (* metadata sits between [{@ocaml] and the [[] that opens the code *)
+        match String.index_from_opt s (i + String.length opening) '[' with
+        | None -> ()
+        | Some lb -> (
+            let meta =
+              String.sub s (i + String.length opening) (lb - i - String.length opening)
+            in
+            let code_start = lb + 1 in
+            match find_close code_start with
+            | None -> ()
+            | Some close ->
+                let code = String.sub s code_start (close - code_start) in
+                found := (tier_of_meta meta, line_of code_start, code) :: !found;
+                search (close + String.length closing)))
+  in
+  search 0;
+  List.rev !found
+
+let () =
+  let opens = ref [] in
+  let files = ref [] in
+  let want = ref Type in
+  let rec parse = function
+    | "--open" :: m :: rest ->
+        opens := m :: !opens;
+        parse rest
+    | "--select" :: "type" :: rest ->
+        want := Type;
+        parse rest
+    | "--select" :: "parse" :: rest ->
+        want := Parse;
+        parse rest
+    | "--select" :: s :: _ -> failwith ("unknown --select " ^ s)
+    | f :: rest ->
+        files := f :: !files;
+        parse rest
+    | [] -> ()
+  in
+  parse (List.tl (Array.to_list Sys.argv));
+  let opens = List.rev !opens in
+  let files = List.rev !files in
+  let want = !want in
+  set_binary_mode_out stdout true;
+  let emit_code line file code =
+    Printf.printf "# %d %S\n" line file;
+    print_string code;
+    (* ensure the block ends on its own line *)
+    if String.length code > 0 && code.[String.length code - 1] <> '\n'
+    then print_char '\n'
+  in
+  let by_file = List.map (fun file -> file, blocks (read_file file)) files in
+  print_string
+    "(* GENERATED by manual/examples-check/extract_examples.ml -- do not edit. *)\n\
+     (* Documentation examples ({@ocaml[ ]} blocks) from the .mli doc-comments and\n\
+    \   .mld manual pages. *)\n\
+     [@@@warning \"-a\"]\n";
+  (* Top-level opens, once: they cover the prelude and every example module
+     (nested modules see the enclosing opens), and putting them here rather than
+     inside each module avoids [open] preceding a bare-expression block. *)
+  List.iter (fun m -> Printf.printf "open %s\n" m) opens;
+  (* Prelude blocks come first, at top level, so the examples can refer to them.
+     Only meaningful for the type unit. *)
+  if want = Type
+  then
+    List.iter
+      (fun (file, bs) ->
+        List.iter (fun (t, line, code) -> if t = Prelude then emit_code line file code) bs)
+      by_file;
+  (* Then the blocks of the wanted tier, each isolated in its own module. *)
+  List.iter
+    (fun (file, bs) ->
+      let id = ident_of_basename (Filename.remove_extension (Filename.basename file)) in
+      bs
+      |> List.filter_map (fun (t, line, code) ->
+          if t = want then Some (line, code) else None)
+      |> List.iteri (fun n (line, code) ->
+          Printf.printf "\nmodule Example_%s_%d = struct\n" id (n + 1);
+          emit_code line file code;
+          print_string "end\n"))
+    by_file;
+  (* Keep the file a non-empty, valid module even when it has no blocks. *)
+  print_string "\nlet () = ()\n"

--- a/manual/examples-check/extract_examples.ml
+++ b/manual/examples-check/extract_examples.ml
@@ -171,7 +171,9 @@ let () =
   in
   parse (List.tl (Array.to_list Sys.argv));
   let opens = List.rev !opens in
-  let files = List.rev !files in
+  (* A [*.mli] glob in dune also matches the ppx-preprocessed [*.pp.mli] copies
+     in the build tree; drop them so each block is not extracted twice. *)
+  let files = List.rev !files |> List.filter (fun f -> not (contains ~sub:".pp." f)) in
   let want = !want in
   set_binary_mode_out stdout true;
   let emit_code line file code =

--- a/manual/javascript-interop.mld
+++ b/manual/javascript-interop.mld
@@ -127,7 +127,7 @@ There are two ways to write these types:
 v}
 
 {b Named class types} — better for reusable or complex interfaces:
-{@ocaml[
+{@ocaml parse[
 class type myObject = object
   method field1 : type1
   method field2 : type2
@@ -198,17 +198,17 @@ or [obj##.some_property_].
 class type canvas = object
   (* All three refer to the same JS method: drawImage *)
   method drawImage :
-      imageElement Js.t -> int -> int -> unit Js.meth
+      Dom_html.imageElement Js.t -> int -> int -> unit Js.meth
   method drawImage_withSize :
-      imageElement Js.t -> int -> int -> int -> int -> unit Js.meth
+      Dom_html.imageElement Js.t -> int -> int -> int -> int -> unit Js.meth
   method drawImage_fromCanvas :
-      canvasElement Js.t -> int -> int -> unit Js.meth
+      Dom_html.canvasElement Js.t -> int -> int -> unit Js.meth
 end
 ]}
 
 {3 Full naming rules}
 
-{@ocaml[
+{@ocaml skip[
 class type example = object
   (* All of these refer to JS field [meth] *)
   method meth : ..
@@ -270,6 +270,9 @@ Global JavaScript variables are properties of the global object. Use
 (* Access document *)
 let doc : Dom_html.document Js.t = Js.Unsafe.global##.document
 
+(* [config] is the type describing your custom global object *)
+type config
+
 (* Read and write a custom global *)
 let get_config () : config Js.t = Js.Unsafe.global##.myAppConfig
 let set_config (x : config Js.t) = Js.Unsafe.global##.myAppConfig := x
@@ -288,12 +291,12 @@ Verify the library documentation before writing type annotations.
 When a property is missing from the OCaml interface, use
 {{!Js_of_ocaml.Js.Unsafe.coerce}Js.Unsafe.coerce} for untyped access:
 
-{@ocaml[
+{@ocaml parse[
 (* Read a property *)
 let value = (Js.Unsafe.coerce obj)##.someProp
 
 (* Write a property *)
-(Js.Unsafe.coerce obj)##.someProp := v
+(Js.Unsafe.coerce obj)##.someProp := value
 ]}
 
 {1:null-undefined Handling null and undefined}
@@ -306,7 +309,7 @@ Js_of_ocaml represents these with distinct types.
 Use {{!Js_of_ocaml.Js.Opt}Js.Opt} for values that may be [null] (e.g., DOM methods that
 return [null] when an element is not found):
 
-{@ocaml[
+{@ocaml parse[
 (* Check if null *)
 let is_present = Js.Opt.test value
 
@@ -331,7 +334,7 @@ let null_val : element Js.t Js.opt = Js.null
 Use {{!Js_of_ocaml.Js.Optdef}Js.Optdef} for values that may be [undefined] (e.g., optional
 object properties, array access beyond bounds):
 
-{@ocaml[
+{@ocaml parse[
 (* Check if defined *)
 let is_defined = Js.Optdef.test value
 
@@ -396,7 +399,7 @@ let slice arr start stop =
 
 Use {{!Js_of_ocaml.Js.Unsafe.call}Js.Unsafe.call} when you need to explicitly set [this]:
 
-{@ocaml[
+{@ocaml parse[
 (* Equivalent to: func.call(thisArg, arg1, arg2) *)
 let result =
   Js.Unsafe.call func thisArg [| Js.Unsafe.inject arg1; Js.Unsafe.inject arg2 |]
@@ -440,7 +443,7 @@ partially applied function.
 
 Use {{!Js_of_ocaml.Js.wrap_meth_callback}Js.wrap_meth_callback} when the callback needs access to [this]:
 
-{@ocaml[
+{@ocaml parse[
 (* The first parameter receives the 'this' value *)
 let callback = Js.wrap_meth_callback (fun this event ->
   let target : Dom_html.element Js.t = this in
@@ -453,7 +456,7 @@ let callback = Js.wrap_meth_callback (fun this event ->
 For DOM events, use {{!Js_of_ocaml.Dom_html.handler}Dom_html.handler} which wraps the function
 and handles the return value ([Js._false] prevents the default action):
 
-{@ocaml[
+{@ocaml parse[
 let handler = Dom_html.handler (fun event ->
   Dom_html.window##alert (Js.string "Clicked!");
   Js._true)
@@ -463,7 +466,7 @@ button##.onclick := handler
 
 For handlers that need access to [this], use {{!Js_of_ocaml.Dom.full_handler}Dom.full_handler}:
 
-{@ocaml[
+{@ocaml parse[
 let handler = Dom.full_handler (fun this event ->
   let element : Dom_html.element Js.t = this in
   (* ... *)
@@ -475,7 +478,7 @@ let handler = Dom.full_handler (fun this event ->
 For performance-critical code, or when you don't need partial application,
 use {{!Js_of_ocaml.Js.Unsafe.callback}Js.Unsafe.callback}:
 
-{@ocaml[
+{@ocaml parse[
 (* Strict callback - missing args become undefined, extra args are lost *)
 let strict_cb = Js.Unsafe.callback (fun x y -> x + y)
 
@@ -488,7 +491,7 @@ let arity_cb = Js.Unsafe.callback_with_arity 2 (fun x y -> x + y)
 Use {{!Js_of_ocaml.Js.Unsafe.callback_with_arguments}Js.Unsafe.callback_with_arguments} when the callback receives a
 variable number of arguments:
 
-{@ocaml[
+{@ocaml parse[
 let varargs_cb = Js.Unsafe.callback_with_arguments (fun args ->
   let len = args##.length in
   Printf.printf "Called with %d arguments\n" len)
@@ -547,6 +550,9 @@ let as_string (x : string_or_number Js.t) : Js.js_string Js.t Js.opt =
 {2 Converting to OCaml variants}
 
 {@ocaml[
+(* The union type from above *)
+type element_or_text
+
 type child =
   | Element of Dom.element Js.t
   | Text of Dom.text Js.t
@@ -559,8 +565,8 @@ let classify_child (x : element_or_text Js.t) : child =
 (* Now use pattern matching *)
 let handle container =
   match classify_child container##.child with
-  | Element e -> (* work with element *)
-  | Text t -> (* work with text node *)
+  | Element e -> () (* work with element *)
+  | Text t -> () (* work with text node *)
 ]}
 
 {1:json JSON serialization}
@@ -570,7 +576,7 @@ provides serialization between OCaml values and JSON strings. The
 deserialization is unsafe in the same way the OCaml
 Marshal.from_string function is.
 
-{@ocaml[
+{@ocaml parse[
 (* OCaml value -> JSON string *)
 let json : Js.js_string Js.t = Json.output value
 

--- a/manual/lwt.mld
+++ b/manual/lwt.mld
@@ -19,7 +19,7 @@ an Lwt thread that will return when the event occurs.
 
 Example:
 
-{@ocaml[
+{@ocaml parse[
 Lwt.ignore_result (Lwt_js_events.click target >>= handler)
 ]}
 
@@ -28,7 +28,7 @@ The handler receives the JS event as parameter.
 Each of these functions has a version (same name with an ending "s")
 that loops when the handler terminates:
 
-{@ocaml[
+{@ocaml parse[
 Lwt.ignore_result (Lwt_js_events.clicks target handler)
 ]}
 
@@ -38,7 +38,7 @@ To remove an event handler, cancel the Lwt thread using [Lwt.cancel].
 You can also use [Lwt.pick]. For example, the following code waits
 for a click on either [t1] or [t2]:
 
-{@ocaml[
+{@ocaml parse[
 Lwt.pick [
   Lwt_js_events.click t1 >>= handler1;
   Lwt_js_events.click t2 >>= handler2

--- a/manual/ppx.mld
+++ b/manual/ppx.mld
@@ -34,7 +34,7 @@ v}
 
 Use [##.] (with a dot) to access a property:
 
-{@ocaml[
+{@ocaml parse[
 (* Get the document title *)
 let title = Dom_html.document##.title
 
@@ -58,7 +58,7 @@ v}
 
 Use [##.] with [:=] to set a property:
 
-{@ocaml[
+{@ocaml parse[
 (* Set the document title *)
 Dom_html.document##.title := Js.string "New Title"
 
@@ -85,7 +85,7 @@ v}
 
 Use [##] (without a dot) to call a method:
 
-{@ocaml[
+{@ocaml parse[
 (* Console logging *)
 Console.console##log (Js.string "Hello")
 Console.console##warn (Js.string "Warning!")
@@ -108,7 +108,7 @@ js_array##forEach (Js.wrap_callback (fun x _idx _arr ->
 
 For easier chaining, you can wrap the method call in parentheses:
 
-{@ocaml[
+{@ocaml parse[
 (* These are equivalent *)
 let result = obj##meth1##meth2##meth3
 let result = obj##(meth1)##(meth2)##(meth3)
@@ -132,7 +132,7 @@ v}
 
 Use [new%js] to call JavaScript constructors:
 
-{@ocaml[
+{@ocaml parse[
 (* Create a Date *)
 let date_constr = Js.Unsafe.global##._Date
 let now = new%js date_constr
@@ -151,8 +151,8 @@ let arr = new%js array_constr 10
 
 When the constructor is not a simple identifier, bind it first:
 
-{@ocaml[
-let constr = (Js.Unsafe.global##.SomeLib)##._SomeClass in
+{@ocaml parse[
+let constr = (Js.Unsafe.global##.SomeLib)##._SomeClass
 let obj = new%js constr arg1 arg2
 ]}
 
@@ -198,9 +198,9 @@ Control property access with attributes:
 {@ocaml[
 object%js
   val readonly_prop = 42                   (* read-only by default *)
-  val also_readonly = 42 [@@readonly]      (* explicit read-only *)
+  val also_readonly_ = 42 [@@readonly]     (* explicit read-only *)
   val mutable readwrite = 42               (* read/write with mutable *)
-  val also_readwrite = 42 [@@readwrite]    (* explicit read/write *)
+  val also_readwrite_ = 42 [@@readwrite]   (* explicit read/write *)
   val writeonly = 42 [@@writeonly]         (* write-only *)
   val optional = Js.undefined [@@optdef]   (* optional/undefined *)
 end
@@ -244,7 +244,7 @@ end
 
 Has the type:
 
-{@ocaml[
+{@ocaml skip[
 < x : int Js.readonly_prop;
   y : int Js.prop;
   add : int -> int -> int Js.meth > Js.t


### PR DESCRIPTION
Closes #1020.

Type-check the code examples embedded in the js_of_ocaml documentation — the manual **and** the library `.mli` doc-comments — so they can't silently rot as the API evolves.

## The convention (checked by default, opt out with a marker)

An `{@ocaml[ … ]}` code block in a `.mld` manual page or a `.mli` doc-comment is checked by default:

| Block | Behaviour |
|---|---|
| `{@ocaml[ … ]}` | **type-checked** against the real library |
| `{@ocaml parse[ … ]}` | parse-only (syntax) — for hypothetical identifiers / placeholder types |
| `{@ocaml skip[ … ]}` | ignored — pseudo-code, elisions, non-parsing fragments |
| `{@ocaml prelude[ … ]}` | shared setup prepended to the type unit (hide it in a plain `(* … *)` comment in a `.mli`) |
| `{[ … ]}` | never checked |

The markers are odoc metadata, stripped from the rendered output, so **readers see no difference** (all render as `<pre class="language-ocaml">`).

## How it works

`manual/examples-check/` extracts the blocks and, for the type tier, compiles them as a **library** — building the `.cma` type-checks every module but skips the final link, so JS-only `external`s still check — against the relevant library + ppx. The parse tier runs `ocamlc -stop-after parsing`. Everything runs under `@runtest`, is **compile-only** (never executed — the examples touch the DOM), and errors are reported at the original source line. Sources needing a different library/ppx get their own unit (`js_of_ocaml`, `js_of_ocaml-tyxml`, `js_of_ocaml-lwt` + `lwt_ppx`, `ppx_deriving_json`); the `js_of_ocaml` interface is globbed, so future examples are covered automatically.

## Coverage

**61 type-checked, 21 parse-only** across:

- the whole manual (`manual/*.mld`) — 50 type / 21 parse / 2 skip;
- the whole `js_of_ocaml` library interface — **9 type / 0 parse** (every example type-checked; only a commented method and a signature sketch stay `{[ ]}`);
- `js_of_ocaml-tyxml` and `js_of_ocaml-lwt` — 1 type each.

## Bugs the checker caught

Most sources only gained invisible markers, but type-checking surfaced real latent bugs, fixed here:

- **javascript-interop** — canvas `class type` used unqualified `imageElement`/`canvasElement` (which don't resolve) → qualified to `Dom_html.*`.
- **ppx page** — a property-attributes `object%js` literal named two fields that mangle to the same JS name (`also_readonly`/`also_readwrite` → `also`) → disambiguated with a trailing underscore.
- **MutationObserver / ResizeObserver** — `observe` (which returns the observer) was called in `if … then` with no `else`, i.e. in `unit` position → wrapped in `ignore`.
- **PerformanceObserver** — the example passed an extra `()` to `observe`.
- **Geolocation** — a stray `;` before an `in`.
- **Performance** — two `perf##mark` results discarded in `;` position (an error under `-strict-sequence`); `perf##measure`'s optional 2nd/3rd args passed as plain strings instead of `Js.def`.
- **Intl** — `letterSort` discarded the result of an in-place `##sort` (which returns the array) in `;` position, forcing a `unit` return that clashed with the real signature (and the `collator` was allocated per-comparison inside the callback → lifted out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
