### PR TITLE
CI: move build-only compiler coverage to a dedicated build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,74 @@
+name: build
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+  schedule:
+    # Prime the caches every Monday
+    - cron: 0 1 * * MON
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+# Build-only compiler coverage: check that every package of the repository
+# (js_of_ocaml and wasm_of_ocaml alike) still installs on these compilers.
+# The test suite runs elsewhere, on a narrower compiler range (see the
+# js_of_ocaml and wasm_of_ocaml workflows).
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        ocaml-name:
+          - ""
+        ocaml-compiler:
+          - "4.13"
+          - "5.0"
+          - "5.1"
+          - "5.2"
+          - "5.3"
+          - "5.4"
+        include:
+          # Build-only: on OCaml >= 5, running the tests generates JS files
+          # larger than the 16 MB Buffer/string ceiling of 32-bit OCaml
+          - ocaml-name: "5.4.0+32bit"
+            ocaml-compiler: "ocaml-variants.5.4.0+options,ocaml-option-32bit"
+
+    runs-on: ubuntu-latest
+
+    name: ${{ matrix.ocaml-name != '' && matrix.ocaml-name || matrix.ocaml-compiler }} / Ubuntu
+
+    steps:
+      - name: Update apt cache
+        run: sudo apt-get update
+
+      - name: Checkout tree
+        uses: actions/checkout@v7
+
+        # EJGA: Note that I tried to fix this upstream as depext is
+        # getting much better, but no luck yet, c.f:
+        # https://github.com/ocaml/opam-repository/pull/26626
+      - name: Install apt 32-bit dependencies
+        if: contains( matrix.ocaml-compiler, 'ocaml-option-32bit')
+        run: |
+          sudo apt-get install aptitude
+          sudo dpkg --add-architecture i386
+          sudo aptitude -o Acquire::Retries=30 update -q
+          # Note we also install the 64-bit versions here as opam will
+          # try to install them anyways, so we save an apt-roundtrip.
+          sudo aptitude -o Acquire::Retries=30 install gcc-multilib g++-multilib pkg-config libgmp-dev libgmp-dev:i386 libx11-dev libx11-dev:i386 libxft-dev libxft-dev:i386 -y
+
+      - name: Set-up OCaml ${{ matrix.ocaml-compiler }}
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+
+      - name: Set-up Binaryen
+        uses: Aandreba/setup-binaryen@v1.0.0
+        with:
+          token: ${{ github.token }}
+
+      - run: opam install . --best-effort --solver builtin-mccs+glpk

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,9 @@
 name: build
 
+# Not run on pull requests: installability across the compiler range is a
+# slow-moving signal, and skipping these jobs at PR time frees runner slots
+# so the long test jobs start sooner.
 on:
-  pull_request:
   push:
     branches:
       - master
@@ -11,7 +13,6 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # Build-only compiler coverage: check that every package of the repository
 # (js_of_ocaml and wasm_of_ocaml alike) still installs on these compilers.

--- a/.github/workflows/js_of_ocaml.yml
+++ b/.github/workflows/js_of_ocaml.yml
@@ -21,106 +21,76 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-        os-name:
-          - Ubuntu
-        ocaml-name:
-          - ""
-        ocaml-compiler:
-          - "4.13"
-          - "5.0"
-          - "5.1"
-          - "5.2"
-          - "5.3"
-          - "5.4"
-        skip-test:
-          - true
-        skip-doc:
-          - true
-        skip-effects:
-          - true
+        # Build-only compiler coverage lives in the build workflow;
+        # every row here runs the test suite.
         include:
           - os: ubuntu-latest
             os-name: Ubuntu
+            ocaml-name: ""
             ocaml-compiler: "4.14"
             skip-effects: true
-            skip-test: false
             skip-doc: true
           - os: ubuntu-latest
             os-name: Ubuntu
             ocaml-name: "4.14.2+32bit"
             ocaml-compiler: "ocaml-variants.4.14.2+options,ocaml-option-32bit"
             skip-effects: true
