### PR TITLE
Lib: add WebGL2 bindings

### DIFF
--- a/API-STATUS.md
+++ b/API-STATUS.md
@@ -88,7 +88,7 @@ This document lists standard JavaScript/Web APIs and their support status in js_
 |-----|------|-----|---------------------|
 | Canvas 2D | Yes | Yes | `Dom_html` (canvasRenderingContext2D) · Brr: `Brr_canvas.C2d` |
 | WebGL | Yes | Yes | `WebGL` · Brr: `Brr_canvas.Gl` |
-| WebGL2 | No | Yes | [#1226](https://github.com/ocsigen/js_of_ocaml/issues/1226) · Brr: `Brr_canvas.Gl` (WebGL2 by default) |
+| WebGL2 | Yes | Yes | `WebGL2` · Brr: `Brr_canvas.Gl` (WebGL2 by default) |
 
 ## Media
 
@@ -194,7 +194,6 @@ Worker/iframe/window communication.
 
 | API | Issue | In Brr | Why |
 |-----|-------|--------|-----|
-| WebGL2 | [#1226](https://github.com/ocsigen/js_of_ocaml/issues/1226) | Yes | 3D graphics. Large API surface, niche audience. |
 | SharedArrayBuffer / Atomics | [#1930](https://github.com/ocsigen/js_of_ocaml/issues/1930) | No | Advanced concurrency. Requires cross-origin isolation headers. |
 | WebRTC | — | No | Peer-to-peer media/data. Very large, complex API. |
 | Web Components — Custom Elements | — | No | Large surface, competes with framework approaches. Shadow DOM portion of Web Components is already bound. |

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,9 @@
   immutable textures, multiple render targets, instanced/range drawing, uniform
   buffer objects, integer vertex attributes and unsigned-integer uniforms, plus
   the new sized internal formats and enumerations. `WebGL2.getContext` requests
-  a `"webgl2"` context (#1226)
+  a `"webgl2"` context. The `webgl` example now uses WebGL2, and a new
+  `webgl2_particles` example demonstrates a GPU particle system driven by
+  transform feedback (#1226)
 * Lib: add `Crypto` — bindings to the Web Crypto API (`crypto`,
   `getRandomValues`, `randomUUID`, and the Promise-typed `SubtleCrypto`), with a
   typed `params` variant (one constructor per algorithm) and

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,11 +5,15 @@
   inherits every method and constant of `WebGL`, and adds the WebGL2 objects
   (vertex array objects, queries, samplers, syncs, transform feedback), 3D and
   immutable textures, multiple render targets, instanced/range drawing, uniform
-  buffer objects, integer vertex attributes and unsigned-integer uniforms, plus
-  the new sized internal formats and enumerations. `WebGL2.getContext` requests
-  a `"webgl2"` context. The `webgl` example now uses WebGL2, and a new
-  `webgl2_particles` example demonstrates a GPU particle system driven by
-  transform feedback (#1226)
+  buffer objects, integer vertex attributes and unsigned-integer uniforms, the
+  pixel-buffer-object and `srcOffset` overloads of the data entry points,
+  introspection (`getIndexedParameter`, `getInternalformatParameter`, the new
+  `getParameter`/uniform-type/framebuffer-attachment enumerations), plus the
+  new sized internal formats. `WebGL.contextAttributes` gains `powerPreference`,
+  `desynchronized` and `xrCompatible`. `WebGL2.getContext` requests a `"webgl2"`
+  context. The `webgl` example now uses WebGL2, and a new `webgl2_particles`
+  example demonstrates a GPU particle system driven by transform feedback
+  (#1226)
 * Lib: add `Crypto` — bindings to the Web Crypto API (`crypto`,
   `getRandomValues`, `randomUUID`, and the Promise-typed `SubtleCrypto`), with a
   typed `params` variant (one constructor per algorithm) and

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,13 @@
 # dev
 
 ## Features/Changes
+* Lib: add `WebGL2` — bindings to the WebGL2 rendering context. The context
+  inherits every method and constant of `WebGL`, and adds the WebGL2 objects
+  (vertex array objects, queries, samplers, syncs, transform feedback), 3D and
+  immutable textures, multiple render targets, instanced/range drawing, uniform
+  buffer objects, integer vertex attributes and unsigned-integer uniforms, plus
+  the new sized internal formats and enumerations. `WebGL2.getContext` requests
+  a `"webgl2"` context (#1226)
 * Lib: add `Crypto` — bindings to the Web Crypto API (`crypto`,
   `getRandomValues`, `randomUUID`, and the Promise-typed `SubtleCrypto`), with a
   typed `params` variant (one constructor per algorithm) and

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,10 +17,13 @@ $> WASM_OF_OCAML=true dune build @examples/boulderdash/default
 
 Compilation artifacts can be found in `${REPO_ROOT}/_build/default/examples/`.
 
-When generating JavaScript code, you can directly open the
-`index.html` files in a browser. When generating Wasm code, you need
-to serve the files, for instance with the following command:
+When generating JavaScript code, you can usually directly open the
+`index.html` files in a browser. When generating Wasm code, or for
+examples fetching resources at runtime (e.g. `webgl` loading its
+model), you need to serve the files, for instance with the following
+command:
 ```
 python -m http.server -d _build/default/examples/boulderdash/
 ```
-and then open `http://localhost:8000/index.html?wasm` in a browser.
+and then open `http://localhost:8000/index.html` in a browser
+(`http://localhost:8000/index.html?wasm` for the Wasm version).

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,11 +17,9 @@ $> WASM_OF_OCAML=true dune build @examples/boulderdash/default
 
 Compilation artifacts can be found in `${REPO_ROOT}/_build/default/examples/`.
 
-When generating JavaScript code, you can usually directly open the
-`index.html` files in a browser. When generating Wasm code, or for
-examples fetching resources at runtime (e.g. `webgl` loading its
-model), you need to serve the files, for instance with the following
-command:
+When generating JavaScript code, you can directly open the
+`index.html` files in a browser. When generating Wasm code, you need
+to serve the files, for instance with the following command:
 ```
 python -m http.server -d _build/default/examples/boulderdash/
 ```

--- a/examples/boulderdash/dune
+++ b/examples/boulderdash/dune
@@ -4,6 +4,9 @@
  (modes js wasm)
  (js_of_ocaml
   (compilation_mode separate)
+  ;; dummy runtime file to opt out of dune's shared standalone runtime,
+  ;; which drops build_runtime_flags (ocaml/dune#15455)
+  (javascript_files force_unshared_runtime.js)
   (build_runtime_flags :standard --file %{dep:maps.txt} --file maps))
  (link_deps
   (glob_files maps/*.map))

--- a/examples/boulderdash/force_unshared_runtime.js
+++ b/examples/boulderdash/force_unshared_runtime.js
@@ -1,0 +1,4 @@
+// Dummy runtime file. Its presence makes dune build a per-executable
+// standalone runtime instead of the shared one, so that the
+// build_runtime_flags --file embeds are honored. Works around
+// ocaml/dune#15455; remove once the fix is released.

--- a/examples/graph_viewer/dune
+++ b/examples/graph_viewer/dune
@@ -15,6 +15,9 @@
    dot_render))
  (js_of_ocaml
   (compilation_mode separate)
+  ;; dummy runtime file to opt out of dune's shared standalone runtime,
+  ;; which drops build_runtime_flags (ocaml/dune#15455)
+  (javascript_files force_unshared_runtime.js)
   (build_runtime_flags :standard --file %{dep:scene.json}))
  (preprocess
   (pps js_of_ocaml-ppx js_of_ocaml-ppx_deriving_json)))

--- a/examples/graph_viewer/force_unshared_runtime.js
+++ b/examples/graph_viewer/force_unshared_runtime.js
@@ -1,0 +1,4 @@
+// Dummy runtime file. Its presence makes dune build a per-executable
+// standalone runtime instead of the shared one, so that the
+// build_runtime_flags --file embeds are honored. Works around
+// ocaml/dune#15455; remove once the fix is released.

--- a/examples/hyperbolic/dune
+++ b/examples/hyperbolic/dune
@@ -4,6 +4,9 @@
  (modes js wasm)
  (js_of_ocaml
   (compilation_mode separate)
+  ;; dummy runtime file to opt out of dune's shared standalone runtime,
+  ;; which drops build_runtime_flags (ocaml/dune#15455)
+  (javascript_files force_unshared_runtime.js)
   (build_runtime_flags
    :standard
    --file

--- a/examples/hyperbolic/force_unshared_runtime.js
+++ b/examples/hyperbolic/force_unshared_runtime.js
@@ -1,0 +1,4 @@
+// Dummy runtime file. Its presence makes dune build a per-executable
+// standalone runtime instead of the shared one, so that the
+// build_runtime_flags --file embeds are honored. Works around
+// ocaml/dune#15455; remove once the fix is released.

--- a/examples/index.html
+++ b/examples/index.html
@@ -71,9 +71,14 @@ footer img { vertical-align: middle; }
         <td><a href="cubes/index.html?wasm">wasm</a></td>
       </tr>
       <tr>
-        <td>WebGL demo</td>
+        <td>WebGL2 monkey</td>
         <td><a href="webgl/index.html">js</a></td>
         <td><a href="webgl/index.html?wasm">wasm</a></td>
+      </tr>
+      <tr>
+        <td>WebGL2 particles (transform feedback)</td>
+        <td><a href="webgl2_particles/index.html">js</a></td>
+        <td><a href="webgl2_particles/index.html?wasm">wasm</a></td>
       </tr>
       <tr>
         <td>Hyperbolic tree</td>

--- a/examples/webgl/dune
+++ b/examples/webgl/dune
@@ -4,6 +4,9 @@
  (modes js wasm)
  (js_of_ocaml
   (compilation_mode separate)
+  ;; dummy runtime file to opt out of dune's shared standalone runtime,
+  ;; which drops build_runtime_flags (ocaml/dune#15455)
+  (javascript_files force_unshared_runtime.js)
   (build_runtime_flags :standard --file %{dep:monkey.model}))
  (preprocess
   (pps js_of_ocaml-ppx)))

--- a/examples/webgl/force_unshared_runtime.js
+++ b/examples/webgl/force_unshared_runtime.js
@@ -1,0 +1,4 @@
+// Dummy runtime file. Its presence makes dune build a per-executable
+// standalone runtime instead of the shared one, so that the
+// build_runtime_flags --file embeds are honored. Works around
+// ocaml/dune#15455; remove once the fix is released.

--- a/examples/webgl/index.html
+++ b/examples/webgl/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>WebGL monkey</title>
+    <title>WebGL2 monkey</title>
 <style type="text/css">
 body {
   background-color: #111;
@@ -38,13 +38,14 @@ canvas {
 }
 </style>
 <script id="vertex-shader" type="x-shader/x-vertex">
-  attribute vec3 a_position;
-  attribute vec3 a_normal;
+  #version 300 es
+  in vec3 a_position;
+  in vec3 a_normal;
 
   uniform mat4 u_proj;
 
-  varying mediump vec3 v_position;
-  varying mediump vec3 v_normal;
+  out mediump vec3 v_position;
+  out mediump vec3 v_normal;
 
   void main() {
     vec4 pos = u_proj * vec4(a_position,1);
@@ -55,18 +56,21 @@ canvas {
   }
 </script>
 <script id="fragment-shader" type="x-shader/x-fragment">
+  #version 300 es
   precision mediump float;
-  varying vec3 v_position;
-  varying vec3 v_normal;
+  in vec3 v_position;
+  in vec3 v_normal;
 
   uniform vec3 u_lightPos;
   uniform vec3 u_ambientLight;
+
+  out vec4 color;
 
   void main() {
     vec3 lightDirection = normalize(u_lightPos - v_position);
     float lighting = max(dot(normalize(v_normal), lightDirection), 0.);
     vec3 col = vec3(1,1,1);
-    gl_FragColor = vec4( col * lighting + u_ambientLight, 1);
+    color = vec4( col * lighting + u_ambientLight, 1);
   }
 </script>
   <script type="text/javascript">
@@ -75,7 +79,7 @@ canvas {
   </script>
   </head>
   <body>
-    <h1>WebGL Monkey</h1>
+    <h1>WebGL2 Monkey</h1>
     <canvas id="canvas" height="500" width="500"></canvas>
     <div class="info"><span id="fps"></span> frames per second</div>
   </body>

--- a/examples/webgl/webgldemo.ml
+++ b/examples/webgl/webgldemo.ml
@@ -209,6 +209,11 @@ let read_model a =
       | Some (V (a, b, c)) -> vertex := (a, b, c) :: !vertex
       | Some (VN (a, b, c)) -> norm := (a, b, c) :: !norm)
     a;
+  if !face = []
+  then
+    alert
+      "could not load the model; note that this example must be served over http, see \
+       examples/README.md";
   make_model
     (Array.of_list (List.rev !vertex))
     (Array.of_list (List.rev !norm))

--- a/examples/webgl/webgldemo.ml
+++ b/examples/webgl/webgldemo.ml
@@ -209,11 +209,7 @@ let read_model a =
       | Some (V (a, b, c)) -> vertex := (a, b, c) :: !vertex
       | Some (VN (a, b, c)) -> norm := (a, b, c) :: !norm)
     a;
-  if !face = []
-  then
-    alert
-      "could not load the model; note that this example must be served over http, see \
-       examples/README.md";
+  if !face = [] then alert "the model file could not be parsed (no faces found)";
   make_model
     (Array.of_list (List.rev !vertex))
     (Array.of_list (List.rev !norm))
@@ -224,7 +220,16 @@ let http_get url =
   >>= fun r ->
   let cod = r.XmlHttpRequest.code in
   let msg = r.XmlHttpRequest.content in
-  if cod = 0 || cod = 200 then Lwt.return msg else fst (Lwt.wait ())
+  (* [code = 0] with a non-empty body is a successful file:// load; anything
+     else (404, CORS-blocked file:// XHR, ...) is a failure *)
+  if cod = 200 || (cod = 0 && String.length msg > 0)
+  then Lwt.return msg
+  else
+    alert
+      "failed to load %s (HTTP code %d); note that this example must be served over \
+       http, see examples/README.md"
+      url
+      cod
 
 let getfile f =
   try Lwt.return (Sys_js.read_file ~name:f)
@@ -265,7 +270,7 @@ let start (pos, norm) =
   gl##uniform3fv_typed lightPos_loc lightPos;
   gl##uniform3fv_typed ambientLight_loc ambientLight;
   let vao = gl##createVertexArray in
-  gl##bindVertexArray (Opt.return vao);
+  gl##bindVertexArray vao;
   let pos_attr = gl##getAttribLocation prog (string "a_position") in
   gl##enableVertexAttribArray pos_attr;
   let array_buffer = gl##createBuffer in

--- a/examples/webgl/webgldemo.ml
+++ b/examples/webgl/webgldemo.ml
@@ -49,12 +49,12 @@ let init_canvas canvas_id =
   in
   let gl =
     Opt.get
-      (try WebGL.getContext canvas with _ -> null)
-      (fun () -> alert "can't initialise webgl context")
+      (try WebGL2.getContext canvas with _ -> null)
+      (fun () -> alert "can't initialise webgl2 context")
   in
   canvas, gl
 
-let load_shader (gl : WebGL.renderingContext t) shader text =
+let load_shader (gl : WebGL2.renderingContext t) shader text =
   gl##shaderSource shader text;
   gl##compileShader shader;
   if not (to_bool (gl##getShaderParameter shader gl##._COMPILE_STATUS_))
@@ -64,7 +64,7 @@ let load_shader (gl : WebGL.renderingContext t) shader text =
       (to_string text)
       (to_string (gl##getShaderInfoLog shader))
 
-let create_program (gl : WebGL.renderingContext t) vert_src frag_src =
+let create_program (gl : WebGL2.renderingContext t) vert_src frag_src =
   let vertexShader = gl##createShader gl##._VERTEX_SHADER_ in
   let fragmentShader = gl##createShader gl##._FRAGMENT_SHADER_ in
   load_shader gl vertexShader vert_src;
@@ -85,7 +85,9 @@ let get_source src_id =
          Dom_html.CoerceTo.script)
       (fun () -> error "can't find script element %s" src_id)
   in
-  script##.text
+  (* GLSL ES 3.00 requires [#version] to be on the very first line, so strip
+     the newline following the opening script tag *)
+  string (String.trim (to_string script##.text))
 
 let float32array a =
   let array = new%js Typed_array.float32Array (Array.length a) in
@@ -257,6 +259,8 @@ let start (pos, norm) =
   let ambientLight = float32array [| 0.1; 0.1; 0.1 |] in
   gl##uniform3fv_typed lightPos_loc lightPos;
   gl##uniform3fv_typed ambientLight_loc ambientLight;
+  let vao = gl##createVertexArray in
+  gl##bindVertexArray (Opt.return vao);
   let pos_attr = gl##getAttribLocation prog (string "a_position") in
   gl##enableVertexAttribArray pos_attr;
   let array_buffer = gl##createBuffer in

--- a/examples/webgl2_particles/dune
+++ b/examples/webgl2_particles/dune
@@ -1,0 +1,17 @@
+(executables
+ (names particles)
+ (libraries js_of_ocaml-lwt)
+ (modes js wasm)
+ (js_of_ocaml
+  (compilation_mode separate))
+ (preprocess
+  (pps js_of_ocaml-ppx)))
+
+(alias
+ (name default)
+ (deps particles.bc.js index.html))
+
+(alias
+ (name default)
+ (enabled_if %{env:WASM_OF_OCAML=false})
+ (deps particles.bc.wasm.js))

--- a/examples/webgl2_particles/index.html
+++ b/examples/webgl2_particles/index.html
@@ -119,7 +119,11 @@ canvas {
     <canvas id="canvas" height="600" width="600"></canvas>
     <div class="info">
       <input id="count" type="range" min="1000" max="200000" step="1000" value="50000">
-      <span id="count-label"></span> particles simulated with transform feedback —
-      move the mouse over the canvas — <span id="fps"></span> frames per second</div>
+      <span id="count-label"></span> particles —
+      speed <input id="speed" type="range" min="0" max="3" step="0.05" value="1">
+      ×<span id="speed-label"></span> —
+      <span id="fps"></span> frames per second<br>
+      simulated with transform feedback — move the mouse over the canvas
+    </div>
   </body>
 </html>

--- a/examples/webgl2_particles/index.html
+++ b/examples/webgl2_particles/index.html
@@ -140,7 +140,8 @@ canvas {
     <h1>WebGL2 Particles</h1>
     <canvas id="canvas" height="600" width="600"></canvas>
     <div class="info">
-      <input id="count" type="range" min="1000" max="200000" step="1000" value="50000">
+      <!-- max and value are set from the OCaml side (max_particles) -->
+      <input id="count" type="range" min="1000" step="1000">
       <span id="count-label"></span> particles —
       speed <input id="speed" type="range" min="0" max="3" step="0.05" value="1">
       ×<span id="speed-label"></span> —

--- a/examples/webgl2_particles/index.html
+++ b/examples/webgl2_particles/index.html
@@ -37,6 +37,11 @@ canvas {
   color: #aaa;
   font-variant-numeric: tabular-nums;
 }
+.info input[type="range"] {
+  vertical-align: middle;
+  width: 160px;
+  accent-color: #67c;
+}
 </style>
 <script id="update-vertex-shader" type="x-shader/x-vertex">
   #version 300 es
@@ -112,7 +117,9 @@ canvas {
   <body>
     <h1>WebGL2 Particles</h1>
     <canvas id="canvas" height="600" width="600"></canvas>
-    <div class="info">50,000 particles simulated with transform feedback —
+    <div class="info">
+      <input id="count" type="range" min="1000" max="200000" step="1000" value="50000">
+      <span id="count-label"></span> particles simulated with transform feedback —
       move the mouse over the canvas — <span id="fps"></span> frames per second</div>
   </body>
 </html>

--- a/examples/webgl2_particles/index.html
+++ b/examples/webgl2_particles/index.html
@@ -52,6 +52,8 @@ canvas {
 
   uniform float u_dt;
   uniform vec2 u_attractor;
+  uniform float u_gravity;
+  uniform float u_damping;
 
   out vec2 v_position;
   out vec2 v_velocity;
@@ -60,8 +62,11 @@ canvas {
     vec2 d = u_attractor - a_position;
     float r = max(length(d), 0.05);
     vec2 dir = d / r;
-    float force = min(0.35 / (r * r), 3.0);
-    vec2 vel = (a_velocity + dir * force * u_dt) * 0.999;
+    float force = min(u_gravity / (r * r), 3.0);
+    // scale the per-frame damping by the timestep so slow motion (or pause)
+    // does not damp more than real time
+    float damping = pow(u_damping, u_dt * 62.5);
+    vec2 vel = (a_velocity + dir * force * u_dt) * damping;
     vec2 pos = a_position + vel * u_dt;
     if (pos.x < -1.0 || pos.x > 1.0) { vel.x = -vel.x; pos.x = clamp(pos.x, -1.0, 1.0); }
     if (pos.y < -1.0 || pos.y > 1.0) { vel.y = -vel.y; pos.y = clamp(pos.y, -1.0, 1.0); }
@@ -78,6 +83,23 @@ canvas {
   void main() {
     // never runs: rasterization is discarded during the simulation pass
     color = vec4(1.0);
+  }
+</script>
+<script id="fade-vertex-shader" type="x-shader/x-vertex">
+  #version 300 es
+  // fullscreen triangle from gl_VertexID, no vertex attributes needed
+  void main() {
+    vec2 p = vec2(float((gl_VertexID << 1) & 2), float(gl_VertexID & 2));
+    gl_Position = vec4(p * 2.0 - 1.0, 0.0, 1.0);
+  }
+</script>
+<script id="fade-fragment-shader" type="x-shader/x-fragment">
+  #version 300 es
+  precision mediump float;
+  uniform float u_fade;
+  out vec4 color;
+  void main() {
+    color = vec4(0.02, 0.02, 0.05, u_fade);
   }
 </script>
 <script id="render-vertex-shader" type="x-shader/x-vertex">
@@ -122,7 +144,13 @@ canvas {
       <span id="count-label"></span> particles —
       speed <input id="speed" type="range" min="0" max="3" step="0.05" value="1">
       ×<span id="speed-label"></span> —
-      <span id="fps"></span> frames per second<br>
+      <span id="fps"></span> fps<br>
+      gravity <input id="gravity" type="range" min="0.02" max="2" step="0.01" value="0.35">
+      <span id="gravity-label"></span> —
+      damping <input id="damping" type="range" min="0.98" max="1.002" step="0.0005" value="0.999">
+      <span id="damping-label"></span> —
+      trails <input id="trail" type="range" min="0" max="0.98" step="0.02" value="0.2">
+      <span id="trail-label"></span><br>
       simulated with transform feedback — move the mouse over the canvas
     </div>
   </body>

--- a/examples/webgl2_particles/index.html
+++ b/examples/webgl2_particles/index.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>WebGL2 particles</title>
+<style type="text/css">
+body {
+  background-color: #111;
+  color: #ddd;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-size: 14px;
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 24px 16px;
+}
+h1 {
+  font-size: 1.6em;
+  font-weight: 300;
+  letter-spacing: 0.05em;
+  color: #eee;
+  margin: 0 0 16px;
+}
+canvas {
+  display: block;
+  border-radius: 8px;
+  box-shadow: 0 0 32px rgba(0,0,0,0.6);
+}
+.info {
+  margin-top: 12px;
+  color: #777;
+  font-size: 0.85em;
+}
+.info span {
+  color: #aaa;
+  font-variant-numeric: tabular-nums;
+}
+</style>
+<script id="update-vertex-shader" type="x-shader/x-vertex">
+  #version 300 es
+  precision highp float;
+
+  layout(location = 0) in vec2 a_position;
+  layout(location = 1) in vec2 a_velocity;
+
+  uniform float u_dt;
+  uniform vec2 u_attractor;
+
+  out vec2 v_position;
+  out vec2 v_velocity;
+
+  void main() {
+    vec2 d = u_attractor - a_position;
+    float r = max(length(d), 0.05);
+    vec2 dir = d / r;
+    float force = min(0.35 / (r * r), 3.0);
+    vec2 vel = (a_velocity + dir * force * u_dt) * 0.999;
+    vec2 pos = a_position + vel * u_dt;
+    if (pos.x < -1.0 || pos.x > 1.0) { vel.x = -vel.x; pos.x = clamp(pos.x, -1.0, 1.0); }
+    if (pos.y < -1.0 || pos.y > 1.0) { vel.y = -vel.y; pos.y = clamp(pos.y, -1.0, 1.0); }
+    v_position = pos;
+    v_velocity = vel;
+    gl_Position = vec4(pos, 0.0, 1.0);
+    gl_PointSize = 1.0;
+  }
+</script>
+<script id="update-fragment-shader" type="x-shader/x-fragment">
+  #version 300 es
+  precision mediump float;
+  out vec4 color;
+  void main() {
+    // never runs: rasterization is discarded during the simulation pass
+    color = vec4(1.0);
+  }
+</script>
+<script id="render-vertex-shader" type="x-shader/x-vertex">
+  #version 300 es
+  precision highp float;
+
+  layout(location = 0) in vec2 a_position;
+  layout(location = 1) in vec2 a_velocity;
+
+  out float v_speed;
+
+  void main() {
+    v_speed = length(a_velocity);
+    gl_Position = vec4(a_position, 0.0, 1.0);
+    gl_PointSize = 2.0;
+  }
+</script>
+<script id="render-fragment-shader" type="x-shader/x-fragment">
+  #version 300 es
+  precision mediump float;
+
+  in float v_speed;
+  out vec4 color;
+
+  void main() {
+    float s = clamp(v_speed * 0.8, 0.0, 1.0);
+    vec3 slow = vec3(0.15, 0.3, 0.9);
+    vec3 fast = vec3(1.0, 0.9, 0.6);
+    color = vec4(mix(slow, fast, s), 0.6);
+  }
+</script>
+  <script type="text/javascript">
+    var s = (new URLSearchParams(location.search)).has('wasm') ? 'particles.bc.wasm.js' : 'particles.bc.js';
+    document.write('<script type="text/javascript" src="' + s + '" defer><\/script>');
+  </script>
+  </head>
+  <body>
+    <h1>WebGL2 Particles</h1>
+    <canvas id="canvas" height="600" width="600"></canvas>
+    <div class="info">50,000 particles simulated with transform feedback —
+      move the mouse over the canvas — <span id="fps"></span> frames per second</div>
+  </body>
+</html>

--- a/examples/webgl2_particles/particles.ml
+++ b/examples/webgl2_particles/particles.ml
@@ -106,14 +106,16 @@ let get_source src_id =
      the newline following the opening script tag *)
   string (String.trim (to_string script##.text))
 
-(* wire a range input to a label; [on_input] receives the slider value and
-   returns the label text *)
-let setup_slider slider_id label_id on_input =
+(* wire a range input to a label; [init] can configure the slider (bounds,
+   initial value) before use, [on_input] receives the slider value and returns
+   the label text *)
+let setup_slider ?(init = fun _ -> ()) slider_id label_id on_input =
   Opt.iter
     (Opt.bind
        (Dom_html.document##getElementById (string slider_id))
        Dom_html.CoerceTo.input)
     (fun slider ->
+      init slider;
       let label_text = Dom_html.document##createTextNode (Js.string "") in
       Opt.iter
         (Opt.bind
@@ -187,20 +189,20 @@ let start () =
   let stride = 4 * 4 in
   let make_vao buf =
     let vao = gl##createVertexArray in
-    gl##bindVertexArray (Opt.return vao);
+    gl##bindVertexArray vao;
     gl##bindBuffer gl##._ARRAY_BUFFER_ buf;
     gl##enableVertexAttribArray 0;
     gl##vertexAttribPointer 0 2 gl##._FLOAT _false stride 0;
     gl##enableVertexAttribArray 1;
     gl##vertexAttribPointer 1 2 gl##._FLOAT _false stride 8;
-    gl##bindVertexArray Opt.empty;
+    gl##bindVertexArray_ Opt.empty;
     vao
   in
   let make_tf buf =
     let tf = gl##createTransformFeedback in
-    gl##bindTransformFeedback gl##._TRANSFORM_FEEDBACK_ (Opt.return tf);
+    gl##bindTransformFeedback gl##._TRANSFORM_FEEDBACK_ tf;
     gl##bindBufferBase gl##._TRANSFORM_FEEDBACK_BUFFER_ 0 buf;
-    gl##bindTransformFeedback gl##._TRANSFORM_FEEDBACK_ Opt.empty;
+    gl##bindTransformFeedback_ gl##._TRANSFORM_FEEDBACK_ Opt.empty;
     tf
   in
   let buf_a = make_buffer () in
@@ -227,8 +229,17 @@ let start () =
   check_error gl;
   debug "ready";
   (* the sliders choose how many particles take part and how fast time runs *)
+  (* [max_particles] is the one load-bearing bound (the GPU buffers are sized
+     from it), so it is pushed onto the slider rather than duplicated in the
+     markup; the other sliders take their ranges from the HTML alone *)
   let nparticles = ref default_particles in
-  setup_slider "count" "count-label" (fun v ->
+  setup_slider
+    ~init:(fun slider ->
+      slider##.max := string (string_of_int max_particles);
+      slider##.value := string (string_of_int default_particles))
+    "count"
+    "count-label"
+    (fun v ->
       (match int_of_string_opt v with
       | Some n -> nparticles := max 1 (min max_particles n)
       | None -> ());
@@ -236,19 +247,19 @@ let start () =
   let speed = ref 1.0 in
   setup_slider "speed" "speed-label" (fun v ->
       (match float_of_string_opt v with
-      | Some s -> speed := max 0. (min 4. s)
+      | Some s -> speed := s
       | None -> ());
       Printf.sprintf "%.2f" !speed);
   let gravity = ref 0.35 in
   setup_slider "gravity" "gravity-label" (fun v ->
       (match float_of_string_opt v with
-      | Some g -> gravity := max 0. (min 5. g)
+      | Some g -> gravity := g
       | None -> ());
       Printf.sprintf "%.2f" !gravity);
   let damping = ref 0.999 in
   setup_slider "damping" "damping-label" (fun v ->
       (match float_of_string_opt v with
-      | Some d -> damping := max 0.9 (min 1.01 d)
+      | Some d -> damping := d
       | None -> ());
       Printf.sprintf "%.4f" !damping);
   let trail = ref 0.2 in
@@ -297,24 +308,24 @@ let start () =
     gl##uniform2f attractor_loc (Js.number_of_float ax) (Js.number_of_float ay);
     gl##uniform1f gravity_loc (Js.number_of_float !gravity);
     gl##uniform1f damping_loc (Js.number_of_float !damping);
-    gl##bindVertexArray (Opt.return read_vao);
-    gl##bindTransformFeedback gl##._TRANSFORM_FEEDBACK_ (Opt.return write_tf);
+    gl##bindVertexArray read_vao;
+    gl##bindTransformFeedback gl##._TRANSFORM_FEEDBACK_ write_tf;
     gl##enable gl##._RASTERIZER_DISCARD_;
     gl##beginTransformFeedback gl##._POINTS;
     gl##drawArrays gl##._POINTS 0 !nparticles;
     gl##endTransformFeedback;
     gl##disable gl##._RASTERIZER_DISCARD_;
-    gl##bindTransformFeedback gl##._TRANSFORM_FEEDBACK_ Opt.empty;
+    gl##bindTransformFeedback_ gl##._TRANSFORM_FEEDBACK_ Opt.empty;
     (* fade pass: dim the previous frame instead of clearing it *)
     gl##useProgram fade_prog;
-    gl##bindVertexArray Opt.empty;
+    gl##bindVertexArray_ Opt.empty;
     gl##blendFunc gl##._SRC_ALPHA_ gl##._ONE_MINUS_SRC_ALPHA_;
     gl##uniform1f fade_loc (Js.number_of_float (1. -. !trail));
     gl##drawArrays gl##._TRIANGLES 0 3;
     (* render pass: draw the freshly written buffer additively on top *)
     gl##useProgram render_prog;
     gl##blendFunc gl##._SRC_ALPHA_ gl##._ONE;
-    gl##bindVertexArray (Opt.return draw_vao);
+    gl##bindVertexArray draw_vao;
     gl##drawArrays gl##._POINTS 0 !nparticles;
     check_error gl;
     let now = get_time () in

--- a/examples/webgl2_particles/particles.ml
+++ b/examples/webgl2_particles/particles.ml
@@ -106,6 +106,29 @@ let get_source src_id =
      the newline following the opening script tag *)
   string (String.trim (to_string script##.text))
 
+(* wire a range input to a label; [on_input] receives the slider value and
+   returns the label text *)
+let setup_slider slider_id label_id on_input =
+  Opt.iter
+    (Opt.bind
+       (Dom_html.document##getElementById (string slider_id))
+       Dom_html.CoerceTo.input)
+    (fun slider ->
+      let label_text = Dom_html.document##createTextNode (Js.string "") in
+      Opt.iter
+        (Opt.bind
+           (Dom_html.document##getElementById (string label_id))
+           Dom_html.CoerceTo.element)
+        (fun span -> Dom.appendChild span label_text);
+      let refresh () =
+        label_text##.data := string (on_input (to_string slider##.value))
+      in
+      refresh ();
+      slider##.oninput :=
+        Dom_html.handler (fun _ ->
+            refresh ();
+            Js._true))
+
 let start () =
   let fps_text = Dom_html.document##createTextNode (Js.string "-") in
   Opt.iter
@@ -190,32 +213,19 @@ let start () =
   gl##clearColor (Js.float 0.02) (Js.float 0.02) (Js.float 0.05) (Js.float 1.);
   check_error gl;
   debug "ready";
-  (* the slider chooses how many of the allocated particles take part *)
+  (* the sliders choose how many particles take part and how fast time runs *)
   let nparticles = ref default_particles in
-  Opt.iter
-    (Opt.bind
-       (Dom_html.document##getElementById (string "count"))
-       Dom_html.CoerceTo.input)
-    (fun slider ->
-      let count_text = Dom_html.document##createTextNode (Js.string "") in
-      Opt.iter
-        (Opt.bind
-           (Dom_html.document##getElementById (string "count-label"))
-           Dom_html.CoerceTo.element)
-        (fun span -> Dom.appendChild span count_text);
-      let update () =
-        (match int_of_string_opt (to_string slider##.value) with
-        | Some n -> nparticles := max 1 (min max_particles n)
-        | None -> ());
-        count_text##.data := string (Printf.sprintf "%d" !nparticles)
-      in
-      slider##.max := string (string_of_int max_particles);
-      slider##.value := string (string_of_int !nparticles);
-      update ();
-      slider##.oninput :=
-        Dom_html.handler (fun _ ->
-            update ();
-            Js._true));
+  setup_slider "count" "count-label" (fun v ->
+      (match int_of_string_opt v with
+      | Some n -> nparticles := max 1 (min max_particles n)
+      | None -> ());
+      Printf.sprintf "%d" !nparticles);
+  let speed = ref 1.0 in
+  setup_slider "speed" "speed-label" (fun v ->
+      (match float_of_string_opt v with
+      | Some s -> speed := max 0. (min 4. s)
+      | None -> ());
+      Printf.sprintf "%.2f" !speed);
   (* the attractor follows the mouse, or orbits while unattended *)
   let attractor = ref None in
   canvas##.onmousemove :=
@@ -252,7 +262,7 @@ let start () =
     in
     (* simulation pass: no fragments, varyings captured into the other buffer *)
     gl##useProgram update_prog;
-    gl##uniform1f dt_loc (Js.number_of_float 0.016);
+    gl##uniform1f dt_loc (Js.number_of_float (0.016 *. !speed));
     gl##uniform2f attractor_loc (Js.number_of_float ax) (Js.number_of_float ay);
     gl##bindVertexArray (Opt.return read_vao);
     gl##bindTransformFeedback gl##._TRANSFORM_FEEDBACK_ (Opt.return write_tf);

--- a/examples/webgl2_particles/particles.ml
+++ b/examples/webgl2_particles/particles.ml
@@ -1,0 +1,260 @@
+(* Js_of_ocaml example
+ * http://www.ocsigen.org/js_of_ocaml/
+ * Copyright (C) 2026 Ocsigen team
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+
+(* GPU particle system simulated entirely with WebGL2 transform feedback:
+   positions and velocities live in GPU buffers; an update program integrates
+   them with rasterization discarded, capturing its varyings into a second
+   buffer (ping-pong), which a render program then draws as points. *)
+
+open Js_of_ocaml
+open Js_of_ocaml_lwt
+open Lwt
+open Js
+
+let nparticles = 50_000
+
+let error f =
+  Printf.ksprintf
+    (fun s ->
+      Console.console##error (Js.string s);
+      failwith s)
+    f
+
+let debug f = Printf.ksprintf (fun s -> Console.console##log (Js.string s)) f
+
+let alert f =
+  Printf.ksprintf
+    (fun s ->
+      Dom_html.window##alert (Js.string s);
+      failwith s)
+    f
+
+let check_error gl = if gl##getError <> gl##._NO_ERROR_ then error "WebGL error"
+
+let init_canvas canvas_id =
+  let canvas =
+    Opt.get
+      (Opt.bind
+         (Dom_html.document##getElementById (string canvas_id))
+         Dom_html.CoerceTo.canvas)
+      (fun () -> error "can't find canvas element %s" canvas_id)
+  in
+  let gl =
+    Opt.get
+      (try WebGL2.getContext canvas with _ -> null)
+      (fun () -> alert "can't initialise webgl2 context")
+  in
+  canvas, gl
+
+let load_shader (gl : WebGL2.renderingContext t) shader text =
+  gl##shaderSource shader text;
+  gl##compileShader shader;
+  if not (to_bool (gl##getShaderParameter shader gl##._COMPILE_STATUS_))
+  then
+    error
+      "An error occurred compiling the shaders: \n%s\n%s"
+      (to_string text)
+      (to_string (gl##getShaderInfoLog shader))
+
+let create_program
+    (gl : WebGL2.renderingContext t)
+    ?(pre_link = fun _ -> ())
+    vert_src
+    frag_src =
+  let vertexShader = gl##createShader gl##._VERTEX_SHADER_ in
+  let fragmentShader = gl##createShader gl##._FRAGMENT_SHADER_ in
+  load_shader gl vertexShader vert_src;
+  load_shader gl fragmentShader frag_src;
+  let prog = gl##createProgram in
+  gl##attachShader prog vertexShader;
+  gl##attachShader prog fragmentShader;
+  pre_link prog;
+  gl##linkProgram prog;
+  if not (to_bool (gl##getProgramParameter prog gl##._LINK_STATUS_))
+  then error "Unable to link the shader program.";
+  prog
+
+let get_source src_id =
+  let script =
+    Opt.get
+      (Opt.bind
+         (Dom_html.document##getElementById (string src_id))
+         Dom_html.CoerceTo.script)
+      (fun () -> error "can't find script element %s" src_id)
+  in
+  (* GLSL ES 3.00 requires [#version] to be on the very first line, so strip
+     the newline following the opening script tag *)
+  string (String.trim (to_string script##.text))
+
+let start () =
+  let fps_text = Dom_html.document##createTextNode (Js.string "-") in
+  Opt.iter
+    (Opt.bind
+       (Dom_html.document##getElementById (string "fps"))
+       Dom_html.CoerceTo.element)
+    (fun span -> Dom.appendChild span fps_text);
+  debug "init canvas";
+  let canvas, gl = init_canvas "canvas" in
+  debug "create programs";
+  let update_prog =
+    (* the transform feedback layout must be declared before linking *)
+    create_program
+      gl
+      ~pre_link:(fun prog ->
+        let varyings = array [| string "v_position"; string "v_velocity" |] in
+        gl##transformFeedbackVaryings prog varyings gl##._INTERLEAVED_ATTRIBS_)
+      (get_source "update-vertex-shader")
+      (get_source "update-fragment-shader")
+  in
+  let render_prog =
+    create_program
+      gl
+      (get_source "render-vertex-shader")
+      (get_source "render-fragment-shader")
+  in
+  (* interleaved particle state: position.xy, velocity.xy *)
+  let initial_data =
+    let data = new%js Typed_array.float32Array (nparticles * 4) in
+    for i = 0 to nparticles - 1 do
+      let x = Random.float 1.8 -. 0.9 and y = Random.float 1.8 -. 0.9 in
+      (* mostly tangential initial velocity, for orbital motion *)
+      let s = 0.4 +. Random.float 0.3 in
+      Typed_array.set data ((i * 4) + 0) (Js.float x);
+      Typed_array.set data ((i * 4) + 1) (Js.float y);
+      Typed_array.set data ((i * 4) + 2) (Js.float ((-.y *. s) +. Random.float 0.05));
+      Typed_array.set data ((i * 4) + 3) (Js.float ((x *. s) +. Random.float 0.05))
+    done;
+    data
+  in
+  let make_buffer () =
+    let buf = gl##createBuffer in
+    gl##bindBuffer gl##._ARRAY_BUFFER_ buf;
+    gl##bufferData gl##._ARRAY_BUFFER_ initial_data gl##._DYNAMIC_COPY_;
+    buf
+  in
+  (* attribute locations are pinned with [layout(location = ...)] in the
+     shaders, so the same VAO layout works for both programs *)
+  let stride = 4 * 4 in
+  let make_vao buf =
+    let vao = gl##createVertexArray in
+    gl##bindVertexArray (Opt.return vao);
+    gl##bindBuffer gl##._ARRAY_BUFFER_ buf;
+    gl##enableVertexAttribArray 0;
+    gl##vertexAttribPointer 0 2 gl##._FLOAT _false stride 0;
+    gl##enableVertexAttribArray 1;
+    gl##vertexAttribPointer 1 2 gl##._FLOAT _false stride 8;
+    gl##bindVertexArray Opt.empty;
+    vao
+  in
+  let make_tf buf =
+    let tf = gl##createTransformFeedback in
+    gl##bindTransformFeedback gl##._TRANSFORM_FEEDBACK_ (Opt.return tf);
+    gl##bindBufferBase gl##._TRANSFORM_FEEDBACK_BUFFER_ 0 buf;
+    gl##bindTransformFeedback gl##._TRANSFORM_FEEDBACK_ Opt.empty;
+    tf
+  in
+  let buf_a = make_buffer () in
+  let buf_b = make_buffer () in
+  let vao_a = make_vao buf_a in
+  let vao_b = make_vao buf_b in
+  let tf_a = make_tf buf_a in
+  let tf_b = make_tf buf_b in
+  (* a buffer being written through transform feedback must not be left bound
+     to the generic ARRAY_BUFFER binding point (which is not part of the VAO
+     state) *)
+  gl##bindBuffer_ gl##._ARRAY_BUFFER_ Opt.empty;
+  let dt_loc = gl##getUniformLocation update_prog (string "u_dt") in
+  let attractor_loc = gl##getUniformLocation update_prog (string "u_attractor") in
+  gl##enable gl##._BLEND;
+  gl##blendFunc gl##._SRC_ALPHA_ gl##._ONE;
+  gl##clearColor (Js.float 0.02) (Js.float 0.02) (Js.float 0.05) (Js.float 1.);
+  check_error gl;
+  debug "ready";
+  (* the attractor follows the mouse, or orbits while unattended *)
+  let attractor = ref None in
+  canvas##.onmousemove :=
+    Dom_html.handler (fun (ev : Dom_html.mouseEvent t) ->
+        let rect = canvas##getBoundingClientRect in
+        let x =
+          (Js.to_float ev##.clientX -. Js.to_float rect##.left)
+          /. float_of_int canvas##.width
+        in
+        let y =
+          (Js.to_float ev##.clientY -. Js.to_float rect##.top)
+          /. float_of_int canvas##.height
+        in
+        attractor := Some ((x *. 2.) -. 1., 1. -. (y *. 2.));
+        Js._true);
+  canvas##.onmouseout :=
+    Dom_html.handler (fun _ ->
+        attractor := None;
+        Js._true);
+  let get_time () = Js.to_float (new%js date_now)##getTime in
+  let last_draw = ref (get_time ()) in
+  let draw_times = Queue.create () in
+  let flip = ref true in
+  let rec f () =
+    let read_vao, write_tf, draw_vao =
+      if !flip then vao_a, tf_b, vao_b else vao_b, tf_a, vao_a
+    in
+    flip := not !flip;
+    let t = get_time () /. 1000. in
+    let ax, ay =
+      match !attractor with
+      | Some p -> p
+      | None -> 0.6 *. cos (0.7 *. t), 0.6 *. sin (1.1 *. t)
+    in
+    (* simulation pass: no fragments, varyings captured into the other buffer *)
+    gl##useProgram update_prog;
+    gl##uniform1f dt_loc (Js.number_of_float 0.016);
+    gl##uniform2f attractor_loc (Js.number_of_float ax) (Js.number_of_float ay);
+    gl##bindVertexArray (Opt.return read_vao);
+    gl##bindTransformFeedback gl##._TRANSFORM_FEEDBACK_ (Opt.return write_tf);
+    gl##enable gl##._RASTERIZER_DISCARD_;
+    gl##beginTransformFeedback gl##._POINTS;
+    gl##drawArrays gl##._POINTS 0 nparticles;
+    gl##endTransformFeedback;
+    gl##disable gl##._RASTERIZER_DISCARD_;
+    gl##bindTransformFeedback gl##._TRANSFORM_FEEDBACK_ Opt.empty;
+    (* render pass: draw the freshly written buffer *)
+    gl##useProgram render_prog;
+    gl##clear gl##._COLOR_BUFFER_BIT_;
+    gl##bindVertexArray (Opt.return draw_vao);
+    gl##drawArrays gl##._POINTS 0 nparticles;
+    check_error gl;
+    let now = get_time () in
+    Queue.push (now -. !last_draw) draw_times;
+    last_draw := now;
+    if Queue.length draw_times > 50 then ignore (Queue.pop draw_times);
+    let fps =
+      1.
+      /. Queue.fold ( +. ) 0. draw_times
+      *. float_of_int (Queue.length draw_times)
+      *. 1000.
+    in
+    fps_text##.data := string (Printf.sprintf "%.1f" fps);
+    Lwt_js.sleep 0.016 >>= f
+  in
+  f ()
+
+let () =
+  ignore
+    (catch
+       (fun () -> start ())
+       (fun exn -> error "uncaught exception: %s" (Printexc.to_string exn)))

--- a/examples/webgl2_particles/particles.ml
+++ b/examples/webgl2_particles/particles.ml
@@ -155,6 +155,13 @@ let start () =
       (get_source "render-vertex-shader")
       (get_source "render-fragment-shader")
   in
+  (* fades the previous frame towards the background color, leaving trails *)
+  let fade_prog =
+    create_program
+      gl
+      (get_source "fade-vertex-shader")
+      (get_source "fade-fragment-shader")
+  in
   (* interleaved particle state: position.xy, velocity.xy *)
   let initial_data =
     let data = new%js Typed_array.float32Array (max_particles * 4) in
@@ -208,9 +215,15 @@ let start () =
   gl##bindBuffer_ gl##._ARRAY_BUFFER_ Opt.empty;
   let dt_loc = gl##getUniformLocation update_prog (string "u_dt") in
   let attractor_loc = gl##getUniformLocation update_prog (string "u_attractor") in
+  let gravity_loc = gl##getUniformLocation update_prog (string "u_gravity") in
+  let damping_loc = gl##getUniformLocation update_prog (string "u_damping") in
+  let fade_loc = gl##getUniformLocation fade_prog (string "u_fade") in
   gl##enable gl##._BLEND;
-  gl##blendFunc gl##._SRC_ALPHA_ gl##._ONE;
   gl##clearColor (Js.float 0.02) (Js.float 0.02) (Js.float 0.05) (Js.float 1.);
+  gl##clear gl##._COLOR_BUFFER_BIT_;
+  (* keep the canvas alpha at 1: the fade pass must only dim the color
+     channels, not make the canvas translucent *)
+  gl##colorMask _true _true _true _false;
   check_error gl;
   debug "ready";
   (* the sliders choose how many particles take part and how fast time runs *)
@@ -226,6 +239,24 @@ let start () =
       | Some s -> speed := max 0. (min 4. s)
       | None -> ());
       Printf.sprintf "%.2f" !speed);
+  let gravity = ref 0.35 in
+  setup_slider "gravity" "gravity-label" (fun v ->
+      (match float_of_string_opt v with
+      | Some g -> gravity := max 0. (min 5. g)
+      | None -> ());
+      Printf.sprintf "%.2f" !gravity);
+  let damping = ref 0.999 in
+  setup_slider "damping" "damping-label" (fun v ->
+      (match float_of_string_opt v with
+      | Some d -> damping := max 0.9 (min 1.01 d)
+      | None -> ());
+      Printf.sprintf "%.4f" !damping);
+  let trail = ref 0.2 in
+  setup_slider "trail" "trail-label" (fun v ->
+      (match float_of_string_opt v with
+      | Some t -> trail := max 0. (min 0.98 t)
+      | None -> ());
+      Printf.sprintf "%.2f" !trail);
   (* the attractor follows the mouse, or orbits while unattended *)
   let attractor = ref None in
   canvas##.onmousemove :=
@@ -264,6 +295,8 @@ let start () =
     gl##useProgram update_prog;
     gl##uniform1f dt_loc (Js.number_of_float (0.016 *. !speed));
     gl##uniform2f attractor_loc (Js.number_of_float ax) (Js.number_of_float ay);
+    gl##uniform1f gravity_loc (Js.number_of_float !gravity);
+    gl##uniform1f damping_loc (Js.number_of_float !damping);
     gl##bindVertexArray (Opt.return read_vao);
     gl##bindTransformFeedback gl##._TRANSFORM_FEEDBACK_ (Opt.return write_tf);
     gl##enable gl##._RASTERIZER_DISCARD_;
@@ -272,9 +305,15 @@ let start () =
     gl##endTransformFeedback;
     gl##disable gl##._RASTERIZER_DISCARD_;
     gl##bindTransformFeedback gl##._TRANSFORM_FEEDBACK_ Opt.empty;
-    (* render pass: draw the freshly written buffer *)
+    (* fade pass: dim the previous frame instead of clearing it *)
+    gl##useProgram fade_prog;
+    gl##bindVertexArray Opt.empty;
+    gl##blendFunc gl##._SRC_ALPHA_ gl##._ONE_MINUS_SRC_ALPHA_;
+    gl##uniform1f fade_loc (Js.number_of_float (1. -. !trail));
+    gl##drawArrays gl##._TRIANGLES 0 3;
+    (* render pass: draw the freshly written buffer additively on top *)
     gl##useProgram render_prog;
-    gl##clear gl##._COLOR_BUFFER_BIT_;
+    gl##blendFunc gl##._SRC_ALPHA_ gl##._ONE;
     gl##bindVertexArray (Opt.return draw_vao);
     gl##drawArrays gl##._POINTS 0 !nparticles;
     check_error gl;

--- a/examples/webgl2_particles/particles.ml
+++ b/examples/webgl2_particles/particles.ml
@@ -27,7 +27,11 @@ open Js_of_ocaml_lwt
 open Lwt
 open Js
 
-let nparticles = 50_000
+(* buffers are allocated for [max_particles]; the slider chooses how many are
+   simulated and drawn *)
+let max_particles = 200_000
+
+let default_particles = 50_000
 
 let error f =
   Printf.ksprintf
@@ -130,8 +134,8 @@ let start () =
   in
   (* interleaved particle state: position.xy, velocity.xy *)
   let initial_data =
-    let data = new%js Typed_array.float32Array (nparticles * 4) in
-    for i = 0 to nparticles - 1 do
+    let data = new%js Typed_array.float32Array (max_particles * 4) in
+    for i = 0 to max_particles - 1 do
       let x = Random.float 1.8 -. 0.9 and y = Random.float 1.8 -. 0.9 in
       (* mostly tangential initial velocity, for orbital motion *)
       let s = 0.4 +. Random.float 0.3 in
@@ -186,6 +190,32 @@ let start () =
   gl##clearColor (Js.float 0.02) (Js.float 0.02) (Js.float 0.05) (Js.float 1.);
   check_error gl;
   debug "ready";
+  (* the slider chooses how many of the allocated particles take part *)
+  let nparticles = ref default_particles in
+  Opt.iter
+    (Opt.bind
+       (Dom_html.document##getElementById (string "count"))
+       Dom_html.CoerceTo.input)
+    (fun slider ->
+      let count_text = Dom_html.document##createTextNode (Js.string "") in
+      Opt.iter
+        (Opt.bind
+           (Dom_html.document##getElementById (string "count-label"))
+           Dom_html.CoerceTo.element)
+        (fun span -> Dom.appendChild span count_text);
+      let update () =
+        (match int_of_string_opt (to_string slider##.value) with
+        | Some n -> nparticles := max 1 (min max_particles n)
+        | None -> ());
+        count_text##.data := string (Printf.sprintf "%d" !nparticles)
+      in
+      slider##.max := string (string_of_int max_particles);
+      slider##.value := string (string_of_int !nparticles);
+      update ();
+      slider##.oninput :=
+        Dom_html.handler (fun _ ->
+            update ();
+            Js._true));
   (* the attractor follows the mouse, or orbits while unattended *)
   let attractor = ref None in
   canvas##.onmousemove :=
@@ -228,7 +258,7 @@ let start () =
     gl##bindTransformFeedback gl##._TRANSFORM_FEEDBACK_ (Opt.return write_tf);
     gl##enable gl##._RASTERIZER_DISCARD_;
     gl##beginTransformFeedback gl##._POINTS;
-    gl##drawArrays gl##._POINTS 0 nparticles;
+    gl##drawArrays gl##._POINTS 0 !nparticles;
     gl##endTransformFeedback;
     gl##disable gl##._RASTERIZER_DISCARD_;
     gl##bindTransformFeedback gl##._TRANSFORM_FEEDBACK_ Opt.empty;
@@ -236,7 +266,7 @@ let start () =
     gl##useProgram render_prog;
     gl##clear gl##._COLOR_BUFFER_BIT_;
     gl##bindVertexArray (Opt.return draw_vao);
-    gl##drawArrays gl##._POINTS 0 nparticles;
+    gl##drawArrays gl##._POINTS 0 !nparticles;
     check_error gl;
     let now = get_time () in
     Queue.push (now -. !last_draw) draw_times;

--- a/lib/js_of_ocaml/js_of_ocaml.ml
+++ b/lib/js_of_ocaml/js_of_ocaml.ml
@@ -59,6 +59,7 @@ module Sys_js = Sys_js
 module Typed_array = Typed_array
 module Url = Url
 module WebGL = WebGL
+module WebGL2 = WebGL2
 module WebSockets = WebSockets
 module Worker = Worker
 module XmlHttpRequest = XmlHttpRequest

--- a/lib/js_of_ocaml/webGL.ml
+++ b/lib/js_of_ocaml/webGL.ml
@@ -136,6 +136,12 @@ class type contextAttributes = object
   method preferLowPowerToHighPerformance : bool t prop
 
   method failIfMajorPerformanceCaveat : bool t prop
+
+  method powerPreference : js_string t prop
+
+  method desynchronized : bool t prop
+
+  method xrCompatible : bool t prop
 end
 
 let defaultContextAttributes =
@@ -149,6 +155,9 @@ let defaultContextAttributes =
        ; "preserveDrawingBuffer", inject _false
        ; "preferLowPowerToHighPerformance", inject _false
        ; "failIfMajorPerformanceCaveat", inject _false
+       ; "powerPreference", inject (string "default")
+       ; "desynchronized", inject _false
+       ; "xrCompatible", inject _false
       |])
 
 type buffer

--- a/lib/js_of_ocaml/webGL.mli
+++ b/lib/js_of_ocaml/webGL.mli
@@ -135,8 +135,16 @@ class type contextAttributes = object
   method preserveDrawingBuffer : bool t prop
 
   method preferLowPowerToHighPerformance : bool t prop
+  (** Removed from the specification, superseded by {!powerPreference}. *)
 
   method failIfMajorPerformanceCaveat : bool t prop
+
+  method powerPreference : js_string t prop
+  (** ["default"], ["low-power"] or ["high-performance"]. *)
+
+  method desynchronized : bool t prop
+
+  method xrCompatible : bool t prop
 end
 
 val defaultContextAttributes : contextAttributes t

--- a/lib/js_of_ocaml/webGL2.ml
+++ b/lib/js_of_ocaml/webGL2.ml
@@ -100,6 +100,20 @@ type wrapMode = WebGL.wrapMode
 
 type depthFunction = WebGL.depthFunction
 
+type 'a programParam = 'a WebGL.programParam
+
+type 'a vertexAttribParam = 'a WebGL.vertexAttribParam
+
+type 'a attachParam = 'a WebGL.attachParam
+
+type framebufferStatus = WebGL.framebufferStatus
+
+type uniformType = WebGL.uniformType
+
+type hintTarget = WebGL.hintTarget
+
+type objectType = WebGL.objectType
+
 (** {2 New WebGL2 objects} *)
 
 type query
@@ -132,7 +146,7 @@ type clearBuffer
 
 type transformFeedbackMode
 
-type samplerParameterName
+type 'a samplerParam
 
 type 'a activeUniformParam
 
@@ -141,6 +155,16 @@ type 'a uniformBlockParam
 type transformFeedbackTarget
 
 type textureCompareMode
+
+type 'a indexedParameter
+
+type 'a internalformatParam
+
+type componentType
+
+type colorEncoding
+
+type syncObjectType
 
 class type renderingContext = object
   inherit WebGL.renderingContext
@@ -157,6 +181,26 @@ class type renderingContext = object
 
   method bindBufferRange :
     bufferTarget -> uint -> buffer t -> intptr -> sizeiptr -> unit meth
+
+  method bufferData_withOffset :
+       bufferTarget
+    -> #Typed_array.arrayBufferView t
+    -> bufferUsage
+    -> int
+    -> int
+    -> unit meth
+  (** [bufferData target srcData usage srcOffset length]; a [length] of [0]
+      means up to the end of [srcData]. *)
+
+  method bufferSubData_withOffset :
+    bufferTarget -> intptr -> #Typed_array.arrayBufferView t -> int -> int -> unit meth
+  (** [bufferSubData target dstByteOffset srcData srcOffset length]. *)
+
+  method getBufferSubData_withOffset :
+    bufferTarget -> intptr -> #Typed_array.arrayBufferView t -> int -> int -> unit meth
+  (** [getBufferSubData target srcByteOffset dstBuffer dstOffset length]. *)
+
+  method getIndexedParameter : 'a. 'a indexedParameter -> uint -> 'a meth
 
   (** {2 5.14.3 Programs and shaders} *)
 
@@ -256,6 +300,121 @@ class type renderingContext = object
     -> #Typed_array.arrayBufferView t
     -> unit meth
 
+  method texImage3D_pbo :
+       texTarget
+    -> int
+    -> pixelFormat
+    -> sizei
+    -> sizei
+    -> sizei
+    -> int
+    -> pixelFormat
+    -> pixelType
+    -> intptr
+    -> unit meth
+  (** [texImage3D] sourcing its data from the buffer bound to
+      [PIXEL_UNPACK_BUFFER], at the given byte offset. *)
+
+  method texImage3D_withOffset :
+       texTarget
+    -> int
+    -> pixelFormat
+    -> sizei
+    -> sizei
+    -> sizei
+    -> int
+    -> pixelFormat
+    -> pixelType
+    -> #Typed_array.arrayBufferView t
+    -> int
+    -> unit meth
+  (** [texImage3D] reading from the view starting at element [srcOffset]. *)
+
+  method texSubImage3D_fromImageData :
+       texTarget
+    -> int
+    -> int
+    -> int
+    -> int
+    -> sizei
+    -> sizei
+    -> sizei
+    -> pixelFormat
+    -> pixelType
+    -> Dom_html.imageData t
+    -> unit meth
+
+  method texSubImage3D_fromImage :
+       texTarget
+    -> int
+    -> int
+    -> int
+    -> int
+    -> sizei
+    -> sizei
+    -> sizei
+    -> pixelFormat
+    -> pixelType
+    -> Dom_html.imageElement t
+    -> unit meth
+
+  method texSubImage3D_fromCanvas :
+       texTarget
+    -> int
+    -> int
+    -> int
+    -> int
+    -> sizei
+    -> sizei
+    -> sizei
+    -> pixelFormat
+    -> pixelType
+    -> Dom_html.canvasElement t
+    -> unit meth
+
+  method texSubImage3D_fromVideo :
+       texTarget
+    -> int
+    -> int
+    -> int
+    -> int
+    -> sizei
+    -> sizei
+    -> sizei
+    -> pixelFormat
+    -> pixelType
+    -> Dom_html.videoElement t
+    -> unit meth
+
+  method texSubImage3D_pbo :
+       texTarget
+    -> int
+    -> int
+    -> int
+    -> int
+    -> sizei
+    -> sizei
+    -> sizei
+    -> pixelFormat
+    -> pixelType
+    -> intptr
+    -> unit meth
+
+  method texSubImage3D_withOffset :
+       texTarget
+    -> int
+    -> int
+    -> int
+    -> int
+    -> sizei
+    -> sizei
+    -> sizei
+    -> pixelFormat
+    -> pixelType
+    -> #Typed_array.arrayBufferView t
+    -> int
+    -> unit meth
+
   method copyTexSubImage3D :
     texTarget -> int -> int -> int -> int -> int -> int -> sizei -> sizei -> unit meth
 
@@ -281,6 +440,112 @@ class type renderingContext = object
     -> sizei
     -> pixelFormat
     -> #Typed_array.arrayBufferView t
+    -> unit meth
+
+  method compressedTexImage2D_pbo :
+       texTarget
+    -> int
+    -> pixelFormat
+    -> sizei
+    -> sizei
+    -> int
+    -> sizei
+    -> intptr
+    -> unit meth
+  (** [compressedTexImage2D target level internalformat width height border
+      imageSize offset], reading from the buffer bound to
+      [PIXEL_UNPACK_BUFFER]. *)
+
+  method compressedTexImage2D_withOffset :
+       texTarget
+    -> int
+    -> pixelFormat
+    -> sizei
+    -> sizei
+    -> int
+    -> #Typed_array.arrayBufferView t
+    -> int
+    -> int
+    -> unit meth
+  (** [compressedTexImage2D ... srcData srcOffset srcLengthOverride]. *)
+
+  method compressedTexSubImage2D_pbo :
+       texTarget
+    -> int
+    -> int
+    -> int
+    -> sizei
+    -> sizei
+    -> pixelFormat
+    -> sizei
+    -> intptr
+    -> unit meth
+
+  method compressedTexSubImage2D_withOffset :
+       texTarget
+    -> int
+    -> int
+    -> int
+    -> sizei
+    -> sizei
+    -> pixelFormat
+    -> #Typed_array.arrayBufferView t
+    -> int
+    -> int
+    -> unit meth
+
+  method compressedTexImage3D_pbo :
+       texTarget
+    -> int
+    -> pixelFormat
+    -> sizei
+    -> sizei
+    -> sizei
+    -> int
+    -> sizei
+    -> intptr
+    -> unit meth
+
+  method compressedTexImage3D_withOffset :
+       texTarget
+    -> int
+    -> pixelFormat
+    -> sizei
+    -> sizei
+    -> sizei
+    -> int
+    -> #Typed_array.arrayBufferView t
+    -> int
+    -> int
+    -> unit meth
+
+  method compressedTexSubImage3D_pbo :
+       texTarget
+    -> int
+    -> int
+    -> int
+    -> int
+    -> sizei
+    -> sizei
+    -> sizei
+    -> pixelFormat
+    -> sizei
+    -> intptr
+    -> unit meth
+
+  method compressedTexSubImage3D_withOffset :
+       texTarget
+    -> int
+    -> int
+    -> int
+    -> int
+    -> sizei
+    -> sizei
+    -> sizei
+    -> pixelFormat
+    -> #Typed_array.arrayBufferView t
+    -> int
+    -> int
     -> unit meth
 
   method texStorage2D : texTarget -> sizei -> pixelFormat -> sizei -> sizei -> unit meth
@@ -323,6 +588,9 @@ class type renderingContext = object
       ({!type:pixelFormat}); the WebGL1 [renderbufferStorage] taking a
       {!type:format} is still available through inheritance. *)
 
+  method getInternalformatParameter :
+    'a. rbTarget -> pixelFormat -> 'a internalformatParam -> 'a meth
+
   (** {2 5.14.8 Texture objects} *)
 
   method texParameterf : texTarget -> number_t texParam -> number_t -> unit meth
@@ -330,16 +598,96 @@ class type renderingContext = object
       {!_TEXTURE_MAX_LOD_}; the integer/enum parameters go through the inherited
       [texParameteri]. *)
 
+  method texImage2D_pbo :
+       texTarget
+    -> int
+    -> pixelFormat
+    -> sizei
+    -> sizei
+    -> int
+    -> pixelFormat
+    -> pixelType
+    -> intptr
+    -> unit meth
+  (** [texImage2D] sourcing its data from the buffer bound to
+      [PIXEL_UNPACK_BUFFER], at the given byte offset. *)
+
+  method texImage2D_withOffset :
+       texTarget
+    -> int
+    -> pixelFormat
+    -> sizei
+    -> sizei
+    -> int
+    -> pixelFormat
+    -> pixelType
+    -> #Typed_array.arrayBufferView t
+    -> int
+    -> unit meth
+  (** [texImage2D] reading from the view starting at element [srcOffset]. *)
+
+  method texSubImage2D_pbo :
+       texTarget
+    -> int
+    -> int
+    -> int
+    -> sizei
+    -> sizei
+    -> pixelFormat
+    -> pixelType
+    -> intptr
+    -> unit meth
+
+  method texSubImage2D_withOffset :
+       texTarget
+    -> int
+    -> int
+    -> int
+    -> sizei
+    -> sizei
+    -> pixelFormat
+    -> pixelType
+    -> #Typed_array.arrayBufferView t
+    -> int
+    -> unit meth
+
+  (** {2 5.14.12 Reading back pixels} *)
+
+  method readPixels_pbo :
+    int -> int -> sizei -> sizei -> pixelFormat -> pixelType -> intptr -> unit meth
+  (** [readPixels] writing into the buffer bound to [PIXEL_PACK_BUFFER], at the
+      given byte offset. *)
+
+  method readPixels_withOffset :
+       int
+    -> int
+    -> sizei
+    -> sizei
+    -> pixelFormat
+    -> pixelType
+    -> #Typed_array.arrayBufferView t
+    -> int
+    -> unit meth
+  (** [readPixels] writing into the view starting at element [dstOffset]. *)
+
   (** {2 5.14.9 Multiple render targets} *)
 
   method drawBuffers : attachmentPoint js_array t -> unit meth
 
-  method clearBufferiv : clearBuffer -> int -> #Typed_array.arrayBufferView t -> unit meth
+  method clearBufferiv : clearBuffer -> int -> Typed_array.int32Array t -> unit meth
 
-  method clearBufferuiv :
-    clearBuffer -> int -> #Typed_array.arrayBufferView t -> unit meth
+  method clearBufferuiv : clearBuffer -> int -> Typed_array.uint32Array t -> unit meth
 
-  method clearBufferfv : clearBuffer -> int -> #Typed_array.arrayBufferView t -> unit meth
+  method clearBufferfv : clearBuffer -> int -> Typed_array.float32Array t -> unit meth
+
+  method clearBufferiv_withOffset :
+    clearBuffer -> int -> Typed_array.int32Array t -> int -> unit meth
+
+  method clearBufferuiv_withOffset :
+    clearBuffer -> int -> Typed_array.uint32Array t -> int -> unit meth
+
+  method clearBufferfv_withOffset :
+    clearBuffer -> int -> Typed_array.float32Array t -> int -> unit meth
 
   method clearBufferfi : clearBuffer -> int -> number_t -> int -> unit meth
 
@@ -369,11 +717,11 @@ class type renderingContext = object
 
   method bindSampler : uint -> sampler t opt -> unit meth
 
-  method samplerParameteri : sampler t -> samplerParameterName -> int -> unit meth
+  method samplerParameteri : 'a. sampler t -> 'a samplerParam -> 'a -> unit meth
 
-  method samplerParameterf : sampler t -> samplerParameterName -> number_t -> unit meth
+  method samplerParameterf : sampler t -> number_t samplerParam -> number_t -> unit meth
 
-  method getSamplerParameter : 'a. sampler t -> samplerParameterName -> 'a meth
+  method getSamplerParameter : 'a. sampler t -> 'a samplerParam -> 'a meth
 
   (** {2 5.14.12 Sync objects} *)
 
@@ -568,6 +916,10 @@ class type renderingContext = object
 
   method _NONE_TCM : textureCompareMode readonly_prop
   (** The [NONE] value for {!_TEXTURE_COMPARE_MODE_}. *)
+
+  method _TEXTURE_IMMUTABLE_FORMAT_ : bool t texParam readonly_prop
+
+  method _TEXTURE_IMMUTABLE_LEVELS_ : int texParam readonly_prop
 
   (** {3 New external formats} *)
 
@@ -765,23 +1117,23 @@ class type renderingContext = object
 
   (** {3 Sampler parameters} *)
 
-  method _TEXTURE_MAG_FILTER_SP : samplerParameterName readonly_prop
+  method _TEXTURE_MAG_FILTER_SP : texFilter samplerParam readonly_prop
 
-  method _TEXTURE_MIN_FILTER_SP : samplerParameterName readonly_prop
+  method _TEXTURE_MIN_FILTER_SP : texFilter samplerParam readonly_prop
 
-  method _TEXTURE_WRAP_S_SP : samplerParameterName readonly_prop
+  method _TEXTURE_WRAP_S_SP : wrapMode samplerParam readonly_prop
 
-  method _TEXTURE_WRAP_T_SP : samplerParameterName readonly_prop
+  method _TEXTURE_WRAP_T_SP : wrapMode samplerParam readonly_prop
 
-  method _TEXTURE_WRAP_R_SP : samplerParameterName readonly_prop
+  method _TEXTURE_WRAP_R_SP : wrapMode samplerParam readonly_prop
 
-  method _TEXTURE_MIN_LOD_SP : samplerParameterName readonly_prop
+  method _TEXTURE_MIN_LOD_SP : number_t samplerParam readonly_prop
 
-  method _TEXTURE_MAX_LOD_SP : samplerParameterName readonly_prop
+  method _TEXTURE_MAX_LOD_SP : number_t samplerParam readonly_prop
 
-  method _TEXTURE_COMPARE_MODE_SP : samplerParameterName readonly_prop
+  method _TEXTURE_COMPARE_MODE_SP : textureCompareMode samplerParam readonly_prop
 
-  method _TEXTURE_COMPARE_FUNC_SP : samplerParameterName readonly_prop
+  method _TEXTURE_COMPARE_FUNC_SP : depthFunction samplerParam readonly_prop
 
   (** {3 Sync objects} *)
 
@@ -806,6 +1158,13 @@ class type renderingContext = object
   method _CONDITION_SATISFIED_ : clientWaitSyncStatus readonly_prop
 
   method _WAIT_FAILED_ : clientWaitSyncStatus readonly_prop
+
+  method _OBJECT_TYPE_ : syncObjectType syncParam readonly_prop
+
+  method _SYNC_FENCE_ : syncObjectType readonly_prop
+
+  method _TIMEOUT_IGNORED_ : number_t readonly_prop
+  (** The special timeout value ([-1]) for [clientWaitSync]/[waitSync]. *)
 
   (** {3 Transform feedback} *)
 
@@ -846,6 +1205,11 @@ class type renderingContext = object
   method _UNIFORM_BLOCK_REFERENCED_BY_FRAGMENT_SHADER_ :
     bool t uniformBlockParam readonly_prop
 
+  method _INVALID_INDEX_ : uint readonly_prop
+  (** Returned by [getUniformIndices]/[getUniformBlockIndex] for unknown names
+      (the value is [0xFFFFFFFF], which does not fit a 32-bit OCaml [int];
+      only use it for equality tests). *)
+
   (** {3 New pixel store parameters} *)
 
   method _PACK_ROW_LENGTH_ : int pixelStoreParam readonly_prop
@@ -883,6 +1247,225 @@ class type renderingContext = object
   method _MAX_FRAGMENT_UNIFORM_BLOCKS_ : int parameter readonly_prop
 
   method _UNIFORM_BUFFER_OFFSET_ALIGNMENT_ : int parameter readonly_prop
+
+  method _MAX_ELEMENTS_VERTICES_ : int parameter readonly_prop
+
+  method _MAX_ELEMENTS_INDICES_ : int parameter readonly_prop
+
+  method _MAX_VARYING_COMPONENTS_ : int parameter readonly_prop
+
+  method _MAX_VERTEX_UNIFORM_COMPONENTS_ : int parameter readonly_prop
+
+  method _MAX_FRAGMENT_UNIFORM_COMPONENTS_ : int parameter readonly_prop
+
+  method _MAX_VERTEX_OUTPUT_COMPONENTS_ : int parameter readonly_prop
+
+  method _MAX_FRAGMENT_INPUT_COMPONENTS_ : int parameter readonly_prop
+
+  method _MIN_PROGRAM_TEXEL_OFFSET_ : int parameter readonly_prop
+
+  method _MAX_PROGRAM_TEXEL_OFFSET_ : int parameter readonly_prop
+
+  method _MAX_COMBINED_UNIFORM_BLOCKS_ : int parameter readonly_prop
+
+  method _MAX_TRANSFORM_FEEDBACK_INTERLEAVED_COMPONENTS_ : int parameter readonly_prop
+
+  method _MAX_TRANSFORM_FEEDBACK_SEPARATE_ATTRIBS_ : int parameter readonly_prop
+
+  method _MAX_TRANSFORM_FEEDBACK_SEPARATE_COMPONENTS_ : int parameter readonly_prop
+
+  method _MAX_ELEMENT_INDEX_ : number_t parameter readonly_prop
+
+  method _MAX_SERVER_WAIT_TIMEOUT_ : number_t parameter readonly_prop
+
+  method _MAX_UNIFORM_BLOCK_SIZE_ : number_t parameter readonly_prop
+
+  method _MAX_COMBINED_VERTEX_UNIFORM_COMPONENTS_ : number_t parameter readonly_prop
+
+  method _MAX_COMBINED_FRAGMENT_UNIFORM_COMPONENTS_ : number_t parameter readonly_prop
+
+  method _MAX_TEXTURE_LOD_BIAS_ : number_t parameter readonly_prop
+
+  method _MAX_CLIENT_WAIT_TIMEOUT_WEBGL_ : number_t parameter readonly_prop
+
+  method _READ_BUFFER_ : attachmentPoint parameter readonly_prop
+
+  method _FRAGMENT_SHADER_DERIVATIVE_HINT_ : hintTarget readonly_prop
+
+  method _TRANSFORM_FEEDBACK_ACTIVE_ : bool t parameter readonly_prop
+
+  method _TRANSFORM_FEEDBACK_PAUSED_ : bool t parameter readonly_prop
+
+  (** {3 Binding-point queries} *)
+
+  method _VERTEX_ARRAY_BINDING_ : vertexArrayObject t opt parameter readonly_prop
+
+  method _SAMPLER_BINDING_ : sampler t opt parameter readonly_prop
+
+  method _READ_FRAMEBUFFER_BINDING_ : framebuffer t opt parameter readonly_prop
+
+  method _DRAW_FRAMEBUFFER_BINDING_ : framebuffer t opt parameter readonly_prop
+
+  method _COPY_READ_BUFFER_BINDING_ : buffer t opt parameter readonly_prop
+
+  method _COPY_WRITE_BUFFER_BINDING_ : buffer t opt parameter readonly_prop
+
+  method _PIXEL_PACK_BUFFER_BINDING_ : buffer t opt parameter readonly_prop
+
+  method _PIXEL_UNPACK_BUFFER_BINDING_ : buffer t opt parameter readonly_prop
+
+  method _TRANSFORM_FEEDBACK_BINDING_ : transformFeedback t opt parameter readonly_prop
+
+  method _DRAW_BUFFER0_ : attachmentPoint parameter readonly_prop
+
+  method _DRAW_BUFFER1_ : attachmentPoint parameter readonly_prop
+
+  method _DRAW_BUFFER2_ : attachmentPoint parameter readonly_prop
+
+  method _DRAW_BUFFER3_ : attachmentPoint parameter readonly_prop
+
+  method _DRAW_BUFFER4_ : attachmentPoint parameter readonly_prop
+
+  method _DRAW_BUFFER5_ : attachmentPoint parameter readonly_prop
+
+  method _DRAW_BUFFER6_ : attachmentPoint parameter readonly_prop
+
+  method _DRAW_BUFFER7_ : attachmentPoint parameter readonly_prop
+
+  method _DRAW_BUFFER8_ : attachmentPoint parameter readonly_prop
+
+  method _DRAW_BUFFER9_ : attachmentPoint parameter readonly_prop
+
+  method _DRAW_BUFFER10_ : attachmentPoint parameter readonly_prop
+
+  method _DRAW_BUFFER11_ : attachmentPoint parameter readonly_prop
+
+  method _DRAW_BUFFER12_ : attachmentPoint parameter readonly_prop
+
+  method _DRAW_BUFFER13_ : attachmentPoint parameter readonly_prop
+
+  method _DRAW_BUFFER14_ : attachmentPoint parameter readonly_prop
+
+  method _DRAW_BUFFER15_ : attachmentPoint parameter readonly_prop
+
+  (** {3 Indexed parameters} *)
+
+  method _TRANSFORM_FEEDBACK_BUFFER_BINDING_ : buffer t opt indexedParameter readonly_prop
+
+  method _TRANSFORM_FEEDBACK_BUFFER_START_ : int indexedParameter readonly_prop
+
+  method _TRANSFORM_FEEDBACK_BUFFER_SIZE_ : int indexedParameter readonly_prop
+
+  method _UNIFORM_BUFFER_BINDING_ : buffer t opt indexedParameter readonly_prop
+
+  method _UNIFORM_BUFFER_START_ : int indexedParameter readonly_prop
+
+  method _UNIFORM_BUFFER_SIZE_ : int indexedParameter readonly_prop
+
+  (** {3 Internal format queries} *)
+
+  method _SAMPLES_IFP : Typed_array.int32Array t internalformatParam readonly_prop
+
+  (** {3 Program and vertex attribute parameters} *)
+
+  method _TRANSFORM_FEEDBACK_BUFFER_MODE_ :
+    transformFeedbackMode programParam readonly_prop
+
+  method _TRANSFORM_FEEDBACK_VARYINGS_ : int programParam readonly_prop
+
+  method _ACTIVE_UNIFORM_BLOCKS_ : int programParam readonly_prop
+
+  method _VERTEX_ATTRIB_ARRAY_INTEGER_ : bool t vertexAttribParam readonly_prop
+
+  method _VERTEX_ATTRIB_ARRAY_DIVISOR_ : int vertexAttribParam readonly_prop
+
+  (** {3 New uniform types} *)
+
+  method _UNSIGNED_INT_UT : uniformType readonly_prop
+
+  method _UNSIGNED_INT_VEC2_ : uniformType readonly_prop
+
+  method _UNSIGNED_INT_VEC3_ : uniformType readonly_prop
+
+  method _UNSIGNED_INT_VEC4_ : uniformType readonly_prop
+
+  method _FLOAT_MAT2x3_ : uniformType readonly_prop
+
+  method _FLOAT_MAT2x4_ : uniformType readonly_prop
+
+  method _FLOAT_MAT3x2_ : uniformType readonly_prop
+
+  method _FLOAT_MAT3x4_ : uniformType readonly_prop
+
+  method _FLOAT_MAT4x2_ : uniformType readonly_prop
+
+  method _FLOAT_MAT4x3_ : uniformType readonly_prop
+
+  method _SAMPLER_3D_ : uniformType readonly_prop
+
+  method _SAMPLER_2D_SHADOW_ : uniformType readonly_prop
+
+  method _SAMPLER_2D_ARRAY_ : uniformType readonly_prop
+
+  method _SAMPLER_2D_ARRAY_SHADOW_ : uniformType readonly_prop
+
+  method _SAMPLER_CUBE_SHADOW_ : uniformType readonly_prop
+
+  method _INT_SAMPLER_2D_ : uniformType readonly_prop
+
+  method _INT_SAMPLER_3D_ : uniformType readonly_prop
+
+  method _INT_SAMPLER_CUBE_ : uniformType readonly_prop
+
+  method _INT_SAMPLER_2D_ARRAY_ : uniformType readonly_prop
+
+  method _UNSIGNED_INT_SAMPLER_2D_ : uniformType readonly_prop
+
+  method _UNSIGNED_INT_SAMPLER_3D_ : uniformType readonly_prop
+
+  method _UNSIGNED_INT_SAMPLER_CUBE_ : uniformType readonly_prop
+
+  method _UNSIGNED_INT_SAMPLER_2D_ARRAY_ : uniformType readonly_prop
+
+  (** {3 Framebuffer introspection} *)
+
+  method _FRAMEBUFFER_ATTACHMENT_RED_SIZE_ : int attachParam readonly_prop
+
+  method _FRAMEBUFFER_ATTACHMENT_GREEN_SIZE_ : int attachParam readonly_prop
+
+  method _FRAMEBUFFER_ATTACHMENT_BLUE_SIZE_ : int attachParam readonly_prop
+
+  method _FRAMEBUFFER_ATTACHMENT_ALPHA_SIZE_ : int attachParam readonly_prop
+
+  method _FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE_ : int attachParam readonly_prop
+
+  method _FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE_ : int attachParam readonly_prop
+
+  method _FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE_ : componentType attachParam readonly_prop
+
+  method _FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING_ : colorEncoding attachParam readonly_prop
+
+  method _FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER_ : int attachParam readonly_prop
+
+  method _FLOAT_CT : componentType readonly_prop
+
+  method _INT_CT : componentType readonly_prop
+
+  method _UNSIGNED_INT_CT : componentType readonly_prop
+
+  method _SIGNED_NORMALIZED_ : componentType readonly_prop
+
+  method _UNSIGNED_NORMALIZED_ : componentType readonly_prop
+
+  method _LINEAR_CE : colorEncoding readonly_prop
+
+  method _SRGB_CE : colorEncoding readonly_prop
+
+  method _DEPTH_STENCIL_ATTACHMENT_ : attachmentPoint readonly_prop
+
+  method _FRAMEBUFFER_DEFAULT_ : objectType readonly_prop
+
+  method _FRAMEBUFFER_INCOMPLETE_MULTISAMPLE_ : framebufferStatus readonly_prop
 end
 
 (** {2 Getting a WebGL2 context} *)

--- a/lib/js_of_ocaml/webGL2.ml
+++ b/lib/js_of_ocaml/webGL2.ml
@@ -1,0 +1,852 @@
+(* Js_of_ocaml library
+ * http://www.ocsigen.org/js_of_ocaml/
+ * Copyright (C) 2024 Ocsigen team
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+
+(** WebGL2 binding.
+
+    WebGL2 ([WebGL2RenderingContext]) is a strict superset of WebGL1, so the
+    context {!type:renderingContext} inherits every method and constant of
+    {!WebGL.renderingContext} and adds the WebGL2 ones on top.
+
+    Following the pragmatic style of {!WebGL}, the enumerations are kept as
+    abstract types shared between related uses.  In particular the many WebGL2
+    sized internal formats and the plain formats share the single type
+    {!type:pixelFormat}; the binding therefore does not enforce, at compile
+    time, that the (internalformat, format, type) triples passed to e.g.
+    {!renderingContext.texImage3D} are mutually coherent (WebGL itself is not
+    type safe there). *)
+
+open Js
+open! Import
+
+(** {2 Types reused from WebGL1} *)
+
+type sizei = WebGL.sizei
+
+type sizeiptr = WebGL.sizeiptr
+
+type intptr = WebGL.intptr
+
+type uint = WebGL.uint
+
+type clampf = WebGL.clampf
+
+type void = WebGL.void
+
+type clearBufferMask = WebGL.clearBufferMask
+
+type beginMode = WebGL.beginMode
+
+type bufferTarget = WebGL.bufferTarget
+
+type bufferUsage = WebGL.bufferUsage
+
+type enableCap = WebGL.enableCap
+
+type dataType = WebGL.dataType
+
+type pixelType = WebGL.pixelType
+
+type pixelFormat = WebGL.pixelFormat
+
+type format = WebGL.format
+
+type texTarget = WebGL.texTarget
+
+type texFilter = WebGL.texFilter
+
+type rbTarget = WebGL.rbTarget
+
+type fbTarget = WebGL.fbTarget
+
+type attachmentPoint = WebGL.attachmentPoint
+
+type 'a parameter = 'a WebGL.parameter
+
+type 'a pixelStoreParam = 'a WebGL.pixelStoreParam
+
+type buffer = WebGL.buffer
+
+type framebuffer = WebGL.framebuffer
+
+type program = WebGL.program
+
+type renderbuffer = WebGL.renderbuffer
+
+type shader = WebGL.shader
+
+type texture = WebGL.texture
+
+type 'a uniformLocation = 'a WebGL.uniformLocation
+
+(** {2 New WebGL2 objects} *)
+
+type query
+
+type sampler
+
+type sync
+
+type transformFeedback
+
+type vertexArrayObject
+
+(** {2 New WebGL2 enumerations} *)
+
+type queryTarget
+
+type currentQueryParam
+
+type 'a queryParam
+
+type syncCondition
+
+type 'a syncParam
+
+type syncStatus
+
+type clientWaitSyncStatus
+
+type clearBuffer
+
+type transformFeedbackMode
+
+type samplerParameterName
+
+type 'a activeUniformParam
+
+type 'a uniformBlockParam
+
+class type renderingContext = object
+  inherit WebGL.renderingContext
+
+  (** {2 5.14.2 Setting and getting state (buffers)} *)
+
+  method copyBufferSubData :
+    bufferTarget -> bufferTarget -> intptr -> intptr -> sizeiptr -> unit meth
+
+  method getBufferSubData :
+    bufferTarget -> intptr -> #Typed_array.arrayBufferView t -> unit meth
+
+  method bindBufferBase : bufferTarget -> uint -> buffer t -> unit meth
+
+  method bindBufferRange :
+    bufferTarget -> uint -> buffer t -> intptr -> sizeiptr -> unit meth
+
+  (** {2 5.14.3 Programs and shaders} *)
+
+  method getFragDataLocation : program t -> js_string t -> int meth
+
+  (** {2 5.14.4 3D textures and texture storage} *)
+
+  method texImage3D :
+       texTarget
+    -> int
+    -> pixelFormat
+    -> sizei
+    -> sizei
+    -> sizei
+    -> int
+    -> pixelFormat
+    -> pixelType
+    -> void opt
+    -> unit meth
+
+  method texImage3D_fromView :
+       texTarget
+    -> int
+    -> pixelFormat
+    -> sizei
+    -> sizei
+    -> sizei
+    -> int
+    -> pixelFormat
+    -> pixelType
+    -> #Typed_array.arrayBufferView t
+    -> unit meth
+
+  method texImage3D_fromImageData :
+       texTarget
+    -> int
+    -> pixelFormat
+    -> sizei
+    -> sizei
+    -> sizei
+    -> int
+    -> pixelFormat
+    -> pixelType
+    -> Dom_html.imageData t
+    -> unit meth
+
+  method texImage3D_fromImage :
+       texTarget
+    -> int
+    -> pixelFormat
+    -> sizei
+    -> sizei
+    -> sizei
+    -> int
+    -> pixelFormat
+    -> pixelType
+    -> Dom_html.imageElement t
+    -> unit meth
+
+  method texImage3D_fromCanvas :
+       texTarget
+    -> int
+    -> pixelFormat
+    -> sizei
+    -> sizei
+    -> sizei
+    -> int
+    -> pixelFormat
+    -> pixelType
+    -> Dom_html.canvasElement t
+    -> unit meth
+
+  method texImage3D_fromVideo :
+       texTarget
+    -> int
+    -> pixelFormat
+    -> sizei
+    -> sizei
+    -> sizei
+    -> int
+    -> pixelFormat
+    -> pixelType
+    -> Dom_html.videoElement t
+    -> unit meth
+
+  method texSubImage3D_fromView :
+       texTarget
+    -> int
+    -> int
+    -> int
+    -> int
+    -> sizei
+    -> sizei
+    -> sizei
+    -> pixelFormat
+    -> pixelType
+    -> #Typed_array.arrayBufferView t
+    -> unit meth
+
+  method copyTexSubImage3D :
+    texTarget -> int -> int -> int -> int -> int -> int -> sizei -> sizei -> unit meth
+
+  method compressedTexImage3D :
+       texTarget
+    -> int
+    -> pixelFormat
+    -> sizei
+    -> sizei
+    -> sizei
+    -> int
+    -> #Typed_array.arrayBufferView t
+    -> unit meth
+
+  method compressedTexSubImage3D :
+       texTarget
+    -> int
+    -> int
+    -> int
+    -> int
+    -> sizei
+    -> sizei
+    -> sizei
+    -> pixelFormat
+    -> #Typed_array.arrayBufferView t
+    -> unit meth
+
+  method texStorage2D : texTarget -> sizei -> pixelFormat -> sizei -> sizei -> unit meth
+
+  method texStorage3D :
+    texTarget -> sizei -> pixelFormat -> sizei -> sizei -> sizei -> unit meth
+
+  (** {2 5.14.5 Framebuffer objects} *)
+
+  method blitFramebuffer :
+       int
+    -> int
+    -> int
+    -> int
+    -> int
+    -> int
+    -> int
+    -> int
+    -> clearBufferMask
+    -> texFilter
+    -> unit meth
+
+  method framebufferTextureLayer :
+    fbTarget -> attachmentPoint -> texture t -> int -> int -> unit meth
+
+  method invalidateFramebuffer : fbTarget -> attachmentPoint js_array t -> unit meth
+
+  method invalidateSubFramebuffer :
+    fbTarget -> attachmentPoint js_array t -> int -> int -> sizei -> sizei -> unit meth
+
+  method readBuffer : attachmentPoint -> unit meth
+
+  (** {2 5.14.6 Renderbuffer objects} *)
+
+  method renderbufferStorageMultisample :
+    rbTarget -> sizei -> pixelFormat -> sizei -> sizei -> unit meth
+
+  method renderbufferStorage_ : rbTarget -> pixelFormat -> sizei -> sizei -> unit meth
+  (** [renderbufferStorage] accepting the WebGL2 sized internal formats
+      ({!type:pixelFormat}); the WebGL1 [renderbufferStorage] taking a
+      {!type:format} is still available through inheritance. *)
+
+  (** {2 5.14.9 Multiple render targets} *)
+
+  method drawBuffers : attachmentPoint js_array t -> unit meth
+
+  method clearBufferiv : clearBuffer -> int -> #Typed_array.arrayBufferView t -> unit meth
+
+  method clearBufferuiv :
+    clearBuffer -> int -> #Typed_array.arrayBufferView t -> unit meth
+
+  method clearBufferfv : clearBuffer -> int -> #Typed_array.arrayBufferView t -> unit meth
+
+  method clearBufferfi : clearBuffer -> int -> number_t -> int -> unit meth
+
+  (** {2 5.14.10 Query objects} *)
+
+  method createQuery : query t meth
+
+  method deleteQuery : query t -> unit meth
+
+  method isQuery : query t -> bool t meth
+
+  method beginQuery : queryTarget -> query t -> unit meth
+
+  method endQuery : queryTarget -> unit meth
+
+  method getQuery : queryTarget -> currentQueryParam -> query t opt meth
+
+  method getQueryParameter : 'a. query t -> 'a queryParam -> 'a meth
+
+  (** {2 5.14.11 Sampler objects} *)
+
+  method createSampler : sampler t meth
+
+  method deleteSampler : sampler t -> unit meth
+
+  method isSampler : sampler t -> bool t meth
+
+  method bindSampler : uint -> sampler t opt -> unit meth
+
+  method samplerParameteri : sampler t -> samplerParameterName -> int -> unit meth
+
+  method samplerParameterf : sampler t -> samplerParameterName -> number_t -> unit meth
+
+  method getSamplerParameter : 'a. sampler t -> samplerParameterName -> 'a meth
+
+  (** {2 5.14.12 Sync objects} *)
+
+  method fenceSync : syncCondition -> int -> sync t meth
+
+  method isSync : sync t -> bool t meth
+
+  method deleteSync : sync t -> unit meth
+
+  method clientWaitSync : sync t -> int -> number_t -> clientWaitSyncStatus meth
+
+  method waitSync : sync t -> int -> number_t -> unit meth
+
+  method getSyncParameter : 'a. sync t -> 'a syncParam -> 'a meth
+
+  (** {2 5.14.13 Transform feedback} *)
+
+  method createTransformFeedback : transformFeedback t meth
+
+  method deleteTransformFeedback : transformFeedback t -> unit meth
+
+  method isTransformFeedback : transformFeedback t -> bool t meth
+
+  method bindTransformFeedback : bufferTarget -> transformFeedback t opt -> unit meth
+
+  method beginTransformFeedback : beginMode -> unit meth
+
+  method endTransformFeedback : unit meth
+
+  method transformFeedbackVaryings :
+    program t -> js_string t js_array t -> transformFeedbackMode -> unit meth
+
+  method getTransformFeedbackVarying : program t -> uint -> WebGL.activeInfo t opt meth
+
+  method pauseTransformFeedback : unit meth
+
+  method resumeTransformFeedback : unit meth
+
+  (** {2 5.14.14 Uniform buffer objects} *)
+
+  method getUniformIndices :
+    program t -> js_string t js_array t -> uint js_array t opt meth
+
+  method getActiveUniforms :
+    'a. program t -> uint js_array t -> 'a activeUniformParam -> 'a js_array t meth
+
+  method getUniformBlockIndex : program t -> js_string t -> uint meth
+
+  method getActiveUniformBlockParameter :
+    'a. program t -> uint -> 'a uniformBlockParam -> 'a meth
+
+  method getActiveUniformBlockName : program t -> uint -> js_string t opt meth
+
+  method uniformBlockBinding : program t -> uint -> uint -> unit meth
+
+  (** {2 5.14.15 Vertex array objects} *)
+
+  method createVertexArray : vertexArrayObject t meth
+
+  method deleteVertexArray : vertexArrayObject t -> unit meth
+
+  method isVertexArray : vertexArrayObject t -> bool t meth
+
+  method bindVertexArray : vertexArrayObject t opt -> unit meth
+
+  (** {2 5.14.16 Instanced and range drawing} *)
+
+  method drawArraysInstanced : beginMode -> int -> sizei -> sizei -> unit meth
+
+  method drawElementsInstanced :
+    beginMode -> sizei -> dataType -> intptr -> sizei -> unit meth
+
+  method drawRangeElements :
+    beginMode -> uint -> uint -> sizei -> dataType -> intptr -> unit meth
+
+  method vertexAttribDivisor : uint -> uint -> unit meth
+
+  (** {2 5.14.17 Integer vertex attributes} *)
+
+  method vertexAttribI4i : uint -> int -> int -> int -> int -> unit meth
+
+  method vertexAttribI4ui : uint -> uint -> uint -> uint -> uint -> unit meth
+
+  method vertexAttribI4iv : uint -> Typed_array.int32Array t -> unit meth
+
+  method vertexAttribI4uiv : uint -> Typed_array.uint32Array t -> unit meth
+
+  method vertexAttribIPointer : uint -> int -> dataType -> sizei -> intptr -> unit meth
+
+  (** {2 5.14.18 Unsigned integer uniforms} *)
+
+  method uniform1ui : int uniformLocation t -> uint -> unit meth
+
+  method uniform2ui : [ `uvec2 ] uniformLocation t -> uint -> uint -> unit meth
+
+  method uniform3ui : [ `uvec3 ] uniformLocation t -> uint -> uint -> uint -> unit meth
+
+  method uniform4ui :
+    [ `uvec4 ] uniformLocation t -> uint -> uint -> uint -> uint -> unit meth
+
+  method uniform1uiv : int uniformLocation t -> Typed_array.uint32Array t -> unit meth
+
+  method uniform2uiv :
+    [ `uvec2 ] uniformLocation t -> Typed_array.uint32Array t -> unit meth
+
+  method uniform3uiv :
+    [ `uvec3 ] uniformLocation t -> Typed_array.uint32Array t -> unit meth
+
+  method uniform4uiv :
+    [ `uvec4 ] uniformLocation t -> Typed_array.uint32Array t -> unit meth
+
+  method uniformMatrix2x3fv :
+    [ `mat2x3 ] uniformLocation t -> bool t -> Typed_array.float32Array t -> unit meth
+
+  method uniformMatrix3x2fv :
+    [ `mat3x2 ] uniformLocation t -> bool t -> Typed_array.float32Array t -> unit meth
+
+  method uniformMatrix2x4fv :
+    [ `mat2x4 ] uniformLocation t -> bool t -> Typed_array.float32Array t -> unit meth
+
+  method uniformMatrix4x2fv :
+    [ `mat4x2 ] uniformLocation t -> bool t -> Typed_array.float32Array t -> unit meth
+
+  method uniformMatrix3x4fv :
+    [ `mat3x4 ] uniformLocation t -> bool t -> Typed_array.float32Array t -> unit meth
+
+  method uniformMatrix4x3fv :
+    [ `mat4x3 ] uniformLocation t -> bool t -> Typed_array.float32Array t -> unit meth
+
+  (** {2 New constants} *)
+
+  (** {3 Buffer targets and usages} *)
+
+  method _COPY_READ_BUFFER_ : bufferTarget readonly_prop
+
+  method _COPY_WRITE_BUFFER_ : bufferTarget readonly_prop
+
+  method _PIXEL_PACK_BUFFER_ : bufferTarget readonly_prop
+
+  method _PIXEL_UNPACK_BUFFER_ : bufferTarget readonly_prop
+
+  method _TRANSFORM_FEEDBACK_BUFFER_ : bufferTarget readonly_prop
+
+  method _UNIFORM_BUFFER_ : bufferTarget readonly_prop
+
+  method _STREAM_READ_ : bufferUsage readonly_prop
+
+  method _STREAM_COPY_ : bufferUsage readonly_prop
+
+  method _STATIC_READ_ : bufferUsage readonly_prop
+
+  method _STATIC_COPY_ : bufferUsage readonly_prop
+
+  method _DYNAMIC_READ_ : bufferUsage readonly_prop
+
+  method _DYNAMIC_COPY_ : bufferUsage readonly_prop
+
+  (** {3 Texture targets} *)
+
+  method _TEXTURE_3D_ : texTarget readonly_prop
+
+  method _TEXTURE_2D_ARRAY_ : texTarget readonly_prop
+
+  (** {3 New external formats} *)
+
+  method _RED_ : pixelFormat readonly_prop
+
+  method _RG_ : pixelFormat readonly_prop
+
+  method _RED_INTEGER_ : pixelFormat readonly_prop
+
+  method _RG_INTEGER_ : pixelFormat readonly_prop
+
+  method _RGB_INTEGER_ : pixelFormat readonly_prop
+
+  method _RGBA_INTEGER_ : pixelFormat readonly_prop
+
+  (** {3 New sized internal formats} *)
+
+  method _R8_ : pixelFormat readonly_prop
+
+  method _R8_SNORM_ : pixelFormat readonly_prop
+
+  method _R16F_ : pixelFormat readonly_prop
+
+  method _R32F_ : pixelFormat readonly_prop
+
+  method _R8UI_ : pixelFormat readonly_prop
+
+  method _R8I_ : pixelFormat readonly_prop
+
+  method _R16UI_ : pixelFormat readonly_prop
+
+  method _R16I_ : pixelFormat readonly_prop
+
+  method _R32UI_ : pixelFormat readonly_prop
+
+  method _R32I_ : pixelFormat readonly_prop
+
+  method _RG8_ : pixelFormat readonly_prop
+
+  method _RG8_SNORM_ : pixelFormat readonly_prop
+
+  method _RG16F_ : pixelFormat readonly_prop
+
+  method _RG32F_ : pixelFormat readonly_prop
+
+  method _RG8UI_ : pixelFormat readonly_prop
+
+  method _RG8I_ : pixelFormat readonly_prop
+
+  method _RG16UI_ : pixelFormat readonly_prop
+
+  method _RG16I_ : pixelFormat readonly_prop
+
+  method _RG32UI_ : pixelFormat readonly_prop
+
+  method _RG32I_ : pixelFormat readonly_prop
+
+  method _RGB8_ : pixelFormat readonly_prop
+
+  method _SRGB8_ : pixelFormat readonly_prop
+
+  method _RGB8_SNORM_ : pixelFormat readonly_prop
+
+  method _R11F_G11F_B10F_ : pixelFormat readonly_prop
+
+  method _RGB9_E5_ : pixelFormat readonly_prop
+
+  method _RGB16F_ : pixelFormat readonly_prop
+
+  method _RGB32F_ : pixelFormat readonly_prop
+
+  method _RGB8UI_ : pixelFormat readonly_prop
+
+  method _RGB8I_ : pixelFormat readonly_prop
+
+  method _RGB16UI_ : pixelFormat readonly_prop
+
+  method _RGB16I_ : pixelFormat readonly_prop
+
+  method _RGB32UI_ : pixelFormat readonly_prop
+
+  method _RGB32I_ : pixelFormat readonly_prop
+
+  method _RGBA8_ : pixelFormat readonly_prop
+
+  method _SRGB8_ALPHA8_ : pixelFormat readonly_prop
+
+  method _RGBA8_SNORM_ : pixelFormat readonly_prop
+
+  method _RGB10_A2_ : pixelFormat readonly_prop
+
+  method _RGBA16F_ : pixelFormat readonly_prop
+
+  method _RGBA32F_ : pixelFormat readonly_prop
+
+  method _RGBA8UI_ : pixelFormat readonly_prop
+
+  method _RGBA8I_ : pixelFormat readonly_prop
+
+  method _RGB10_A2UI_ : pixelFormat readonly_prop
+
+  method _RGBA16UI_ : pixelFormat readonly_prop
+
+  method _RGBA16I_ : pixelFormat readonly_prop
+
+  method _RGBA32UI_ : pixelFormat readonly_prop
+
+  method _RGBA32I_ : pixelFormat readonly_prop
+
+  method _DEPTH_COMPONENT24_ : pixelFormat readonly_prop
+
+  method _DEPTH_COMPONENT32F_ : pixelFormat readonly_prop
+
+  method _DEPTH24_STENCIL8_ : pixelFormat readonly_prop
+
+  method _DEPTH32F_STENCIL8_ : pixelFormat readonly_prop
+
+  (** {3 New pixel types} *)
+
+  method _HALF_FLOAT_ : pixelType readonly_prop
+
+  method _UNSIGNED_INT_2_10_10_10_REV_ : pixelType readonly_prop
+
+  method _UNSIGNED_INT_10F_11F_11F_REV_ : pixelType readonly_prop
+
+  method _UNSIGNED_INT_5_9_9_9_REV_ : pixelType readonly_prop
+
+  method _UNSIGNED_INT_24_8_ : pixelType readonly_prop
+
+  method _FLOAT_32_UNSIGNED_INT_24_8_REV_ : pixelType readonly_prop
+
+  (** {3 New data types (vertex attributes)} *)
+
+  method _HALF_FLOAT_DT : dataType readonly_prop
+
+  (** {3 Draw / read buffers} *)
+
+  method _BACK_ : attachmentPoint readonly_prop
+
+  method _NONE_ : attachmentPoint readonly_prop
+
+  method _COLOR_ATTACHMENT1_ : attachmentPoint readonly_prop
+
+  method _COLOR_ATTACHMENT2_ : attachmentPoint readonly_prop
+
+  method _COLOR_ATTACHMENT3_ : attachmentPoint readonly_prop
+
+  method _COLOR_ATTACHMENT4_ : attachmentPoint readonly_prop
+
+  method _COLOR_ATTACHMENT5_ : attachmentPoint readonly_prop
+
+  method _COLOR_ATTACHMENT6_ : attachmentPoint readonly_prop
+
+  method _COLOR_ATTACHMENT7_ : attachmentPoint readonly_prop
+
+  method _COLOR_ATTACHMENT8_ : attachmentPoint readonly_prop
+
+  method _COLOR_ATTACHMENT9_ : attachmentPoint readonly_prop
+
+  method _COLOR_ATTACHMENT10_ : attachmentPoint readonly_prop
+
+  method _COLOR_ATTACHMENT11_ : attachmentPoint readonly_prop
+
+  method _COLOR_ATTACHMENT12_ : attachmentPoint readonly_prop
+
+  method _COLOR_ATTACHMENT13_ : attachmentPoint readonly_prop
+
+  method _COLOR_ATTACHMENT14_ : attachmentPoint readonly_prop
+
+  method _COLOR_ATTACHMENT15_ : attachmentPoint readonly_prop
+
+  (** {3 clearBuffer targets} *)
+
+  method _COLOR_CB : clearBuffer readonly_prop
+
+  method _DEPTH_CB : clearBuffer readonly_prop
+
+  method _STENCIL_CB : clearBuffer readonly_prop
+
+  method _DEPTH_STENCIL_CB : clearBuffer readonly_prop
+
+  (** {3 Query targets and parameters} *)
+
+  method _ANY_SAMPLES_PASSED_ : queryTarget readonly_prop
+
+  method _ANY_SAMPLES_PASSED_CONSERVATIVE_ : queryTarget readonly_prop
+
+  method _TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN_ : queryTarget readonly_prop
+
+  method _CURRENT_QUERY_ : currentQueryParam readonly_prop
+
+  method _QUERY_RESULT_ : int queryParam readonly_prop
+
+  method _QUERY_RESULT_AVAILABLE_ : bool t queryParam readonly_prop
+
+  (** {3 Sampler parameters} *)
+
+  method _TEXTURE_MAG_FILTER_SP : samplerParameterName readonly_prop
+
+  method _TEXTURE_MIN_FILTER_SP : samplerParameterName readonly_prop
+
+  method _TEXTURE_WRAP_S_SP : samplerParameterName readonly_prop
+
+  method _TEXTURE_WRAP_T_SP : samplerParameterName readonly_prop
+
+  method _TEXTURE_WRAP_R_SP : samplerParameterName readonly_prop
+
+  method _TEXTURE_MIN_LOD_SP : samplerParameterName readonly_prop
+
+  method _TEXTURE_MAX_LOD_SP : samplerParameterName readonly_prop
+
+  method _TEXTURE_COMPARE_MODE_SP : samplerParameterName readonly_prop
+
+  method _TEXTURE_COMPARE_FUNC_SP : samplerParameterName readonly_prop
+
+  (** {3 Sync objects} *)
+
+  method _SYNC_GPU_COMMANDS_COMPLETE_ : syncCondition readonly_prop
+
+  method _SYNC_FLUSH_COMMANDS_BIT_ : int readonly_prop
+
+  method _SYNC_STATUS_ : syncStatus syncParam readonly_prop
+
+  method _SYNC_CONDITION_ : syncCondition syncParam readonly_prop
+
+  method _SYNC_FLAGS_ : int syncParam readonly_prop
+
+  method _SIGNALED_ : syncStatus readonly_prop
+
+  method _UNSIGNALED_ : syncStatus readonly_prop
+
+  method _ALREADY_SIGNALED_ : clientWaitSyncStatus readonly_prop
+
+  method _TIMEOUT_EXPIRED_ : clientWaitSyncStatus readonly_prop
+
+  method _CONDITION_SATISFIED_ : clientWaitSyncStatus readonly_prop
+
+  method _WAIT_FAILED_ : clientWaitSyncStatus readonly_prop
+
+  (** {3 Transform feedback} *)
+
+  method _INTERLEAVED_ATTRIBS_ : transformFeedbackMode readonly_prop
+
+  method _SEPARATE_ATTRIBS_ : transformFeedbackMode readonly_prop
+
+  (** {3 Uniform buffer objects} *)
+
+  method _UNIFORM_TYPE_ : int activeUniformParam readonly_prop
+
+  method _UNIFORM_SIZE_ : int activeUniformParam readonly_prop
+
+  method _UNIFORM_BLOCK_INDEX_ : int activeUniformParam readonly_prop
+
+  method _UNIFORM_OFFSET_ : int activeUniformParam readonly_prop
+
+  method _UNIFORM_ARRAY_STRIDE_ : int activeUniformParam readonly_prop
+
+  method _UNIFORM_MATRIX_STRIDE_ : int activeUniformParam readonly_prop
+
+  method _UNIFORM_IS_ROW_MAJOR_ : bool t activeUniformParam readonly_prop
+
+  method _UNIFORM_BLOCK_BINDING_ : int uniformBlockParam readonly_prop
+
+  method _UNIFORM_BLOCK_DATA_SIZE_ : int uniformBlockParam readonly_prop
+
+  method _UNIFORM_BLOCK_ACTIVE_UNIFORMS_ : int uniformBlockParam readonly_prop
+
+  method _UNIFORM_BLOCK_ACTIVE_UNIFORM_INDICES_ :
+    Typed_array.uint32Array t uniformBlockParam readonly_prop
+
+  method _UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER_ :
+    bool t uniformBlockParam readonly_prop
+
+  method _UNIFORM_BLOCK_REFERENCED_BY_FRAGMENT_SHADER_ :
+    bool t uniformBlockParam readonly_prop
+
+  (** {3 New pixel store parameters} *)
+
+  method _PACK_ROW_LENGTH_ : int pixelStoreParam readonly_prop
+
+  method _PACK_SKIP_PIXELS_ : int pixelStoreParam readonly_prop
+
+  method _PACK_SKIP_ROWS_ : int pixelStoreParam readonly_prop
+
+  method _UNPACK_ROW_LENGTH_ : int pixelStoreParam readonly_prop
+
+  method _UNPACK_IMAGE_HEIGHT_ : int pixelStoreParam readonly_prop
+
+  method _UNPACK_SKIP_PIXELS_ : int pixelStoreParam readonly_prop
+
+  method _UNPACK_SKIP_ROWS_ : int pixelStoreParam readonly_prop
+
+  method _UNPACK_SKIP_IMAGES_ : int pixelStoreParam readonly_prop
+
+  (** {3 New integer query parameters} *)
+
+  method _MAX_3D_TEXTURE_SIZE_ : int parameter readonly_prop
+
+  method _MAX_ARRAY_TEXTURE_LAYERS_ : int parameter readonly_prop
+
+  method _MAX_COLOR_ATTACHMENTS_ : int parameter readonly_prop
+
+  method _MAX_DRAW_BUFFERS_ : int parameter readonly_prop
+
+  method _MAX_SAMPLES_ : int parameter readonly_prop
+
+  method _MAX_UNIFORM_BUFFER_BINDINGS_ : int parameter readonly_prop
+
+  method _MAX_VERTEX_UNIFORM_BLOCKS_ : int parameter readonly_prop
+
+  method _MAX_FRAGMENT_UNIFORM_BLOCKS_ : int parameter readonly_prop
+
+  method _UNIFORM_BUFFER_OFFSET_ALIGNMENT_ : int parameter readonly_prop
+end
+
+(** {2 Getting a WebGL2 context} *)
+
+class type canvasElement = object
+  method getContext : js_string t -> renderingContext t opt meth
+
+  method getContext_ :
+    js_string t -> WebGL.contextAttributes t -> renderingContext t opt meth
+end
+
+let getContext (c : Dom_html.canvasElement t) =
+  let c : canvasElement t = Js.Unsafe.coerce c in
+  c##getContext (Js.string "webgl2")
+
+let getContextWithAttributes (c : Dom_html.canvasElement t) attribs =
+  let c : canvasElement t = Js.Unsafe.coerce c in
+  c##getContext_ (Js.string "webgl2") attribs

--- a/lib/js_of_ocaml/webGL2.ml
+++ b/lib/js_of_ocaml/webGL2.ml
@@ -182,6 +182,12 @@ class type renderingContext = object
   method bindBufferRange :
     bufferTarget -> uint -> buffer t -> intptr -> sizeiptr -> unit meth
 
+  method bindBufferBase_ : bufferTarget -> uint -> buffer t opt -> unit meth
+  (** [bindBufferBase] accepting [null], to release an indexed binding. *)
+
+  method bindBufferRange_ :
+    bufferTarget -> uint -> buffer t opt -> intptr -> sizeiptr -> unit meth
+
   method bufferData_withOffset :
        bufferTarget
     -> #Typed_array.arrayBufferView t
@@ -571,10 +577,22 @@ class type renderingContext = object
   method framebufferTextureLayer :
     fbTarget -> attachmentPoint -> texture t -> int -> int -> unit meth
 
+  method framebufferTextureLayer_ :
+    fbTarget -> attachmentPoint -> texture t opt -> int -> int -> unit meth
+  (** [framebufferTextureLayer] accepting [null], to detach the attachment. *)
+
   method invalidateFramebuffer : fbTarget -> attachmentPoint js_array t -> unit meth
 
   method invalidateSubFramebuffer :
     fbTarget -> attachmentPoint js_array t -> int -> int -> sizei -> sizei -> unit meth
+
+  method invalidateFramebuffer_default : fbTarget -> clearBuffer js_array t -> unit meth
+  (** [invalidateFramebuffer] for when the default framebuffer is bound, whose
+      attachments are named by {!_COLOR_CB}, {!_DEPTH_CB} and {!_STENCIL_CB}
+      rather than by {!type:attachmentPoint}. *)
+
+  method invalidateSubFramebuffer_default :
+    fbTarget -> clearBuffer js_array t -> int -> int -> sizei -> sizei -> unit meth
 
   method readBuffer : attachmentPoint -> unit meth
 
@@ -715,7 +733,9 @@ class type renderingContext = object
 
   method isSampler : sampler t -> bool t meth
 
-  method bindSampler : uint -> sampler t opt -> unit meth
+  method bindSampler : uint -> sampler t -> unit meth
+
+  method bindSampler_ : uint -> sampler t opt -> unit meth
 
   method samplerParameteri : 'a. sampler t -> 'a samplerParam -> 'a -> unit meth
 
@@ -746,6 +766,9 @@ class type renderingContext = object
   method isTransformFeedback : transformFeedback t -> bool t meth
 
   method bindTransformFeedback :
+    transformFeedbackTarget -> transformFeedback t -> unit meth
+
+  method bindTransformFeedback_ :
     transformFeedbackTarget -> transformFeedback t opt -> unit meth
 
   method beginTransformFeedback : beginMode -> unit meth
@@ -786,7 +809,9 @@ class type renderingContext = object
 
   method isVertexArray : vertexArrayObject t -> bool t meth
 
-  method bindVertexArray : vertexArrayObject t opt -> unit meth
+  method bindVertexArray : vertexArrayObject t -> unit meth
+
+  method bindVertexArray_ : vertexArrayObject t opt -> unit meth
 
   (** {2 5.14.16 Instanced and range drawing} *)
 
@@ -1164,7 +1189,9 @@ class type renderingContext = object
   method _SYNC_FENCE_ : syncObjectType readonly_prop
 
   method _TIMEOUT_IGNORED_ : number_t readonly_prop
-  (** The special timeout value ([-1]) for [clientWaitSync]/[waitSync]. *)
+  (** The special timeout value ([-1]), accepted only by [waitSync];
+      [clientWaitSync] timeouts are instead capped by
+      {!_MAX_CLIENT_WAIT_TIMEOUT_WEBGL_}. *)
 
   (** {3 Transform feedback} *)
 
@@ -1460,8 +1487,6 @@ class type renderingContext = object
   method _LINEAR_CE : colorEncoding readonly_prop
 
   method _SRGB_CE : colorEncoding readonly_prop
-
-  method _DEPTH_STENCIL_ATTACHMENT_ : attachmentPoint readonly_prop
 
   method _FRAMEBUFFER_DEFAULT_ : objectType readonly_prop
 

--- a/lib/js_of_ocaml/webGL2.ml
+++ b/lib/js_of_ocaml/webGL2.ml
@@ -94,6 +94,12 @@ type texture = WebGL.texture
 
 type 'a uniformLocation = 'a WebGL.uniformLocation
 
+type 'a texParam = 'a WebGL.texParam
+
+type wrapMode = WebGL.wrapMode
+
+type depthFunction = WebGL.depthFunction
+
 (** {2 New WebGL2 objects} *)
 
 type query
@@ -131,6 +137,10 @@ type samplerParameterName
 type 'a activeUniformParam
 
 type 'a uniformBlockParam
+
+type transformFeedbackTarget
+
+type textureCompareMode
 
 class type renderingContext = object
   inherit WebGL.renderingContext
@@ -313,6 +323,13 @@ class type renderingContext = object
       ({!type:pixelFormat}); the WebGL1 [renderbufferStorage] taking a
       {!type:format} is still available through inheritance. *)
 
+  (** {2 5.14.8 Texture objects} *)
+
+  method texParameterf : texTarget -> number_t texParam -> number_t -> unit meth
+  (** [texParameterf] for the float texture parameters {!_TEXTURE_MIN_LOD_} and
+      {!_TEXTURE_MAX_LOD_}; the integer/enum parameters go through the inherited
+      [texParameteri]. *)
+
   (** {2 5.14.9 Multiple render targets} *)
 
   method drawBuffers : attachmentPoint js_array t -> unit meth
@@ -380,7 +397,8 @@ class type renderingContext = object
 
   method isTransformFeedback : transformFeedback t -> bool t meth
 
-  method bindTransformFeedback : bufferTarget -> transformFeedback t opt -> unit meth
+  method bindTransformFeedback :
+    transformFeedbackTarget -> transformFeedback t opt -> unit meth
 
   method beginTransformFeedback : beginMode -> unit meth
 
@@ -514,11 +532,42 @@ class type renderingContext = object
 
   method _DYNAMIC_COPY_ : bufferUsage readonly_prop
 
+  (** {3 Framebuffer targets} *)
+
+  method _READ_FRAMEBUFFER_ : fbTarget readonly_prop
+
+  method _DRAW_FRAMEBUFFER_ : fbTarget readonly_prop
+
+  (** {3 New capabilities} *)
+
+  method _RASTERIZER_DISCARD_ : enableCap readonly_prop
+
   (** {3 Texture targets} *)
 
   method _TEXTURE_3D_ : texTarget readonly_prop
 
   method _TEXTURE_2D_ARRAY_ : texTarget readonly_prop
+
+  (** {3 New texture parameters} *)
+
+  method _TEXTURE_WRAP_R_ : wrapMode texParam readonly_prop
+
+  method _TEXTURE_BASE_LEVEL_ : int texParam readonly_prop
+
+  method _TEXTURE_MAX_LEVEL_ : int texParam readonly_prop
+
+  method _TEXTURE_MIN_LOD_ : number_t texParam readonly_prop
+
+  method _TEXTURE_MAX_LOD_ : number_t texParam readonly_prop
+
+  method _TEXTURE_COMPARE_MODE_ : textureCompareMode texParam readonly_prop
+
+  method _TEXTURE_COMPARE_FUNC_ : depthFunction texParam readonly_prop
+
+  method _COMPARE_REF_TO_TEXTURE_ : textureCompareMode readonly_prop
+
+  method _NONE_TCM : textureCompareMode readonly_prop
+  (** The [NONE] value for {!_TEXTURE_COMPARE_MODE_}. *)
 
   (** {3 New external formats} *)
 
@@ -759,6 +808,8 @@ class type renderingContext = object
   method _WAIT_FAILED_ : clientWaitSyncStatus readonly_prop
 
   (** {3 Transform feedback} *)
+
+  method _TRANSFORM_FEEDBACK_ : transformFeedbackTarget readonly_prop
 
   method _INTERLEAVED_ATTRIBS_ : transformFeedbackMode readonly_prop
 

--- a/lib/js_of_ocaml/webGL2.mli
+++ b/lib/js_of_ocaml/webGL2.mli
@@ -93,6 +93,12 @@ type texture = WebGL.texture
 
 type 'a uniformLocation = 'a WebGL.uniformLocation
 
+type 'a texParam = 'a WebGL.texParam
+
+type wrapMode = WebGL.wrapMode
+
+type depthFunction = WebGL.depthFunction
+
 (** {2 New WebGL2 objects} *)
 
 type query
@@ -130,6 +136,10 @@ type samplerParameterName
 type 'a activeUniformParam
 
 type 'a uniformBlockParam
+
+type transformFeedbackTarget
+
+type textureCompareMode
 
 class type renderingContext = object
   inherit WebGL.renderingContext
@@ -312,6 +322,13 @@ class type renderingContext = object
       ({!type:pixelFormat}); the WebGL1 [renderbufferStorage] taking a
       {!type:format} is still available through inheritance. *)
 
+  (** {2 5.14.8 Texture objects} *)
+
+  method texParameterf : texTarget -> number_t texParam -> number_t -> unit meth
+  (** [texParameterf] for the float texture parameters {!_TEXTURE_MIN_LOD_} and
+      {!_TEXTURE_MAX_LOD_}; the integer/enum parameters go through the inherited
+      [texParameteri]. *)
+
   (** {2 5.14.9 Multiple render targets} *)
 
   method drawBuffers : attachmentPoint js_array t -> unit meth
@@ -379,7 +396,8 @@ class type renderingContext = object
 
   method isTransformFeedback : transformFeedback t -> bool t meth
 
-  method bindTransformFeedback : bufferTarget -> transformFeedback t opt -> unit meth
+  method bindTransformFeedback :
+    transformFeedbackTarget -> transformFeedback t opt -> unit meth
 
   method beginTransformFeedback : beginMode -> unit meth
 
@@ -513,11 +531,42 @@ class type renderingContext = object
 
   method _DYNAMIC_COPY_ : bufferUsage readonly_prop
 
+  (** {3 Framebuffer targets} *)
+
+  method _READ_FRAMEBUFFER_ : fbTarget readonly_prop
+
+  method _DRAW_FRAMEBUFFER_ : fbTarget readonly_prop
+
+  (** {3 New capabilities} *)
+
+  method _RASTERIZER_DISCARD_ : enableCap readonly_prop
+
   (** {3 Texture targets} *)
 
   method _TEXTURE_3D_ : texTarget readonly_prop
 
   method _TEXTURE_2D_ARRAY_ : texTarget readonly_prop
+
+  (** {3 New texture parameters} *)
+
+  method _TEXTURE_WRAP_R_ : wrapMode texParam readonly_prop
+
+  method _TEXTURE_BASE_LEVEL_ : int texParam readonly_prop
+
+  method _TEXTURE_MAX_LEVEL_ : int texParam readonly_prop
+
+  method _TEXTURE_MIN_LOD_ : number_t texParam readonly_prop
+
+  method _TEXTURE_MAX_LOD_ : number_t texParam readonly_prop
+
+  method _TEXTURE_COMPARE_MODE_ : textureCompareMode texParam readonly_prop
+
+  method _TEXTURE_COMPARE_FUNC_ : depthFunction texParam readonly_prop
+
+  method _COMPARE_REF_TO_TEXTURE_ : textureCompareMode readonly_prop
+
+  method _NONE_TCM : textureCompareMode readonly_prop
+  (** The [NONE] value for {!_TEXTURE_COMPARE_MODE_}. *)
 
   (** {3 New external formats} *)
 
@@ -758,6 +807,8 @@ class type renderingContext = object
   method _WAIT_FAILED_ : clientWaitSyncStatus readonly_prop
 
   (** {3 Transform feedback} *)
+
+  method _TRANSFORM_FEEDBACK_ : transformFeedbackTarget readonly_prop
 
   method _INTERLEAVED_ATTRIBS_ : transformFeedbackMode readonly_prop
 

--- a/lib/js_of_ocaml/webGL2.mli
+++ b/lib/js_of_ocaml/webGL2.mli
@@ -181,6 +181,12 @@ class type renderingContext = object
   method bindBufferRange :
     bufferTarget -> uint -> buffer t -> intptr -> sizeiptr -> unit meth
 
+  method bindBufferBase_ : bufferTarget -> uint -> buffer t opt -> unit meth
+  (** [bindBufferBase] accepting [null], to release an indexed binding. *)
+
+  method bindBufferRange_ :
+    bufferTarget -> uint -> buffer t opt -> intptr -> sizeiptr -> unit meth
+
   method bufferData_withOffset :
        bufferTarget
     -> #Typed_array.arrayBufferView t
@@ -570,10 +576,22 @@ class type renderingContext = object
   method framebufferTextureLayer :
     fbTarget -> attachmentPoint -> texture t -> int -> int -> unit meth
 
+  method framebufferTextureLayer_ :
+    fbTarget -> attachmentPoint -> texture t opt -> int -> int -> unit meth
+  (** [framebufferTextureLayer] accepting [null], to detach the attachment. *)
+
   method invalidateFramebuffer : fbTarget -> attachmentPoint js_array t -> unit meth
 
   method invalidateSubFramebuffer :
     fbTarget -> attachmentPoint js_array t -> int -> int -> sizei -> sizei -> unit meth
+
+  method invalidateFramebuffer_default : fbTarget -> clearBuffer js_array t -> unit meth
+  (** [invalidateFramebuffer] for when the default framebuffer is bound, whose
+      attachments are named by {!_COLOR_CB}, {!_DEPTH_CB} and {!_STENCIL_CB}
+      rather than by {!type:attachmentPoint}. *)
+
+  method invalidateSubFramebuffer_default :
+    fbTarget -> clearBuffer js_array t -> int -> int -> sizei -> sizei -> unit meth
 
   method readBuffer : attachmentPoint -> unit meth
 
@@ -714,7 +732,9 @@ class type renderingContext = object
 
   method isSampler : sampler t -> bool t meth
 
-  method bindSampler : uint -> sampler t opt -> unit meth
+  method bindSampler : uint -> sampler t -> unit meth
+
+  method bindSampler_ : uint -> sampler t opt -> unit meth
 
   method samplerParameteri : 'a. sampler t -> 'a samplerParam -> 'a -> unit meth
 
@@ -745,6 +765,9 @@ class type renderingContext = object
   method isTransformFeedback : transformFeedback t -> bool t meth
 
   method bindTransformFeedback :
+    transformFeedbackTarget -> transformFeedback t -> unit meth
+
+  method bindTransformFeedback_ :
     transformFeedbackTarget -> transformFeedback t opt -> unit meth
 
   method beginTransformFeedback : beginMode -> unit meth
@@ -785,7 +808,9 @@ class type renderingContext = object
 
   method isVertexArray : vertexArrayObject t -> bool t meth
 
-  method bindVertexArray : vertexArrayObject t opt -> unit meth
+  method bindVertexArray : vertexArrayObject t -> unit meth
+
+  method bindVertexArray_ : vertexArrayObject t opt -> unit meth
 
   (** {2 5.14.16 Instanced and range drawing} *)
 
@@ -1163,7 +1188,9 @@ class type renderingContext = object
   method _SYNC_FENCE_ : syncObjectType readonly_prop
 
   method _TIMEOUT_IGNORED_ : number_t readonly_prop
-  (** The special timeout value ([-1]) for [clientWaitSync]/[waitSync]. *)
+  (** The special timeout value ([-1]), accepted only by [waitSync];
+      [clientWaitSync] timeouts are instead capped by
+      {!_MAX_CLIENT_WAIT_TIMEOUT_WEBGL_}. *)
 
   (** {3 Transform feedback} *)
 
@@ -1459,8 +1486,6 @@ class type renderingContext = object
   method _LINEAR_CE : colorEncoding readonly_prop
 
   method _SRGB_CE : colorEncoding readonly_prop
-
-  method _DEPTH_STENCIL_ATTACHMENT_ : attachmentPoint readonly_prop
 
   method _FRAMEBUFFER_DEFAULT_ : objectType readonly_prop
 

--- a/lib/js_of_ocaml/webGL2.mli
+++ b/lib/js_of_ocaml/webGL2.mli
@@ -99,6 +99,20 @@ type wrapMode = WebGL.wrapMode
 
 type depthFunction = WebGL.depthFunction
 
+type 'a programParam = 'a WebGL.programParam
+
+type 'a vertexAttribParam = 'a WebGL.vertexAttribParam
+
+type 'a attachParam = 'a WebGL.attachParam
+
+type framebufferStatus = WebGL.framebufferStatus
+
+type uniformType = WebGL.uniformType
+
+type hintTarget = WebGL.hintTarget
+
+type objectType = WebGL.objectType
+
 (** {2 New WebGL2 objects} *)
 
 type query
@@ -131,7 +145,7 @@ type clearBuffer
 
 type transformFeedbackMode
 
-type samplerParameterName
+type 'a samplerParam
 
 type 'a activeUniformParam
 
@@ -140,6 +154,16 @@ type 'a uniformBlockParam
 type transformFeedbackTarget
 
 type textureCompareMode
+
+type 'a indexedParameter
+
+type 'a internalformatParam
+
+type componentType
+
+type colorEncoding
+
+type syncObjectType
 
 class type renderingContext = object
   inherit WebGL.renderingContext
@@ -156,6 +180,26 @@ class type renderingContext = object
 
   method bindBufferRange :
     bufferTarget -> uint -> buffer t -> intptr -> sizeiptr -> unit meth
+
+  method bufferData_withOffset :
+       bufferTarget
+    -> #Typed_array.arrayBufferView t
+    -> bufferUsage
+    -> int
+    -> int
+    -> unit meth
+  (** [bufferData target srcData usage srcOffset length]; a [length] of [0]
+      means up to the end of [srcData]. *)
+
+  method bufferSubData_withOffset :
+    bufferTarget -> intptr -> #Typed_array.arrayBufferView t -> int -> int -> unit meth
+  (** [bufferSubData target dstByteOffset srcData srcOffset length]. *)
+
+  method getBufferSubData_withOffset :
+    bufferTarget -> intptr -> #Typed_array.arrayBufferView t -> int -> int -> unit meth
+  (** [getBufferSubData target srcByteOffset dstBuffer dstOffset length]. *)
+
+  method getIndexedParameter : 'a. 'a indexedParameter -> uint -> 'a meth
 
   (** {2 5.14.3 Programs and shaders} *)
 
@@ -255,6 +299,121 @@ class type renderingContext = object
     -> #Typed_array.arrayBufferView t
     -> unit meth
 
+  method texImage3D_pbo :
+       texTarget
+    -> int
+    -> pixelFormat
+    -> sizei
+    -> sizei
+    -> sizei
+    -> int
+    -> pixelFormat
+    -> pixelType
+    -> intptr
+    -> unit meth
+  (** [texImage3D] sourcing its data from the buffer bound to
+      [PIXEL_UNPACK_BUFFER], at the given byte offset. *)
+
+  method texImage3D_withOffset :
+       texTarget
+    -> int
+    -> pixelFormat
+    -> sizei
+    -> sizei
+    -> sizei
+    -> int
+    -> pixelFormat
+    -> pixelType
+    -> #Typed_array.arrayBufferView t
+    -> int
+    -> unit meth
+  (** [texImage3D] reading from the view starting at element [srcOffset]. *)
+
+  method texSubImage3D_fromImageData :
+       texTarget
+    -> int
+    -> int
+    -> int
+    -> int
+    -> sizei
+    -> sizei
+    -> sizei
+    -> pixelFormat
+    -> pixelType
+    -> Dom_html.imageData t
+    -> unit meth
+
+  method texSubImage3D_fromImage :
+       texTarget
+    -> int
+    -> int
+    -> int
+    -> int
+    -> sizei
+    -> sizei
+    -> sizei
+    -> pixelFormat
+    -> pixelType
+    -> Dom_html.imageElement t
+    -> unit meth
+
+  method texSubImage3D_fromCanvas :
+       texTarget
+    -> int
+    -> int
+    -> int
+    -> int
+    -> sizei
+    -> sizei
+    -> sizei
+    -> pixelFormat
+    -> pixelType
+    -> Dom_html.canvasElement t
+    -> unit meth
+
+  method texSubImage3D_fromVideo :
+       texTarget
+    -> int
+    -> int
+    -> int
+    -> int
+    -> sizei
+    -> sizei
+    -> sizei
+    -> pixelFormat
+    -> pixelType
+    -> Dom_html.videoElement t
+    -> unit meth
+
+  method texSubImage3D_pbo :
+       texTarget
+    -> int
+    -> int
+    -> int
+    -> int
+    -> sizei
+    -> sizei
+    -> sizei
+    -> pixelFormat
+    -> pixelType
+    -> intptr
+    -> unit meth
+
+  method texSubImage3D_withOffset :
+       texTarget
+    -> int
+    -> int
+    -> int
+    -> int
+    -> sizei
+    -> sizei
+    -> sizei
+    -> pixelFormat
+    -> pixelType
+    -> #Typed_array.arrayBufferView t
+    -> int
+    -> unit meth
+
   method copyTexSubImage3D :
     texTarget -> int -> int -> int -> int -> int -> int -> sizei -> sizei -> unit meth
 
@@ -280,6 +439,112 @@ class type renderingContext = object
     -> sizei
     -> pixelFormat
     -> #Typed_array.arrayBufferView t
+    -> unit meth
+
+  method compressedTexImage2D_pbo :
+       texTarget
+    -> int
+    -> pixelFormat
+    -> sizei
+    -> sizei
+    -> int
+    -> sizei
+    -> intptr
+    -> unit meth
+  (** [compressedTexImage2D target level internalformat width height border
+      imageSize offset], reading from the buffer bound to
+      [PIXEL_UNPACK_BUFFER]. *)
+
+  method compressedTexImage2D_withOffset :
+       texTarget
+    -> int
+    -> pixelFormat
+    -> sizei
+    -> sizei
+    -> int
+    -> #Typed_array.arrayBufferView t
+    -> int
+    -> int
+    -> unit meth
+  (** [compressedTexImage2D ... srcData srcOffset srcLengthOverride]. *)
+
+  method compressedTexSubImage2D_pbo :
+       texTarget
+    -> int
+    -> int
+    -> int
+    -> sizei
+    -> sizei
+    -> pixelFormat
+    -> sizei
+    -> intptr
+    -> unit meth
+
+  method compressedTexSubImage2D_withOffset :
+       texTarget
+    -> int
+    -> int
+    -> int
+    -> sizei
+    -> sizei
+    -> pixelFormat
+    -> #Typed_array.arrayBufferView t
+    -> int
+    -> int
+    -> unit meth
+
+  method compressedTexImage3D_pbo :
+       texTarget
+    -> int
+    -> pixelFormat
+    -> sizei
+    -> sizei
+    -> sizei
+    -> int
+    -> sizei
+    -> intptr
+    -> unit meth
+
+  method compressedTexImage3D_withOffset :
+       texTarget
+    -> int
+    -> pixelFormat
+    -> sizei
+    -> sizei
+    -> sizei
+    -> int
+    -> #Typed_array.arrayBufferView t
+    -> int
+    -> int
+    -> unit meth
+
+  method compressedTexSubImage3D_pbo :
+       texTarget
+    -> int
+    -> int
+    -> int
+    -> int
+    -> sizei
+    -> sizei
+    -> sizei
+    -> pixelFormat
+    -> sizei
+    -> intptr
+    -> unit meth
+
+  method compressedTexSubImage3D_withOffset :
+       texTarget
+    -> int
+    -> int
+    -> int
+    -> int
+    -> sizei
+    -> sizei
+    -> sizei
+    -> pixelFormat
+    -> #Typed_array.arrayBufferView t
+    -> int
+    -> int
     -> unit meth
 
   method texStorage2D : texTarget -> sizei -> pixelFormat -> sizei -> sizei -> unit meth
@@ -322,6 +587,9 @@ class type renderingContext = object
       ({!type:pixelFormat}); the WebGL1 [renderbufferStorage] taking a
       {!type:format} is still available through inheritance. *)
 
+  method getInternalformatParameter :
+    'a. rbTarget -> pixelFormat -> 'a internalformatParam -> 'a meth
+
   (** {2 5.14.8 Texture objects} *)
 
   method texParameterf : texTarget -> number_t texParam -> number_t -> unit meth
@@ -329,16 +597,96 @@ class type renderingContext = object
       {!_TEXTURE_MAX_LOD_}; the integer/enum parameters go through the inherited
       [texParameteri]. *)
 
+  method texImage2D_pbo :
+       texTarget
+    -> int
+    -> pixelFormat
+    -> sizei
+    -> sizei
+    -> int
+    -> pixelFormat
+    -> pixelType
+    -> intptr
+    -> unit meth
+  (** [texImage2D] sourcing its data from the buffer bound to
+      [PIXEL_UNPACK_BUFFER], at the given byte offset. *)
+
+  method texImage2D_withOffset :
+       texTarget
+    -> int
+    -> pixelFormat
+    -> sizei
+    -> sizei
+    -> int
+    -> pixelFormat
+    -> pixelType
+    -> #Typed_array.arrayBufferView t
+    -> int
+    -> unit meth
+  (** [texImage2D] reading from the view starting at element [srcOffset]. *)
+
+  method texSubImage2D_pbo :
+       texTarget
+    -> int
+    -> int
+    -> int
+    -> sizei
+    -> sizei
+    -> pixelFormat
+    -> pixelType
+    -> intptr
+    -> unit meth
+
+  method texSubImage2D_withOffset :
+       texTarget
+    -> int
+    -> int
+    -> int
+    -> sizei
+    -> sizei
+    -> pixelFormat
+    -> pixelType
+    -> #Typed_array.arrayBufferView t
+    -> int
+    -> unit meth
+
+  (** {2 5.14.12 Reading back pixels} *)
+
+  method readPixels_pbo :
+    int -> int -> sizei -> sizei -> pixelFormat -> pixelType -> intptr -> unit meth
+  (** [readPixels] writing into the buffer bound to [PIXEL_PACK_BUFFER], at the
+      given byte offset. *)
+
+  method readPixels_withOffset :
+       int
+    -> int
+    -> sizei
+    -> sizei
+    -> pixelFormat
+    -> pixelType
+    -> #Typed_array.arrayBufferView t
+    -> int
+    -> unit meth
+  (** [readPixels] writing into the view starting at element [dstOffset]. *)
+
   (** {2 5.14.9 Multiple render targets} *)
 
   method drawBuffers : attachmentPoint js_array t -> unit meth
 
-  method clearBufferiv : clearBuffer -> int -> #Typed_array.arrayBufferView t -> unit meth
+  method clearBufferiv : clearBuffer -> int -> Typed_array.int32Array t -> unit meth
 
-  method clearBufferuiv :
-    clearBuffer -> int -> #Typed_array.arrayBufferView t -> unit meth
+  method clearBufferuiv : clearBuffer -> int -> Typed_array.uint32Array t -> unit meth
 
-  method clearBufferfv : clearBuffer -> int -> #Typed_array.arrayBufferView t -> unit meth
+  method clearBufferfv : clearBuffer -> int -> Typed_array.float32Array t -> unit meth
+
+  method clearBufferiv_withOffset :
+    clearBuffer -> int -> Typed_array.int32Array t -> int -> unit meth
+
+  method clearBufferuiv_withOffset :
+    clearBuffer -> int -> Typed_array.uint32Array t -> int -> unit meth
+
+  method clearBufferfv_withOffset :
+    clearBuffer -> int -> Typed_array.float32Array t -> int -> unit meth
 
   method clearBufferfi : clearBuffer -> int -> number_t -> int -> unit meth
 
@@ -368,11 +716,11 @@ class type renderingContext = object
 
   method bindSampler : uint -> sampler t opt -> unit meth
 
-  method samplerParameteri : sampler t -> samplerParameterName -> int -> unit meth
+  method samplerParameteri : 'a. sampler t -> 'a samplerParam -> 'a -> unit meth
 
-  method samplerParameterf : sampler t -> samplerParameterName -> number_t -> unit meth
+  method samplerParameterf : sampler t -> number_t samplerParam -> number_t -> unit meth
 
-  method getSamplerParameter : 'a. sampler t -> samplerParameterName -> 'a meth
+  method getSamplerParameter : 'a. sampler t -> 'a samplerParam -> 'a meth
 
   (** {2 5.14.12 Sync objects} *)
 
@@ -567,6 +915,10 @@ class type renderingContext = object
 
   method _NONE_TCM : textureCompareMode readonly_prop
   (** The [NONE] value for {!_TEXTURE_COMPARE_MODE_}. *)
+
+  method _TEXTURE_IMMUTABLE_FORMAT_ : bool t texParam readonly_prop
+
+  method _TEXTURE_IMMUTABLE_LEVELS_ : int texParam readonly_prop
 
   (** {3 New external formats} *)
 
@@ -764,23 +1116,23 @@ class type renderingContext = object
 
   (** {3 Sampler parameters} *)
 
-  method _TEXTURE_MAG_FILTER_SP : samplerParameterName readonly_prop
+  method _TEXTURE_MAG_FILTER_SP : texFilter samplerParam readonly_prop
 
-  method _TEXTURE_MIN_FILTER_SP : samplerParameterName readonly_prop
+  method _TEXTURE_MIN_FILTER_SP : texFilter samplerParam readonly_prop
 
-  method _TEXTURE_WRAP_S_SP : samplerParameterName readonly_prop
+  method _TEXTURE_WRAP_S_SP : wrapMode samplerParam readonly_prop
 
-  method _TEXTURE_WRAP_T_SP : samplerParameterName readonly_prop
+  method _TEXTURE_WRAP_T_SP : wrapMode samplerParam readonly_prop
 
-  method _TEXTURE_WRAP_R_SP : samplerParameterName readonly_prop
+  method _TEXTURE_WRAP_R_SP : wrapMode samplerParam readonly_prop
 
-  method _TEXTURE_MIN_LOD_SP : samplerParameterName readonly_prop
+  method _TEXTURE_MIN_LOD_SP : number_t samplerParam readonly_prop
 
-  method _TEXTURE_MAX_LOD_SP : samplerParameterName readonly_prop
+  method _TEXTURE_MAX_LOD_SP : number_t samplerParam readonly_prop
 
-  method _TEXTURE_COMPARE_MODE_SP : samplerParameterName readonly_prop
+  method _TEXTURE_COMPARE_MODE_SP : textureCompareMode samplerParam readonly_prop
 
-  method _TEXTURE_COMPARE_FUNC_SP : samplerParameterName readonly_prop
+  method _TEXTURE_COMPARE_FUNC_SP : depthFunction samplerParam readonly_prop
 
   (** {3 Sync objects} *)
 
@@ -805,6 +1157,13 @@ class type renderingContext = object
   method _CONDITION_SATISFIED_ : clientWaitSyncStatus readonly_prop
 
   method _WAIT_FAILED_ : clientWaitSyncStatus readonly_prop
+
+  method _OBJECT_TYPE_ : syncObjectType syncParam readonly_prop
+
+  method _SYNC_FENCE_ : syncObjectType readonly_prop
+
+  method _TIMEOUT_IGNORED_ : number_t readonly_prop
+  (** The special timeout value ([-1]) for [clientWaitSync]/[waitSync]. *)
 
   (** {3 Transform feedback} *)
 
@@ -845,6 +1204,11 @@ class type renderingContext = object
   method _UNIFORM_BLOCK_REFERENCED_BY_FRAGMENT_SHADER_ :
     bool t uniformBlockParam readonly_prop
 
+  method _INVALID_INDEX_ : uint readonly_prop
+  (** Returned by [getUniformIndices]/[getUniformBlockIndex] for unknown names
+      (the value is [0xFFFFFFFF], which does not fit a 32-bit OCaml [int];
+      only use it for equality tests). *)
+
   (** {3 New pixel store parameters} *)
 
   method _PACK_ROW_LENGTH_ : int pixelStoreParam readonly_prop
@@ -882,6 +1246,225 @@ class type renderingContext = object
   method _MAX_FRAGMENT_UNIFORM_BLOCKS_ : int parameter readonly_prop
 
   method _UNIFORM_BUFFER_OFFSET_ALIGNMENT_ : int parameter readonly_prop
+
+  method _MAX_ELEMENTS_VERTICES_ : int parameter readonly_prop
+
+  method _MAX_ELEMENTS_INDICES_ : int parameter readonly_prop
+
+  method _MAX_VARYING_COMPONENTS_ : int parameter readonly_prop
+
+  method _MAX_VERTEX_UNIFORM_COMPONENTS_ : int parameter readonly_prop
+
+  method _MAX_FRAGMENT_UNIFORM_COMPONENTS_ : int parameter readonly_prop
+
+  method _MAX_VERTEX_OUTPUT_COMPONENTS_ : int parameter readonly_prop
+
+  method _MAX_FRAGMENT_INPUT_COMPONENTS_ : int parameter readonly_prop
+
+  method _MIN_PROGRAM_TEXEL_OFFSET_ : int parameter readonly_prop
+
+  method _MAX_PROGRAM_TEXEL_OFFSET_ : int parameter readonly_prop
+
+  method _MAX_COMBINED_UNIFORM_BLOCKS_ : int parameter readonly_prop
+
+  method _MAX_TRANSFORM_FEEDBACK_INTERLEAVED_COMPONENTS_ : int parameter readonly_prop
+
+  method _MAX_TRANSFORM_FEEDBACK_SEPARATE_ATTRIBS_ : int parameter readonly_prop
+
+  method _MAX_TRANSFORM_FEEDBACK_SEPARATE_COMPONENTS_ : int parameter readonly_prop
+
+  method _MAX_ELEMENT_INDEX_ : number_t parameter readonly_prop
+
+  method _MAX_SERVER_WAIT_TIMEOUT_ : number_t parameter readonly_prop
+
+  method _MAX_UNIFORM_BLOCK_SIZE_ : number_t parameter readonly_prop
+
+  method _MAX_COMBINED_VERTEX_UNIFORM_COMPONENTS_ : number_t parameter readonly_prop
+
+  method _MAX_COMBINED_FRAGMENT_UNIFORM_COMPONENTS_ : number_t parameter readonly_prop
+
+  method _MAX_TEXTURE_LOD_BIAS_ : number_t parameter readonly_prop
+
+  method _MAX_CLIENT_WAIT_TIMEOUT_WEBGL_ : number_t parameter readonly_prop
+
+  method _READ_BUFFER_ : attachmentPoint parameter readonly_prop
+
+  method _FRAGMENT_SHADER_DERIVATIVE_HINT_ : hintTarget readonly_prop
+
+  method _TRANSFORM_FEEDBACK_ACTIVE_ : bool t parameter readonly_prop
+
+  method _TRANSFORM_FEEDBACK_PAUSED_ : bool t parameter readonly_prop
+
+  (** {3 Binding-point queries} *)
+
+  method _VERTEX_ARRAY_BINDING_ : vertexArrayObject t opt parameter readonly_prop
+
+  method _SAMPLER_BINDING_ : sampler t opt parameter readonly_prop
+
+  method _READ_FRAMEBUFFER_BINDING_ : framebuffer t opt parameter readonly_prop
+
+  method _DRAW_FRAMEBUFFER_BINDING_ : framebuffer t opt parameter readonly_prop
+
+  method _COPY_READ_BUFFER_BINDING_ : buffer t opt parameter readonly_prop
+
+  method _COPY_WRITE_BUFFER_BINDING_ : buffer t opt parameter readonly_prop
+
+  method _PIXEL_PACK_BUFFER_BINDING_ : buffer t opt parameter readonly_prop
+
+  method _PIXEL_UNPACK_BUFFER_BINDING_ : buffer t opt parameter readonly_prop
+
+  method _TRANSFORM_FEEDBACK_BINDING_ : transformFeedback t opt parameter readonly_prop
+
+  method _DRAW_BUFFER0_ : attachmentPoint parameter readonly_prop
+
+  method _DRAW_BUFFER1_ : attachmentPoint parameter readonly_prop
+
+  method _DRAW_BUFFER2_ : attachmentPoint parameter readonly_prop
+
+  method _DRAW_BUFFER3_ : attachmentPoint parameter readonly_prop
+
+  method _DRAW_BUFFER4_ : attachmentPoint parameter readonly_prop
+
+  method _DRAW_BUFFER5_ : attachmentPoint parameter readonly_prop
+
+  method _DRAW_BUFFER6_ : attachmentPoint parameter readonly_prop
+
+  method _DRAW_BUFFER7_ : attachmentPoint parameter readonly_prop
+
+  method _DRAW_BUFFER8_ : attachmentPoint parameter readonly_prop
+
+  method _DRAW_BUFFER9_ : attachmentPoint parameter readonly_prop
+
+  method _DRAW_BUFFER10_ : attachmentPoint parameter readonly_prop
+
+  method _DRAW_BUFFER11_ : attachmentPoint parameter readonly_prop
+
+  method _DRAW_BUFFER12_ : attachmentPoint parameter readonly_prop
+
+  method _DRAW_BUFFER13_ : attachmentPoint parameter readonly_prop
+
+  method _DRAW_BUFFER14_ : attachmentPoint parameter readonly_prop
+
+  method _DRAW_BUFFER15_ : attachmentPoint parameter readonly_prop
+
+  (** {3 Indexed parameters} *)
+
+  method _TRANSFORM_FEEDBACK_BUFFER_BINDING_ : buffer t opt indexedParameter readonly_prop
+
+  method _TRANSFORM_FEEDBACK_BUFFER_START_ : int indexedParameter readonly_prop
+
+  method _TRANSFORM_FEEDBACK_BUFFER_SIZE_ : int indexedParameter readonly_prop
+
+  method _UNIFORM_BUFFER_BINDING_ : buffer t opt indexedParameter readonly_prop
+
+  method _UNIFORM_BUFFER_START_ : int indexedParameter readonly_prop
+
+  method _UNIFORM_BUFFER_SIZE_ : int indexedParameter readonly_prop
+
+  (** {3 Internal format queries} *)
+
+  method _SAMPLES_IFP : Typed_array.int32Array t internalformatParam readonly_prop
+
+  (** {3 Program and vertex attribute parameters} *)
+
+  method _TRANSFORM_FEEDBACK_BUFFER_MODE_ :
+    transformFeedbackMode programParam readonly_prop
+
+  method _TRANSFORM_FEEDBACK_VARYINGS_ : int programParam readonly_prop
+
+  method _ACTIVE_UNIFORM_BLOCKS_ : int programParam readonly_prop
+
+  method _VERTEX_ATTRIB_ARRAY_INTEGER_ : bool t vertexAttribParam readonly_prop
+
+  method _VERTEX_ATTRIB_ARRAY_DIVISOR_ : int vertexAttribParam readonly_prop
+
+  (** {3 New uniform types} *)
+
+  method _UNSIGNED_INT_UT : uniformType readonly_prop
+
+  method _UNSIGNED_INT_VEC2_ : uniformType readonly_prop
+
+  method _UNSIGNED_INT_VEC3_ : uniformType readonly_prop
+
+  method _UNSIGNED_INT_VEC4_ : uniformType readonly_prop
+
+  method _FLOAT_MAT2x3_ : uniformType readonly_prop
+
+  method _FLOAT_MAT2x4_ : uniformType readonly_prop
+
+  method _FLOAT_MAT3x2_ : uniformType readonly_prop
+
+  method _FLOAT_MAT3x4_ : uniformType readonly_prop
+
+  method _FLOAT_MAT4x2_ : uniformType readonly_prop
+
+  method _FLOAT_MAT4x3_ : uniformType readonly_prop
+
+  method _SAMPLER_3D_ : uniformType readonly_prop
+
+  method _SAMPLER_2D_SHADOW_ : uniformType readonly_prop
+
+  method _SAMPLER_2D_ARRAY_ : uniformType readonly_prop
+
+  method _SAMPLER_2D_ARRAY_SHADOW_ : uniformType readonly_prop
+
+  method _SAMPLER_CUBE_SHADOW_ : uniformType readonly_prop
+
+  method _INT_SAMPLER_2D_ : uniformType readonly_prop
+
+  method _INT_SAMPLER_3D_ : uniformType readonly_prop
+
+  method _INT_SAMPLER_CUBE_ : uniformType readonly_prop
+
+  method _INT_SAMPLER_2D_ARRAY_ : uniformType readonly_prop
+
+  method _UNSIGNED_INT_SAMPLER_2D_ : uniformType readonly_prop
+
+  method _UNSIGNED_INT_SAMPLER_3D_ : uniformType readonly_prop
+
+  method _UNSIGNED_INT_SAMPLER_CUBE_ : uniformType readonly_prop
+
+  method _UNSIGNED_INT_SAMPLER_2D_ARRAY_ : uniformType readonly_prop
+
+  (** {3 Framebuffer introspection} *)
+
+  method _FRAMEBUFFER_ATTACHMENT_RED_SIZE_ : int attachParam readonly_prop
+
+  method _FRAMEBUFFER_ATTACHMENT_GREEN_SIZE_ : int attachParam readonly_prop
+
+  method _FRAMEBUFFER_ATTACHMENT_BLUE_SIZE_ : int attachParam readonly_prop
+
+  method _FRAMEBUFFER_ATTACHMENT_ALPHA_SIZE_ : int attachParam readonly_prop
+
+  method _FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE_ : int attachParam readonly_prop
+
+  method _FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE_ : int attachParam readonly_prop
+
+  method _FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE_ : componentType attachParam readonly_prop
+
+  method _FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING_ : colorEncoding attachParam readonly_prop
+
+  method _FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER_ : int attachParam readonly_prop
+
+  method _FLOAT_CT : componentType readonly_prop
+
+  method _INT_CT : componentType readonly_prop
+
+  method _UNSIGNED_INT_CT : componentType readonly_prop
+
+  method _SIGNED_NORMALIZED_ : componentType readonly_prop
+
+  method _UNSIGNED_NORMALIZED_ : componentType readonly_prop
+
+  method _LINEAR_CE : colorEncoding readonly_prop
+
+  method _SRGB_CE : colorEncoding readonly_prop
+
+  method _DEPTH_STENCIL_ATTACHMENT_ : attachmentPoint readonly_prop
+
+  method _FRAMEBUFFER_DEFAULT_ : objectType readonly_prop
+
+  method _FRAMEBUFFER_INCOMPLETE_MULTISAMPLE_ : framebufferStatus readonly_prop
 end
 
 (** {2 Getting a WebGL2 context} *)

--- a/lib/js_of_ocaml/webGL2.mli
+++ b/lib/js_of_ocaml/webGL2.mli
@@ -1,0 +1,841 @@
+(* Js_of_ocaml library
+ * http://www.ocsigen.org/js_of_ocaml/
+ * Copyright (C) 2024 Ocsigen team
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+
+(** WebGL2 binding.
+
+    WebGL2 ([WebGL2RenderingContext]) is a strict superset of WebGL1, so the
+    context {!type:renderingContext} inherits every method and constant of
+    {!WebGL.renderingContext} and adds the WebGL2 ones on top.
+
+    Following the pragmatic style of {!WebGL}, the enumerations are kept as
+    abstract types shared between related uses.  In particular the many WebGL2
+    sized internal formats and the plain formats share the single type
+    {!type:pixelFormat}; the binding therefore does not enforce, at compile
+    time, that the (internalformat, format, type) triples passed to e.g.
+    {!renderingContext.texImage3D} are mutually coherent (WebGL itself is not
+    type safe there). *)
+
+open Js
+
+(** {2 Types reused from WebGL1} *)
+
+type sizei = WebGL.sizei
+
+type sizeiptr = WebGL.sizeiptr
+
+type intptr = WebGL.intptr
+
+type uint = WebGL.uint
+
+type clampf = WebGL.clampf
+
+type void = WebGL.void
+
+type clearBufferMask = WebGL.clearBufferMask
+
+type beginMode = WebGL.beginMode
+
+type bufferTarget = WebGL.bufferTarget
+
+type bufferUsage = WebGL.bufferUsage
+
+type enableCap = WebGL.enableCap
+
+type dataType = WebGL.dataType
+
+type pixelType = WebGL.pixelType
+
+type pixelFormat = WebGL.pixelFormat
+
+type format = WebGL.format
+
+type texTarget = WebGL.texTarget
+
+type texFilter = WebGL.texFilter
+
+type rbTarget = WebGL.rbTarget
+
+type fbTarget = WebGL.fbTarget
+
+type attachmentPoint = WebGL.attachmentPoint
+
+type 'a parameter = 'a WebGL.parameter
+
+type 'a pixelStoreParam = 'a WebGL.pixelStoreParam
+
+type buffer = WebGL.buffer
+
+type framebuffer = WebGL.framebuffer
+
+type program = WebGL.program
+
+type renderbuffer = WebGL.renderbuffer
+
+type shader = WebGL.shader
+
+type texture = WebGL.texture
+
+type 'a uniformLocation = 'a WebGL.uniformLocation
+
+(** {2 New WebGL2 objects} *)
+
+type query
+
+type sampler
+
+type sync
+
+type transformFeedback
+
+type vertexArrayObject
+
+(** {2 New WebGL2 enumerations} *)
+
+type queryTarget
+
+type currentQueryParam
+
+type 'a queryParam
+
+type syncCondition
+
+type 'a syncParam
+
+type syncStatus
+
+type clientWaitSyncStatus
+
+type clearBuffer
+
+type transformFeedbackMode
+
+type samplerParameterName
+
+type 'a activeUniformParam
+
+type 'a uniformBlockParam
+
+class type renderingContext = object
+  inherit WebGL.renderingContext
+
+  (** {2 5.14.2 Setting and getting state (buffers)} *)
+
+  method copyBufferSubData :
+    bufferTarget -> bufferTarget -> intptr -> intptr -> sizeiptr -> unit meth
+
+  method getBufferSubData :
+    bufferTarget -> intptr -> #Typed_array.arrayBufferView t -> unit meth
+
+  method bindBufferBase : bufferTarget -> uint -> buffer t -> unit meth
+
+  method bindBufferRange :
+    bufferTarget -> uint -> buffer t -> intptr -> sizeiptr -> unit meth
+
+  (** {2 5.14.3 Programs and shaders} *)
+
+  method getFragDataLocation : program t -> js_string t -> int meth
+
+  (** {2 5.14.4 3D textures and texture storage} *)
+
+  method texImage3D :
+       texTarget
+    -> int
+    -> pixelFormat
+    -> sizei
+    -> sizei
+    -> sizei
+    -> int
+    -> pixelFormat
+    -> pixelType
+    -> void opt
+    -> unit meth
+
+  method texImage3D_fromView :
+       texTarget
+    -> int
+    -> pixelFormat
+    -> sizei
+    -> sizei
+    -> sizei
+    -> int
+    -> pixelFormat
+    -> pixelType
+    -> #Typed_array.arrayBufferView t
+    -> unit meth
+
+  method texImage3D_fromImageData :
+       texTarget
+    -> int
+    -> pixelFormat
+    -> sizei
+    -> sizei
+    -> sizei
+    -> int
+    -> pixelFormat
+    -> pixelType
+    -> Dom_html.imageData t
+    -> unit meth
+
+  method texImage3D_fromImage :
+       texTarget
+    -> int
+    -> pixelFormat
+    -> sizei
+    -> sizei
+    -> sizei
+    -> int
+    -> pixelFormat
+    -> pixelType
+    -> Dom_html.imageElement t
+    -> unit meth
+
+  method texImage3D_fromCanvas :
+       texTarget
+    -> int
+    -> pixelFormat
+    -> sizei
+    -> sizei
+    -> sizei
+    -> int
+    -> pixelFormat
+    -> pixelType
+    -> Dom_html.canvasElement t
+    -> unit meth
+
+  method texImage3D_fromVideo :
+       texTarget
+    -> int
+    -> pixelFormat
+    -> sizei
+    -> sizei
+    -> sizei
+    -> int
+    -> pixelFormat
+    -> pixelType
+    -> Dom_html.videoElement t
+    -> unit meth
+
+  method texSubImage3D_fromView :
+       texTarget
+    -> int
+    -> int
+    -> int
+    -> int
+    -> sizei
+    -> sizei
+    -> sizei
+    -> pixelFormat
+    -> pixelType
+    -> #Typed_array.arrayBufferView t
+    -> unit meth
+
+  method copyTexSubImage3D :
+    texTarget -> int -> int -> int -> int -> int -> int -> sizei -> sizei -> unit meth
+
+  method compressedTexImage3D :
+       texTarget
+    -> int
+    -> pixelFormat
+    -> sizei
+    -> sizei
+    -> sizei
+    -> int
+    -> #Typed_array.arrayBufferView t
+    -> unit meth
+
+  method compressedTexSubImage3D :
+       texTarget
+    -> int
+    -> int
+    -> int
+    -> int
+    -> sizei
+    -> sizei
+    -> sizei
+    -> pixelFormat
+    -> #Typed_array.arrayBufferView t
+    -> unit meth
+
+  method texStorage2D : texTarget -> sizei -> pixelFormat -> sizei -> sizei -> unit meth
+
+  method texStorage3D :
+    texTarget -> sizei -> pixelFormat -> sizei -> sizei -> sizei -> unit meth
+
+  (** {2 5.14.5 Framebuffer objects} *)
+
+  method blitFramebuffer :
+       int
+    -> int
+    -> int
+    -> int
+    -> int
+    -> int
+    -> int
+    -> int
+    -> clearBufferMask
+    -> texFilter
+    -> unit meth
+
+  method framebufferTextureLayer :
+    fbTarget -> attachmentPoint -> texture t -> int -> int -> unit meth
+
+  method invalidateFramebuffer : fbTarget -> attachmentPoint js_array t -> unit meth
+
+  method invalidateSubFramebuffer :
+    fbTarget -> attachmentPoint js_array t -> int -> int -> sizei -> sizei -> unit meth
+
+  method readBuffer : attachmentPoint -> unit meth
+
+  (** {2 5.14.6 Renderbuffer objects} *)
+
+  method renderbufferStorageMultisample :
+    rbTarget -> sizei -> pixelFormat -> sizei -> sizei -> unit meth
+
+  method renderbufferStorage_ : rbTarget -> pixelFormat -> sizei -> sizei -> unit meth
+  (** [renderbufferStorage] accepting the WebGL2 sized internal formats
+      ({!type:pixelFormat}); the WebGL1 [renderbufferStorage] taking a
+      {!type:format} is still available through inheritance. *)
+
+  (** {2 5.14.9 Multiple render targets} *)
+
+  method drawBuffers : attachmentPoint js_array t -> unit meth
+
+  method clearBufferiv : clearBuffer -> int -> #Typed_array.arrayBufferView t -> unit meth
+
+  method clearBufferuiv :
+    clearBuffer -> int -> #Typed_array.arrayBufferView t -> unit meth
+
+  method clearBufferfv : clearBuffer -> int -> #Typed_array.arrayBufferView t -> unit meth
+
+  method clearBufferfi : clearBuffer -> int -> number_t -> int -> unit meth
+
+  (** {2 5.14.10 Query objects} *)
+
+  method createQuery : query t meth
+
+  method deleteQuery : query t -> unit meth
+
+  method isQuery : query t -> bool t meth
+
+  method beginQuery : queryTarget -> query t -> unit meth
+
+  method endQuery : queryTarget -> unit meth
+
+  method getQuery : queryTarget -> currentQueryParam -> query t opt meth
+
+  method getQueryParameter : 'a. query t -> 'a queryParam -> 'a meth
+
+  (** {2 5.14.11 Sampler objects} *)
+
+  method createSampler : sampler t meth
+
+  method deleteSampler : sampler t -> unit meth
+
+  method isSampler : sampler t -> bool t meth
+
+  method bindSampler : uint -> sampler t opt -> unit meth
+
+  method samplerParameteri : sampler t -> samplerParameterName -> int -> unit meth
+
+  method samplerParameterf : sampler t -> samplerParameterName -> number_t -> unit meth
+
+  method getSamplerParameter : 'a. sampler t -> samplerParameterName -> 'a meth
+
+  (** {2 5.14.12 Sync objects} *)
+
+  method fenceSync : syncCondition -> int -> sync t meth
+
+  method isSync : sync t -> bool t meth
+
+  method deleteSync : sync t -> unit meth
+
+  method clientWaitSync : sync t -> int -> number_t -> clientWaitSyncStatus meth
+
+  method waitSync : sync t -> int -> number_t -> unit meth
+
+  method getSyncParameter : 'a. sync t -> 'a syncParam -> 'a meth
+
+  (** {2 5.14.13 Transform feedback} *)
+
+  method createTransformFeedback : transformFeedback t meth
+
+  method deleteTransformFeedback : transformFeedback t -> unit meth
+
+  method isTransformFeedback : transformFeedback t -> bool t meth
+
+  method bindTransformFeedback : bufferTarget -> transformFeedback t opt -> unit meth
+
+  method beginTransformFeedback : beginMode -> unit meth
+
+  method endTransformFeedback : unit meth
+
+  method transformFeedbackVaryings :
+    program t -> js_string t js_array t -> transformFeedbackMode -> unit meth
+
+  method getTransformFeedbackVarying : program t -> uint -> WebGL.activeInfo t opt meth
+
+  method pauseTransformFeedback : unit meth
+
+  method resumeTransformFeedback : unit meth
+
+  (** {2 5.14.14 Uniform buffer objects} *)
+
+  method getUniformIndices :
+    program t -> js_string t js_array t -> uint js_array t opt meth
+
+  method getActiveUniforms :
+    'a. program t -> uint js_array t -> 'a activeUniformParam -> 'a js_array t meth
+
+  method getUniformBlockIndex : program t -> js_string t -> uint meth
+
+  method getActiveUniformBlockParameter :
+    'a. program t -> uint -> 'a uniformBlockParam -> 'a meth
+
+  method getActiveUniformBlockName : program t -> uint -> js_string t opt meth
+
+  method uniformBlockBinding : program t -> uint -> uint -> unit meth
+
+  (** {2 5.14.15 Vertex array objects} *)
+
+  method createVertexArray : vertexArrayObject t meth
+
+  method deleteVertexArray : vertexArrayObject t -> unit meth
+
+  method isVertexArray : vertexArrayObject t -> bool t meth
+
+  method bindVertexArray : vertexArrayObject t opt -> unit meth
+
+  (** {2 5.14.16 Instanced and range drawing} *)
+
+  method drawArraysInstanced : beginMode -> int -> sizei -> sizei -> unit meth
+
+  method drawElementsInstanced :
+    beginMode -> sizei -> dataType -> intptr -> sizei -> unit meth
+
+  method drawRangeElements :
+    beginMode -> uint -> uint -> sizei -> dataType -> intptr -> unit meth
+
+  method vertexAttribDivisor : uint -> uint -> unit meth
+
+  (** {2 5.14.17 Integer vertex attributes} *)
+
+  method vertexAttribI4i : uint -> int -> int -> int -> int -> unit meth
+
+  method vertexAttribI4ui : uint -> uint -> uint -> uint -> uint -> unit meth
+
+  method vertexAttribI4iv : uint -> Typed_array.int32Array t -> unit meth
+
+  method vertexAttribI4uiv : uint -> Typed_array.uint32Array t -> unit meth
+
+  method vertexAttribIPointer : uint -> int -> dataType -> sizei -> intptr -> unit meth
+
+  (** {2 5.14.18 Unsigned integer uniforms} *)
+
+  method uniform1ui : int uniformLocation t -> uint -> unit meth
+
+  method uniform2ui : [ `uvec2 ] uniformLocation t -> uint -> uint -> unit meth
+
+  method uniform3ui : [ `uvec3 ] uniformLocation t -> uint -> uint -> uint -> unit meth
+
+  method uniform4ui :
+    [ `uvec4 ] uniformLocation t -> uint -> uint -> uint -> uint -> unit meth
+
+  method uniform1uiv : int uniformLocation t -> Typed_array.uint32Array t -> unit meth
+
+  method uniform2uiv :
+    [ `uvec2 ] uniformLocation t -> Typed_array.uint32Array t -> unit meth
+
+  method uniform3uiv :
+    [ `uvec3 ] uniformLocation t -> Typed_array.uint32Array t -> unit meth
+
+  method uniform4uiv :
+    [ `uvec4 ] uniformLocation t -> Typed_array.uint32Array t -> unit meth
+
+  method uniformMatrix2x3fv :
+    [ `mat2x3 ] uniformLocation t -> bool t -> Typed_array.float32Array t -> unit meth
+
+  method uniformMatrix3x2fv :
+    [ `mat3x2 ] uniformLocation t -> bool t -> Typed_array.float32Array t -> unit meth
+
+  method uniformMatrix2x4fv :
+    [ `mat2x4 ] uniformLocation t -> bool t -> Typed_array.float32Array t -> unit meth
+
+  method uniformMatrix4x2fv :
+    [ `mat4x2 ] uniformLocation t -> bool t -> Typed_array.float32Array t -> unit meth
+
+  method uniformMatrix3x4fv :
+    [ `mat3x4 ] uniformLocation t -> bool t -> Typed_array.float32Array t -> unit meth
+
+  method uniformMatrix4x3fv :
+    [ `mat4x3 ] uniformLocation t -> bool t -> Typed_array.float32Array t -> unit meth
+
+  (** {2 New constants} *)
+
+  (** {3 Buffer targets and usages} *)
+
+  method _COPY_READ_BUFFER_ : bufferTarget readonly_prop
+
+  method _COPY_WRITE_BUFFER_ : bufferTarget readonly_prop
+
+  method _PIXEL_PACK_BUFFER_ : bufferTarget readonly_prop
+
+  method _PIXEL_UNPACK_BUFFER_ : bufferTarget readonly_prop
+
+  method _TRANSFORM_FEEDBACK_BUFFER_ : bufferTarget readonly_prop
+
+  method _UNIFORM_BUFFER_ : bufferTarget readonly_prop
+
+  method _STREAM_READ_ : bufferUsage readonly_prop
+
+  method _STREAM_COPY_ : bufferUsage readonly_prop
+
+  method _STATIC_READ_ : bufferUsage readonly_prop
+
+  method _STATIC_COPY_ : bufferUsage readonly_prop
+
+  method _DYNAMIC_READ_ : bufferUsage readonly_prop
+
+  method _DYNAMIC_COPY_ : bufferUsage readonly_prop
+
+  (** {3 Texture targets} *)
+
+  method _TEXTURE_3D_ : texTarget readonly_prop
+
+  method _TEXTURE_2D_ARRAY_ : texTarget readonly_prop
+
+  (** {3 New external formats} *)
+
+  method _RED_ : pixelFormat readonly_prop
+
+  method _RG_ : pixelFormat readonly_prop
+
+  method _RED_INTEGER_ : pixelFormat readonly_prop
+
+  method _RG_INTEGER_ : pixelFormat readonly_prop
+
+  method _RGB_INTEGER_ : pixelFormat readonly_prop
+
+  method _RGBA_INTEGER_ : pixelFormat readonly_prop
+
+  (** {3 New sized internal formats} *)
+
+  method _R8_ : pixelFormat readonly_prop
+
+  method _R8_SNORM_ : pixelFormat readonly_prop
+
+  method _R16F_ : pixelFormat readonly_prop
+
+  method _R32F_ : pixelFormat readonly_prop
+
+  method _R8UI_ : pixelFormat readonly_prop
+
+  method _R8I_ : pixelFormat readonly_prop
+
+  method _R16UI_ : pixelFormat readonly_prop
+
+  method _R16I_ : pixelFormat readonly_prop
+
+  method _R32UI_ : pixelFormat readonly_prop
+
+  method _R32I_ : pixelFormat readonly_prop
+
+  method _RG8_ : pixelFormat readonly_prop
+
+  method _RG8_SNORM_ : pixelFormat readonly_prop
+
+  method _RG16F_ : pixelFormat readonly_prop
+
+  method _RG32F_ : pixelFormat readonly_prop
+
+  method _RG8UI_ : pixelFormat readonly_prop
+
+  method _RG8I_ : pixelFormat readonly_prop
+
+  method _RG16UI_ : pixelFormat readonly_prop
+
+  method _RG16I_ : pixelFormat readonly_prop
+
+  method _RG32UI_ : pixelFormat readonly_prop
+
+  method _RG32I_ : pixelFormat readonly_prop
+
+  method _RGB8_ : pixelFormat readonly_prop
+
+  method _SRGB8_ : pixelFormat readonly_prop
+
+  method _RGB8_SNORM_ : pixelFormat readonly_prop
+
+  method _R11F_G11F_B10F_ : pixelFormat readonly_prop
+
+  method _RGB9_E5_ : pixelFormat readonly_prop
+
+  method _RGB16F_ : pixelFormat readonly_prop
+
+  method _RGB32F_ : pixelFormat readonly_prop
+
+  method _RGB8UI_ : pixelFormat readonly_prop
+
+  method _RGB8I_ : pixelFormat readonly_prop
+
+  method _RGB16UI_ : pixelFormat readonly_prop
+
+  method _RGB16I_ : pixelFormat readonly_prop
+
+  method _RGB32UI_ : pixelFormat readonly_prop
+
+  method _RGB32I_ : pixelFormat readonly_prop
+
+  method _RGBA8_ : pixelFormat readonly_prop
+
+  method _SRGB8_ALPHA8_ : pixelFormat readonly_prop
+
+  method _RGBA8_SNORM_ : pixelFormat readonly_prop
+
+  method _RGB10_A2_ : pixelFormat readonly_prop
+
+  method _RGBA16F_ : pixelFormat readonly_prop
+
+  method _RGBA32F_ : pixelFormat readonly_prop
+
+  method _RGBA8UI_ : pixelFormat readonly_prop
+
+  method _RGBA8I_ : pixelFormat readonly_prop
+
+  method _RGB10_A2UI_ : pixelFormat readonly_prop
+
+  method _RGBA16UI_ : pixelFormat readonly_prop
+
+  method _RGBA16I_ : pixelFormat readonly_prop
+
+  method _RGBA32UI_ : pixelFormat readonly_prop
+
+  method _RGBA32I_ : pixelFormat readonly_prop
+
+  method _DEPTH_COMPONENT24_ : pixelFormat readonly_prop
+
+  method _DEPTH_COMPONENT32F_ : pixelFormat readonly_prop
+
+  method _DEPTH24_STENCIL8_ : pixelFormat readonly_prop
+
+  method _DEPTH32F_STENCIL8_ : pixelFormat readonly_prop
+
+  (** {3 New pixel types} *)
+
+  method _HALF_FLOAT_ : pixelType readonly_prop
+
+  method _UNSIGNED_INT_2_10_10_10_REV_ : pixelType readonly_prop
+
+  method _UNSIGNED_INT_10F_11F_11F_REV_ : pixelType readonly_prop
+
+  method _UNSIGNED_INT_5_9_9_9_REV_ : pixelType readonly_prop
+
+  method _UNSIGNED_INT_24_8_ : pixelType readonly_prop
+
+  method _FLOAT_32_UNSIGNED_INT_24_8_REV_ : pixelType readonly_prop
+
+  (** {3 New data types (vertex attributes)} *)
+
+  method _HALF_FLOAT_DT : dataType readonly_prop
+
+  (** {3 Draw / read buffers} *)
+
+  method _BACK_ : attachmentPoint readonly_prop
+
+  method _NONE_ : attachmentPoint readonly_prop
+
+  method _COLOR_ATTACHMENT1_ : attachmentPoint readonly_prop
+
+  method _COLOR_ATTACHMENT2_ : attachmentPoint readonly_prop
+
+  method _COLOR_ATTACHMENT3_ : attachmentPoint readonly_prop
+
+  method _COLOR_ATTACHMENT4_ : attachmentPoint readonly_prop
+
+  method _COLOR_ATTACHMENT5_ : attachmentPoint readonly_prop
+
+  method _COLOR_ATTACHMENT6_ : attachmentPoint readonly_prop
+
+  method _COLOR_ATTACHMENT7_ : attachmentPoint readonly_prop
+
+  method _COLOR_ATTACHMENT8_ : attachmentPoint readonly_prop
+
+  method _COLOR_ATTACHMENT9_ : attachmentPoint readonly_prop
+
+  method _COLOR_ATTACHMENT10_ : attachmentPoint readonly_prop
+
+  method _COLOR_ATTACHMENT11_ : attachmentPoint readonly_prop
+
+  method _COLOR_ATTACHMENT12_ : attachmentPoint readonly_prop
+
+  method _COLOR_ATTACHMENT13_ : attachmentPoint readonly_prop
+
+  method _COLOR_ATTACHMENT14_ : attachmentPoint readonly_prop
+
+  method _COLOR_ATTACHMENT15_ : attachmentPoint readonly_prop
+
+  (** {3 clearBuffer targets} *)
+
+  method _COLOR_CB : clearBuffer readonly_prop
+
+  method _DEPTH_CB : clearBuffer readonly_prop
+
+  method _STENCIL_CB : clearBuffer readonly_prop
+
+  method _DEPTH_STENCIL_CB : clearBuffer readonly_prop
+
+  (** {3 Query targets and parameters} *)
+
+  method _ANY_SAMPLES_PASSED_ : queryTarget readonly_prop
+
+  method _ANY_SAMPLES_PASSED_CONSERVATIVE_ : queryTarget readonly_prop
+
+  method _TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN_ : queryTarget readonly_prop
+
+  method _CURRENT_QUERY_ : currentQueryParam readonly_prop
+
+  method _QUERY_RESULT_ : int queryParam readonly_prop
+
+  method _QUERY_RESULT_AVAILABLE_ : bool t queryParam readonly_prop
+
+  (** {3 Sampler parameters} *)
+
+  method _TEXTURE_MAG_FILTER_SP : samplerParameterName readonly_prop
+
+  method _TEXTURE_MIN_FILTER_SP : samplerParameterName readonly_prop
+
+  method _TEXTURE_WRAP_S_SP : samplerParameterName readonly_prop
+
+  method _TEXTURE_WRAP_T_SP : samplerParameterName readonly_prop
+
+  method _TEXTURE_WRAP_R_SP : samplerParameterName readonly_prop
+
+  method _TEXTURE_MIN_LOD_SP : samplerParameterName readonly_prop
+
+  method _TEXTURE_MAX_LOD_SP : samplerParameterName readonly_prop
+
+  method _TEXTURE_COMPARE_MODE_SP : samplerParameterName readonly_prop
+
+  method _TEXTURE_COMPARE_FUNC_SP : samplerParameterName readonly_prop
+
+  (** {3 Sync objects} *)
+
+  method _SYNC_GPU_COMMANDS_COMPLETE_ : syncCondition readonly_prop
+
+  method _SYNC_FLUSH_COMMANDS_BIT_ : int readonly_prop
+
+  method _SYNC_STATUS_ : syncStatus syncParam readonly_prop
+
+  method _SYNC_CONDITION_ : syncCondition syncParam readonly_prop
+
+  method _SYNC_FLAGS_ : int syncParam readonly_prop
+
+  method _SIGNALED_ : syncStatus readonly_prop
+
+  method _UNSIGNALED_ : syncStatus readonly_prop
+
+  method _ALREADY_SIGNALED_ : clientWaitSyncStatus readonly_prop
+
+  method _TIMEOUT_EXPIRED_ : clientWaitSyncStatus readonly_prop
+
+  method _CONDITION_SATISFIED_ : clientWaitSyncStatus readonly_prop
+
+  method _WAIT_FAILED_ : clientWaitSyncStatus readonly_prop
+
+  (** {3 Transform feedback} *)
+
+  method _INTERLEAVED_ATTRIBS_ : transformFeedbackMode readonly_prop
+
+  method _SEPARATE_ATTRIBS_ : transformFeedbackMode readonly_prop
+
+  (** {3 Uniform buffer objects} *)
+
+  method _UNIFORM_TYPE_ : int activeUniformParam readonly_prop
+
+  method _UNIFORM_SIZE_ : int activeUniformParam readonly_prop
+
+  method _UNIFORM_BLOCK_INDEX_ : int activeUniformParam readonly_prop
+
+  method _UNIFORM_OFFSET_ : int activeUniformParam readonly_prop
+
+  method _UNIFORM_ARRAY_STRIDE_ : int activeUniformParam readonly_prop
+
+  method _UNIFORM_MATRIX_STRIDE_ : int activeUniformParam readonly_prop
+
+  method _UNIFORM_IS_ROW_MAJOR_ : bool t activeUniformParam readonly_prop
+
+  method _UNIFORM_BLOCK_BINDING_ : int uniformBlockParam readonly_prop
+
+  method _UNIFORM_BLOCK_DATA_SIZE_ : int uniformBlockParam readonly_prop
+
+  method _UNIFORM_BLOCK_ACTIVE_UNIFORMS_ : int uniformBlockParam readonly_prop
+
+  method _UNIFORM_BLOCK_ACTIVE_UNIFORM_INDICES_ :
+    Typed_array.uint32Array t uniformBlockParam readonly_prop
+
+  method _UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER_ :
+    bool t uniformBlockParam readonly_prop
+
+  method _UNIFORM_BLOCK_REFERENCED_BY_FRAGMENT_SHADER_ :
+    bool t uniformBlockParam readonly_prop
+
+  (** {3 New pixel store parameters} *)
+
+  method _PACK_ROW_LENGTH_ : int pixelStoreParam readonly_prop
+
+  method _PACK_SKIP_PIXELS_ : int pixelStoreParam readonly_prop
+
+  method _PACK_SKIP_ROWS_ : int pixelStoreParam readonly_prop
+
+  method _UNPACK_ROW_LENGTH_ : int pixelStoreParam readonly_prop
+
+  method _UNPACK_IMAGE_HEIGHT_ : int pixelStoreParam readonly_prop
+
+  method _UNPACK_SKIP_PIXELS_ : int pixelStoreParam readonly_prop
+
+  method _UNPACK_SKIP_ROWS_ : int pixelStoreParam readonly_prop
+
+  method _UNPACK_SKIP_IMAGES_ : int pixelStoreParam readonly_prop
+
+  (** {3 New integer query parameters} *)
+
+  method _MAX_3D_TEXTURE_SIZE_ : int parameter readonly_prop
+
+  method _MAX_ARRAY_TEXTURE_LAYERS_ : int parameter readonly_prop
+
+  method _MAX_COLOR_ATTACHMENTS_ : int parameter readonly_prop
+
+  method _MAX_DRAW_BUFFERS_ : int parameter readonly_prop
+
+  method _MAX_SAMPLES_ : int parameter readonly_prop
+
+  method _MAX_UNIFORM_BUFFER_BINDINGS_ : int parameter readonly_prop
+
+  method _MAX_VERTEX_UNIFORM_BLOCKS_ : int parameter readonly_prop
+
+  method _MAX_FRAGMENT_UNIFORM_BLOCKS_ : int parameter readonly_prop
+
+  method _UNIFORM_BUFFER_OFFSET_ALIGNMENT_ : int parameter readonly_prop
+end
+
+(** {2 Getting a WebGL2 context} *)
+
+val getContext : Dom_html.canvasElement t -> renderingContext t opt
+
+val getContextWithAttributes :
+  Dom_html.canvasElement t -> WebGL.contextAttributes t -> renderingContext t opt

--- a/lib/tests/test_webgl.ml
+++ b/lib/tests/test_webgl.ml
@@ -1,0 +1,50 @@
+(* Js_of_ocaml
+ * http://www.ocsigen.org/js_of_ocaml/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+open Js_of_ocaml
+
+(* No WebGL context is available in the test engines, so the suite exercises
+   the parts that do not need one: the context-attributes record and the
+   module surfaces. *)
+
+let%expect_test "context attributes record can be populated" =
+  let a = WebGL.defaultContextAttributes in
+  a##.antialias := Js._false;
+  a##.powerPreference := Js.string "high-performance";
+  a##.desynchronized := Js._true;
+  print_endline (string_of_bool (Js.to_bool a##.antialias));
+  print_endline (Js.to_string a##.powerPreference);
+  print_endline (string_of_bool (Js.to_bool a##.desynchronized));
+  print_endline (string_of_bool (Js.to_bool a##.xrCompatible));
+  [%expect {|
+    false
+    high-performance
+    true
+    false |}]
+
+let%expect_test "context constructors are exposed" =
+  let (_ : Dom_html.canvasElement Js.t -> WebGL.renderingContext Js.t Js.opt) =
+    WebGL.getContext
+  in
+  let (_ : Dom_html.canvasElement Js.t -> WebGL2.renderingContext Js.t Js.opt) =
+    WebGL2.getContext
+  in
+  let (_
+        :    Dom_html.canvasElement Js.t
+          -> WebGL.contextAttributes Js.t
+          -> WebGL2.renderingContext Js.t Js.opt) =
+    WebGL2.getContextWithAttributes
+  in
+  print_endline "PASSED";
+  [%expect {| PASSED |}]

--- a/manual/api.mld
+++ b/manual/api.mld
@@ -55,6 +55,7 @@ Js_of_ocaml.ResizeObserver
 Js_of_ocaml.ServiceWorker
 Js_of_ocaml.Url
 Js_of_ocaml.WebGL
+Js_of_ocaml.WebGL2
 Js_of_ocaml.WebSockets
 Js_of_ocaml.Worker
 Js_of_ocaml.XmlHttpRequest

--- a/manual/files/dune.inc
+++ b/manual/files/dune.inc
@@ -80,6 +80,14 @@
 
 (rule
  (alias doc-manual)
+ (targets (dir webgl2_particles))
+ (deps
+  ../../examples/webgl2_particles/particles.bc.js
+  ../../examples/webgl2_particles/index.html)
+ (action (bash "mkdir -p webgl2_particles && cp -r ../../examples/webgl2_particles/particles.bc.js ../../examples/webgl2_particles/index.html webgl2_particles")))
+
+(rule
+ (alias doc-manual)
  (targets (dir wiki))
  (deps
   ../../examples/wiki/main.bc.js

--- a/manual/files/dune.inc
+++ b/manual/files/dune.inc
@@ -15,8 +15,10 @@
  (deps
   ../../examples/boulderdash/boulderdash.bc.js
   ../../examples/boulderdash/index.html
+  ../../examples/boulderdash/maps.txt
+  (source_tree ../../examples/boulderdash/maps/)
   (source_tree ../../examples/boulderdash/sprites/))
- (action (bash "mkdir -p boulderdash && cp -r ../../examples/boulderdash/boulderdash.bc.js ../../examples/boulderdash/index.html ../../examples/boulderdash/sprites boulderdash")))
+ (action (bash "mkdir -p boulderdash && cp -r ../../examples/boulderdash/boulderdash.bc.js ../../examples/boulderdash/index.html ../../examples/boulderdash/maps.txt ../../examples/boulderdash/maps ../../examples/boulderdash/sprites boulderdash")))
 
 (rule
  (alias doc-manual)
@@ -31,8 +33,9 @@
  (targets (dir graph_viewer))
  (deps
   ../../examples/graph_viewer/viewer_js.bc.js
+  ../../examples/graph_viewer/scene.json
   ../../examples/graph_viewer/index.html)
- (action (bash "mkdir -p graph_viewer && cp -r ../../examples/graph_viewer/viewer_js.bc.js ../../examples/graph_viewer/index.html graph_viewer")))
+ (action (bash "mkdir -p graph_viewer && cp -r ../../examples/graph_viewer/viewer_js.bc.js ../../examples/graph_viewer/scene.json ../../examples/graph_viewer/index.html graph_viewer")))
 
 (rule
  (alias doc-manual)
@@ -48,9 +51,12 @@
  (deps
   ../../examples/hyperbolic/hypertree.bc.js
   ../../examples/hyperbolic/index.html
+  ../../examples/hyperbolic/image_info.json
+  ../../examples/hyperbolic/messages.json
+  ../../examples/hyperbolic/tree.json
   (source_tree ../../examples/hyperbolic/icons/)
   (source_tree ../../examples/hyperbolic/thumbnails/))
- (action (bash "mkdir -p hyperbolic && cp -r ../../examples/hyperbolic/hypertree.bc.js ../../examples/hyperbolic/index.html ../../examples/hyperbolic/icons ../../examples/hyperbolic/thumbnails hyperbolic")))
+ (action (bash "mkdir -p hyperbolic && cp -r ../../examples/hyperbolic/hypertree.bc.js ../../examples/hyperbolic/index.html ../../examples/hyperbolic/image_info.json ../../examples/hyperbolic/messages.json ../../examples/hyperbolic/tree.json ../../examples/hyperbolic/icons ../../examples/hyperbolic/thumbnails hyperbolic")))
 
 (rule
  (alias doc-manual)
@@ -75,8 +81,9 @@
  (targets (dir webgl))
  (deps
   ../../examples/webgl/webgldemo.bc.js
+  ../../examples/webgl/monkey.model
   ../../examples/webgl/index.html)
- (action (bash "mkdir -p webgl && cp -r ../../examples/webgl/webgldemo.bc.js ../../examples/webgl/index.html webgl")))
+ (action (bash "mkdir -p webgl && cp -r ../../examples/webgl/webgldemo.bc.js ../../examples/webgl/monkey.model ../../examples/webgl/index.html webgl")))
 
 (rule
  (alias doc-manual)

--- a/manual/gen_dune_inc.ml
+++ b/manual/gen_dune_inc.ml
@@ -150,11 +150,13 @@ let is_dir x =
    default alias deps. This avoids having to manually update this file
    whenever a new example is added.
 
-   Note that files passed via --file in build_runtime_flags are copied like
-   any other dep: they used to be embedded into the .bc.js, but with
-   separate compilation the shared runtime is built without the
-   per-executable build_runtime_flags, so the examples fetch them over http
-   at run time. *)
+   Files passed via --file in build_runtime_flags are copied like any other
+   dep. Whether they are additionally embedded into the .bc.js depends on
+   how the executable is built: since dune 3.23, separately-compiled
+   executables share a standalone runtime built without the per-executable
+   build_runtime_flags (see ocaml/dune#15455), in which case the example
+   falls back to fetching the file over http at run time. Shipping the
+   files makes the pages work in both cases. *)
 let discover_examples () : desc list =
   let examples_dir = "../../examples" in
   let entries = Sys.readdir examples_dir in

--- a/manual/gen_dune_inc.ml
+++ b/manual/gen_dune_inc.ml
@@ -146,35 +146,15 @@ let is_dir x =
   let len = String.length x in
   len > 0 && String.get x (len - 1) = '/'
 
-(* Collect filenames passed via --file in build_runtime_flags.
-   These files are embedded into the .bc.js and do not need to be installed. *)
-let extract_embedded_files sexps =
-  let files = ref [] in
-  let rec scan_list = function
-    | [] -> ()
-    | Atom "--file" :: Atom f :: rest ->
-        let len = String.length f in
-        let name =
-          if len > 7 && String.sub f 0 6 = "%{dep:" && f.[len - 1] = '}'
-          then String.sub f 6 (len - 7)
-          else f
-        in
-        files := name :: !files;
-        scan_list rest
-    | _ :: rest -> scan_list rest
-  in
-  let rec walk = function
-    | Atom _ -> ()
-    | List items ->
-        scan_list items;
-        List.iter walk items
-  in
-  List.iter walk sexps;
-  !files
-
 (* Scan ../examples/ for subdirectories with a dune file and extract their
    default alias deps. This avoids having to manually update this file
-   whenever a new example is added. *)
+   whenever a new example is added.
+
+   Note that files passed via --file in build_runtime_flags are copied like
+   any other dep: they used to be embedded into the .bc.js, but with
+   separate compilation the shared runtime is built without the
+   per-executable build_runtime_flags, so the examples fetch them over http
+   at run time. *)
 let discover_examples () : desc list =
   let examples_dir = "../../examples" in
   let entries = Sys.readdir examples_dir in
@@ -192,16 +172,6 @@ let discover_examples () : desc list =
         let content = read_file dune_path in
         let sexps = parse_sexps content in
         let file_deps = extract_default_alias_deps sexps in
-        let embedded = extract_embedded_files sexps in
-        let file_deps =
-          List.filter
-            (fun dep ->
-              let base =
-                if is_dir dep then String.sub dep 0 (String.length dep - 1) else dep
-              in
-              not (List.mem base embedded))
-            file_deps
-        in
         if file_deps <> [] then Some (dir, name, file_deps) else None
       else None)
 


### PR DESCRIPTION
Addresses #1226 — adds a `WebGL2` binding.

## What

A new `WebGL2` module whose `renderingContext` `inherit`s `WebGL.renderingContext` (WebGL2 is a strict superset), adding the WebGL2 surface:

- **New objects**: `query`, `sampler`, `sync`, `transformFeedback`, `vertexArrayObject` (create/delete/is/bind, with `_`-suffixed variants for unbinding/detaching, following the WebGL1 convention).
- **3D & immutable textures**: `texImage3D` (+ view/imageData/image/canvas/video overloads), `texSubImage3D`, `copyTexSubImage3D`, `compressedTexImage3D`/`compressedTexSubImage3D`, `texStorage2D`/`texStorage3D`.
- **Framebuffers / MRT**: `blitFramebuffer`, `framebufferTextureLayer`, `invalidate(Sub)Framebuffer` (plus `_default` overloads for the default framebuffer), `readBuffer`, `drawBuffers`, `renderbufferStorageMultisample`, `clearBuffer[iuf]v`/`clearBufferfi`.
- **Buffers**: `copyBufferSubData`, `getBufferSubData`, `bindBufferBase`/`bindBufferRange`, PBO / `srcOffset` overloads of the pixel-transfer entry points.
- **Instancing / UBO / transform feedback**: `drawArraysInstanced`, `drawElementsInstanced`, `drawRangeElements`, `vertexAttribDivisor`, uniform-block introspection/binding (`getActiveUniforms`, `getUniformBlockIndex`, `getActiveUniformBlock*`, `uniformBlockBinding`, …), transform-feedback lifecycle and varyings introspection.
- **Integer attribs & uint uniforms**: `vertexAttribI4*`, `vertexAttribIPointer`, `uniform{1..4}ui(v)`, non-square `uniformMatrix*fv`.
- **Constants**: sized internal formats, new external formats, pixel/data types, sampler params, query/sync/UBO/blit/transform-feedback enums, and new `int parameter` / `pixelStoreParam` limits.
- `getContext` / `getContextWithAttributes` requesting a `"webgl2"` context, and `contextAttributes`.

## Design

Per the discussion in #1226, this follows the **pragmatic** approach (dbuenzli's "typing GL is more trouble than benefit"): enumerations stay abstract and are shared between related uses. In particular internalformat and format share the single `pixelFormat` type, so the binding does **not** enforce (internalformat, format, type) coherence at compile time — WebGL itself is not type safe there. WebGL1's abstract types are re-exported as manifest aliases so inherited methods like `getParameter`/`pixelStorei` accept the new constants.

## Examples & tests

- The existing `examples/webgl` demo is upgraded to request a WebGL2 context (with a loud failure when the model cannot be fetched, instead of hanging).
- A new `examples/webgl2_particles` demo exercises the WebGL2-only surface (transform feedback, VAOs, instancing) with UI controls for particle count, simulation speed, gravity, damping and trails; it is listed on the examples index page.
- `lib/tests/test_webgl.ml` covers the context constructor surfaces and the `contextAttributes` fields.
- Examples using `--file` embeds get a dummy `javascript_files` entry to opt out of dune's shared standalone runtime, which drops per-executable `build_runtime_flags` since dune 3.23 (ocaml/dune#15455) — so they keep working from `file://`.

## Docs

`API-STATUS.md`, `manual/api.mld` and `CHANGES.md` updated. The manual now ships the runtime data files (`monkey.model`, boulderdash maps, graph_viewer `scene.json`) alongside the examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
