### PR TITLE
ci(doc): fail the build on a dead reference or a leftover wiki image

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -72,6 +72,7 @@ jobs:
           opam exec -- wodoc build --config doc/wodoc
           --menu https://ocsigen.org/doc/menu.html
           --out "$PWD/_doc-site/dev" --label dev
+          --strict-refs
 
       - name: Deploy to gh-pages (replace only dev/, keep the rest)
         uses: JamesIves/github-pages-deploy-action@v4


### PR DESCRIPTION
`wodoc build` reports the markup that was meant to become a link or an image and
did not, and `--strict-refs` makes it fatal (ocsigen/wodoc#14, refined in #17, #18
and #20).

Verified on the rebuild just now: **zero repairable defects**, so this changes
nothing today and only guards against a regression — the kind that had the
tutorial serving raw wikicréole where its screenshots should be, and 34 dead
intra-manual links, unnoticed.

Added to the `dev` build only; the release job builds a tagged tree, which should
not start failing over something that shipped.

One number worth a look, separately from this PR: the check counts **12 759**
references into dependencies the site does not host, across 487 pages — far more
than any other Ocsigen project (tyxml 130, ocsigenserver 186). They are mostly
`Stdlib` and friends from the bindings' signatures. Nothing is broken, the
references simply render as text; but if you wanted them to be links, that is the
one project where it would pay.