-            skip-test: false
             skip-doc: true
           - os: macos-latest
             os-name: Macos
+            ocaml-name: ""
             ocaml-compiler: "4.14"
             skip-effects: true
-            skip-test: false
             skip-doc: true
           - os: windows-latest
             os-name: Windows
+            ocaml-name: ""
             ocaml-compiler: "4.14"
             skip-effects: true
-            skip-test: false
             skip-doc: true
           - os: ubuntu-latest
             os-name: Ubuntu
+            ocaml-name: ""
             ocaml-compiler: "5.5"
             skip-effects: false
-            skip-test: false
             skip-doc: false
           - os: ubuntu-latest
             os-name: Ubuntu
             ocaml-name: "5.6+trunk"
             ocaml-compiler: "ocaml-variants.5.6.0+trunk"
             skip-effects: false
-            skip-test: false
             # odoc is not installable against 5.6+trunk yet
             skip-doc: true
+          # Note this OCaml compiler is bytecode only
           - os: ubuntu-latest
             os-name: Ubuntu
+            ocaml-name: ""
             ocaml-compiler: "5.1"
             skip-effects: false
-            skip-test: false
-            skip-doc: true
-            # Note this OCaml compiler is bytecode only
-          - os: ubuntu-latest
-            os-name: Ubuntu
-            ocaml-name: "5.4.0+32bit"
-            ocaml-compiler: "ocaml-variants.5.4.0+options,ocaml-option-32bit"
-            skip-effects: true # disabled for the same reason as `skip-test`
-            # On OCaml >= 5, `dune build @all` generates JS files larger than
-            # the 16 MB Buffer/string ceiling of 32-bit OCaml
-            # (js_of_ocaml.cma.js, the toplevel examples)
-            skip-test: true
             skip-doc: true
           - os: macos-latest
             os-name: MacOS
+            ocaml-name: ""
             ocaml-compiler: "5.4.0"
             skip-effects: true
-            skip-test: false
             skip-doc: true
           - os: windows-latest
             os-name: Windows
+            ocaml-name: ""
             ocaml-compiler: "5.4.0"
             skip-effects: false
-            skip-test: false
             skip-doc: true
           - os: ubuntu-latest
             os-name: Ubuntu
             ocaml-name: "OxCaml"
             ocaml-compiler: "ocaml-variants.5.2.0+ox"
             skip-effects: false
-            skip-test: false
             skip-doc: true
 
     runs-on: ${{ matrix.os }}
 
     name:
-       ${{ matrix.ocaml-name != '' && matrix.ocaml-name || matrix.ocaml-compiler}} / ${{ matrix.os-name }}${{ ! matrix.skip-test && ' / Tests' || ''}}${{ ! matrix.skip-effects && ' / Effects' || ''}}${{ ! matrix.skip-doc && ' / Docs' || ''}}
+       ${{ matrix.ocaml-name != '' && matrix.ocaml-name || matrix.ocaml-compiler}} / ${{ matrix.os-name }} / Tests${{ ! matrix.skip-effects && ' / Effects' || ''}}${{ ! matrix.skip-doc && ' / Docs' || ''}}
 
 
     steps:
@@ -179,12 +149,8 @@ jobs:
         with:
           token: ${{ github.token }}
 
-      - run: opam install . --best-effort --solver builtin-mccs+glpk
-        if: ${{ matrix.skip-test }}
-
       - run: opam install . --deps-only --with-test
         # Install the test dependencies
-        if: ${{ !matrix.skip-test }}
 
       - name: Pin js_of_ocaml
         # OxCaml wants a precise version of Js_of_ocaml
@@ -192,16 +158,13 @@ jobs:
 
       - run: opam install .
         # Install the packages (without running the tests)
-        if: ${{ !matrix.skip-test }}
 
       - run: opam exec -- make all
