### PR TITLE
Wasm: resolve assets relative to the runtime file, not require.main

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -72,6 +72,9 @@
   load Stdlib at startup (#1721)
 * Runtime: fix comparison between an immediate and a custom block that
   provides a compare op (e.g. zarith), broken by #2290 (#2391)
+* Wasm: resolve `.wasm` assets relative to the runtime file rather than the
+  process entry point, so they load when the program is `require`d (e.g. a CLI
+  wrapper), not only when run directly (#2389)
 * Toplevel: keep the `/static/cmis` directory on the load path across
   `Toploop.initialize_toplevel_env`, so libraries whose cmis are loaded at
   runtime stay resolvable; previously the directory was registered only while

--- a/compiler/tests-wasm_of_ocaml/wasm_asset_resolution.t
+++ b/compiler/tests-wasm_of_ocaml/wasm_asset_resolution.t
@@ -1,0 +1,20 @@
+Wasm assets are located relative to the runtime file, not the process entry
+point, so a program still finds them when it is loaded through `require` (e.g.
+behind a CLI wrapper) rather than run directly.
+
+  $ echo 'let () = print_string "ok\n"' > prog.ml
+  $ ocamlc prog.ml -o prog.bc
+  $ dune exec -- wasm_of_ocaml prog.bc -o prog.js
+
+Run directly:
+
+  $ node prog.js
+  ok
+
+Load through a wrapper in another directory, so `require.main` is the wrapper
+rather than the compiled program:
+
+  $ mkdir sub
+  $ echo 'require("../prog.js")' > sub/wrapper.js
+  $ node sub/wrapper.js
+  ok

--- a/runtime/wasm/runtime-wasi.js
+++ b/runtime/wasm/runtime-wasi.js
@@ -38,7 +38,7 @@
   const imports = wasi.getImportObject();
   function loadRelative(src) {
     const path = require("node:path");
-    const f = path.join(path.dirname(require.main.filename), src);
+    const f = path.join(path.dirname(module.filename), src);
     return require("node:fs/promises").readFile(f);
   }
   async function instantiateModule(code) {

--- a/runtime/wasm/runtime.js
+++ b/runtime/wasm/runtime.js
@@ -867,7 +867,7 @@
 
   function loadRelative(src) {
     const path = require("node:path");
-    const f = path.join(path.dirname(require.main.filename), src);
+    const f = path.join(path.dirname(module.filename), src);
     return require("node:fs/promises").readFile(f);
   }
   const fetchBase = globalThis?.document?.currentScript?.src;


### PR DESCRIPTION
The node runtime loaded the separately-compiled `.wasm` assets from `path.dirname(require.main.filename)` — the process entry point — so a program failed to find them when loaded through `require` (e.g. behind a CLI wrapper) or a symlink, and crashed outright when `require.main` was undefined (worker threads, `node -e`). Use `module.filename` instead, locating the assets relative to the runtime file itself, matching the browser branch which already self-locates via `document.currentScript.src`. `module` is already an allowed runtime global, so nothing else changes. Same fix in the WASI runtime.