### PR TITLE
Lwt_js_events: accept any element (not only images) in load/error/abort

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,8 @@
   asynchronous toplevel originally contributed in the unmerged #435 (#66, #833)
 * Lib: add `FontFace` module — partial binding to the CSS Font Loading
   API, plus a `fonts` property on `Dom_html.document` (#2255)
+* Lib: `Lwt_js_events` `load`/`error`/`abort` and their `seq_loop` variants now
+  accept any element, not only images (#2404)
 
 ## Bug fixes
 * Compiler/Wasm runtime: fix toplevels built on Windows — the embedded cmi

--- a/lib/lwt/lwt_js_events.mli
+++ b/lib/lwt/lwt_js_events.mli
@@ -481,19 +481,19 @@ val transitioncancel :
 val load :
      ?use_capture:bool
   -> ?passive:bool
-  -> #Dom_html.imageElement Js.t
+  -> #Dom_html.element Js.t
   -> Dom_html.event Js.t Lwt.t
 
 val error :
      ?use_capture:bool
   -> ?passive:bool
-  -> #Dom_html.imageElement Js.t
+  -> #Dom_html.element Js.t
   -> Dom_html.event Js.t Lwt.t
 
 val abort :
      ?use_capture:bool
   -> ?passive:bool
-  -> #Dom_html.imageElement Js.t
+  -> #Dom_html.element Js.t
   -> Dom_html.event Js.t Lwt.t
 
 val canplay :
@@ -880,7 +880,7 @@ val loads :
      ?cancel_handler:bool
   -> ?use_capture:bool
   -> ?passive:bool
-  -> #Dom_html.imageElement Js.t
+  -> #Dom_html.element Js.t
   -> (Dom_html.event Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
 
@@ -888,7 +888,7 @@ val errors :
      ?cancel_handler:bool
   -> ?use_capture:bool
   -> ?passive:bool
-  -> #Dom_html.imageElement Js.t
+  -> #Dom_html.element Js.t
   -> (Dom_html.event Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
 
@@ -896,7 +896,7 @@ val aborts :
      ?cancel_handler:bool
   -> ?use_capture:bool
   -> ?passive:bool
-  -> #Dom_html.imageElement Js.t
+  -> #Dom_html.element Js.t
   -> (Dom_html.event Js.t -> unit Lwt.t -> unit Lwt.t)
   -> unit Lwt.t
 


### PR DESCRIPTION
This widens the element type accepted by the `load` / `error` / `abort` helpers
of `Lwt_js_events` (and their `seq_loop` variants `loads` / `errors` / `aborts`)
from `#Dom_html.imageElement Js.t` to `#Dom_html.element Js.t`.

### Motivation

These events fire on many elements, not only `<img>`: `<script>`, `<link>`,
`<iframe>`, media elements, and so on. Today, loading e.g. a `<script>` and
waiting for its `load` event forces a workaround through the low-level
`Lwt_js_events.make_event (Dom_html.Event.make "load") s`, because
`Lwt_js_events.load` only accepts an `imageElement`. With this change it becomes
simply `Lwt_js_events.load s`.

### Why this is a pure signature widening

The implementation (`.ml`) was already fully generic
(`make_event Dom_html.Event.load ... target`, with no reference to
`imageElement`); the restriction lived only in the `.mli`. This PR touches the
`.mli` only, no change to the `.ml`.

It is backward compatible: `imageElement` is an `element`, so every existing
call site keeps type-checking. We only accept a superset.

### Note for reviewers

This is an API type change, flagged for discussion: if you would rather restrict
the accepted type to a narrower set of elements than `element`, let me know and I
will adjust.