-        if: ${{ !matrix.skip-test }}
 
       - run: opam exec -- make tests
-        if: ${{ !matrix.skip-test }}
 
       - name: Run Babel downleveling test
-        if: ${{ !matrix.skip-test && runner.os == 'Linux' }}
+        if: ${{ runner.os == 'Linux' }}
         run: |
           npm install
           opam exec -- make test-babel-downlevel
@@ -213,7 +176,6 @@ jobs:
         if: ${{ !matrix.skip-effects }}
 
       - run: opam exec -- git diff --exit-code
-        if: ${{ !matrix.skip-test }}
 
       # Documentation is built and deployed by a dedicated workflow (doc.yml):
       # odoc (manual + API) + the interactive examples, themed with the Ocsigen

--- a/.github/workflows/js_of_ocaml.yml
+++ b/.github/workflows/js_of_ocaml.yml
@@ -71,13 +71,13 @@ jobs:
           - os: macos-latest
             os-name: MacOS
             ocaml-name: ""
-            ocaml-compiler: "5.4.0"
+            ocaml-compiler: "5.5"
             skip-effects: true
             skip-doc: true
           - os: windows-latest
             os-name: Windows
             ocaml-name: ""
-            ocaml-compiler: "5.4.0"
+            ocaml-compiler: "5.5"
             skip-effects: false
             skip-doc: true
           - os: ubuntu-latest

--- a/.github/workflows/js_of_ocaml.yml
+++ b/.github/workflows/js_of_ocaml.yml
@@ -21,66 +21,48 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Build-only compiler coverage lives in the build workflow;
-        # every row here runs the test suite.
+        # 4.14 and 5.5 are tested on all three OSes; build-only compiler
+        # coverage lives in the build workflow.
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+        ocaml-compiler:
+          - "4.14"
+          - "5.5"
+        ocaml-name:
+          - ""
         include:
+          # Display names for the OSes
           - os: ubuntu-latest
             os-name: Ubuntu
-            ocaml-name: ""
-            ocaml-compiler: "4.14"
-            skip-doc: true
+          - os: macos-latest
+            os-name: MacOS
+          - os: windows-latest
+            os-name: Windows
+          # Extra configurations, Ubuntu-only
           - os: ubuntu-latest
             os-name: Ubuntu
             ocaml-name: "4.14.2+32bit"
             ocaml-compiler: "ocaml-variants.4.14.2+options,ocaml-option-32bit"
-            skip-doc: true
-          - os: macos-latest
-            os-name: Macos
-            ocaml-name: ""
-            ocaml-compiler: "4.14"
-            skip-doc: true
-          - os: windows-latest
-            os-name: Windows
-            ocaml-name: ""
-            ocaml-compiler: "4.14"
-            skip-doc: true
-          - os: ubuntu-latest
-            os-name: Ubuntu
-            ocaml-name: ""
-            ocaml-compiler: "5.5"
-            skip-doc: false
           - os: ubuntu-latest
             os-name: Ubuntu
             ocaml-name: "5.6+trunk"
             ocaml-compiler: "ocaml-variants.5.6.0+trunk"
-            # odoc is not installable against 5.6+trunk yet
-            skip-doc: true
           # Note this OCaml compiler is bytecode only
           - os: ubuntu-latest
             os-name: Ubuntu
             ocaml-name: ""
             ocaml-compiler: "5.1"
-            skip-doc: true
-          - os: macos-latest
-            os-name: MacOS
-            ocaml-name: ""
-            ocaml-compiler: "5.5"
-            skip-doc: true
-          - os: windows-latest
-            os-name: Windows
-            ocaml-name: ""
-            ocaml-compiler: "5.5"
-            skip-doc: true
           - os: ubuntu-latest
             os-name: Ubuntu
             ocaml-name: "OxCaml"
             ocaml-compiler: "ocaml-variants.5.2.0+ox"
