### PR TITLE
Add pointer-capture and missing pointerEvent bindings to Dom_html

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -93,6 +93,8 @@
   path form (ocaml/dune#15156) no longer breaks their expected output (#2384)
 * Lib: add `Element.setPointerCapture`/`releasePointerCapture`/`hasPointerCapture`
   bindings to `Dom_html.element` (#2403)
+* Lib: add `pointerEvent` bindings `getPredictedEvents`, `altitudeAngle` and
+  `azimuthAngle` (#2403)
 
 # 6.4.0 (2026-06-21) - Lille
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -91,6 +91,8 @@
   instead of `%{dep:...}` in the `md5`/`md5_nat`, `dump_sourcemap` and
   `check-prim` tests, which echo the path verbatim, so dune 3.24's leading-`./`
   path form (ocaml/dune#15156) no longer breaks their expected output (#2384)
+* Lib: add `Element.setPointerCapture`/`releasePointerCapture`/`hasPointerCapture`
+  bindings to `Dom_html.element` (#2403)
 
 # 6.4.0 (2026-06-21) - Lille
 

--- a/lib/js_of_ocaml/dom_html.ml
+++ b/lib/js_of_ocaml/dom_html.ml
@@ -1410,6 +1410,12 @@ and element = object
 
   method blur : unit meth
 
+  method setPointerCapture : int -> unit meth
+
+  method releasePointerCapture : int -> unit meth
+
+  method hasPointerCapture : int -> bool t meth
+
   method requestFullscreen : unit Promise.t meth
 
   method requestPointerLock : unit Promise.t meth

--- a/lib/js_of_ocaml/dom_html.ml
+++ b/lib/js_of_ocaml/dom_html.ml
@@ -912,11 +912,17 @@ and pointerEvent = object
 
   method twist : int readonly_prop
 
+  method altitudeAngle : number_t readonly_prop
+
+  method azimuthAngle : number_t readonly_prop
+
   method pointerType : js_string t readonly_prop
 
   method isPrimary : bool t readonly_prop
 
   method getCoalescedEvents : pointerEvent t js_array t meth
+
+  method getPredictedEvents : pointerEvent t js_array t meth
 end
 
 and storageEvent = object

--- a/lib/js_of_ocaml/dom_html.mli
+++ b/lib/js_of_ocaml/dom_html.mli
@@ -931,11 +931,22 @@ and pointerEvent = object
 
   method twist : int readonly_prop
 
+  method altitudeAngle : number_t readonly_prop
+  (** Angle in radians between the pointer axis and the surface (Pointer
+      Events level 3). *)
+
+  method azimuthAngle : number_t readonly_prop
+  (** Angle in radians of the pointer projection on the surface (Pointer
+      Events level 3). *)
+
   method pointerType : js_string t readonly_prop
 
   method isPrimary : bool t readonly_prop
 
   method getCoalescedEvents : pointerEvent t js_array t meth
+
+  method getPredictedEvents : pointerEvent t js_array t meth
+  (** Predicted future pointer events, as computed by the browser. *)
 end
 
 and storageEvent = object

--- a/lib/js_of_ocaml/dom_html.mli
+++ b/lib/js_of_ocaml/dom_html.mli
@@ -1452,6 +1452,16 @@ and element = object
 
   method blur : unit meth
 
+  method setPointerCapture : int -> unit meth
+  (** Set the element as capture target for the pointer with this
+      [pointerId] (Pointer Events, [Element.setPointerCapture]). *)
+
+  method releasePointerCapture : int -> unit meth
+  (** Release a pointer capture previously set for this pointer id. *)
+
+  method hasPointerCapture : int -> bool t meth
+  (** Whether the element currently captures this pointer id. *)
+
   method requestFullscreen : unit Promise.t meth
 
   method requestPointerLock : unit Promise.t meth


### PR DESCRIPTION
Add the typed bindings for the Pointer Capture API on `Dom_html.element`, which
were missing so far and had to be called through `Js.Unsafe.meth_call`:

```
method setPointerCapture : int -> unit meth
method releasePointerCapture : int -> unit meth
method hasPointerCapture : int -> bool t meth
```

The related capture events (`gotpointercapture` / `lostpointercapture`) already
exist both as `element` listeners and in `Event`, so this completes the Pointer
Capture API.

While there, complete the `pointerEvent` type with a few standard members that
were also missing:

* `getPredictedEvents` (counterpart to the existing `getCoalescedEvents`);
* `altitudeAngle` and `azimuthAngle` (Pointer Events level 3 stylus tilt, in
  radians).

`Lwt_js_events` already wraps all pointer events (including the two capture
events), so nothing is needed there.

Two commits: one for the `element` capture methods, one for the `pointerEvent`
members.
