### PR TITLE
Fix wasm toplevels built on Windows

### DIFF
--- a/.github/workflows/wasm_of_ocaml.yml
+++ b/.github/workflows/wasm_of_ocaml.yml
@@ -50,7 +50,10 @@ jobs:
             wasi: false
           - os: windows-latest
             os-name: Windows
-            ocaml-compiler: "5.3"
+            # 5.5 exercises the toplevel cmi embedding on Windows: on
+            # OCaml >= 5.4 the expect tests fail if the virtual filesystem
+            # paths are wrong
+            ocaml-compiler: "5.5"
             separate_compilation: true
             # Jane Street tests disabled for now (basement only works on Linux)
             jane_street_tests: false

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,11 @@
   API, plus a `fonts` property on `Dom_html.document` (#2255)
 
 ## Bug fixes
+* Compiler/Wasm runtime: fix toplevels built on Windows — the embedded cmi
+  paths were built with `Filename.concat`, putting `\` separators in the
+  unix-style virtual filesystem, and its lookups did not normalize the `\`
+  separators the program uses when running on Windows; loading Stdlib then
+  failed with `Env.Error` on OCaml >= 5.4 (#2397)
 * Compiler: only fuse `if (e) var x = e; else var x = e2` into
   `var x = e || e2` when the condition is effect-free; an effectful
   condition structurally equal to the branch (e.g. two calls to the same

--- a/compiler/lib/pseudo_fs.ml
+++ b/compiler/lib/pseudo_fs.ml
@@ -19,13 +19,18 @@
 
 open! Stdlib
 
+(* Virtual paths live in the unix-style pseudo filesystem of the runtime;
+   build them with '/' explicitly, since [Filename.concat] would introduce
+   '\\' when compiling on Windows. *)
+let virt_concat dir base = dir ^ "/" ^ base
+
 let expand_path exts real virt =
   let rec loop realfile virtfile acc =
     if try Sys.is_directory realfile with _ -> false
     then
       let l = Array.to_list (Sys.readdir realfile) |> List.sort ~cmp:String.compare in
       List.fold_left l ~init:acc ~f:(fun acc s ->
-          loop (Filename.concat realfile s) (Filename.concat virtfile s) acc)
+          loop (Filename.concat realfile s) (virt_concat virtfile s) acc)
     else
       let exmatch =
         try
@@ -76,7 +81,7 @@ let find_cmi paths base =
         | Some cmi -> Some (name, cmi)
         | None -> None)
   with
-  | Some (name, filename) -> Some (Filename.concat "/static/cmis" name, filename)
+  | Some (name, filename) -> Some (virt_concat "/static/cmis" name, filename)
   | None -> None
 
 let instr_of_name_content prim ~name ~content =

--- a/runtime/wasm/runtime.js
+++ b/runtime/wasm/runtime.js
@@ -68,13 +68,21 @@
 
   const fs = isNode && require("node:fs");
 
+  const on_windows = isNode && globalThis.process.platform === "win32";
+
   // Virtual filesystem for embedded files (e.g. CMIs for toplevel)
   const virtual_files = new Map(); // path -> Uint8Array
   const virtual_dirs = new Set(); // directory paths
   const virtual_fds = new Map(); // fd -> { data, offset }
   let next_virtual_fd = 1000000;
 
+  // The virtual filesystem uses "/" as path separator. On Windows, the
+  // program manipulates paths with "\" (Sys.os_type is "Win32"), so
+  // normalize paths on registration and before each lookup.
+  const virtual_path = on_windows ? (p) => p.replaceAll("\\", "/") : (p) => p;
+
   function register_virtual_file(name, content) {
+    name = virtual_path(name);
     virtual_files.set(name, content);
     let dir = name;
     while (true) {
@@ -266,7 +274,6 @@
     );
   }
 
-  const on_windows = isNode && globalThis.process.platform === "win32";
   const on_arm64 = globalThis.process?.arch === "arm64";
 
   // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack
@@ -582,9 +589,10 @@
         access_flags.reduce((f, v, i) => (flags & (1 << i) ? f | v : f), 0),
       ),
     open: (p, flags, perm) => {
-      if (virtual_files.has(p) && !(flags & 2)) {
+      const vp = virtual_path(p);
+      if (virtual_files.has(vp) && !(flags & 2)) {
         const fd = next_virtual_fd++;
-        virtual_fds.set(fd, { data: virtual_files.get(p), offset: 0 });
+        virtual_fds.set(fd, { data: virtual_files.get(vp), offset: 0 });
         return fd;
       }
       return fs.openSync(
@@ -664,7 +672,8 @@
     readlink: (p) => fs.readlinkSync(p),
     unlink: (p) => fs.unlinkSync(p),
     read_dir: (p) => {
-      const prefix = p.endsWith("/") ? p : p + "/";
+      const vp = virtual_path(p);
+      const prefix = vp.endsWith("/") ? vp : vp + "/";
       const entries = new Set();
       for (const name of virtual_files.keys()) {
         if (name.startsWith(prefix)) {
@@ -699,18 +708,21 @@
     chmod: (p, perms) => fs.chmodSync(p, perms),
     fchmod: (p, perms) => fs.fchmodSync(p, perms),
     file_exists: (p) => {
-      if (virtual_files.has(p) || virtual_dirs.has(p)) return 1;
+      const vp = virtual_path(p);
+      if (virtual_files.has(vp) || virtual_dirs.has(vp)) return 1;
       return fs ? +fs.existsSync(p) : 0;
     },
     is_directory: (p) => {
-      if (virtual_dirs.has(p)) return 1;
-      if (virtual_files.has(p)) return 0;
+      const vp = virtual_path(p);
+      if (virtual_dirs.has(vp)) return 1;
+      if (virtual_files.has(vp)) return 0;
       // Follow symlinks, like native and the JS runtime (statSync, not lstat).
       return +fs.statSync(p).isDirectory();
     },
     is_file: (p) => {
-      if (virtual_files.has(p)) return 1;
-      if (virtual_dirs.has(p)) return 0;
+      const vp = virtual_path(p);
+      if (virtual_files.has(vp)) return 1;
+      if (virtual_dirs.has(vp)) return 0;
       // Follow symlinks, like native and the JS runtime (statSync, not lstat).
       return +fs.statSync(p).isFile();
     },
@@ -817,7 +829,7 @@
       for (const name of names) inst.exports[name + ".init"]();
     },
     register_file: (name, data) => register_virtual_file(name, data),
-    read_file: (name) => virtual_files.get(name) ?? null,
+    read_file: (name) => virtual_files.get(virtual_path(name)) ?? null,
   };
   const string_ops = {
     test: (v) => +(typeof v === "string"),


### PR DESCRIPTION
Testing wasm_of_ocaml on Windows with OCaml 5.5 (#2396) failed all `compiler/tests-ocaml` expect suites with `Fatal error: exception Env.Error(_)` from the wasm expect-test runner, while the same tests pass on Windows with 5.3, and on Linux/macOS with 5.5.

Two coordinated defects around the runtime's unix-style virtual filesystem (introduced with it, latent until now):

- `Pseudo_fs.find_cmi` (and the virtual side of `expand_path`) built virtual paths with `Filename.concat`, so a compiler running on Windows embedded names like `/static/cmis\stdlib.cmi`. The runtime derives virtual directories by splitting on `/`, so no `/static/cmis` directory exists and `readdir` cannot see the cmis; on OCaml ≥ 5.4 the toplevel's load path relies on that and `Toploop.initialize_toplevel_env` dies with `Env.Error` while loading Stdlib. (5.3 tolerated it because direct path probing accidentally works: the program reports `Sys.os_type = "Win32"` and reconstructs the same backslashed string.)
- Symmetrically, the runtime's virtual lookups matched paths exactly, so once names are stored with `/`, a program running on Windows — which builds paths with `\` — would not find them.

Fix both: build virtual paths with `/` explicitly in `Pseudo_fs`, and normalize `\` to `/` in the wasm runtime's virtual filesystem (registration and lookups) when running on Windows, mirroring what the JS runtime's fake filesystem already does.

Reproduced on Linux/OCaml 5.5 by forcing a backslash into the embedded path — that yields exactly the CI symptom; with this fix the expect suites pass. Windows validation: the `wasm / 5.5 / Windows` row added in #2396 exercises exactly this path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)