-            skip-doc: true
 
     runs-on: ${{ matrix.os }}
 
     name:
-       ${{ matrix.ocaml-name != '' && matrix.ocaml-name || matrix.ocaml-compiler}} / ${{ matrix.os-name }} / Tests${{ (startsWith(matrix.ocaml-compiler, '5.') || startsWith(matrix.ocaml-compiler, 'ocaml-variants.5.')) && ' / Effects' || ''}}${{ ! matrix.skip-doc && ' / Docs' || ''}}
+       ${{ matrix.ocaml-name != '' && matrix.ocaml-name || matrix.ocaml-compiler}} / ${{ matrix.os-name }} / Tests${{ (startsWith(matrix.ocaml-compiler, '5.') || startsWith(matrix.ocaml-compiler, 'ocaml-variants.5.')) && ' / Effects' || ''}}${{ (matrix.os == 'ubuntu-latest' && matrix.ocaml-compiler == '5.5') && ' / Docs' || ''}}
 
 
     steps:
@@ -173,8 +155,10 @@ jobs:
       # chrome and published to gh-pages (ocsigen.org/js_of_ocaml/). Here we only
       # check that it compiles. The old `make doc` -> wikidoc -> html_of_wiki
       # pipeline has been retired.
+      # Documentation is checked once, on the latest release (odoc is not
+      # installable against trunk)
       - name: build doc (compile check)
-        if: ${{ !matrix.skip-doc }}
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.ocaml-compiler == '5.5' }}
         run: |
           opam install odoc yojson ocp-indent graphics higlo
           opam exec -- make doc

--- a/.github/workflows/js_of_ocaml.yml
+++ b/.github/workflows/js_of_ocaml.yml
@@ -28,37 +28,31 @@ jobs:
             os-name: Ubuntu
             ocaml-name: ""
             ocaml-compiler: "4.14"
-            skip-effects: true
             skip-doc: true
           - os: ubuntu-latest
             os-name: Ubuntu
             ocaml-name: "4.14.2+32bit"
             ocaml-compiler: "ocaml-variants.4.14.2+options,ocaml-option-32bit"
-            skip-effects: true
             skip-doc: true
           - os: macos-latest
             os-name: Macos
             ocaml-name: ""
             ocaml-compiler: "4.14"
-            skip-effects: true
             skip-doc: true
           - os: windows-latest
             os-name: Windows
             ocaml-name: ""
             ocaml-compiler: "4.14"
-            skip-effects: true
             skip-doc: true
           - os: ubuntu-latest
             os-name: Ubuntu
             ocaml-name: ""
             ocaml-compiler: "5.5"
-            skip-effects: false
             skip-doc: false
           - os: ubuntu-latest
             os-name: Ubuntu
             ocaml-name: "5.6+trunk"
             ocaml-compiler: "ocaml-variants.5.6.0+trunk"
-            skip-effects: false
             # odoc is not installable against 5.6+trunk yet
             skip-doc: true
           # Note this OCaml compiler is bytecode only
@@ -66,31 +60,27 @@ jobs:
             os-name: Ubuntu
             ocaml-name: ""
             ocaml-compiler: "5.1"
-            skip-effects: false
             skip-doc: true
           - os: macos-latest
             os-name: MacOS
             ocaml-name: ""
             ocaml-compiler: "5.5"
-            skip-effects: true
             skip-doc: true
           - os: windows-latest
             os-name: Windows
             ocaml-name: ""
             ocaml-compiler: "5.5"
-            skip-effects: false
             skip-doc: true
           - os: ubuntu-latest
             os-name: Ubuntu
             ocaml-name: "OxCaml"
             ocaml-compiler: "ocaml-variants.5.2.0+ox"
-            skip-effects: false
             skip-doc: true
 
     runs-on: ${{ matrix.os }}
 
     name:
-       ${{ matrix.ocaml-name != '' && matrix.ocaml-name || matrix.ocaml-compiler}} / ${{ matrix.os-name }} / Tests${{ ! matrix.skip-effects && ' / Effects' || ''}}${{ ! matrix.skip-doc && ' / Docs' || ''}}
+       ${{ matrix.ocaml-name != '' && matrix.ocaml-name || matrix.ocaml-compiler}} / ${{ matrix.os-name }} / Tests${{ (startsWith(matrix.ocaml-compiler, '5.') || startsWith(matrix.ocaml-compiler, 'ocaml-variants.5.')) && ' / Effects' || ''}}${{ ! matrix.skip-doc && ' / Docs' || ''}}
 
 
     steps:
@@ -169,11 +159,12 @@ jobs:
           npm install
           opam exec -- make test-babel-downlevel
 
+      # Effect handlers require OCaml 5
       - run: opam exec -- dune build @all @runtest @runtest-js --profile with-effects
-        if: ${{ !matrix.skip-effects }}
+        if: ${{ startsWith(matrix.ocaml-compiler, '5.') || startsWith(matrix.ocaml-compiler, 'ocaml-variants.5.') }}
 
       - run: opam exec -- dune build @all @runtest @runtest-js --profile with-effects-double-translation
-        if: ${{ !matrix.skip-effects }}
+        if: ${{ startsWith(matrix.ocaml-compiler, '5.') || startsWith(matrix.ocaml-compiler, 'ocaml-variants.5.') }}
 
       - run: opam exec -- git diff --exit-code
 

--- a/.github/workflows/wasm_of_ocaml.yml
+++ b/.github/workflows/wasm_of_ocaml.yml
@@ -22,47 +22,50 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # 4.14 and 5.5 are tested on all three OSes; build-only compiler
+        # coverage lives in the build workflow. 5.5 exercises the toplevel
+        # cmi embedding on Windows: on OCaml >= 5.4 the expect tests fail
+        # if the virtual filesystem paths are wrong.
         os:
           - ubuntu-latest
-        os-name:
-           - Ubuntu
+          - macos-latest
+          - windows-latest
         ocaml-compiler:
           - "4.14"
-          - "5.0"
-          - "5.1"
-          - "5.2"
-          - "5.3"
-          - "5.4"
+          - "5.5"
+        ocaml-name:
+          - ""
         wasi:
           - false
         include:
-          - os: macos-latest
-            os-name: MacOS
-            ocaml-compiler: "5.3"
-            wasi: false
-          - os: windows-latest
-            os-name: Windows
-            # 5.5 exercises the toplevel cmi embedding on Windows: on
-            # OCaml >= 5.4 the expect tests fail if the virtual filesystem
-            # paths are wrong
-            ocaml-compiler: "5.5"
+          # Display names for the OSes
           - os: ubuntu-latest
             os-name: Ubuntu
+          - os: macos-latest
+            os-name: MacOS
+          - os: windows-latest
+            os-name: Windows
+          # Extra configurations, Ubuntu-only
+          - os: ubuntu-latest
+            os-name: Ubuntu
+            ocaml-name: "5.6+trunk"
             ocaml-compiler: "ocaml-variants.5.6.0+trunk"
             wasi: false
           - os: ubuntu-latest
             os-name: Ubuntu
+            ocaml-name: "OxCaml"
             ocaml-compiler: "ocaml-variants.5.2.0+ox"
             wasi: false
           - os: ubuntu-latest
             os-name: Ubuntu
-            ocaml-compiler: "5.3"
+            ocaml-name: ""
+            ocaml-compiler: "5.5"
             wasi: true
 
     runs-on: ${{ matrix.os }}
 
     name:
-       ${{ matrix.wasi && 'WASI / ' || '' }}${{ matrix.ocaml-compiler }} / ${{ matrix.os-name }}
+       ${{ matrix.wasi && 'WASI / ' || '' }}${{ matrix.ocaml-name != '' && matrix.ocaml-name || matrix.ocaml-compiler }} / ${{ matrix.os-name }}
 
     steps:
       - name: Update apt cache
@@ -105,7 +108,7 @@ jobs:
         if: ${{ endsWith(matrix.ocaml-compiler, '+ox') }}
 
       - name: Pin ppxlib
-        if: matrix.ocaml-compiler == 'ocaml-variants.5.6.0+trunk'
+        if: matrix.ocaml-name == '5.6+trunk'
         run: opam pin add -n ppxlib https://github.com/hhugo/ppxlib.git#support-5.6
 
       - name: Set-up Binaryen
@@ -154,13 +157,13 @@ jobs:
       # See https://github.com/libuv/libuv/issues/3622
 
       - name: Run tests with CPS effects
-        if: ${{ matrix.ocaml-compiler >= '5.' && ! matrix.wasi }}
+        if: ${{ (startsWith(matrix.ocaml-compiler, '5.') || startsWith(matrix.ocaml-compiler, 'ocaml-variants.5.')) && ! matrix.wasi }}
         continue-on-error: ${{ matrix.os == 'windows-latest' }}
         working-directory: ./wasm_of_ocaml
         run: opam exec -- dune build @runtest-wasm --profile with-effects
 
       - name: Run tests with native effects
-        if: ${{ matrix.ocaml-compiler >= '5.' && matrix.os != 'windows-latest' }}
+        if: ${{ (startsWith(matrix.ocaml-compiler, '5.') || startsWith(matrix.ocaml-compiler, 'ocaml-variants.5.')) && matrix.os != 'windows-latest' }}
         working-directory: ./wasm_of_ocaml
         run: opam exec -- dune build @runtest-wasm --profile with-native-effects
 


### PR DESCRIPTION
Stacked on #2394.

The js_of_ocaml workflow mixed two kinds of matrix rows: full test runs, and `skip-test` rows that only check `opam install . --best-effort` across a compiler range (4.13–5.4 plus 32-bit 5.4). This moves the build-only rows to a dedicated `build.yml`.

Since `opam install .` installs every package in the repository, the new workflow covers js_of_ocaml and wasm_of_ocaml alike (the wasm workflow never had build-only rows). It's also leaner per job: no Node.js set-up, no OxCaml machinery — just checkout, setup-ocaml, Binaryen and the best-effort install. It runs on pushes to master and the weekly cron, not on pull requests: installability across the compiler range is a slow-moving signal, and a push currently launches more jobs than the public-repo runner concurrency, so skipping these seven jobs at PR time lets the long test jobs start sooner (the timing report measured up to 13 min of runner queueing).

The follow-up commits then simplify the test matrices:
- `js_of_ocaml.yml`: the `skip-test` axis, best-effort step and conditions disappear; macOS/Windows move from OCaml 5.4.0 to 5.5; `skip-effects` is replaced by a version check (effects need OCaml 5 — a `startsWith` pair, since `>= '5.'` would wrongly match `ocaml-variants.4.x`), so macOS 5.5 starts running the effects profiles; the matrix becomes real `os × {4.14, 5.5}` axes with os-names attached by include-augmentation entries and only the Ubuntu-only configurations (32-bit 4.14, 5.6+trunk, bytecode-only 5.1, OxCaml) as genuine includes. `skip-doc` becomes an expression too: docs are checked once, on Ubuntu/5.5.
- `wasm_of_ocaml.yml`: same shape. Coverage changes: Ubuntu drops the 5.0–5.4 test rows (still installed by the build workflow) and gains 5.5 — previously never tested on wasm; macOS and Windows move from 5.3 to 4.14 + 5.5; the WASI row moves from 5.3 to 5.5.

Job names change accordingly: build-only jobs appear as `build / <compiler> / Ubuntu` (on master), and test rows read `<compiler> / <OS> / Tests[ / Effects][ / Docs]`. Branch-protection required checks may need updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)