### PR TITLE
tests-full: refresh stdlib 5.6 snapshot for OCaml trunk changes

### DIFF
--- a/compiler/tests-full/stdlib.cma.5.6.expected.js
+++ b/compiler/tests-full/stdlib.cma.5.6.expected.js
@@ -1327,107 +1327,107 @@
     max_floatarray_length = max_array_length / 2 | 0,
     max_string_length = (4 * max_array_length | 0) - 1 | 0,
     io_buffer_size =
-       /*<<sys.ml.in:75:21>>*/ runtime.caml_sys_io_buffer_size(0);
-   function set_signal(sig_num, sig_beh){ /*<<sys.ml.in:89:63>>*/ return 0;}
+       /*<<sys.ml.in:76:21>>*/ runtime.caml_sys_io_buffer_size(0);
+   function set_signal(sig_num, sig_beh){ /*<<sys.ml.in:90:63>>*/ return 0;}
    function signal_to_string(s){
-     /*<<sys.ml.in:123:2>>*/ if(s === -1)
-      /*<<sys.ml.in:123:22>>*/ return "SIGABRT";
-     /*<<sys.ml.in:124:7>>*/ if(s === -2)
-      /*<<sys.ml.in:124:27>>*/ return "SIGALRM";
-     /*<<sys.ml.in:125:7>>*/ if(s === -3)
-      /*<<sys.ml.in:125:26>>*/ return "SIGFPE";
-     /*<<sys.ml.in:126:7>>*/ if(s === -4)
-      /*<<sys.ml.in:126:26>>*/ return "SIGHUP";
-     /*<<sys.ml.in:127:7>>*/ if(s === -5)
-      /*<<sys.ml.in:127:26>>*/ return "SIGILL";
-     /*<<sys.ml.in:128:7>>*/ if(s === -6)
-      /*<<sys.ml.in:128:26>>*/ return "SIGINT";
-     /*<<sys.ml.in:129:7>>*/ if(s === -7)
-      /*<<sys.ml.in:129:27>>*/ return "SIGKILL";
-     /*<<sys.ml.in:130:7>>*/ if(s === -8)
-      /*<<sys.ml.in:130:27>>*/ return "SIGPIPE";
-     /*<<sys.ml.in:131:7>>*/ if(s === -9)
-      /*<<sys.ml.in:131:27>>*/ return "SIGQUIT";
-     /*<<sys.ml.in:132:7>>*/ if(s === -10)
-      /*<<sys.ml.in:132:27>>*/ return "SIGSEGV";
-     /*<<sys.ml.in:133:7>>*/ if(s === -11)
-      /*<<sys.ml.in:133:27>>*/ return "SIGTERM";
-     /*<<sys.ml.in:134:7>>*/ if(s === -12)
-      /*<<sys.ml.in:134:27>>*/ return "SIGUSR1";
-     /*<<sys.ml.in:135:7>>*/ if(s === -13)
-      /*<<sys.ml.in:135:27>>*/ return "SIGUSR2";
-     /*<<sys.ml.in:136:7>>*/ if(s === -14)
-      /*<<sys.ml.in:136:27>>*/ return "SIGCHLD";
-     /*<<sys.ml.in:137:7>>*/ if(s === -15)
-      /*<<sys.ml.in:137:27>>*/ return "SIGCONT";
-     /*<<sys.ml.in:138:7>>*/ if(s === -16)
-      /*<<sys.ml.in:138:27>>*/ return "SIGSTOP";
-     /*<<sys.ml.in:139:7>>*/ if(s === -17)
-      /*<<sys.ml.in:139:27>>*/ return "SIGTSTP";
-     /*<<sys.ml.in:140:7>>*/ if(s === -18)
-      /*<<sys.ml.in:140:27>>*/ return "SIGTTIN";
-     /*<<sys.ml.in:141:7>>*/ if(s === -19)
-      /*<<sys.ml.in:141:27>>*/ return "SIGTTOU";
-     /*<<sys.ml.in:142:7>>*/ if(s === -20)
-      /*<<sys.ml.in:142:29>>*/ return "SIGVTALRM";
-     /*<<sys.ml.in:143:7>>*/ if(s === -21)
-      /*<<sys.ml.in:143:27>>*/ return "SIGPROF";
-     /*<<sys.ml.in:144:7>>*/ if(s === -22)
-      /*<<sys.ml.in:144:26>>*/ return "SIGBUS";
-     /*<<sys.ml.in:145:7>>*/ if(s === -23)
-      /*<<sys.ml.in:145:27>>*/ return "SIGPOLL";
-     /*<<sys.ml.in:146:7>>*/ if(s === -24)
-      /*<<sys.ml.in:146:26>>*/ return "SIGSYS";
-     /*<<sys.ml.in:147:7>>*/ if(s === -25)
-      /*<<sys.ml.in:147:27>>*/ return "SIGTRAP";
-     /*<<sys.ml.in:148:7>>*/ if(s === -26)
-      /*<<sys.ml.in:148:26>>*/ return "SIGURG";
-     /*<<sys.ml.in:149:7>>*/ if(s === -27)
-      /*<<sys.ml.in:149:27>>*/ return "SIGXCPU";
-     /*<<sys.ml.in:150:7>>*/ if(s === -28)
-      /*<<sys.ml.in:150:27>>*/ return "SIGXFSZ";
-     /*<<sys.ml.in:151:7>>*/ if(s === -29)
-      /*<<sys.ml.in:151:25>>*/ return "SIGIO";
-     /*<<sys.ml.in:152:7>>*/ if(s === -30)
-      /*<<sys.ml.in:152:28>>*/ return "SIGWINCH";
-     /*<<sys.ml.in:153:7>>*/ if(s < -30)
-      /*<<sys.ml.in:153:28>>*/ return Stdlib[1].call
-             (null, "Sys.signal_to_string") /*<<sys.ml.in:154:37>>*/ ;
+     /*<<sys.ml.in:124:2>>*/ if(s === -1)
+      /*<<sys.ml.in:124:22>>*/ return "SIGABRT";
+     /*<<sys.ml.in:125:7>>*/ if(s === -2)
+      /*<<sys.ml.in:125:27>>*/ return "SIGALRM";
+     /*<<sys.ml.in:126:7>>*/ if(s === -3)
+      /*<<sys.ml.in:126:26>>*/ return "SIGFPE";
+     /*<<sys.ml.in:127:7>>*/ if(s === -4)
+      /*<<sys.ml.in:127:26>>*/ return "SIGHUP";
+     /*<<sys.ml.in:128:7>>*/ if(s === -5)
+      /*<<sys.ml.in:128:26>>*/ return "SIGILL";
+     /*<<sys.ml.in:129:7>>*/ if(s === -6)
+      /*<<sys.ml.in:129:26>>*/ return "SIGINT";
+     /*<<sys.ml.in:130:7>>*/ if(s === -7)
+      /*<<sys.ml.in:130:27>>*/ return "SIGKILL";
+     /*<<sys.ml.in:131:7>>*/ if(s === -8)
+      /*<<sys.ml.in:131:27>>*/ return "SIGPIPE";
+     /*<<sys.ml.in:132:7>>*/ if(s === -9)
+      /*<<sys.ml.in:132:27>>*/ return "SIGQUIT";
+     /*<<sys.ml.in:133:7>>*/ if(s === -10)
+      /*<<sys.ml.in:133:27>>*/ return "SIGSEGV";
+     /*<<sys.ml.in:134:7>>*/ if(s === -11)
+      /*<<sys.ml.in:134:27>>*/ return "SIGTERM";
+     /*<<sys.ml.in:135:7>>*/ if(s === -12)
+      /*<<sys.ml.in:135:27>>*/ return "SIGUSR1";
+     /*<<sys.ml.in:136:7>>*/ if(s === -13)
+      /*<<sys.ml.in:136:27>>*/ return "SIGUSR2";
+     /*<<sys.ml.in:137:7>>*/ if(s === -14)
+      /*<<sys.ml.in:137:27>>*/ return "SIGCHLD";
+     /*<<sys.ml.in:138:7>>*/ if(s === -15)
+      /*<<sys.ml.in:138:27>>*/ return "SIGCONT";
+     /*<<sys.ml.in:139:7>>*/ if(s === -16)
+      /*<<sys.ml.in:139:27>>*/ return "SIGSTOP";
+     /*<<sys.ml.in:140:7>>*/ if(s === -17)
+      /*<<sys.ml.in:140:27>>*/ return "SIGTSTP";
+     /*<<sys.ml.in:141:7>>*/ if(s === -18)
+      /*<<sys.ml.in:141:27>>*/ return "SIGTTIN";
+     /*<<sys.ml.in:142:7>>*/ if(s === -19)
+      /*<<sys.ml.in:142:27>>*/ return "SIGTTOU";
+     /*<<sys.ml.in:143:7>>*/ if(s === -20)
+      /*<<sys.ml.in:143:29>>*/ return "SIGVTALRM";
+     /*<<sys.ml.in:144:7>>*/ if(s === -21)
+      /*<<sys.ml.in:144:27>>*/ return "SIGPROF";
+     /*<<sys.ml.in:145:7>>*/ if(s === -22)
+      /*<<sys.ml.in:145:26>>*/ return "SIGBUS";
+     /*<<sys.ml.in:146:7>>*/ if(s === -23)
+      /*<<sys.ml.in:146:27>>*/ return "SIGPOLL";
+     /*<<sys.ml.in:147:7>>*/ if(s === -24)
+      /*<<sys.ml.in:147:26>>*/ return "SIGSYS";
+     /*<<sys.ml.in:148:7>>*/ if(s === -25)
+      /*<<sys.ml.in:148:27>>*/ return "SIGTRAP";
+     /*<<sys.ml.in:149:7>>*/ if(s === -26)
+      /*<<sys.ml.in:149:26>>*/ return "SIGURG";
+     /*<<sys.ml.in:150:7>>*/ if(s === -27)
+      /*<<sys.ml.in:150:27>>*/ return "SIGXCPU";
+     /*<<sys.ml.in:151:7>>*/ if(s === -28)
+      /*<<sys.ml.in:151:27>>*/ return "SIGXFSZ";
+     /*<<sys.ml.in:152:7>>*/ if(s === -29)
+      /*<<sys.ml.in:152:25>>*/ return "SIGIO";
+     /*<<sys.ml.in:153:7>>*/ if(s === -30)
+      /*<<sys.ml.in:153:28>>*/ return "SIGWINCH";
+     /*<<sys.ml.in:154:7>>*/ if(s < -30)
+      /*<<sys.ml.in:154:28>>*/ return Stdlib[1].call
+             (null, "Sys.signal_to_string") /*<<sys.ml.in:155:37>>*/ ;
     var
-     _a_ =  /*<<sys.ml.in:154:16>>*/ Stdlib[33].call(null, s),
+     _a_ =  /*<<sys.ml.in:155:16>>*/ Stdlib[33].call(null, s),
      _a_ = Stdlib[28].call(null, _a_, ")");
-     /*<<sys.ml.in:154:37>>*/ return Stdlib[28].call(null, "SIG(", _a_);
+     /*<<sys.ml.in:155:37>>*/ return Stdlib[28].call(null, "SIG(", _a_);
    }
    function signal_of_int(i){
-     /*<<sys.ml.in:162:2>>*/ return 0 <= i
-            ?  /*<<sys.ml.in:163:7>>*/ runtime.caml_sys_rev_convert_signal_number
+     /*<<sys.ml.in:163:2>>*/ return 0 <= i
+            ?  /*<<sys.ml.in:164:7>>*/ runtime.caml_sys_rev_convert_signal_number
               (i)
-            :  /*<<sys.ml.in:162:16>>*/ Stdlib
+            :  /*<<sys.ml.in:163:16>>*/ Stdlib
                [1].call
-              (null, "Sys.signal_of_int") /*<<sys.ml.in:163:34>>*/ ;
+              (null, "Sys.signal_of_int") /*<<sys.ml.in:164:34>>*/ ;
    }
    function signal_to_int(i){
-     /*<<sys.ml.in:166:2>>*/ return i < -30
-            ?  /*<<sys.ml.in:166:23>>*/ Stdlib
+     /*<<sys.ml.in:167:2>>*/ return i < -30
+            ?  /*<<sys.ml.in:167:23>>*/ Stdlib
                [1].call
               (null, "Sys.signal_to_int")
-            :  /*<<sys.ml.in:167:7>>*/ runtime.caml_sys_convert_signal_number
-              (i) /*<<sys.ml.in:167:30>>*/ ;
+            :  /*<<sys.ml.in:168:7>>*/ runtime.caml_sys_convert_signal_number
+              (i) /*<<sys.ml.in:168:30>>*/ ;
    }
    var
     Break =
-       /*<<sys.ml.in:75:38>>*/ [248,
+       /*<<sys.ml.in:76:38>>*/ [248,
        "Stdlib.Sys.Break",
        runtime.caml_fresh_oo_id(0)];
    function catch_break(on){
-     /*<<sys.ml.in:172:2>>*/ return on ? 0 : 0 /*<<sys.ml.in:175:36>>*/ ;
+     /*<<sys.ml.in:173:2>>*/ return on ? 0 : 0 /*<<sys.ml.in:176:36>>*/ ;
    }
    function Make(Immediate, Non_immediate){
-     /*<<sys.ml.in:229:8>>*/ return [0, 1];
+     /*<<sys.ml.in:230:8>>*/ return [0, 1];
    }
    var
     Stdlib_Sys =
-       /*<<sys.ml.in:75:38>>*/ [0,
+       /*<<sys.ml.in:76:38>>*/ [0,
        executable_name,
        runtime_executable,
        runtime.caml_sys_getenv_opt,
@@ -1493,7 +1493,7 @@
 
 //# unitInfo: Provides: Stdlib__Obj
 //# unitInfo: Requires: Stdlib, Stdlib__Sys
-//# shape: Stdlib__Obj:[F(1)*,F(2),F(3),N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,[F(1),F(1)*,F(1)*],[F(1),F(1)*,F(2),F(2),F(3),F(2),F(2),F(5),F(1),F(1),F(2),F(1),F(1),F(2),N]]
+//# shape: Stdlib__Obj:[F(1)*,F(2),F(3),F(1),N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,[F(1),F(1)*,F(1)*],[F(1),F(1)*,F(2),F(2),F(3),F(2),F(2),F(5),F(1),F(1),F(2),F(1),F(1),F(2),N]]
 (function
   (globalThis){
    "use strict";
@@ -1514,11 +1514,33 @@
      /*<<obj.ml:37:2>>*/ caml_check_bound(x, i)[i + 1] = v;
      /*<<obj.ml:37:41>>*/ return 0;
    }
+   function hash_variant(s){
+    var
+     _b_ =  /*<<obj.ml:53:2>>*/ runtime.caml_ml_string_length(s) - 1 | 0,
+     _a_ =  /*<<obj.ml:52:2>>*/ 0;
+     /*<<obj.ml:53:2>>*/ if(_b_ < 0)
+     var accu$1 = _a_;
+    else{
+     var accu$0 = _a_, i = 0;
+     for(;;){
+       /*<<obj.ml:54:36>>*/ _a_ =
+       (223 * accu$0 | 0) + runtime.caml_string_get(s, i) | 0;
+      var _c_ =  /*<<obj.ml:54:52>>*/ i + 1 | 0;
+      if(_b_ === i){accu$1 = _a_; break;}
+      accu$0 = _a_;
+      i = _c_;
+     }
+    }
+    var accu =  /*<<obj.ml:57:2>>*/ accu$1 & 2147483647;
+     /*<<obj.ml:59:2>>*/ return 1073741823 < accu
+            ? accu + 2147483648 | 0
+            : accu /*<<obj.ml:59:58>>*/ ;
+   }
    function of_val(x){
     var
      slot =
-        /*<<obj.ml:77:21>>*/ 1 - (typeof x === "number")
-        ?  /*<<obj.ml:77:25>>*/ caml_obj_tag
+        /*<<obj.ml:91:21>>*/ 1 - (typeof x === "number")
+        ?  /*<<obj.ml:91:25>>*/ caml_obj_tag
            (x)
           !== 248
           ? 1 <= x.length - 1 ? x[1] : x
@@ -1527,87 +1549,87 @@
      cst_Obj_extension_constructor =  /*<<?>>*/ "Obj.extension_constructor";
     a:
     {
-      /*<<obj.ml:81:24>>*/ if
+      /*<<obj.ml:95:24>>*/ if
       (1 - (typeof slot === "number")
-       &&  /*<<obj.ml:81:28>>*/ caml_obj_tag(slot) === 248){
-      var name =  /*<<obj.ml:81:69>>*/ slot[1];
+       &&  /*<<obj.ml:95:28>>*/ caml_obj_tag(slot) === 248){
+      var name =  /*<<obj.ml:95:69>>*/ slot[1];
       break a;
      }
-      /*<<obj.ml:82:50>>*/ name =
-       /*<<obj.ml:82:11>>*/ Stdlib[1].call
+      /*<<obj.ml:96:50>>*/ name =
+       /*<<obj.ml:96:11>>*/ Stdlib[1].call
        (null, cst_Obj_extension_constructor);
     }
-     /*<<obj.ml:84:9>>*/ return caml_obj_tag(name) === 252
+     /*<<obj.ml:98:9>>*/ return caml_obj_tag(name) === 252
             ? slot
-            :  /*<<obj.ml:85:11>>*/ Stdlib
+            :  /*<<obj.ml:99:11>>*/ Stdlib
                [1].call
-              (null, cst_Obj_extension_constructor) /*<<obj.ml:85:50>>*/ ;
+              (null, cst_Obj_extension_constructor) /*<<obj.ml:99:50>>*/ ;
    }
-   function name(slot){ /*<<obj.ml:88:30>>*/ return slot[1];}
-   function id(slot){ /*<<obj.ml:91:30>>*/ return slot[2];}
+   function name(slot){ /*<<obj.ml:102:30>>*/ return slot[1];}
+   function id(slot){ /*<<obj.ml:105:30>>*/ return slot[2];}
    var max_ephe_length =  /*<<?>>*/ Stdlib_Sys[15] - 2 | 0;
    function create(l){
     var
-     _a_ =  /*<<obj.ml:105:4>>*/ 0 <= l,
+     _a_ =  /*<<obj.ml:119:4>>*/ 0 <= l,
      _a_ = _a_ ? l <= max_ephe_length : _a_;
     if(1 - _a_)
-      /*<<obj.ml:106:6>>*/ Stdlib[1].call(null, "Obj.Ephemeron.create");
-     /*<<obj.ml:107:4>>*/ return runtime.caml_ephe_create(l) /*<<obj.ml:107:12>>*/ ;
+      /*<<obj.ml:120:6>>*/ Stdlib[1].call(null, "Obj.Ephemeron.create");
+     /*<<obj.ml:121:4>>*/ return runtime.caml_ephe_create(l) /*<<obj.ml:121:12>>*/ ;
    }
    function length(x){
-     /*<<obj.ml:109:17>>*/ return x.length - 3 | 0;
-    /*<<obj.ml:109:49>>*/ }
+     /*<<obj.ml:123:17>>*/ return x.length - 3 | 0;
+    /*<<obj.ml:123:49>>*/ }
    function raise_if_invalid_offset(e, o, msg){
     var
-     _a_ =  /*<<obj.ml:112:4>>*/ 0 <= o,
-     _a_ = _a_ ? o <  /*<<obj.ml:112:26>>*/ length(e) : _a_,
-     _a_ =  /*<<obj.ml:112:4>>*/ 1 - _a_;
-    return _a_ ?  /*<<obj.ml:113:6>>*/ Stdlib[1].call(null, msg) : _a_ /*<<obj.ml:113:21>>*/ ;
+     _a_ =  /*<<obj.ml:126:4>>*/ 0 <= o,
+     _a_ = _a_ ? o <  /*<<obj.ml:126:26>>*/ length(e) : _a_,
+     _a_ =  /*<<obj.ml:126:4>>*/ 1 - _a_;
+    return _a_ ?  /*<<obj.ml:127:6>>*/ Stdlib[1].call(null, msg) : _a_ /*<<obj.ml:127:21>>*/ ;
    }
    function get_key(e, o){
-     /*<<obj.ml:117:4>>*/ raise_if_invalid_offset
+     /*<<obj.ml:131:4>>*/ raise_if_invalid_offset
      (e, o, "Obj.Ephemeron.get_key");
-     /*<<obj.ml:118:4>>*/ return runtime.caml_ephe_get_key(e, o) /*<<obj.ml:118:15>>*/ ;
+     /*<<obj.ml:132:4>>*/ return runtime.caml_ephe_get_key(e, o) /*<<obj.ml:132:15>>*/ ;
    }
    function get_key_copy(e, o){
-     /*<<obj.ml:122:4>>*/ raise_if_invalid_offset
+     /*<<obj.ml:136:4>>*/ raise_if_invalid_offset
      (e, o, "Obj.Ephemeron.get_key_copy");
-     /*<<obj.ml:123:4>>*/ return runtime.caml_ephe_get_key_copy(e, o) /*<<obj.ml:123:20>>*/ ;
+     /*<<obj.ml:137:4>>*/ return runtime.caml_ephe_get_key_copy(e, o) /*<<obj.ml:137:20>>*/ ;
    }
    function set_key(e, o, x){
-     /*<<obj.ml:127:4>>*/ raise_if_invalid_offset
+     /*<<obj.ml:141:4>>*/ raise_if_invalid_offset
      (e, o, "Obj.Ephemeron.set_key");
-     /*<<obj.ml:128:4>>*/ return runtime.caml_ephe_set_key(e, o, x) /*<<obj.ml:128:17>>*/ ;
+     /*<<obj.ml:142:4>>*/ return runtime.caml_ephe_set_key(e, o, x) /*<<obj.ml:142:17>>*/ ;
    }
    function unset_key(e, o){
-     /*<<obj.ml:132:4>>*/ raise_if_invalid_offset
+     /*<<obj.ml:146:4>>*/ raise_if_invalid_offset
      (e, o, "Obj.Ephemeron.unset_key");
-     /*<<obj.ml:133:4>>*/ return runtime.caml_ephe_unset_key(e, o) /*<<obj.ml:133:17>>*/ ;
+     /*<<obj.ml:147:4>>*/ return runtime.caml_ephe_unset_key(e, o) /*<<obj.ml:147:17>>*/ ;
    }
    function check_key(e, o){
-     /*<<obj.ml:137:4>>*/ raise_if_invalid_offset
+     /*<<obj.ml:151:4>>*/ raise_if_invalid_offset
      (e, o, "Obj.Ephemeron.check_key");
-     /*<<obj.ml:138:4>>*/ return runtime.caml_ephe_check_key(e, o) /*<<obj.ml:138:17>>*/ ;
+     /*<<obj.ml:152:4>>*/ return runtime.caml_ephe_check_key(e, o) /*<<obj.ml:152:17>>*/ ;
    }
    function blit_key(e1, o1, e2, o2, l){
-     /*<<obj.ml:144:4>>*/ if
+     /*<<obj.ml:158:4>>*/ if
      (0 <= l
       &&
        0 <= o1
        &&
-        ( /*<<obj.ml:144:31>>*/ length(e1) - l | 0) >= o1
-        && 0 <= o2 && ( /*<<obj.ml:145:25>>*/ length(e2) - l | 0) >= o2){
+        ( /*<<obj.ml:158:31>>*/ length(e1) - l | 0) >= o1
+        && 0 <= o2 && ( /*<<obj.ml:159:25>>*/ length(e2) - l | 0) >= o2){
      var
-      _a_ =  /*<<obj.ml:147:9>>*/ 0 !== l ? 1 : 0,
+      _a_ =  /*<<obj.ml:161:9>>*/ 0 !== l ? 1 : 0,
       _a_ =
         _a_
-         ?  /*<<obj.ml:147:24>>*/ runtime.caml_ephe_blit_key
+         ?  /*<<obj.ml:161:24>>*/ runtime.caml_ephe_blit_key
            (e1, o1, e2, o2, l)
          : _a_;
-      /*<<obj.ml:147:9>>*/ return _a_;
+      /*<<obj.ml:161:9>>*/ return _a_;
     }
-     /*<<obj.ml:146:9>>*/ return Stdlib[1].call
-            (null, "Obj.Ephemeron.blit_key") /*<<obj.ml:147:46>>*/ ;
+     /*<<obj.ml:160:9>>*/ return Stdlib[1].call
+            (null, "Obj.Ephemeron.blit_key") /*<<obj.ml:161:46>>*/ ;
    }
    var
     Stdlib_Obj =
@@ -1615,6 +1637,7 @@
        is_block,
        double_field,
        set_double_field,
+       hash_variant,
        0,
        243,
        244,
@@ -1669,7 +1692,7 @@
     return [0, Id];
     /*<<type.ml:32:57>>*/ }
    function uid(A){
-     /*<<type.ml:35:4>>*/ return Stdlib_Obj[22][3].call(null, A[1]) /*<<type.ml:35:62>>*/ ;
+     /*<<type.ml:35:4>>*/ return Stdlib_Obj[23][3].call(null, A[1]) /*<<type.ml:35:62>>*/ ;
    }
    var _a_ =  /*<<?>>*/ [0, 0];
    function provably_equal(A, B){
@@ -1941,12 +1964,12 @@
    }
    function force_gen(only_val, lzv){
     var t =  /*<<camlinternalLazy.ml:99:10>>*/ caml_obj_tag(lzv);
-     /*<<camlinternalLazy.ml:100:2>>*/ if(t === Stdlib_Obj[12])
+     /*<<camlinternalLazy.ml:100:2>>*/ if(t === Stdlib_Obj[13])
       /*<<camlinternalLazy.ml:101:28>>*/ return lzv[1];
-     /*<<camlinternalLazy.ml:103:7>>*/ if(t === Stdlib_Obj[6])
+     /*<<camlinternalLazy.ml:103:7>>*/ if(t === Stdlib_Obj[7])
       /*<<camlinternalLazy.ml:103:35>>*/ throw caml_maybe_attach_backtrace
             (Undefined, 1);
-     /*<<camlinternalLazy.ml:104:7>>*/ return t !== Stdlib_Obj[8]
+     /*<<camlinternalLazy.ml:104:7>>*/ return t !== Stdlib_Obj[9]
             ? lzv
             :  /*<<camlinternalLazy.ml:105:7>>*/ force_gen_lazy_block
               (only_val, lzv) /*<<camlinternalLazy.ml:105:41>>*/ ;
@@ -1954,7 +1977,7 @@
    function indirect(lzv){
     var t =  /*<<camlinternalLazy.ml:117:10>>*/ caml_obj_tag(lzv);
      /*<<camlinternalLazy.ml:118:2>>*/ if
-     (t !== Stdlib_Obj[8] && t !== Stdlib_Obj[6])
+     (t !== Stdlib_Obj[9] && t !== Stdlib_Obj[7])
       /*<<camlinternalLazy.ml:120:7>>*/ return lzv;
      /*<<camlinternalLazy.ml:119:7>>*/ return [246,
             function(_a_){ /*<<?>>*/ return force_lazy_block(lzv);}] /*<<camlinternalLazy.ml:119:7>>*/ ;
@@ -1994,20 +2017,20 @@
      /*<<lazy.ml:56:18>>*/ return CamlinternalLazy[3].call(null, 1, l) /*<<lazy.ml:56:61>>*/ ;
    }
    function from_fun(f){
-    var x =  /*<<lazy.ml:59:10>>*/ runtime.caml_obj_block(Stdlib_Obj[8], 1);
+    var x =  /*<<lazy.ml:59:10>>*/ runtime.caml_obj_block(Stdlib_Obj[9], 1);
      /*<<lazy.ml:60:2>>*/ x[1] = f;
      /*<<lazy.ml:60:32>>*/ return x;
     /*<<lazy.ml:61:22>>*/ }
    function from_val(v){
     var t =  /*<<lazy.ml:64:10>>*/ caml_obj_tag(v);
      /*<<lazy.ml:65:2>>*/ if
-     (t !== Stdlib_Obj[12]
-      && t !== Stdlib_Obj[8] && t !== Stdlib_Obj[6] && t !== Stdlib_Obj[16])
+     (t !== Stdlib_Obj[13]
+      && t !== Stdlib_Obj[9] && t !== Stdlib_Obj[7] && t !== Stdlib_Obj[17])
       /*<<lazy.ml:69:5>>*/ return v;
      /*<<lazy.ml:66:52>>*/ return runtime.caml_lazy_make_forward(v) /*<<lazy.ml:70:5>>*/ ;
    }
    function is_val(l){
-    var _a_ =  /*<<lazy.ml:72:26>>*/ Stdlib_Obj[8];
+    var _a_ =  /*<<lazy.ml:72:26>>*/ Stdlib_Obj[9];
     return caml_obj_tag(l) !== _a_ ? 1 : 0 /*<<lazy.ml:72:46>>*/ ;
     /*<<lazy.ml:72:62>>*/ }
    function map(f, x){
@@ -3080,7 +3103,7 @@
 
 //# unitInfo: Provides: Stdlib__Option
 //# unitInfo: Requires: Stdlib, Stdlib__Seq
-//# shape: Stdlib__Option:[N,F(1)*->[N],F(2)*,F(1),$0=F(2),F(1)*,F(2),$1=F(2)*,F(3),F(2),F(3),F(2),F(2),F(1)*,F(1)*,F(3),F(3),F(2)*->[N],F(1)*,F(1)*->F(1)*,[$0,$1,F(2),$1]]
+//# shape: Stdlib__Option:[N,F(1)*->[N],F(2)*,F(1),$0=F(2),F(1)*,F(2),$1=F(2)*,F(3),F(2),F(3),F(2),F(2),F(2),F(1)*,F(1)*,F(3),F(3),F(2)*->[N],F(1)*,F(1)*->F(1)*,[$0,$1,F(2),$1]]
 (function
   (globalThis){
    "use strict";
@@ -3194,28 +3217,33 @@
     var v =  /*<<option.ml:54:11>>*/ param[1];
      /*<<option.ml:56:14>>*/ return caml_call1(p, v) /*<<option.ml:56:17>>*/ ;
    }
+   function try_value(o, f){
+     /*<<option.ml:58:20>>*/ return o
+            ? o
+            :  /*<<option.ml:58:43>>*/ caml_call1(f, 0) /*<<option.ml:58:56>>*/ ;
+   }
    function to_result(none, param){
-     /*<<option.ml:58:14>>*/ if(! param)
-      /*<<option.ml:58:39>>*/ return [1, none];
-    var v =  /*<<option.ml:58:14>>*/ param[1];
-     /*<<option.ml:58:62>>*/ return [0, v];
-    /*<<option.ml:58:66>>*/ }
+     /*<<option.ml:60:14>>*/ if(! param)
+      /*<<option.ml:60:39>>*/ return [1, none];
+    var v =  /*<<option.ml:60:14>>*/ param[1];
+     /*<<option.ml:60:62>>*/ return [0, v];
+    /*<<option.ml:60:66>>*/ }
    function to_list(param){
-     /*<<option.ml:59:14>>*/ if(! param)  /*<<option.ml:59:31>>*/ return 0;
-    var v =  /*<<option.ml:59:14>>*/ param[1];
-     /*<<option.ml:59:46>>*/ return [0, v, 0];
-    /*<<option.ml:59:49>>*/ }
+     /*<<option.ml:61:14>>*/ if(! param)  /*<<option.ml:61:31>>*/ return 0;
+    var v =  /*<<option.ml:61:14>>*/ param[1];
+     /*<<option.ml:61:46>>*/ return [0, v, 0];
+    /*<<option.ml:61:49>>*/ }
    function to_seq(param){
-     /*<<option.ml:60:13>>*/ if(! param)
-      /*<<option.ml:60:30>>*/ return Stdlib_Seq[20];
+     /*<<option.ml:62:13>>*/ if(! param)
+      /*<<option.ml:62:30>>*/ return Stdlib_Seq[20];
     var
-     v =  /*<<option.ml:60:13>>*/ param[1],
-     _a_ =  /*<<option.ml:60:52>>*/ Stdlib_Seq[21];
+     v =  /*<<option.ml:62:13>>*/ param[1],
+     _a_ =  /*<<option.ml:62:52>>*/ Stdlib_Seq[21];
     return function(_b_){
-      /*<<?>>*/ return _a_(v, _b_);} /*<<option.ml:60:52>>*/ ;
-    /*<<option.ml:60:64>>*/ }
+      /*<<?>>*/ return _a_(v, _b_);} /*<<option.ml:62:52>>*/ ;
+    /*<<option.ml:62:64>>*/ }
    function let$(o, f){
-     /*<<option.ml:65:21>>*/ return map(f, o) /*<<option.ml:65:28>>*/ ;
+     /*<<option.ml:67:21>>*/ return map(f, o) /*<<option.ml:67:28>>*/ ;
    }
     /*<<?>>*/ runtime.caml_register_global
     ([0,
@@ -3232,6 +3260,7 @@
       blend,
       for_all,
       exists,
+      try_value,
       is_none,
       is_some,
       equal,
@@ -3340,7 +3369,7 @@
 
 //# unitInfo: Provides: Stdlib__Result
 //# unitInfo: Requires: Stdlib, Stdlib__Seq
-//# shape: Stdlib__Result:[F(1)*->[N],F(1)*->[N],F(2)*,F(1),F(1),F(1),F(1),$0=F(2),F(1)*,F(2),$1=F(2)*,F(2),F(3),F(1)*,F(2),F(2),F(1)*,F(1)*,F(4),F(4),F(1)*,F(1)*,F(1)*->F(1)*,[$0,$1,F(2),$1]]
+//# shape: Stdlib__Result:[F(1)*->[N],F(1)*->[N],F(2)*,F(1),F(1),F(1),F(1),$0=F(2),F(1)*,F(2),$1=F(2)*,F(2),F(3),F(1)*,F(2),F(2),F(2),F(1)*,F(1)*,F(4),F(4),F(1)*,F(1)*,F(1)*->F(1)*,[$0,$1,F(2),$1]]
 (function
   (globalThis){
    "use strict";
@@ -3461,64 +3490,69 @@
     var e =  /*<<result.ml:37:15>>*/ param[1];
      /*<<result.ml:37:39>>*/ return caml_call1(f, e) /*<<result.ml:37:55>>*/ ;
    }
+   function try_value(r, f){
+     /*<<result.ml:38:20>>*/ if(0 === r[0])  /*<<result.ml:38:57>>*/ return r;
+    var e =  /*<<result.ml:38:20>>*/ r[1];
+     /*<<result.ml:38:46>>*/ return caml_call1(f, e) /*<<result.ml:38:58>>*/ ;
+   }
    function is_ok(param){
-     /*<<result.ml:38:12>>*/ return 0 === param[0] ? 1 : 0 /*<<result.ml:38:52>>*/ ;
+     /*<<result.ml:39:12>>*/ return 0 === param[0] ? 1 : 0 /*<<result.ml:39:52>>*/ ;
    }
    function is_error(param){
-     /*<<result.ml:39:15>>*/ return 0 === param[0] ? 0 : 1 /*<<result.ml:39:55>>*/ ;
+     /*<<result.ml:40:15>>*/ return 0 === param[0] ? 0 : 1 /*<<result.ml:40:55>>*/ ;
    }
    function equal(ok, error, r0, r1){
-     /*<<result.ml:41:29>>*/ if(0 === r0[0]){
+     /*<<result.ml:42:29>>*/ if(0 === r0[0]){
      var v0 = r0[1];
      if(0 === r1[0]){
       var v1 = r1[1];
-       /*<<result.ml:42:18>>*/ return caml_call2(ok, v0, v1) /*<<result.ml:44:15>>*/ ;
+       /*<<result.ml:43:18>>*/ return caml_call2(ok, v0, v1) /*<<result.ml:45:15>>*/ ;
      }
     }
     else{
-     var e0 =  /*<<result.ml:41:29>>*/ r0[1];
+     var e0 =  /*<<result.ml:42:29>>*/ r0[1];
      if(0 !== r1[0]){
       var e1 = r1[1];
-       /*<<result.ml:43:24>>*/ return caml_call2(error, e0, e1) /*<<result.ml:44:15>>*/ ;
+       /*<<result.ml:44:24>>*/ return caml_call2(error, e0, e1) /*<<result.ml:45:15>>*/ ;
      }
     }
-     /*<<result.ml:44:10>>*/ return 0;
-    /*<<result.ml:44:15>>*/ }
+     /*<<result.ml:45:10>>*/ return 0;
+    /*<<result.ml:45:15>>*/ }
    function compare(ok, error, r0, r1){
-     /*<<result.ml:46:31>>*/ if(0 === r0[0]){
+     /*<<result.ml:47:31>>*/ if(0 === r0[0]){
      var v0 = r0[1];
-     if(0 !== r1[0])  /*<<result.ml:49:19>>*/ return -1;
-     var v1 =  /*<<result.ml:46:31>>*/ r1[1];
-      /*<<result.ml:47:18>>*/ return caml_call2(ok, v0, v1) /*<<result.ml:50:20>>*/ ;
+     if(0 !== r1[0])  /*<<result.ml:50:19>>*/ return -1;
+     var v1 =  /*<<result.ml:47:31>>*/ r1[1];
+      /*<<result.ml:48:18>>*/ return caml_call2(ok, v0, v1) /*<<result.ml:51:20>>*/ ;
     }
-    var e0 =  /*<<result.ml:46:31>>*/ r0[1];
-    if(0 === r1[0])  /*<<result.ml:50:19>>*/ return 1;
-    var e1 =  /*<<result.ml:46:31>>*/ r1[1];
-     /*<<result.ml:48:24>>*/ return caml_call2(error, e0, e1) /*<<result.ml:50:20>>*/ ;
+    var e0 =  /*<<result.ml:47:31>>*/ r0[1];
+    if(0 === r1[0])  /*<<result.ml:51:19>>*/ return 1;
+    var e1 =  /*<<result.ml:47:31>>*/ r1[1];
+     /*<<result.ml:49:24>>*/ return caml_call2(error, e0, e1) /*<<result.ml:51:20>>*/ ;
    }
    function to_option(param){
-     /*<<result.ml:52:16>>*/ if(0 !== param[0])
-      /*<<result.ml:52:53>>*/ return 0;
-    var v =  /*<<result.ml:52:16>>*/ param[1];
-     /*<<result.ml:52:33>>*/ return [0, v];
-    /*<<result.ml:52:57>>*/ }
+     /*<<result.ml:53:16>>*/ if(0 !== param[0])
+      /*<<result.ml:53:53>>*/ return 0;
+    var v =  /*<<result.ml:53:16>>*/ param[1];
+     /*<<result.ml:53:33>>*/ return [0, v];
+    /*<<result.ml:53:57>>*/ }
    function to_list(param){
-     /*<<result.ml:53:14>>*/ if(0 !== param[0])
-      /*<<result.ml:53:48>>*/ return 0;
-    var v =  /*<<result.ml:53:14>>*/ param[1];
-     /*<<result.ml:53:31>>*/ return [0, v, 0];
-    /*<<result.ml:53:50>>*/ }
+     /*<<result.ml:54:14>>*/ if(0 !== param[0])
+      /*<<result.ml:54:48>>*/ return 0;
+    var v =  /*<<result.ml:54:14>>*/ param[1];
+     /*<<result.ml:54:31>>*/ return [0, v, 0];
+    /*<<result.ml:54:50>>*/ }
    function to_seq(param){
-     /*<<result.ml:54:13>>*/ if(0 !== param[0])
-      /*<<result.ml:54:56>>*/ return Stdlib_Seq[20];
+     /*<<result.ml:55:13>>*/ if(0 !== param[0])
+      /*<<result.ml:55:56>>*/ return Stdlib_Seq[20];
     var
-     v =  /*<<result.ml:54:13>>*/ param[1],
-     _a_ =  /*<<result.ml:54:30>>*/ Stdlib_Seq[21];
+     v =  /*<<result.ml:55:13>>*/ param[1],
+     _a_ =  /*<<result.ml:55:30>>*/ Stdlib_Seq[21];
     return function(_b_){
-      /*<<?>>*/ return _a_(v, _b_);} /*<<result.ml:54:30>>*/ ;
-    /*<<result.ml:54:65>>*/ }
+      /*<<?>>*/ return _a_(v, _b_);} /*<<result.ml:55:30>>*/ ;
+    /*<<result.ml:55:65>>*/ }
    function let$(r, f){
-     /*<<result.ml:59:21>>*/ return map(f, r) /*<<result.ml:59:28>>*/ ;
+     /*<<result.ml:60:21>>*/ return map(f, r) /*<<result.ml:60:28>>*/ ;
    }
     /*<<?>>*/ runtime.caml_register_global
     ([0,
@@ -3538,6 +3572,7 @@
       retract,
       iter,
       iter_error,
+      try_value,
       is_ok,
       is_error,
       equal,
@@ -3811,7 +3846,7 @@
 
 //# unitInfo: Provides: Stdlib__Uchar
 //# unitInfo: Requires: Stdlib
-//# shape: Stdlib__Uchar:[N,N,N,N,F(1),F(1),F(1)*,F(1),F(1)*,F(1)*,F(1)*,F(1)*,F(1),F(1)*,F(2)*,F(2)*,F(2)*,F(1)*,F(1)*,F(1)*,F(1)*,F(2)*,F(1)*,F(1)*,N,F(1),F(1)]
+//# shape: Stdlib__Uchar:[N,N,N,N,F(1),F(1),F(1)*,F(1),F(1)*,F(1)*,F(1)*,F(1),$0=F(1)*,$1=F(1),$0,F(1)*,$1,F(1)*,F(2)*,F(2)*,F(2)*,F(1)*,F(1)*,F(1)*,F(1)*,F(2)*,F(1)*,F(1)*,N,F(1),F(1)]
 (function
   (globalThis){
    "use strict";
@@ -3823,117 +3858,130 @@
     Assert_failure = runtime.caml_get_global_predef("Assert_failure"),
     Stdlib = runtime.caml_get_global("Stdlib");
    function succ(u){
-     /*<<uchar.ml:34:2>>*/ return u === 55295
+     /*<<uchar.ml:35:2>>*/ return u === 55295
             ? 57344
             : u
               === 1114111
-              ?  /*<<uchar.ml:35:18>>*/ Stdlib
+              ?  /*<<uchar.ml:36:18>>*/ Stdlib
                  [1].call
                 (null, "U+10FFFF has no successor")
-              : u + 1 | 0 /*<<uchar.ml:36:7>>*/ ;
+              : u + 1 | 0 /*<<uchar.ml:37:7>>*/ ;
    }
    function pred(u){
-     /*<<uchar.ml:39:2>>*/ return u === 57344
+     /*<<uchar.ml:40:2>>*/ return u === 57344
             ? 55295
             : u
               === 0
-              ?  /*<<uchar.ml:40:18>>*/ Stdlib
+              ?  /*<<uchar.ml:41:18>>*/ Stdlib
                  [1].call
                 (null, "U+0000 has no predecessor")
-              : u - 1 | 0 /*<<uchar.ml:41:7>>*/ ;
+              : u - 1 | 0 /*<<uchar.ml:42:7>>*/ ;
    }
    function is_valid(i){
     var
-     _e_ =  /*<<uchar.ml:43:17>>*/ 0 <= i ? 1 : 0,
+     _e_ =  /*<<uchar.ml:44:17>>*/ 0 <= i ? 1 : 0,
      _e_ = _e_ ? i <= 55295 ? 1 : 0 : _e_;
     if(_e_)
      ;
     else{_e_ = 57344 <= i ? 1 : 0; _e_ = _e_ ? i <= 1114111 ? 1 : 0 : _e_;}
     return _e_;
-    /*<<uchar.ml:43:75>>*/ }
+    /*<<uchar.ml:44:75>>*/ }
    function of_int(i){
-     /*<<uchar.ml:44:18>>*/ if(is_valid(i))  /*<<uchar.ml:44:34>>*/ return i;
+     /*<<uchar.ml:45:18>>*/ if(is_valid(i))  /*<<uchar.ml:45:34>>*/ return i;
     var
      _e_ =
         /*<<uchar.ml:20:19>>*/  /*<<uchar.ml:20:36>>*/ Stdlib[28].call
         (null,
           /*<<uchar.ml:20:19>>*/ caml_format_int("%X", i),
          " is not a Unicode scalar value");
-     /*<<uchar.ml:44:67>>*/ return Stdlib[1].call(null, _e_);
+     /*<<uchar.ml:45:67>>*/ return Stdlib[1].call(null, _e_);
    }
-   function is_char(u){
-     /*<<uchar.ml:48:16>>*/ return u < 256 ? 1 : 0;
-    /*<<uchar.ml:48:23>>*/ }
-   function of_char(c){
-     /*<<uchar.ml:49:16>>*/ return c;
-    /*<<uchar.ml:49:27>>*/ }
-   function to_char(u){
-     /*<<uchar.ml:51:2>>*/ if(255 >= u)  /*<<uchar.ml:52:2>>*/ return u;
+   function is_ascii(u){
+     /*<<uchar.ml:49:17>>*/ return u < 128 ? 1 : 0;
+    /*<<uchar.ml:49:24>>*/ }
+   var cst_04X =  /*<<?>>*/ "%04X", cst_U = "U+";
+   function ascii_to_char(u){
+     /*<<uchar.ml:51:2>>*/ if(128 > u)  /*<<uchar.ml:52:2>>*/ return u;
     var
      _e_ =
-        /*<<uchar.ml:21:30>>*/ Stdlib[28].call
-        (null, caml_format_int("%04X", u), " is not a latin1 character"),
-     _e_ =  /*<<uchar.ml:21:80>>*/ Stdlib[28].call(null, "U+", _e_);
+        /*<<uchar.ml:21:29>>*/ Stdlib[28].call
+        (null, caml_format_int(cst_04X, u), " is not an ASCII character"),
+     _e_ =  /*<<uchar.ml:21:79>>*/ Stdlib[28].call(null, cst_U, _e_);
      /*<<uchar.ml:51:48>>*/ return Stdlib[1].call(null, _e_) /*<<uchar.ml:52:19>>*/ ;
    }
+   function is_latin1(u){
+     /*<<uchar.ml:53:18>>*/ return u < 256 ? 1 : 0;
+    /*<<uchar.ml:53:25>>*/ }
+   function latin1_to_char(u){
+     /*<<uchar.ml:55:2>>*/ if(256 > u)  /*<<uchar.ml:56:2>>*/ return u;
+    var
+     _e_ =
+        /*<<uchar.ml:22:30>>*/ Stdlib[28].call
+        (null, caml_format_int(cst_04X, u), " is not a latin1 character"),
+     _e_ =  /*<<uchar.ml:22:80>>*/ Stdlib[28].call(null, cst_U, _e_);
+     /*<<uchar.ml:55:49>>*/ return Stdlib[1].call(null, _e_) /*<<uchar.ml:56:19>>*/ ;
+   }
+   function of_char(c){
+     /*<<uchar.ml:58:16>>*/ return c;
+    /*<<uchar.ml:58:27>>*/ }
    function unsafe_to_char(_e_){ /*<<?>>*/ return _e_;}
    function equal(_e_, _d_){return _e_ === _d_ ? 1 : 0;}
    var compare = runtime.caml_int_compare;
    function seeded_hash(seed, x){
-     /*<<uchar.ml:61:25>>*/ return caml_hash(10, 100, seed, x) /*<<uchar.ml:61:56>>*/ ;
+     /*<<uchar.ml:68:25>>*/ return caml_hash(10, 100, seed, x) /*<<uchar.ml:68:56>>*/ ;
    }
    function hash(x){
-     /*<<uchar.ml:62:13>>*/ return caml_hash(10, 100, 0, x) /*<<uchar.ml:62:41>>*/ ;
+     /*<<uchar.ml:69:13>>*/ return caml_hash(10, 100, 0, x) /*<<uchar.ml:69:41>>*/ ;
    }
    function utf_decode_is_valid(d){
-     /*<<uchar.ml:77:37>>*/ return 1 === (d >>> 27 | 0) ? 1 : 0;
-    /*<<uchar.ml:77:58>>*/ }
+     /*<<uchar.ml:84:37>>*/ return 1 === (d >>> 27 | 0) ? 1 : 0;
+    /*<<uchar.ml:84:58>>*/ }
    function utf_decode_length(d){
-     /*<<uchar.ml:78:35>>*/ return (d >>> 24 | 0) & 7;
-    /*<<uchar.ml:78:65>>*/ }
+     /*<<uchar.ml:85:35>>*/ return (d >>> 24 | 0) & 7;
+    /*<<uchar.ml:85:65>>*/ }
    function utf_decode_uchar(d){
-     /*<<uchar.ml:79:34>>*/ return d & 16777215;
-    /*<<uchar.ml:79:65>>*/ }
+     /*<<uchar.ml:86:34>>*/ return d & 16777215;
+    /*<<uchar.ml:86:65>>*/ }
    function utf_decode(n, u){
-     /*<<uchar.ml:80:30>>*/ return (8 | n) << 24 | u;
-    /*<<uchar.ml:80:72>>*/ }
+     /*<<uchar.ml:87:30>>*/ return (8 | n) << 24 | u;
+    /*<<uchar.ml:87:72>>*/ }
    function utf_decode_invalid(n){
-     /*<<uchar.ml:81:36>>*/ return n << 24 | 65533;
-    /*<<uchar.ml:81:63>>*/ }
+     /*<<uchar.ml:88:36>>*/ return n << 24 | 65533;
+    /*<<uchar.ml:88:63>>*/ }
    function utf_8_decode_length_of_byte(param){
-     /*<<uchar.ml:83:34>>*/ return 194 <= param
+     /*<<uchar.ml:90:34>>*/ return 194 <= param
             ? 240 <= param ? 245 <= param ? 0 : 4 : 224 <= param ? 3 : 2
-            : 128 <= param ? 0 : 1 /*<<uchar.ml:89:10>>*/ ;
+            : 128 <= param ? 0 : 1 /*<<uchar.ml:96:10>>*/ ;
    }
    var
     cst_uchar_ml =  /*<<?>>*/ "uchar.ml",
-    _a_ = [0, cst_uchar_ml, 99, 7],
-    _b_ = [0, cst_uchar_ml, 94, 18];
+    _a_ = [0, cst_uchar_ml, 106, 7],
+    _b_ = [0, cst_uchar_ml, 101, 18];
    function utf_8_byte_length(u){
-     /*<<uchar.ml:94:9>>*/ if(0 > u)
-      /*<<uchar.ml:94:18>>*/ throw caml_maybe_attach_backtrace
+     /*<<uchar.ml:101:9>>*/ if(0 > u)
+      /*<<uchar.ml:101:18>>*/ throw caml_maybe_attach_backtrace
             ([0, Assert_failure, _b_], 1);
-     /*<<uchar.ml:95:9>>*/ if(127 >= u)  /*<<uchar.ml:95:24>>*/ return 1;
-     /*<<uchar.ml:96:9>>*/ if(2047 >= u)  /*<<uchar.ml:96:24>>*/ return 2;
-     /*<<uchar.ml:97:9>>*/ if(65535 >= u)  /*<<uchar.ml:97:24>>*/ return 3;
-     /*<<uchar.ml:98:9>>*/ if(1114111 < u)
-      /*<<uchar.ml:99:7>>*/ throw caml_maybe_attach_backtrace
+     /*<<uchar.ml:102:9>>*/ if(127 >= u)  /*<<uchar.ml:102:24>>*/ return 1;
+     /*<<uchar.ml:103:9>>*/ if(2047 >= u)  /*<<uchar.ml:103:24>>*/ return 2;
+     /*<<uchar.ml:104:9>>*/ if(65535 >= u)  /*<<uchar.ml:104:24>>*/ return 3;
+     /*<<uchar.ml:105:9>>*/ if(1114111 < u)
+      /*<<uchar.ml:106:7>>*/ throw caml_maybe_attach_backtrace
             ([0, Assert_failure, _a_], 1);
-     /*<<uchar.ml:98:26>>*/ return 4;
-    /*<<uchar.ml:99:19>>*/ }
+     /*<<uchar.ml:105:26>>*/ return 4;
+    /*<<uchar.ml:106:19>>*/ }
    var
-    _c_ =  /*<<?>>*/ [0, cst_uchar_ml, 105, 7],
-    _d_ = [0, cst_uchar_ml, 102, 18];
+    _c_ =  /*<<?>>*/ [0, cst_uchar_ml, 112, 7],
+    _d_ = [0, cst_uchar_ml, 109, 18];
    function utf_16_byte_length(u){
-     /*<<uchar.ml:102:9>>*/ if(0 > u)
-      /*<<uchar.ml:102:18>>*/ throw caml_maybe_attach_backtrace
+     /*<<uchar.ml:109:9>>*/ if(0 > u)
+      /*<<uchar.ml:109:18>>*/ throw caml_maybe_attach_backtrace
             ([0, Assert_failure, _d_], 1);
-     /*<<uchar.ml:103:9>>*/ if(65535 >= u)  /*<<uchar.ml:103:24>>*/ return 2;
-     /*<<uchar.ml:104:9>>*/ if(1114111 < u)
-      /*<<uchar.ml:105:7>>*/ throw caml_maybe_attach_backtrace
+     /*<<uchar.ml:110:9>>*/ if(65535 >= u)  /*<<uchar.ml:110:24>>*/ return 2;
+     /*<<uchar.ml:111:9>>*/ if(1114111 < u)
+      /*<<uchar.ml:112:7>>*/ throw caml_maybe_attach_backtrace
             ([0, Assert_failure, _c_], 1);
-     /*<<uchar.ml:104:26>>*/ return 4;
-    /*<<uchar.ml:105:19>>*/ }
+     /*<<uchar.ml:111:26>>*/ return 4;
+    /*<<uchar.ml:112:19>>*/ }
    var
     Stdlib_Uchar =
        /*<<?>>*/ [0,
@@ -3947,9 +3995,13 @@
        of_int,
        function(_d_){return _d_;},
        function(_d_){return _d_;},
-       is_char,
+       is_ascii,
+       ascii_to_char,
+       is_latin1,
+       latin1_to_char,
+       is_latin1,
        of_char,
-       to_char,
+       latin1_to_char,
        unsafe_to_char,
        equal,
        compare,
@@ -8333,7 +8385,7 @@
             :  /*<<bytes.ml:546:29>>*/ caml_bytes_set64
               (b, i,  /*<<bytes.ml:546:46>>*/ caml_int64_bswap(x)) /*<<bytes.ml:547:25>>*/ ;
    }
-   var dec_invalid =  /*<<bytes.ml:53:20>>*/ Stdlib_Uchar[23];
+   var dec_invalid =  /*<<bytes.ml:53:20>>*/ Stdlib_Uchar[27];
    function get_utf_8_uchar(b, i){
     var
      b0 =  /*<<bytes.ml:597:11>>*/ caml_bytes_get(b, i),
@@ -8362,7 +8414,7 @@
               /*<<bytes.ml:586:2>>*/ (b0 & 15) << 12 | (b1$4 & 63) << 6
              | b2$3 & 63,
            _i_ =  /*<<bytes.ml:557:46>>*/ Stdlib_Uchar[9].call(null, u$5);
-           /*<<bytes.ml:557:69>>*/ return Stdlib_Uchar[22].call(null, 3, _i_) /*<<bytes.ml:648:22>>*/ ;
+           /*<<bytes.ml:557:69>>*/ return Stdlib_Uchar[26].call(null, 3, _i_) /*<<bytes.ml:648:22>>*/ ;
          case 3:
           var i$4 =  /*<<bytes.ml:625:6>>*/ i + 1 | 0;
            /*<<bytes.ml:625:23>>*/ if(max < i$4)
@@ -8391,7 +8443,7 @@
              | (b2$1 & 63) << 6
              | b3$1 & 63,
            _i_ =  /*<<bytes.ml:557:46>>*/ Stdlib_Uchar[9].call(null, u$1);
-           /*<<bytes.ml:557:69>>*/ return Stdlib_Uchar[22].call(null, 4, _i_) /*<<bytes.ml:648:22>>*/ ;
+           /*<<bytes.ml:557:69>>*/ return Stdlib_Uchar[26].call(null, 4, _i_) /*<<bytes.ml:648:22>>*/ ;
          case 7:
           var i$10 =  /*<<bytes.ml:641:6>>*/ i + 1 | 0;
            /*<<bytes.ml:641:23>>*/ if(max < i$10)
@@ -8417,7 +8469,7 @@
              | (b2 & 63) << 6
              | b3 & 63,
            _i_ =  /*<<bytes.ml:557:46>>*/ Stdlib_Uchar[9].call(null, u$2);
-           /*<<bytes.ml:557:69>>*/ return Stdlib_Uchar[22].call(null, 4, _i_) /*<<bytes.ml:648:22>>*/ ;
+           /*<<bytes.ml:557:69>>*/ return Stdlib_Uchar[26].call(null, 4, _i_) /*<<bytes.ml:648:22>>*/ ;
          case 1:
          case 2: break;
          default:
@@ -8445,7 +8497,7 @@
              | (b2$0 & 63) << 6
              | b3$0 & 63,
            _i_ =  /*<<bytes.ml:557:46>>*/ Stdlib_Uchar[9].call(null, u$3);
-           /*<<bytes.ml:557:69>>*/ return Stdlib_Uchar[22].call(null, 4, _i_) /*<<bytes.ml:648:22>>*/ ;
+           /*<<bytes.ml:557:69>>*/ return Stdlib_Uchar[26].call(null, 4, _i_) /*<<bytes.ml:648:22>>*/ ;
        }
       }
       else if(225 > b0){
@@ -8466,7 +8518,7 @@
            /*<<bytes.ml:586:2>>*/ (b0 & 15) << 12 | (b1$5 & 63) << 6
           | b2$4 & 63,
         _i_ =  /*<<bytes.ml:557:46>>*/ Stdlib_Uchar[9].call(null, u$0);
-        /*<<bytes.ml:557:69>>*/ return Stdlib_Uchar[22].call(null, 3, _i_) /*<<bytes.ml:648:22>>*/ ;
+        /*<<bytes.ml:557:69>>*/ return Stdlib_Uchar[26].call(null, 3, _i_) /*<<bytes.ml:648:22>>*/ ;
       }
       var i$2 =  /*<<bytes.ml:613:6>>*/ i + 1 | 0;
        /*<<bytes.ml:613:23>>*/ if(max < i$2)
@@ -8485,11 +8537,11 @@
           /*<<bytes.ml:586:2>>*/ (b0 & 15) << 12 | (b1$3 & 63) << 6
          | b2$2 & 63,
        _i_ =  /*<<bytes.ml:557:46>>*/ Stdlib_Uchar[9].call(null, u$4);
-       /*<<bytes.ml:557:69>>*/ return Stdlib_Uchar[22].call(null, 3, _i_) /*<<bytes.ml:648:22>>*/ ;
+       /*<<bytes.ml:557:69>>*/ return Stdlib_Uchar[26].call(null, 3, _i_) /*<<bytes.ml:648:22>>*/ ;
      }
       /*<<bytes.ml:600:2>>*/ if(128 > b0){
        /*<<bytes.ml:557:46>>*/ _i_ = Stdlib_Uchar[9].call(null, b0);
-       /*<<bytes.ml:557:69>>*/ return Stdlib_Uchar[22].call(null, 1, _i_) /*<<bytes.ml:648:22>>*/ ;
+       /*<<bytes.ml:557:69>>*/ return Stdlib_Uchar[26].call(null, 1, _i_) /*<<bytes.ml:648:22>>*/ ;
      }
       /*<<bytes.ml:600:2>>*/ if(194 <= b0){
       var i$15 =  /*<<bytes.ml:603:6>>*/ i + 1 | 0;
@@ -8501,7 +8553,7 @@
       var
        u =  /*<<bytes.ml:582:2>>*/ (b0 & 31) << 6 | b1 & 63,
        _i_ =  /*<<bytes.ml:557:46>>*/ Stdlib_Uchar[9].call(null, u);
-       /*<<bytes.ml:557:69>>*/ return Stdlib_Uchar[22].call(null, 2, _i_) /*<<bytes.ml:648:22>>*/ ;
+       /*<<bytes.ml:557:69>>*/ return Stdlib_Uchar[26].call(null, 2, _i_) /*<<bytes.ml:648:22>>*/ ;
      }
     }
      /*<<bytes.ml:648:9>>*/ return dec_invalid(1) /*<<bytes.ml:648:22>>*/ ;
@@ -8737,12 +8789,12 @@
         u =
            /*<<bytes.ml:758:10>>*/ ((hi & 1023) << 10 | lo & 1023) + 65536 | 0,
         _g_ =  /*<<bytes.ml:557:46>>*/ Stdlib_Uchar[9].call(null, u);
-        /*<<bytes.ml:557:69>>*/ return Stdlib_Uchar[22].call(null, 4, _g_) /*<<bytes.ml:759:21>>*/ ;
+        /*<<bytes.ml:557:69>>*/ return Stdlib_Uchar[26].call(null, 4, _g_) /*<<bytes.ml:759:21>>*/ ;
       }
        /*<<bytes.ml:756:43>>*/ return dec_invalid(2) /*<<bytes.ml:759:21>>*/ ;
      }
       /*<<bytes.ml:557:46>>*/ _g_ = Stdlib_Uchar[9].call(null, hi);
-      /*<<bytes.ml:557:69>>*/ return Stdlib_Uchar[22].call(null, 2, _g_) /*<<bytes.ml:759:21>>*/ ;
+      /*<<bytes.ml:557:69>>*/ return Stdlib_Uchar[26].call(null, 2, _g_) /*<<bytes.ml:759:21>>*/ ;
     }
      /*<<bytes.ml:747:27>>*/ return Stdlib[1].call
             (null, cst_index_out_of_bounds) /*<<bytes.ml:759:21>>*/ ;
@@ -8821,12 +8873,12 @@
         u =
            /*<<bytes.ml:812:10>>*/ ((hi & 1023) << 10 | lo & 1023) + 65536 | 0,
         _g_ =  /*<<bytes.ml:557:46>>*/ Stdlib_Uchar[9].call(null, u);
-        /*<<bytes.ml:557:69>>*/ return Stdlib_Uchar[22].call(null, 4, _g_) /*<<bytes.ml:813:21>>*/ ;
+        /*<<bytes.ml:557:69>>*/ return Stdlib_Uchar[26].call(null, 4, _g_) /*<<bytes.ml:813:21>>*/ ;
       }
        /*<<bytes.ml:810:43>>*/ return dec_invalid(2) /*<<bytes.ml:813:21>>*/ ;
      }
       /*<<bytes.ml:557:46>>*/ _g_ = Stdlib_Uchar[9].call(null, hi);
-      /*<<bytes.ml:557:69>>*/ return Stdlib_Uchar[22].call(null, 2, _g_) /*<<bytes.ml:813:21>>*/ ;
+      /*<<bytes.ml:557:69>>*/ return Stdlib_Uchar[26].call(null, 2, _g_) /*<<bytes.ml:813:21>>*/ ;
     }
      /*<<bytes.ml:801:27>>*/ return Stdlib[1].call
             (null, cst_index_out_of_bounds) /*<<bytes.ml:813:21>>*/ ;
@@ -10456,8 +10508,8 @@
      if(i >= slen)  /*<<string.ml:686:2>>*/ return [0, uchars, k];
      var
       dec =  /*<<string.ml:681:14>>*/ get_utf_8_uchar(s, i),
-      _b_ =  /*<<string.ml:682:14>>*/ i + Stdlib_Uchar[21].call(null, dec) | 0,
-      _c_ =  /*<<string.ml:683:19>>*/ Stdlib_Uchar[20].call(null, dec);
+      _b_ =  /*<<string.ml:682:14>>*/ i + Stdlib_Uchar[25].call(null, dec) | 0,
+      _c_ =  /*<<string.ml:683:19>>*/ Stdlib_Uchar[24].call(null, dec);
       /*<<string.ml:683:4>>*/ caml_check_bound(uchars, k)[k + 1] = _c_;
      var k$0 =  /*<<string.ml:683:45>>*/ k + 1 | 0;
      i = _b_;
@@ -10535,7 +10587,7 @@
          /*<<string.ml:706:32>>*/ _b_ = caml_check_bound(s0$1, _b_)[_b_ + 1];
         var
          cost =
-            /*<<string.ml:706:20>>*/ Stdlib_Uchar[15].call(null, _b_, _a_)
+            /*<<string.ml:706:20>>*/ Stdlib_Uchar[19].call(null, _b_, _a_)
             ? 0
             : 1,
          _a_ =  /*<<string.ml:707:6>>*/ j - 1 | 0,
@@ -10561,12 +10613,12 @@
           /*<<string.ml:719:41>>*/ _b_ = i - 1 | 0;
           /*<<string.ml:719:33>>*/ _a_ = caml_check_bound(s1$0, _a_)[_a_ + 1];
           /*<<string.ml:719:24>>*/ _b_ = caml_check_bound(s0$1, _b_)[_b_ + 1];
-          /*<<string.ml:719:12>>*/ if(Stdlib_Uchar[15].call(null, _b_, _a_)){
+          /*<<string.ml:719:12>>*/ if(Stdlib_Uchar[19].call(null, _b_, _a_)){
            /*<<string.ml:719:41>>*/ _a_ = j - 1 | 0;
            /*<<string.ml:720:41>>*/ _b_ = i - 2 | 0;
            /*<<string.ml:720:33>>*/ _a_ = caml_check_bound(s1$0, _a_)[_a_ + 1];
            /*<<string.ml:720:24>>*/ _b_ = caml_check_bound(s0$1, _b_)[_b_ + 1];
-           /*<<string.ml:720:12>>*/ if(Stdlib_Uchar[15].call(null, _b_, _a_)){
+           /*<<string.ml:720:12>>*/ if(Stdlib_Uchar[19].call(null, _b_, _a_)){
             /*<<string.ml:721:13>>*/ _a_ = j - 2 | 0;
             /*<<string.ml:721:26>>*/ _a_ =
             caml_check_bound(row_minus2, _a_)[_a_ + 1] + cost | 0;
@@ -10625,7 +10677,7 @@
      }
      var
       dec_len =
-         /*<<string.ml:670:4>>*/  /*<<string.ml:670:18>>*/ Stdlib_Uchar[24].call
+         /*<<string.ml:670:4>>*/  /*<<string.ml:670:18>>*/ Stdlib_Uchar[28].call
          (null,  /*<<string.ml:670:4>>*/ caml_string_unsafe_get(s, i)),
       _a_ =  /*<<string.ml:671:4>>*/ 0 === dec_len ? 1 : dec_len,
       ulen$0 =  /*<<string.ml:672:4>>*/ ulen + 1 | 0;
@@ -24098,11 +24150,11 @@
      /*<<printexc.ml:26:9>>*/ if(! Stdlib_Obj[1].call(null, f))
       /*<<printexc.ml:27:4>>*/ return caml_call1
              (Stdlib_Printf[4].call(null, _d_), f) /*<<printexc.ml:33:7>>*/ ;
-    var _E_ =  /*<<printexc.ml:28:10>>*/ Stdlib_Obj[15];
+    var _E_ =  /*<<printexc.ml:28:10>>*/ Stdlib_Obj[16];
     if(caml_obj_tag(f) === _E_)
       /*<<printexc.ml:29:4>>*/ return caml_call1
              (Stdlib_Printf[4].call(null, _c_), f) /*<<printexc.ml:33:7>>*/ ;
-     /*<<printexc.ml:30:10>>*/ _E_ = Stdlib_Obj[16];
+     /*<<printexc.ml:30:10>>*/ _E_ = Stdlib_Obj[17];
     return caml_obj_tag(f) === _E_
             ?  /*<<printexc.ml:31:4>>*/ Stdlib[35].call(null, f)
             : "_" /*<<printexc.ml:33:7>>*/ ;
@@ -28296,7 +28348,7 @@
    function create(l){
     var
      _h_ =  /*<<weak.ml:28:2>>*/ 0 <= l,
-     _h_ = _h_ ? l <= Stdlib_Obj[23][15] : _h_;
+     _h_ = _h_ ? l <= Stdlib_Obj[24][15] : _h_;
     if(1 - _h_)  /*<<weak.ml:29:4>>*/ Stdlib[1].call(null, "Weak.create");
      /*<<weak.ml:30:2>>*/ return runtime.caml_weak_create(l) /*<<weak.ml:30:10>>*/ ;
    }
@@ -28639,7 +28691,7 @@
       found = 0;
      for(;;){
       if
-       (i < sz &&  /*<<weak.ml:281:21>>*/ Stdlib_Option[14].call(null, found)){
+       (i < sz &&  /*<<weak.ml:281:21>>*/ Stdlib_Option[15].call(null, found)){
         /*<<weak.ml:282:13>>*/ if(h !== caml_check_bound(hashes, i)[i + 1]){
         var i$2 =  /*<<weak.ml:289:15>>*/ i + 1 | 0;
         i = i$2;
@@ -30917,7 +30969,7 @@
     Stdlib_Obj = runtime.caml_get_global("Stdlib__Obj");
    function register_exception(name, exn){
     var
-     _a_ =  /*<<callback.ml:26:16>>*/ Stdlib_Obj[10],
+     _a_ =  /*<<callback.ml:26:16>>*/ Stdlib_Obj[11],
      slot = runtime.caml_obj_tag(exn) === _a_ ? exn : exn[1];
      /*<<callback.ml:27:2>>*/ return caml_register_named_value(name, slot) /*<<callback.ml:27:32>>*/ ;
    }
@@ -31487,7 +31539,7 @@
     var
      obj =
         /*<<camlinternalOO.ml:352:12>>*/ caml_obj_block
-        (Stdlib_Obj[10], table[1]);
+        (Stdlib_Obj[11], table[1]);
      /*<<camlinternalOO.ml:354:2>>*/ obj[1] = table[2];
      /*<<camlinternalOO.ml:355:10>>*/ return caml_set_oo_id(obj) /*<<camlinternalOO.ml:355:22>>*/ ;
    }
@@ -31497,7 +31549,7 @@
     var
      obj =
         /*<<camlinternalOO.ml:360:14>>*/ caml_obj_block
-        (Stdlib_Obj[10], table[1]);
+        (Stdlib_Obj[11], table[1]);
      /*<<camlinternalOO.ml:362:4>>*/ obj[1] = table[2];
      /*<<camlinternalOO.ml:363:12>>*/ return caml_set_oo_id(obj) /*<<camlinternalOO.ml:364:5>>*/ ;
    }
@@ -31926,7 +31978,7 @@
 
 //# unitInfo: Provides: Stdlib__Dynarray
 //# unitInfo: Requires: CamlinternalOO, Stdlib, Stdlib__Array, Stdlib__Iarray, Stdlib__Obj, Stdlib__Printf, Stdlib__Seq, Stdlib__Sys
-//# shape: Stdlib__Dynarray:[F(1)*,F(2),F(2),F(2),F(3),F(1)*,F(1)*,F(1),F(1),F(1),F(2),F(2),F(2),F(2),F(2),F(3),F(5),F(1),F(1),F(1),F(2),F(1),F(2),F(2),F(2),F(2),F(2),F(2),F(3),F(3),F(2),F(2),F(2),F(2),F(3),F(3),F(2),F(2),F(2),F(2),F(2),F(2),F(3),F(3),F(1),F(1),F(1),F(1),F(1),F(1),F(1),F(1)->F(1),F(1)*->F(1),F(1)->F(1),F(1)*->F(1),F(1)*,F(2),F(2),F(1),F(2),F(1),F(2)]
+//# shape: Stdlib__Dynarray:[F(1)*,F(2),F(2),F(2),F(3),F(1)*,F(1)*,F(1),F(1),F(1),F(2),F(2),F(2),F(2),F(2),F(2),F(3),F(5),F(1),F(1),F(1),F(2),F(1),F(2),F(2),F(2),F(2),F(2),F(2),F(3),F(3),F(2),F(2),F(2),F(2),F(3),F(3),F(2),F(2),F(2),F(2),F(2),F(2),F(3),F(3),F(1),F(1),F(1),F(1),F(1),F(1),F(1),F(1)->F(1),F(1)*->F(1),F(1)->F(1),F(1)*->F(1),F(1)*,F(2),F(2),F(1),F(2),F(1),F(2)]
 (function
   (globalThis){
    "use strict";
@@ -31964,7 +32016,7 @@
     Stdlib_Obj = caml_get_global("Stdlib__Obj"),
     CamlinternalOO = caml_get_global("CamlinternalOO");
    function copy_from_array(a, dummy){
-    var _O_ =  /*<<dynarray.ml:273:14>>*/ Stdlib_Obj[17];
+    var _O_ =  /*<<dynarray.ml:273:14>>*/ Stdlib_Obj[18];
     if(caml_obj_tag(a) !== _O_)
       /*<<dynarray.ml:274:8>>*/ return Stdlib_Array[7].call(null, a) /*<<dynarray.ml:283:9>>*/ ;
     var
@@ -31983,7 +32035,7 @@
      /*<<dynarray.ml:282:8>>*/ return arr;
     /*<<dynarray.ml:283:9>>*/ }
    function unsafe_nocopy_from_array(a, dummy){
-    var _O_ =  /*<<dynarray.ml:286:14>>*/ Stdlib_Obj[17];
+    var _O_ =  /*<<dynarray.ml:286:14>>*/ Stdlib_Obj[18];
     return caml_obj_tag(a) !== _O_
             ? a
             :  /*<<dynarray.ml:288:11>>*/ copy_from_array(a, dummy) /*<<dynarray.ml:288:35>>*/ ;
@@ -32199,7 +32251,7 @@
    function make(n, x){
      /*<<dynarray.ml:533:2>>*/ if(n < 0)
       /*<<dynarray.ml:533:16>>*/ negative_length_requested("make", n);
-    var _N_ =  /*<<dynarray.ml:259:14>>*/ Stdlib_Obj[16];
+    var _N_ =  /*<<dynarray.ml:259:14>>*/ Stdlib_Obj[17];
     if(caml_obj_tag(x) !== _N_)
      var
       arr$0 =
@@ -32637,7 +32689,7 @@
      /*<<dynarray.ml:825:2>>*/ if(arr.length - 1 < (length_a + length_b | 0))
       /*<<dynarray.ml:825:49>>*/ return 0;
      /*<<dynarray.ml:826:7>>*/ _I_[1] = length_a + length_b | 0;
-     /*<<dynarray.ml:323:14>>*/ _I_ = Stdlib_Obj[17];
+     /*<<dynarray.ml:323:14>>*/ _I_ = Stdlib_Obj[18];
     if(caml_obj_tag(src) !== _I_)
       /*<<dynarray.ml:324:8>>*/ Stdlib_Array[9].call
       (null, src, 0, arr, length_a, length_b);
@@ -32668,38 +32720,41 @@
       /*<<dynarray.ml:864:39>>*/ if(! _I_) return _I_;
     }
     /*<<dynarray.ml:866:31>>*/ }
+   function append_iarray(a, b){
+     /*<<dynarray.ml:871:2>>*/ return append_array(a, b) /*<<dynarray.ml:871:43>>*/ ;
+   }
    var cst_append =  /*<<?>>*/ "append";
    function append_if_room(param, b, length_b){
-    var length_a =  /*<<dynarray.ml:876:2>>*/ param[1], arr_a = param[2];
-     /*<<dynarray.ml:877:2>>*/ return arr_a.length - 1
+    var length_a =  /*<<dynarray.ml:881:2>>*/ param[1], arr_a = param[2];
+     /*<<dynarray.ml:882:2>>*/ return arr_a.length - 1
             < (length_a + length_b | 0)
             ? 0
-            : ( /*<<dynarray.ml:881:4>>*/ blit_assume_room
+            : ( /*<<dynarray.ml:886:4>>*/ blit_assume_room
                (b, 0, length_b, param, length_a, length_a, length_b),
-               /*<<dynarray.ml:885:4>>*/ check_same_length
+               /*<<dynarray.ml:890:4>>*/ check_same_length
                (cst_append, b, length_b),
-              1) /*<<dynarray.ml:887:5>>*/ ;
+              1) /*<<dynarray.ml:892:5>>*/ ;
    }
    function append(a, b){
     var length_b =  /*<<dynarray.ml:568:22>>*/ b[1];
-     /*<<dynarray.ml:891:5>>*/ if(append_if_room(a, b, length_b))
-      /*<<dynarray.ml:891:39>>*/ return 0;
-     /*<<dynarray.ml:891:33>>*/ for(;;){
-      /*<<dynarray.ml:895:6>>*/ ensure_extra_capacity(a, length_b);
-      /*<<dynarray.ml:902:6>>*/ check_same_length(cst_append, b, length_b);
-     var _I_ =  /*<<dynarray.ml:903:13>>*/ 1 - append_if_room(a, b, length_b);
-      /*<<dynarray.ml:903:43>>*/ if(! _I_) return _I_;
+     /*<<dynarray.ml:896:5>>*/ if(append_if_room(a, b, length_b))
+      /*<<dynarray.ml:896:39>>*/ return 0;
+     /*<<dynarray.ml:896:33>>*/ for(;;){
+      /*<<dynarray.ml:900:6>>*/ ensure_extra_capacity(a, length_b);
+      /*<<dynarray.ml:907:6>>*/ check_same_length(cst_append, b, length_b);
+     var _I_ =  /*<<dynarray.ml:908:13>>*/ 1 - append_if_room(a, b, length_b);
+      /*<<dynarray.ml:908:43>>*/ if(! _I_) return _I_;
     }
-    /*<<dynarray.ml:906:5>>*/ }
+    /*<<dynarray.ml:911:5>>*/ }
    function iter(fname, f, a){
     var
-     length =  /*<<dynarray.ml:926:2>>*/ a[1],
+     length =  /*<<dynarray.ml:931:2>>*/ a[1],
      arr = a[2],
      dummy = a[3],
      capacity =  /*<<dynarray.ml:508:2>>*/ arr.length - 1;
      /*<<dynarray.ml:509:2>>*/ if(capacity < length)
       /*<<dynarray.ml:510:4>>*/ invalid_length(length, capacity);
-    var _I_ =  /*<<dynarray.ml:950:31>>*/ length - 1 | 0;
+    var _I_ =  /*<<dynarray.ml:955:31>>*/ length - 1 | 0;
     if(_I_ >= 0){
      var i = 0;
      for(;;){
@@ -32709,26 +32764,26 @@
           /*<<dynarray.ml:518:27>>*/ v === dummy
           ?  /*<<dynarray.ml:519:7>>*/ missing_element(i, length)
           : v;
-       /*<<dynarray.ml:952:4>>*/ caml_call1(f, _H_);
-       /*<<dynarray.ml:952:40>>*/ _H_ = i + 1 | 0;
+       /*<<dynarray.ml:957:4>>*/ caml_call1(f, _H_);
+       /*<<dynarray.ml:957:40>>*/ _H_ = i + 1 | 0;
       if(_I_ === i) break;
       i = _H_;
      }
     }
-     /*<<dynarray.ml:954:2>>*/ return check_same_length(fname, a, length) /*<<dynarray.ml:954:35>>*/ ;
+     /*<<dynarray.ml:959:2>>*/ return check_same_length(fname, a, length) /*<<dynarray.ml:959:35>>*/ ;
    }
    function iter$0(f, a){
-     /*<<dynarray.ml:957:2>>*/ return iter("iter", f, a) /*<<dynarray.ml:957:18>>*/ ;
+     /*<<dynarray.ml:962:2>>*/ return iter("iter", f, a) /*<<dynarray.ml:962:18>>*/ ;
    }
    function iteri(f, a){
     var
-     length =  /*<<dynarray.ml:960:2>>*/ a[1],
+     length =  /*<<dynarray.ml:965:2>>*/ a[1],
      arr = a[2],
      dummy = a[3],
      capacity =  /*<<dynarray.ml:508:2>>*/ arr.length - 1;
      /*<<dynarray.ml:509:2>>*/ if(capacity < length)
       /*<<dynarray.ml:510:4>>*/ invalid_length(length, capacity);
-    var _H_ =  /*<<dynarray.ml:961:31>>*/ length - 1 | 0;
+    var _H_ =  /*<<dynarray.ml:966:31>>*/ length - 1 | 0;
     if(_H_ >= 0){
      var i = 0;
      for(;;){
@@ -32738,23 +32793,23 @@
           /*<<dynarray.ml:518:27>>*/ v === dummy
           ?  /*<<dynarray.ml:519:7>>*/ missing_element(i, length)
           : v;
-       /*<<dynarray.ml:963:4>>*/ caml_call2(f, i, _G_);
-       /*<<dynarray.ml:963:42>>*/ _G_ = i + 1 | 0;
+       /*<<dynarray.ml:968:4>>*/ caml_call2(f, i, _G_);
+       /*<<dynarray.ml:968:42>>*/ _G_ = i + 1 | 0;
       if(_H_ === i) break;
       i = _G_;
      }
     }
-     /*<<dynarray.ml:965:2>>*/ return check_same_length("iteri", a, length) /*<<dynarray.ml:965:37>>*/ ;
+     /*<<dynarray.ml:970:2>>*/ return check_same_length("iteri", a, length) /*<<dynarray.ml:970:37>>*/ ;
    }
    function rev_iter(f, a){
     var
-     length =  /*<<dynarray.ml:968:2>>*/ a[1],
+     length =  /*<<dynarray.ml:973:2>>*/ a[1],
      arr = a[2],
      dummy = a[3],
      capacity =  /*<<dynarray.ml:508:2>>*/ arr.length - 1;
      /*<<dynarray.ml:509:2>>*/ if(capacity < length)
       /*<<dynarray.ml:510:4>>*/ invalid_length(length, capacity);
-    var _G_ =  /*<<dynarray.ml:969:31>>*/ length - 1 | 0;
+    var _G_ =  /*<<dynarray.ml:974:31>>*/ length - 1 | 0;
     if(_G_ >= 0){
      var i = _G_;
      for(;;){
@@ -32764,23 +32819,23 @@
           /*<<dynarray.ml:518:27>>*/ v === dummy
           ?  /*<<dynarray.ml:519:7>>*/ missing_element(i, length)
           : v;
-       /*<<dynarray.ml:971:4>>*/ caml_call1(f, _G_);
-       /*<<dynarray.ml:971:40>>*/ _G_ = i - 1 | 0;
+       /*<<dynarray.ml:976:4>>*/ caml_call1(f, _G_);
+       /*<<dynarray.ml:976:40>>*/ _G_ = i - 1 | 0;
       if(0 === i) break;
       i = _G_;
      }
     }
-     /*<<dynarray.ml:973:2>>*/ return check_same_length("rev_iter", a, length) /*<<dynarray.ml:973:40>>*/ ;
+     /*<<dynarray.ml:978:2>>*/ return check_same_length("rev_iter", a, length) /*<<dynarray.ml:978:40>>*/ ;
    }
    function rev_iteri(f, a){
     var
-     length =  /*<<dynarray.ml:976:2>>*/ a[1],
+     length =  /*<<dynarray.ml:981:2>>*/ a[1],
      arr = a[2],
      dummy = a[3],
      capacity =  /*<<dynarray.ml:508:2>>*/ arr.length - 1;
      /*<<dynarray.ml:509:2>>*/ if(capacity < length)
       /*<<dynarray.ml:510:4>>*/ invalid_length(length, capacity);
-    var _G_ =  /*<<dynarray.ml:977:31>>*/ length - 1 | 0;
+    var _G_ =  /*<<dynarray.ml:982:31>>*/ length - 1 | 0;
     if(_G_ >= 0){
      var i = _G_;
      for(;;){
@@ -32790,26 +32845,26 @@
           /*<<dynarray.ml:518:27>>*/ v === dummy
           ?  /*<<dynarray.ml:519:7>>*/ missing_element(i, length)
           : v;
-       /*<<dynarray.ml:979:4>>*/ caml_call2(f, i, _G_);
-       /*<<dynarray.ml:979:42>>*/ _G_ = i - 1 | 0;
+       /*<<dynarray.ml:984:4>>*/ caml_call2(f, i, _G_);
+       /*<<dynarray.ml:984:42>>*/ _G_ = i - 1 | 0;
       if(0 === i) break;
       i = _G_;
      }
     }
-     /*<<dynarray.ml:981:2>>*/ return check_same_length
-            ("rev_iteri", a, length) /*<<dynarray.ml:981:41>>*/ ;
+     /*<<dynarray.ml:986:2>>*/ return check_same_length
+            ("rev_iteri", a, length) /*<<dynarray.ml:986:41>>*/ ;
    }
    function map(f, a){
     var
-     length =  /*<<dynarray.ml:984:2>>*/ a[1],
+     length =  /*<<dynarray.ml:989:2>>*/ a[1],
      arr_in = a[2],
      dummy = a[3],
      capacity =  /*<<dynarray.ml:508:2>>*/ arr_in.length - 1;
      /*<<dynarray.ml:509:2>>*/ if(capacity < length)
       /*<<dynarray.ml:510:4>>*/ invalid_length(length, capacity);
     var
-     arr_out =  /*<<dynarray.ml:986:16>>*/ caml_array_make(length, dummy),
-     _G_ =  /*<<dynarray.ml:987:2>>*/ length - 1 | 0;
+     arr_out =  /*<<dynarray.ml:991:16>>*/ caml_array_make(length, dummy),
+     _G_ =  /*<<dynarray.ml:992:2>>*/ length - 1 | 0;
     if(_G_ >= 0){
      var i = 0;
      for(;;){
@@ -32819,26 +32874,26 @@
           /*<<dynarray.ml:518:27>>*/ v === dummy
           ?  /*<<dynarray.ml:519:7>>*/ missing_element(i, length)
           : v;
-       /*<<dynarray.ml:989:20>>*/ arr_out[i + 1] = caml_call1(f, _F_);
-       /*<<dynarray.ml:989:62>>*/ _F_ = i + 1 | 0;
+       /*<<dynarray.ml:994:20>>*/ arr_out[i + 1] = caml_call1(f, _F_);
+       /*<<dynarray.ml:994:62>>*/ _F_ = i + 1 | 0;
       if(_G_ === i) break;
       i = _F_;
      }
     }
-     /*<<dynarray.ml:996:2>>*/ check_same_length("map", a, length);
-     /*<<dynarray.ml:996:35>>*/ return [0, length, arr_out, dummy];
-    /*<<dynarray.ml:997:5>>*/ }
+     /*<<dynarray.ml:1001:2>>*/ check_same_length("map", a, length);
+     /*<<dynarray.ml:1001:35>>*/ return [0, length, arr_out, dummy];
+    /*<<dynarray.ml:1002:5>>*/ }
    function mapi(f, a){
     var
-     length =  /*<<dynarray.ml:1000:2>>*/ a[1],
+     length =  /*<<dynarray.ml:1005:2>>*/ a[1],
      arr_in = a[2],
      dummy = a[3],
      capacity =  /*<<dynarray.ml:508:2>>*/ arr_in.length - 1;
      /*<<dynarray.ml:509:2>>*/ if(capacity < length)
       /*<<dynarray.ml:510:4>>*/ invalid_length(length, capacity);
     var
-     arr_out =  /*<<dynarray.ml:1002:16>>*/ caml_array_make(length, dummy),
-     _F_ =  /*<<dynarray.ml:1003:2>>*/ length - 1 | 0;
+     arr_out =  /*<<dynarray.ml:1007:16>>*/ caml_array_make(length, dummy),
+     _F_ =  /*<<dynarray.ml:1008:2>>*/ length - 1 | 0;
     if(_F_ >= 0){
      var i = 0;
      for(;;){
@@ -32848,24 +32903,24 @@
           /*<<dynarray.ml:518:27>>*/ v === dummy
           ?  /*<<dynarray.ml:519:7>>*/ missing_element(i, length)
           : v;
-       /*<<dynarray.ml:1005:20>>*/ arr_out[i + 1] = caml_call2(f, i, _E_);
-       /*<<dynarray.ml:1005:64>>*/ _E_ = i + 1 | 0;
+       /*<<dynarray.ml:1010:20>>*/ arr_out[i + 1] = caml_call2(f, i, _E_);
+       /*<<dynarray.ml:1010:64>>*/ _E_ = i + 1 | 0;
       if(_F_ === i) break;
       i = _E_;
      }
     }
-     /*<<dynarray.ml:1012:2>>*/ check_same_length("mapi", a, length);
-     /*<<dynarray.ml:1012:36>>*/ return [0, length, arr_out, dummy];
-    /*<<dynarray.ml:1013:5>>*/ }
+     /*<<dynarray.ml:1017:2>>*/ check_same_length("mapi", a, length);
+     /*<<dynarray.ml:1017:36>>*/ return [0, length, arr_out, dummy];
+    /*<<dynarray.ml:1018:5>>*/ }
    function fold_left(f, acc, a){
     var
-     length =  /*<<dynarray.ml:1016:2>>*/ a[1],
+     length =  /*<<dynarray.ml:1021:2>>*/ a[1],
      arr = a[2],
      dummy = a[3],
      capacity =  /*<<dynarray.ml:508:2>>*/ arr.length - 1;
      /*<<dynarray.ml:509:2>>*/ if(capacity < length)
       /*<<dynarray.ml:510:4>>*/ invalid_length(length, capacity);
-    var _C_ =  /*<<dynarray.ml:1019:2>>*/ length - 1 | 0;
+    var _C_ =  /*<<dynarray.ml:1024:2>>*/ length - 1 | 0;
     if(_C_ < 0)
      var r$0 = acc;
     else{
@@ -32877,25 +32932,25 @@
           /*<<dynarray.ml:518:27>>*/ v$0 === dummy
           ?  /*<<dynarray.ml:519:7>>*/ missing_element(i, length)
           : v$0,
-       _D_ =  /*<<dynarray.ml:1021:9>>*/ caml_call2(f, r, v),
-       _E_ =  /*<<dynarray.ml:1021:15>>*/ i + 1 | 0;
+       _D_ =  /*<<dynarray.ml:1026:9>>*/ caml_call2(f, r, v),
+       _E_ =  /*<<dynarray.ml:1026:15>>*/ i + 1 | 0;
       if(_C_ === i){r$0 = _D_; break;}
       r = _D_;
       i = _E_;
      }
     }
-     /*<<dynarray.ml:1023:2>>*/ check_same_length("fold_left", a, length);
-     /*<<dynarray.ml:1023:41>>*/ return r$0;
-    /*<<dynarray.ml:1024:4>>*/ }
+     /*<<dynarray.ml:1028:2>>*/ check_same_length("fold_left", a, length);
+     /*<<dynarray.ml:1028:41>>*/ return r$0;
+    /*<<dynarray.ml:1029:4>>*/ }
    function fold_right(f, a, acc){
     var
-     length =  /*<<dynarray.ml:1027:2>>*/ a[1],
+     length =  /*<<dynarray.ml:1032:2>>*/ a[1],
      arr = a[2],
      dummy = a[3],
      capacity =  /*<<dynarray.ml:508:2>>*/ arr.length - 1;
      /*<<dynarray.ml:509:2>>*/ if(capacity < length)
       /*<<dynarray.ml:510:4>>*/ invalid_length(length, capacity);
-    var _B_ =  /*<<dynarray.ml:1030:2>>*/ length - 1 | 0;
+    var _B_ =  /*<<dynarray.ml:1035:2>>*/ length - 1 | 0;
     if(_B_ < 0)
      var r$0 = acc;
     else{
@@ -32907,28 +32962,28 @@
           /*<<dynarray.ml:518:27>>*/ v$0 === dummy
           ?  /*<<dynarray.ml:519:7>>*/ missing_element(i, length)
           : v$0,
-       _B_ =  /*<<dynarray.ml:1032:9>>*/ caml_call2(f, v, r),
-       _C_ =  /*<<dynarray.ml:1032:15>>*/ i - 1 | 0;
+       _B_ =  /*<<dynarray.ml:1037:9>>*/ caml_call2(f, v, r),
+       _C_ =  /*<<dynarray.ml:1037:15>>*/ i - 1 | 0;
       if(0 === i){r$0 = _B_; break;}
       r = _B_;
       i = _C_;
      }
     }
-     /*<<dynarray.ml:1034:2>>*/ check_same_length("fold_right", a, length);
-     /*<<dynarray.ml:1034:42>>*/ return r$0;
-    /*<<dynarray.ml:1035:4>>*/ }
+     /*<<dynarray.ml:1039:2>>*/ check_same_length("fold_right", a, length);
+     /*<<dynarray.ml:1039:42>>*/ return r$0;
+    /*<<dynarray.ml:1040:4>>*/ }
    function exists(p, a){
     var
-     length =  /*<<dynarray.ml:1038:2>>*/ a[1],
+     length =  /*<<dynarray.ml:1043:2>>*/ a[1],
      arr = a[2],
      dummy = a[3],
      capacity =  /*<<dynarray.ml:508:2>>*/ arr.length - 1;
      /*<<dynarray.ml:509:2>>*/ if(capacity < length)
       /*<<dynarray.ml:510:4>>*/ invalid_length(length, capacity);
-    var i =  /*<<dynarray.ml:1046:12>>*/ 0;
+    var i =  /*<<dynarray.ml:1051:12>>*/ 0;
     for(;;){
-      /*<<dynarray.ml:1041:4>>*/ if(i === length)
-      var res =  /*<<dynarray.ml:1041:23>>*/ 0;
+      /*<<dynarray.ml:1046:4>>*/ if(i === length)
+      var res =  /*<<dynarray.ml:1046:23>>*/ 0;
      else{
       var
        v =  /*<<dynarray.ml:517:10>>*/ arr[i + 1],
@@ -32936,30 +32991,30 @@
           /*<<dynarray.ml:518:27>>*/ v === dummy
           ?  /*<<dynarray.ml:519:7>>*/ missing_element(i, length)
           : v,
-       _B_ =  /*<<dynarray.ml:1043:6>>*/ caml_call1(p, _B_);
-       /*<<dynarray.ml:1043:42>>*/ if(! _B_){
+       _B_ =  /*<<dynarray.ml:1048:6>>*/ caml_call1(p, _B_);
+       /*<<dynarray.ml:1048:42>>*/ if(! _B_){
        var i$0 = i + 1 | 0;
        i = i$0;
        continue;
       }
       res = _B_;
      }
-      /*<<dynarray.ml:1047:2>>*/ check_same_length("exists", a, length);
-      /*<<dynarray.ml:1047:38>>*/ return res;
+      /*<<dynarray.ml:1052:2>>*/ check_same_length("exists", a, length);
+      /*<<dynarray.ml:1052:38>>*/ return res;
     }
-    /*<<dynarray.ml:1048:5>>*/ }
+    /*<<dynarray.ml:1053:5>>*/ }
    function for_all(p, a){
     var
-     length =  /*<<dynarray.ml:1051:2>>*/ a[1],
+     length =  /*<<dynarray.ml:1056:2>>*/ a[1],
      arr = a[2],
      dummy = a[3],
      capacity =  /*<<dynarray.ml:508:2>>*/ arr.length - 1;
      /*<<dynarray.ml:509:2>>*/ if(capacity < length)
       /*<<dynarray.ml:510:4>>*/ invalid_length(length, capacity);
-    var i =  /*<<dynarray.ml:1059:12>>*/ 0;
+    var i =  /*<<dynarray.ml:1064:12>>*/ 0;
     for(;;){
-      /*<<dynarray.ml:1054:4>>*/ if(i === length)
-      var res =  /*<<dynarray.ml:1054:23>>*/ 1;
+      /*<<dynarray.ml:1059:4>>*/ if(i === length)
+      var res =  /*<<dynarray.ml:1059:23>>*/ 1;
      else{
       var
        v =  /*<<dynarray.ml:517:10>>*/ arr[i + 1],
@@ -32967,24 +33022,24 @@
           /*<<dynarray.ml:518:27>>*/ v === dummy
           ?  /*<<dynarray.ml:519:7>>*/ missing_element(i, length)
           : v,
-       _B_ =  /*<<dynarray.ml:1056:6>>*/ caml_call1(p, _B_);
-       /*<<dynarray.ml:1056:42>>*/ if(_B_){
+       _B_ =  /*<<dynarray.ml:1061:6>>*/ caml_call1(p, _B_);
+       /*<<dynarray.ml:1061:42>>*/ if(_B_){
        var i$0 = i + 1 | 0;
        i = i$0;
        continue;
       }
       res = _B_;
      }
-      /*<<dynarray.ml:1060:2>>*/ check_same_length("for_all", a, length);
-      /*<<dynarray.ml:1060:39>>*/ return res;
+      /*<<dynarray.ml:1065:2>>*/ check_same_length("for_all", a, length);
+      /*<<dynarray.ml:1065:39>>*/ return res;
     }
-    /*<<dynarray.ml:1061:5>>*/ }
+    /*<<dynarray.ml:1066:5>>*/ }
    function exists2(p, a1, a2){
     var
-     length1 =  /*<<dynarray.ml:1064:2>>*/ a1[1],
+     length1 =  /*<<dynarray.ml:1069:2>>*/ a1[1],
      arr1 = a1[2],
      dummy1 = a1[3],
-     length2 =  /*<<dynarray.ml:1065:2>>*/ a2[1],
+     length2 =  /*<<dynarray.ml:1070:2>>*/ a2[1],
      arr2 = a2[2],
      dummy2 = a2[3],
      capacity$0 =  /*<<dynarray.ml:508:2>>*/ arr1.length - 1;
@@ -32994,13 +33049,13 @@
      /*<<dynarray.ml:509:2>>*/ if(capacity < length2)
       /*<<dynarray.ml:510:4>>*/ invalid_length(length2, capacity);
     var cst_exists2 =  /*<<?>>*/ "exists2";
-     /*<<dynarray.ml:1067:33>>*/ if(length1 !== length2)
-      /*<<dynarray.ml:1069:4>>*/ different_lengths
+     /*<<dynarray.ml:1072:33>>*/ if(length1 !== length2)
+      /*<<dynarray.ml:1074:4>>*/ different_lengths
       (cst_exists2, length1, length2);
-    var i =  /*<<dynarray.ml:1077:12>>*/ 0;
+    var i =  /*<<dynarray.ml:1082:12>>*/ 0;
     for(;;){
-      /*<<dynarray.ml:1071:4>>*/ if(i === length1)
-      var res =  /*<<dynarray.ml:1071:23>>*/ 0;
+      /*<<dynarray.ml:1076:4>>*/ if(i === length1)
+      var res =  /*<<dynarray.ml:1076:23>>*/ 0;
      else{
       var
        v$0 =  /*<<dynarray.ml:517:10>>*/ arr2[i + 1],
@@ -33013,25 +33068,25 @@
           /*<<dynarray.ml:518:27>>*/ v === dummy1
           ?  /*<<dynarray.ml:519:7>>*/ missing_element(i, length1)
           : v,
-       _A_ =  /*<<dynarray.ml:1073:6>>*/ caml_call2(p, _A_, _B_);
-       /*<<dynarray.ml:1074:50>>*/ if(! _A_){
+       _A_ =  /*<<dynarray.ml:1078:6>>*/ caml_call2(p, _A_, _B_);
+       /*<<dynarray.ml:1079:50>>*/ if(! _A_){
        var i$0 = i + 1 | 0;
        i = i$0;
        continue;
       }
       res = _A_;
      }
-      /*<<dynarray.ml:1078:2>>*/ check_same_length(cst_exists2, a1, length1);
-      /*<<dynarray.ml:1079:2>>*/ check_same_length(cst_exists2, a2, length2);
-      /*<<dynarray.ml:1079:48>>*/ return res;
+      /*<<dynarray.ml:1083:2>>*/ check_same_length(cst_exists2, a1, length1);
+      /*<<dynarray.ml:1084:2>>*/ check_same_length(cst_exists2, a2, length2);
+      /*<<dynarray.ml:1084:48>>*/ return res;
     }
-    /*<<dynarray.ml:1080:5>>*/ }
+    /*<<dynarray.ml:1085:5>>*/ }
    function for_all2(p, a1, a2){
     var
-     length1 =  /*<<dynarray.ml:1083:2>>*/ a1[1],
+     length1 =  /*<<dynarray.ml:1088:2>>*/ a1[1],
      arr1 = a1[2],
      dummy1 = a1[3],
-     length2 =  /*<<dynarray.ml:1084:2>>*/ a2[1],
+     length2 =  /*<<dynarray.ml:1089:2>>*/ a2[1],
      arr2 = a2[2],
      dummy2 = a2[3],
      capacity$0 =  /*<<dynarray.ml:508:2>>*/ arr1.length - 1;
@@ -33041,13 +33096,13 @@
      /*<<dynarray.ml:509:2>>*/ if(capacity < length2)
       /*<<dynarray.ml:510:4>>*/ invalid_length(length2, capacity);
     var cst_for_all2 =  /*<<?>>*/ "for_all2";
-     /*<<dynarray.ml:1086:33>>*/ if(length1 !== length2)
-      /*<<dynarray.ml:1088:4>>*/ different_lengths
+     /*<<dynarray.ml:1091:33>>*/ if(length1 !== length2)
+      /*<<dynarray.ml:1093:4>>*/ different_lengths
       (cst_for_all2, length1, length2);
-    var i =  /*<<dynarray.ml:1096:12>>*/ 0;
+    var i =  /*<<dynarray.ml:1101:12>>*/ 0;
     for(;;){
-      /*<<dynarray.ml:1090:4>>*/ if(i === length1)
-      var res =  /*<<dynarray.ml:1090:23>>*/ 1;
+      /*<<dynarray.ml:1095:4>>*/ if(i === length1)
+      var res =  /*<<dynarray.ml:1095:23>>*/ 1;
      else{
       var
        v$0 =  /*<<dynarray.ml:517:10>>*/ arr2[i + 1],
@@ -33060,58 +33115,58 @@
           /*<<dynarray.ml:518:27>>*/ v === dummy1
           ?  /*<<dynarray.ml:519:7>>*/ missing_element(i, length1)
           : v,
-       _z_ =  /*<<dynarray.ml:1092:6>>*/ caml_call2(p, _z_, _A_);
-       /*<<dynarray.ml:1093:50>>*/ if(_z_){
+       _z_ =  /*<<dynarray.ml:1097:6>>*/ caml_call2(p, _z_, _A_);
+       /*<<dynarray.ml:1098:50>>*/ if(_z_){
        var i$0 = i + 1 | 0;
        i = i$0;
        continue;
       }
       res = _z_;
      }
-      /*<<dynarray.ml:1097:2>>*/ check_same_length(cst_for_all2, a1, length1);
-      /*<<dynarray.ml:1098:2>>*/ check_same_length(cst_for_all2, a2, length2);
-      /*<<dynarray.ml:1098:49>>*/ return res;
+      /*<<dynarray.ml:1102:2>>*/ check_same_length(cst_for_all2, a1, length1);
+      /*<<dynarray.ml:1103:2>>*/ check_same_length(cst_for_all2, a2, length2);
+      /*<<dynarray.ml:1103:49>>*/ return res;
     }
-    /*<<dynarray.ml:1099:5>>*/ }
+    /*<<dynarray.ml:1104:5>>*/ }
    function filter(f, a){
-    var b =  /*<<dynarray.ml:1102:10>>*/ create(0);
-     /*<<dynarray.ml:1103:2>>*/ iter
-     ("filter",
-      function(x){
-       var _z_ =  /*<<dynarray.ml:1103:30>>*/ caml_call1(f, x);
-        /*<<dynarray.ml:1103:33>>*/ return _z_
-               ?  /*<<dynarray.ml:1103:39>>*/ add_last(b, x)
-               : _z_ /*<<dynarray.ml:1103:51>>*/ ;
-      },
-      a);
-     /*<<dynarray.ml:1103:54>>*/ return b;
-    /*<<dynarray.ml:1104:3>>*/ }
-   function filter_map(f, a){
     var b =  /*<<dynarray.ml:1107:10>>*/ create(0);
      /*<<dynarray.ml:1108:2>>*/ iter
-     ("filter_map",
+     ("filter",
       function(x){
-       var match =  /*<<dynarray.ml:1109:10>>*/ caml_call1(f, x);
-        /*<<dynarray.ml:1109:13>>*/ if(! match)
-         /*<<dynarray.ml:1110:14>>*/ return 0;
-       var y =  /*<<dynarray.ml:1109:13>>*/ match[1];
-        /*<<dynarray.ml:1111:16>>*/ return add_last(b, y) /*<<dynarray.ml:1111:28>>*/ ;
+       var _z_ =  /*<<dynarray.ml:1108:30>>*/ caml_call1(f, x);
+        /*<<dynarray.ml:1108:33>>*/ return _z_
+               ?  /*<<dynarray.ml:1108:39>>*/ add_last(b, x)
+               : _z_ /*<<dynarray.ml:1108:51>>*/ ;
       },
       a);
-     /*<<dynarray.ml:1112:5>>*/ return b;
-    /*<<dynarray.ml:1113:3>>*/ }
+     /*<<dynarray.ml:1108:54>>*/ return b;
+    /*<<dynarray.ml:1109:3>>*/ }
+   function filter_map(f, a){
+    var b =  /*<<dynarray.ml:1112:10>>*/ create(0);
+     /*<<dynarray.ml:1113:2>>*/ iter
+     ("filter_map",
+      function(x){
+       var match =  /*<<dynarray.ml:1114:10>>*/ caml_call1(f, x);
+        /*<<dynarray.ml:1114:13>>*/ if(! match)
+         /*<<dynarray.ml:1115:14>>*/ return 0;
+       var y =  /*<<dynarray.ml:1114:13>>*/ match[1];
+        /*<<dynarray.ml:1116:16>>*/ return add_last(b, y) /*<<dynarray.ml:1116:28>>*/ ;
+      },
+      a);
+     /*<<dynarray.ml:1117:5>>*/ return b;
+    /*<<dynarray.ml:1118:3>>*/ }
    function mem(x, a){
     var
-     length =  /*<<dynarray.ml:1116:2>>*/ a[1],
+     length =  /*<<dynarray.ml:1121:2>>*/ a[1],
      arr = a[2],
      dummy = a[3],
      capacity =  /*<<dynarray.ml:508:2>>*/ arr.length - 1;
      /*<<dynarray.ml:509:2>>*/ if(capacity < length)
       /*<<dynarray.ml:510:4>>*/ invalid_length(length, capacity);
-    var i =  /*<<dynarray.ml:1124:12>>*/ 0;
+    var i =  /*<<dynarray.ml:1129:12>>*/ 0;
     for(;;){
-      /*<<dynarray.ml:1119:4>>*/ if(i === length)
-      var res =  /*<<dynarray.ml:1119:23>>*/ 0;
+      /*<<dynarray.ml:1124:4>>*/ if(i === length)
+      var res =  /*<<dynarray.ml:1124:23>>*/ 0;
      else{
       var
        v =  /*<<dynarray.ml:517:10>>*/ arr[i + 1],
@@ -33119,29 +33174,29 @@
           /*<<dynarray.ml:518:27>>*/ v === dummy
           ?  /*<<dynarray.ml:519:7>>*/ missing_element(i, length)
           : v;
-       /*<<dynarray.ml:1120:12>>*/ if(0 !== runtime.caml_compare(_z_, x)){
-       var i$0 =  /*<<dynarray.ml:1122:9>>*/ i + 1 | 0;
+       /*<<dynarray.ml:1125:12>>*/ if(0 !== runtime.caml_compare(_z_, x)){
+       var i$0 =  /*<<dynarray.ml:1127:9>>*/ i + 1 | 0;
        i = i$0;
        continue;
       }
-       /*<<dynarray.ml:1121:6>>*/ res = 1;
+       /*<<dynarray.ml:1126:6>>*/ res = 1;
      }
-      /*<<dynarray.ml:1125:2>>*/ check_same_length("mem", a, length);
-      /*<<dynarray.ml:1125:35>>*/ return res;
+      /*<<dynarray.ml:1130:2>>*/ check_same_length("mem", a, length);
+      /*<<dynarray.ml:1130:35>>*/ return res;
     }
-    /*<<dynarray.ml:1126:5>>*/ }
+    /*<<dynarray.ml:1131:5>>*/ }
    function memq(x, a){
     var
-     length =  /*<<dynarray.ml:1129:2>>*/ a[1],
+     length =  /*<<dynarray.ml:1134:2>>*/ a[1],
      arr = a[2],
      dummy = a[3],
      capacity =  /*<<dynarray.ml:508:2>>*/ arr.length - 1;
      /*<<dynarray.ml:509:2>>*/ if(capacity < length)
       /*<<dynarray.ml:510:4>>*/ invalid_length(length, capacity);
-    var i =  /*<<dynarray.ml:1137:12>>*/ 0;
+    var i =  /*<<dynarray.ml:1142:12>>*/ 0;
     for(;;){
-      /*<<dynarray.ml:1132:4>>*/ if(i === length)
-      var res =  /*<<dynarray.ml:1132:23>>*/ 0;
+      /*<<dynarray.ml:1137:4>>*/ if(i === length)
+      var res =  /*<<dynarray.ml:1137:23>>*/ 0;
      else{
       var
        v =  /*<<dynarray.ml:517:10>>*/ arr[i + 1],
@@ -33149,29 +33204,29 @@
           /*<<dynarray.ml:518:27>>*/ v === dummy
           ?  /*<<dynarray.ml:519:7>>*/ missing_element(i, length)
           : v;
-       /*<<dynarray.ml:1133:46>>*/ if(_z_ !== x){
-       var i$0 =  /*<<dynarray.ml:1135:9>>*/ i + 1 | 0;
+       /*<<dynarray.ml:1138:46>>*/ if(_z_ !== x){
+       var i$0 =  /*<<dynarray.ml:1140:9>>*/ i + 1 | 0;
        i = i$0;
        continue;
       }
-       /*<<dynarray.ml:1134:6>>*/ res = 1;
+       /*<<dynarray.ml:1139:6>>*/ res = 1;
      }
-      /*<<dynarray.ml:1138:2>>*/ check_same_length("memq", a, length);
-      /*<<dynarray.ml:1138:36>>*/ return res;
+      /*<<dynarray.ml:1143:2>>*/ check_same_length("memq", a, length);
+      /*<<dynarray.ml:1143:36>>*/ return res;
     }
-    /*<<dynarray.ml:1139:5>>*/ }
+    /*<<dynarray.ml:1144:5>>*/ }
    function find_opt(p, a){
     var
-     length =  /*<<dynarray.ml:1142:2>>*/ a[1],
+     length =  /*<<dynarray.ml:1147:2>>*/ a[1],
      arr = a[2],
      dummy = a[3],
      capacity =  /*<<dynarray.ml:508:2>>*/ arr.length - 1;
      /*<<dynarray.ml:509:2>>*/ if(capacity < length)
       /*<<dynarray.ml:510:4>>*/ invalid_length(length, capacity);
-    var i =  /*<<dynarray.ml:1151:12>>*/ 0;
+    var i =  /*<<dynarray.ml:1156:12>>*/ 0;
     for(;;){
-      /*<<dynarray.ml:1145:4>>*/ if(i === length)
-      var res =  /*<<dynarray.ml:1145:23>>*/ 0;
+      /*<<dynarray.ml:1150:4>>*/ if(i === length)
+      var res =  /*<<dynarray.ml:1150:23>>*/ 0;
      else{
       var
        v =  /*<<dynarray.ml:517:10>>*/ arr[i + 1],
@@ -33179,29 +33234,29 @@
           /*<<dynarray.ml:518:27>>*/ v === dummy
           ?  /*<<dynarray.ml:519:7>>*/ missing_element(i, length)
           : v;
-       /*<<dynarray.ml:1148:9>>*/ if(! caml_call1(p, x)){
-       var i$0 =  /*<<dynarray.ml:1149:11>>*/ i + 1 | 0;
+       /*<<dynarray.ml:1153:9>>*/ if(! caml_call1(p, x)){
+       var i$0 =  /*<<dynarray.ml:1154:11>>*/ i + 1 | 0;
        i = i$0;
        continue;
       }
-       /*<<dynarray.ml:1148:18>>*/ res = [0, x];
+       /*<<dynarray.ml:1153:18>>*/ res = [0, x];
      }
-      /*<<dynarray.ml:1152:2>>*/ check_same_length("find_opt", a, length);
-      /*<<dynarray.ml:1152:40>>*/ return res;
+      /*<<dynarray.ml:1157:2>>*/ check_same_length("find_opt", a, length);
+      /*<<dynarray.ml:1157:40>>*/ return res;
     }
-    /*<<dynarray.ml:1153:5>>*/ }
+    /*<<dynarray.ml:1158:5>>*/ }
    function find_index(p, a){
     var
-     length =  /*<<dynarray.ml:1156:2>>*/ a[1],
+     length =  /*<<dynarray.ml:1161:2>>*/ a[1],
      arr = a[2],
      dummy = a[3],
      capacity =  /*<<dynarray.ml:508:2>>*/ arr.length - 1;
      /*<<dynarray.ml:509:2>>*/ if(capacity < length)
       /*<<dynarray.ml:510:4>>*/ invalid_length(length, capacity);
-    var i =  /*<<dynarray.ml:1165:12>>*/ 0;
+    var i =  /*<<dynarray.ml:1170:12>>*/ 0;
     for(;;){
-      /*<<dynarray.ml:1159:4>>*/ if(i === length)
-      var res =  /*<<dynarray.ml:1159:23>>*/ 0;
+      /*<<dynarray.ml:1164:4>>*/ if(i === length)
+      var res =  /*<<dynarray.ml:1164:23>>*/ 0;
      else{
       var
        v =  /*<<dynarray.ml:517:10>>*/ arr[i + 1],
@@ -33209,29 +33264,29 @@
           /*<<dynarray.ml:518:27>>*/ v === dummy
           ?  /*<<dynarray.ml:519:7>>*/ missing_element(i, length)
           : v;
-       /*<<dynarray.ml:1162:9>>*/ if(! caml_call1(p, x)){
-       var i$0 =  /*<<dynarray.ml:1163:11>>*/ i + 1 | 0;
+       /*<<dynarray.ml:1167:9>>*/ if(! caml_call1(p, x)){
+       var i$0 =  /*<<dynarray.ml:1168:11>>*/ i + 1 | 0;
        i = i$0;
        continue;
       }
-       /*<<dynarray.ml:1162:18>>*/ res = [0, i];
+       /*<<dynarray.ml:1167:18>>*/ res = [0, i];
      }
-      /*<<dynarray.ml:1166:2>>*/ check_same_length("find_index", a, length);
-      /*<<dynarray.ml:1166:42>>*/ return res;
+      /*<<dynarray.ml:1171:2>>*/ check_same_length("find_index", a, length);
+      /*<<dynarray.ml:1171:42>>*/ return res;
     }
-    /*<<dynarray.ml:1167:5>>*/ }
+    /*<<dynarray.ml:1172:5>>*/ }
    function find_map(p, a){
     var
-     length =  /*<<dynarray.ml:1170:2>>*/ a[1],
+     length =  /*<<dynarray.ml:1175:2>>*/ a[1],
      arr = a[2],
      dummy = a[3],
      capacity =  /*<<dynarray.ml:508:2>>*/ arr.length - 1;
      /*<<dynarray.ml:509:2>>*/ if(capacity < length)
       /*<<dynarray.ml:510:4>>*/ invalid_length(length, capacity);
-    var i =  /*<<dynarray.ml:1179:12>>*/ 0;
+    var i =  /*<<dynarray.ml:1184:12>>*/ 0;
     for(;;){
-      /*<<dynarray.ml:1173:4>>*/ if(i === length)
-      var res =  /*<<dynarray.ml:1173:23>>*/ 0;
+      /*<<dynarray.ml:1178:4>>*/ if(i === length)
+      var res =  /*<<dynarray.ml:1178:23>>*/ 0;
      else{
       var
        v =  /*<<dynarray.ml:517:10>>*/ arr[i + 1],
@@ -33239,30 +33294,30 @@
           /*<<dynarray.ml:518:27>>*/ v === dummy
           ?  /*<<dynarray.ml:519:7>>*/ missing_element(i, length)
           : v,
-       r =  /*<<dynarray.ml:1175:12>>*/ caml_call1(p, _z_);
-       /*<<dynarray.ml:1175:48>>*/ if(! r){
-       var i$0 =  /*<<dynarray.ml:1176:16>>*/ i + 1 | 0;
+       r =  /*<<dynarray.ml:1180:12>>*/ caml_call1(p, _z_);
+       /*<<dynarray.ml:1180:48>>*/ if(! r){
+       var i$0 =  /*<<dynarray.ml:1181:16>>*/ i + 1 | 0;
        i = i$0;
        continue;
       }
-       /*<<dynarray.ml:1175:48>>*/ res = r;
+       /*<<dynarray.ml:1180:48>>*/ res = r;
      }
-      /*<<dynarray.ml:1180:2>>*/ check_same_length("find_map", a, length);
-      /*<<dynarray.ml:1180:40>>*/ return res;
+      /*<<dynarray.ml:1185:2>>*/ check_same_length("find_map", a, length);
+      /*<<dynarray.ml:1185:40>>*/ return res;
     }
-    /*<<dynarray.ml:1181:5>>*/ }
+    /*<<dynarray.ml:1186:5>>*/ }
    function find_mapi(p, a){
     var
-     length =  /*<<dynarray.ml:1184:2>>*/ a[1],
+     length =  /*<<dynarray.ml:1189:2>>*/ a[1],
      arr = a[2],
      dummy = a[3],
      capacity =  /*<<dynarray.ml:508:2>>*/ arr.length - 1;
      /*<<dynarray.ml:509:2>>*/ if(capacity < length)
       /*<<dynarray.ml:510:4>>*/ invalid_length(length, capacity);
-    var i =  /*<<dynarray.ml:1193:12>>*/ 0;
+    var i =  /*<<dynarray.ml:1198:12>>*/ 0;
     for(;;){
-      /*<<dynarray.ml:1187:4>>*/ if(i === length)
-      var res =  /*<<dynarray.ml:1187:23>>*/ 0;
+      /*<<dynarray.ml:1192:4>>*/ if(i === length)
+      var res =  /*<<dynarray.ml:1192:23>>*/ 0;
      else{
       var
        v =  /*<<dynarray.ml:517:10>>*/ arr[i + 1],
@@ -33270,38 +33325,38 @@
           /*<<dynarray.ml:518:27>>*/ v === dummy
           ?  /*<<dynarray.ml:519:7>>*/ missing_element(i, length)
           : v,
-       r =  /*<<dynarray.ml:1189:12>>*/ caml_call2(p, i, _z_);
-       /*<<dynarray.ml:1189:50>>*/ if(! r){
-       var i$0 =  /*<<dynarray.ml:1190:16>>*/ i + 1 | 0;
+       r =  /*<<dynarray.ml:1194:12>>*/ caml_call2(p, i, _z_);
+       /*<<dynarray.ml:1194:50>>*/ if(! r){
+       var i$0 =  /*<<dynarray.ml:1195:16>>*/ i + 1 | 0;
        i = i$0;
        continue;
       }
-       /*<<dynarray.ml:1189:50>>*/ res = r;
+       /*<<dynarray.ml:1194:50>>*/ res = r;
      }
-      /*<<dynarray.ml:1194:2>>*/ check_same_length("find_mapi", a, length);
-      /*<<dynarray.ml:1194:41>>*/ return res;
+      /*<<dynarray.ml:1199:2>>*/ check_same_length("find_mapi", a, length);
+      /*<<dynarray.ml:1199:41>>*/ return res;
     }
-    /*<<dynarray.ml:1195:5>>*/ }
+    /*<<dynarray.ml:1200:5>>*/ }
    function equal(eq, a1, a2){
     var
-     length =  /*<<dynarray.ml:1198:2>>*/ a1[1],
+     length =  /*<<dynarray.ml:1203:2>>*/ a1[1],
      arr1 = a1[2],
      dummy = a1[3],
-     len2 =  /*<<dynarray.ml:1199:2>>*/ a2[1],
+     len2 =  /*<<dynarray.ml:1204:2>>*/ a2[1],
      arr2 = a2[2],
      dummy$0 = a2[3];
-     /*<<dynarray.ml:1200:2>>*/ if(length !== len2)
-      /*<<dynarray.ml:1200:25>>*/ return 0;
+     /*<<dynarray.ml:1205:2>>*/ if(length !== len2)
+      /*<<dynarray.ml:1205:25>>*/ return 0;
     var capacity$0 =  /*<<dynarray.ml:508:2>>*/ arr1.length - 1;
      /*<<dynarray.ml:509:2>>*/ if(capacity$0 < length)
       /*<<dynarray.ml:510:4>>*/ invalid_length(length, capacity$0);
     var capacity =  /*<<dynarray.ml:508:2>>*/ arr2.length - 1;
      /*<<dynarray.ml:509:2>>*/ if(capacity < length)
       /*<<dynarray.ml:510:4>>*/ invalid_length(length, capacity);
-    var i =  /*<<dynarray.ml:1212:12>>*/ 0;
+    var i =  /*<<dynarray.ml:1217:12>>*/ 0;
     for(;;){
-      /*<<dynarray.ml:1205:6>>*/ if(i === length)
-      var r =  /*<<dynarray.ml:1205:25>>*/ 1;
+      /*<<dynarray.ml:1210:6>>*/ if(i === length)
+      var r =  /*<<dynarray.ml:1210:25>>*/ 1;
      else{
       var
        v$0 =  /*<<dynarray.ml:517:10>>*/ arr2[i + 1],
@@ -33314,40 +33369,40 @@
           /*<<dynarray.ml:518:27>>*/ v === dummy
           ?  /*<<dynarray.ml:519:7>>*/ missing_element(i, length)
           : v,
-       _y_ =  /*<<dynarray.ml:1207:8>>*/ caml_call2(eq, _z_, _y_);
-       /*<<dynarray.ml:1209:50>>*/ if(_y_){
+       _y_ =  /*<<dynarray.ml:1212:8>>*/ caml_call2(eq, _z_, _y_);
+       /*<<dynarray.ml:1214:50>>*/ if(_y_){
        var i$0 = i + 1 | 0;
        i = i$0;
        continue;
       }
       r = _y_;
      }
-      /*<<dynarray.ml:1213:4>>*/ _y_ = "equal";
+      /*<<dynarray.ml:1218:4>>*/ _y_ = "equal";
      check_same_length(_y_, a1, length);
-      /*<<dynarray.ml:1214:4>>*/ check_same_length(_y_, a2, length);
-      /*<<dynarray.ml:1214:40>>*/ return r;
+      /*<<dynarray.ml:1219:4>>*/ check_same_length(_y_, a2, length);
+      /*<<dynarray.ml:1219:40>>*/ return r;
     }
-    /*<<dynarray.ml:1216:5>>*/ }
+    /*<<dynarray.ml:1221:5>>*/ }
    function compare(cmp, a1, a2){
     var
-     length =  /*<<dynarray.ml:1219:2>>*/ a1[1],
+     length =  /*<<dynarray.ml:1224:2>>*/ a1[1],
      arr1 = a1[2],
      dummy = a1[3],
-     len2 =  /*<<dynarray.ml:1220:2>>*/ a2[1],
+     len2 =  /*<<dynarray.ml:1225:2>>*/ a2[1],
      arr2 = a2[2],
      dummy$0 = a2[3];
-     /*<<dynarray.ml:1221:2>>*/ if(length !== len2)
-      /*<<dynarray.ml:1221:25>>*/ return length - len2 | 0;
+     /*<<dynarray.ml:1226:2>>*/ if(length !== len2)
+      /*<<dynarray.ml:1226:25>>*/ return length - len2 | 0;
     var capacity$0 =  /*<<dynarray.ml:508:2>>*/ arr1.length - 1;
      /*<<dynarray.ml:509:2>>*/ if(capacity$0 < length)
       /*<<dynarray.ml:510:4>>*/ invalid_length(length, capacity$0);
     var capacity =  /*<<dynarray.ml:508:2>>*/ arr2.length - 1;
      /*<<dynarray.ml:509:2>>*/ if(capacity < length)
       /*<<dynarray.ml:510:4>>*/ invalid_length(length, capacity);
-    var i =  /*<<dynarray.ml:1236:12>>*/ 0;
+    var i =  /*<<dynarray.ml:1241:12>>*/ 0;
     for(;;){
-      /*<<dynarray.ml:1226:6>>*/ if(i === length)
-      var r =  /*<<dynarray.ml:1226:25>>*/ 0;
+      /*<<dynarray.ml:1231:6>>*/ if(i === length)
+      var r =  /*<<dynarray.ml:1231:25>>*/ 0;
      else{
       var
        v$0 =  /*<<dynarray.ml:517:10>>*/ arr2[i + 1],
@@ -33360,29 +33415,29 @@
           /*<<dynarray.ml:518:27>>*/ v === dummy
           ?  /*<<dynarray.ml:519:7>>*/ missing_element(i, length)
           : v,
-       c =  /*<<dynarray.ml:1229:10>>*/ caml_call2(cmp, _y_, _x_);
-       /*<<dynarray.ml:1233:8>>*/ if(0 === c){
-       var i$0 =  /*<<dynarray.ml:1234:13>>*/ i + 1 | 0;
+       c =  /*<<dynarray.ml:1234:10>>*/ caml_call2(cmp, _y_, _x_);
+       /*<<dynarray.ml:1238:8>>*/ if(0 === c){
+       var i$0 =  /*<<dynarray.ml:1239:13>>*/ i + 1 | 0;
        i = i$0;
        continue;
       }
-       /*<<dynarray.ml:1233:8>>*/ r = c;
+       /*<<dynarray.ml:1238:8>>*/ r = c;
      }
-      /*<<dynarray.ml:1237:4>>*/ _x_ = "compare";
+      /*<<dynarray.ml:1242:4>>*/ _x_ = "compare";
      check_same_length(_x_, a1, length);
-      /*<<dynarray.ml:1238:4>>*/ check_same_length(_x_, a2, length);
-      /*<<dynarray.ml:1238:42>>*/ return r;
+      /*<<dynarray.ml:1243:4>>*/ check_same_length(_x_, a2, length);
+      /*<<dynarray.ml:1243:42>>*/ return r;
     }
-    /*<<dynarray.ml:1240:5>>*/ }
+    /*<<dynarray.ml:1245:5>>*/ }
    function of_array(a){
     var
-     length =  /*<<dynarray.ml:1250:2>>*/ a.length - 1,
-     arr =  /*<<dynarray.ml:1252:12>>*/ copy_from_array(a, dummy);
-     /*<<dynarray.ml:1253:2>>*/ return [0, length, arr, dummy];
-    /*<<dynarray.ml:1257:3>>*/ }
+     length =  /*<<dynarray.ml:1255:2>>*/ a.length - 1,
+     arr =  /*<<dynarray.ml:1257:12>>*/ copy_from_array(a, dummy);
+     /*<<dynarray.ml:1258:2>>*/ return [0, length, arr, dummy];
+    /*<<dynarray.ml:1262:3>>*/ }
    function to_array(a){
     var
-     length =  /*<<dynarray.ml:1260:2>>*/ a[1],
+     length =  /*<<dynarray.ml:1265:2>>*/ a[1],
      arr = a[2],
      dummy = a[3],
      capacity =  /*<<dynarray.ml:508:2>>*/ arr.length - 1;
@@ -33390,28 +33445,28 @@
       /*<<dynarray.ml:510:4>>*/ invalid_length(length, capacity);
     var
      res =
-        /*<<dynarray.ml:1262:12>>*/ Stdlib_Array[1].call
+        /*<<dynarray.ml:1267:12>>*/ Stdlib_Array[1].call
         (null,
          length,
          function(i){
           var v =  /*<<dynarray.ml:517:10>>*/ arr[i + 1];
            /*<<dynarray.ml:518:27>>*/ return v === dummy
                   ?  /*<<dynarray.ml:519:7>>*/ missing_element(i, length)
-                  : v /*<<dynarray.ml:1263:36>>*/ ;
+                  : v /*<<dynarray.ml:1268:36>>*/ ;
          });
-     /*<<dynarray.ml:1265:2>>*/ check_same_length("to_array", a, length);
-     /*<<dynarray.ml:1265:40>>*/ return res;
-    /*<<dynarray.ml:1266:5>>*/ }
+     /*<<dynarray.ml:1270:2>>*/ check_same_length("to_array", a, length);
+     /*<<dynarray.ml:1270:40>>*/ return res;
+    /*<<dynarray.ml:1271:5>>*/ }
    function of_iarray(a){
     var
-     length =  /*<<dynarray.ml:1269:2>>*/ a.length - 1,
-     arr =  /*<<dynarray.ml:1271:12>>*/ Stdlib_Iarray[7].call(null, a),
-     arr$0 =  /*<<dynarray.ml:1272:12>>*/ unsafe_nocopy_from_array(arr, dummy);
-     /*<<dynarray.ml:1273:2>>*/ return [0, length, arr$0, dummy];
-    /*<<dynarray.ml:1277:3>>*/ }
+     length =  /*<<dynarray.ml:1274:2>>*/ a.length - 1,
+     arr =  /*<<dynarray.ml:1276:12>>*/ Stdlib_Iarray[7].call(null, a),
+     arr$0 =  /*<<dynarray.ml:1277:12>>*/ unsafe_nocopy_from_array(arr, dummy);
+     /*<<dynarray.ml:1278:2>>*/ return [0, length, arr$0, dummy];
+    /*<<dynarray.ml:1282:3>>*/ }
    function to_iarray(a){
     var
-     length =  /*<<dynarray.ml:1280:2>>*/ a[1],
+     length =  /*<<dynarray.ml:1285:2>>*/ a[1],
      arr = a[2],
      dummy = a[3],
      capacity =  /*<<dynarray.ml:508:2>>*/ arr.length - 1;
@@ -33419,37 +33474,37 @@
       /*<<dynarray.ml:510:4>>*/ invalid_length(length, capacity);
     var
      res =
-        /*<<dynarray.ml:1282:12>>*/ Stdlib_Iarray[1].call
+        /*<<dynarray.ml:1287:12>>*/ Stdlib_Iarray[1].call
         (null,
          length,
          function(i){
           var v =  /*<<dynarray.ml:517:10>>*/ arr[i + 1];
            /*<<dynarray.ml:518:27>>*/ return v === dummy
                   ?  /*<<dynarray.ml:519:7>>*/ missing_element(i, length)
-                  : v /*<<dynarray.ml:1283:36>>*/ ;
+                  : v /*<<dynarray.ml:1288:36>>*/ ;
          });
-     /*<<dynarray.ml:1285:2>>*/ check_same_length("to_iarray", a, length);
-     /*<<dynarray.ml:1285:41>>*/ return res;
-    /*<<dynarray.ml:1286:5>>*/ }
+     /*<<dynarray.ml:1290:2>>*/ check_same_length("to_iarray", a, length);
+     /*<<dynarray.ml:1290:41>>*/ return res;
+    /*<<dynarray.ml:1291:5>>*/ }
    function of_list(li){
     var
-     a =  /*<<dynarray.ml:1289:10>>*/ Stdlib_Array[11].call(null, li),
-     length =  /*<<dynarray.ml:1290:2>>*/ a.length - 1,
-     arr =  /*<<dynarray.ml:1292:12>>*/ unsafe_nocopy_from_array(a, dummy);
-     /*<<dynarray.ml:1293:2>>*/ return [0, length, arr, dummy];
-    /*<<dynarray.ml:1297:3>>*/ }
+     a =  /*<<dynarray.ml:1294:10>>*/ Stdlib_Array[11].call(null, li),
+     length =  /*<<dynarray.ml:1295:2>>*/ a.length - 1,
+     arr =  /*<<dynarray.ml:1297:12>>*/ unsafe_nocopy_from_array(a, dummy);
+     /*<<dynarray.ml:1298:2>>*/ return [0, length, arr, dummy];
+    /*<<dynarray.ml:1302:3>>*/ }
    function to_list(a){
     var
-     length =  /*<<dynarray.ml:1300:2>>*/ a[1],
+     length =  /*<<dynarray.ml:1305:2>>*/ a[1],
      arr = a[2],
      dummy = a[3],
      capacity =  /*<<dynarray.ml:508:2>>*/ arr.length - 1;
      /*<<dynarray.ml:509:2>>*/ if(capacity < length)
       /*<<dynarray.ml:510:4>>*/ invalid_length(length, capacity);
     var
-     _x_ =  /*<<dynarray.ml:1303:2>>*/ length - 1 | 0,
-     _w_ =  /*<<dynarray.ml:1301:31>>*/ 0;
-     /*<<dynarray.ml:1303:2>>*/ if(_x_ < 0)
+     _x_ =  /*<<dynarray.ml:1308:2>>*/ length - 1 | 0,
+     _w_ =  /*<<dynarray.ml:1306:31>>*/ 0;
+     /*<<dynarray.ml:1308:2>>*/ if(_x_ < 0)
      var l$0 = _w_;
     else{
      var l = _w_, i = _x_;
@@ -33460,114 +33515,114 @@
           /*<<dynarray.ml:518:27>>*/ v === dummy
           ?  /*<<dynarray.ml:519:7>>*/ missing_element(i, length)
           : v,
-       _w_ =  /*<<dynarray.ml:1304:41>>*/ [0, _w_, l],
+       _w_ =  /*<<dynarray.ml:1309:41>>*/ [0, _w_, l],
        _x_ = i - 1 | 0;
       if(0 === i){l$0 = _w_; break;}
       l = _w_;
       i = _x_;
      }
     }
-     /*<<dynarray.ml:1306:2>>*/ check_same_length("to_list", a, length);
-     /*<<dynarray.ml:1306:39>>*/ return l$0;
-    /*<<dynarray.ml:1307:4>>*/ }
+     /*<<dynarray.ml:1311:2>>*/ check_same_length("to_list", a, length);
+     /*<<dynarray.ml:1311:39>>*/ return l$0;
+    /*<<dynarray.ml:1312:4>>*/ }
    function of_seq(seq){
-    var init =  /*<<dynarray.ml:1310:13>>*/ create(0);
-     /*<<dynarray.ml:1311:2>>*/ append_seq(init, seq);
-     /*<<dynarray.ml:1311:21>>*/ return init;
-    /*<<dynarray.ml:1312:6>>*/ }
+    var init =  /*<<dynarray.ml:1315:13>>*/ create(0);
+     /*<<dynarray.ml:1316:2>>*/ append_seq(init, seq);
+     /*<<dynarray.ml:1316:21>>*/ return init;
+    /*<<dynarray.ml:1317:6>>*/ }
    function to_seq(a){
     var
-     length =  /*<<dynarray.ml:1315:2>>*/ a[1],
+     length =  /*<<dynarray.ml:1320:2>>*/ a[1],
      arr = a[2],
      dummy = a[3],
      capacity =  /*<<dynarray.ml:508:2>>*/ arr.length - 1;
      /*<<dynarray.ml:509:2>>*/ if(capacity < length)
       /*<<dynarray.ml:510:4>>*/ invalid_length(length, capacity);
     function aux(i){
-      /*<<dynarray.ml:1317:18>>*/ return function(param){
-       /*<<dynarray.ml:1318:4>>*/ check_same_length("to_seq", a, length);
-       /*<<dynarray.ml:1318:40>>*/ if(length <= i)
-        /*<<dynarray.ml:1319:24>>*/ return 0;
+      /*<<dynarray.ml:1322:18>>*/ return function(param){
+       /*<<dynarray.ml:1323:4>>*/ check_same_length("to_seq", a, length);
+       /*<<dynarray.ml:1323:40>>*/ if(length <= i)
+        /*<<dynarray.ml:1324:24>>*/ return 0;
       var
        v$0 =  /*<<dynarray.ml:517:10>>*/ arr[i + 1],
        v =
           /*<<dynarray.ml:518:27>>*/ v$0 === dummy
           ?  /*<<dynarray.ml:519:7>>*/ missing_element(i, length)
           : v$0;
-       /*<<dynarray.ml:1322:19>>*/ return [0, v, aux(i + 1 | 0)] /*<<dynarray.ml:1322:30>>*/ ; /*<<dynarray.ml:1323:7>>*/ } /*<<dynarray.ml:1317:18>>*/ ;
-     /*<<dynarray.ml:1323:7>>*/ }
-     /*<<dynarray.ml:1325:2>>*/ return aux(0) /*<<dynarray.ml:1325:7>>*/ ;
+       /*<<dynarray.ml:1327:19>>*/ return [0, v, aux(i + 1 | 0)] /*<<dynarray.ml:1327:30>>*/ ; /*<<dynarray.ml:1328:7>>*/ } /*<<dynarray.ml:1322:18>>*/ ;
+     /*<<dynarray.ml:1328:7>>*/ }
+     /*<<dynarray.ml:1330:2>>*/ return aux(0) /*<<dynarray.ml:1330:7>>*/ ;
    }
    function to_seq_reentrant(a){
     function aux(i){
-      /*<<dynarray.ml:1328:18>>*/ return function(param){
-       /*<<dynarray.ml:1329:20>>*/ if(a[1] <= i)
-        /*<<dynarray.ml:1329:26>>*/ return 0;
-      var v =  /*<<dynarray.ml:1331:14>>*/ get(a, i);
-       /*<<dynarray.ml:1332:19>>*/ return [0, v, aux(i + 1 | 0)] /*<<dynarray.ml:1332:30>>*/ ; /*<<dynarray.ml:1333:7>>*/ } /*<<dynarray.ml:1328:18>>*/ ;
-     /*<<dynarray.ml:1333:7>>*/ }
-     /*<<dynarray.ml:1335:2>>*/ return aux(0) /*<<dynarray.ml:1335:7>>*/ ;
+      /*<<dynarray.ml:1333:18>>*/ return function(param){
+       /*<<dynarray.ml:1334:20>>*/ if(a[1] <= i)
+        /*<<dynarray.ml:1334:26>>*/ return 0;
+      var v =  /*<<dynarray.ml:1336:14>>*/ get(a, i);
+       /*<<dynarray.ml:1337:19>>*/ return [0, v, aux(i + 1 | 0)] /*<<dynarray.ml:1337:30>>*/ ; /*<<dynarray.ml:1338:7>>*/ } /*<<dynarray.ml:1333:18>>*/ ;
+     /*<<dynarray.ml:1338:7>>*/ }
+     /*<<dynarray.ml:1340:2>>*/ return aux(0) /*<<dynarray.ml:1340:7>>*/ ;
    }
    function to_seq_rev(a){
     var
-     length =  /*<<dynarray.ml:1338:2>>*/ a[1],
+     length =  /*<<dynarray.ml:1343:2>>*/ a[1],
      arr = a[2],
      dummy = a[3],
      capacity =  /*<<dynarray.ml:508:2>>*/ arr.length - 1;
      /*<<dynarray.ml:509:2>>*/ if(capacity < length)
       /*<<dynarray.ml:510:4>>*/ invalid_length(length, capacity);
     function aux(i){
-      /*<<dynarray.ml:1340:18>>*/ return function(param){
-       /*<<dynarray.ml:1341:4>>*/ check_same_length("to_seq_rev", a, length);
-       /*<<dynarray.ml:1341:44>>*/ if(0 > i)
-        /*<<dynarray.ml:1342:18>>*/ return 0;
+      /*<<dynarray.ml:1345:18>>*/ return function(param){
+       /*<<dynarray.ml:1346:4>>*/ check_same_length("to_seq_rev", a, length);
+       /*<<dynarray.ml:1346:44>>*/ if(0 > i)
+        /*<<dynarray.ml:1347:18>>*/ return 0;
       var
        v =  /*<<dynarray.ml:517:10>>*/ arr[i + 1],
        v$0 =
           /*<<dynarray.ml:518:27>>*/ v === dummy
           ?  /*<<dynarray.ml:519:7>>*/ missing_element(i, length)
           : v;
-       /*<<dynarray.ml:1345:19>>*/ return [0, v$0, aux(i - 1 | 0)] /*<<dynarray.ml:1345:30>>*/ ; /*<<dynarray.ml:1346:7>>*/ } /*<<dynarray.ml:1340:18>>*/ ;
-     /*<<dynarray.ml:1346:7>>*/ }
-     /*<<dynarray.ml:1348:2>>*/ return aux(length - 1 | 0) /*<<dynarray.ml:1348:18>>*/ ;
+       /*<<dynarray.ml:1350:19>>*/ return [0, v$0, aux(i - 1 | 0)] /*<<dynarray.ml:1350:30>>*/ ; /*<<dynarray.ml:1351:7>>*/ } /*<<dynarray.ml:1345:18>>*/ ;
+     /*<<dynarray.ml:1351:7>>*/ }
+     /*<<dynarray.ml:1353:2>>*/ return aux(length - 1 | 0) /*<<dynarray.ml:1353:18>>*/ ;
    }
    function to_seq_rev_reentrant(a){
     function aux(i){
-      /*<<dynarray.ml:1351:18>>*/ return function(param){
-       /*<<dynarray.ml:1352:4>>*/ if(0 > i)
-        /*<<dynarray.ml:1352:18>>*/ return 0;
-       /*<<dynarray.ml:1353:25>>*/ if(a[1] <= i)
-        /*<<dynarray.ml:1356:19>>*/ return aux(a[1] - 1 | 0)(0) /*<<dynarray.ml:1360:7>>*/ ;
-      var v =  /*<<dynarray.ml:1358:14>>*/ get(a, i);
-       /*<<dynarray.ml:1359:19>>*/ return [0, v, aux(i - 1 | 0)] /*<<dynarray.ml:1359:30>>*/ ; /*<<dynarray.ml:1360:7>>*/ } /*<<dynarray.ml:1351:18>>*/ ;
-     /*<<dynarray.ml:1360:7>>*/ }
-     /*<<dynarray.ml:1362:15>>*/ return aux(a[1] - 1 | 0) /*<<dynarray.ml:1362:20>>*/ ;
+      /*<<dynarray.ml:1356:18>>*/ return function(param){
+       /*<<dynarray.ml:1357:4>>*/ if(0 > i)
+        /*<<dynarray.ml:1357:18>>*/ return 0;
+       /*<<dynarray.ml:1358:25>>*/ if(a[1] <= i)
+        /*<<dynarray.ml:1361:19>>*/ return aux(a[1] - 1 | 0)(0) /*<<dynarray.ml:1365:7>>*/ ;
+      var v =  /*<<dynarray.ml:1363:14>>*/ get(a, i);
+       /*<<dynarray.ml:1364:19>>*/ return [0, v, aux(i - 1 | 0)] /*<<dynarray.ml:1364:30>>*/ ; /*<<dynarray.ml:1365:7>>*/ } /*<<dynarray.ml:1356:18>>*/ ;
+     /*<<dynarray.ml:1365:7>>*/ }
+     /*<<dynarray.ml:1367:15>>*/ return aux(a[1] - 1 | 0) /*<<dynarray.ml:1367:20>>*/ ;
    }
    function unsafe_to_iarray(capacity, f){
-    var a$0 =  /*<<dynarray.ml:1367:10>>*/ create(0);
-     /*<<dynarray.ml:1368:2>>*/ set_capacity(a$0, capacity);
-     /*<<dynarray.ml:1369:2>>*/ caml_call1(f, a$0);
+    var a$0 =  /*<<dynarray.ml:1372:10>>*/ create(0);
+     /*<<dynarray.ml:1373:2>>*/ set_capacity(a$0, capacity);
+     /*<<dynarray.ml:1374:2>>*/ caml_call1(f, a$0);
     var
-     length =  /*<<dynarray.ml:1369:5>>*/ a$0[1],
+     length =  /*<<dynarray.ml:1374:5>>*/ a$0[1],
      arr = a$0[2],
      dummy = a$0[3];
-     /*<<dynarray.ml:1371:2>>*/ reset(a$0);
+     /*<<dynarray.ml:1376:2>>*/ reset(a$0);
     var
-     capacity$0 =  /*<<dynarray.ml:1371:9>>*/ arr.length - 1,
+     capacity$0 =  /*<<dynarray.ml:1376:9>>*/ arr.length - 1,
      capacity$1 =  /*<<dynarray.ml:508:2>>*/ arr.length - 1;
      /*<<dynarray.ml:509:2>>*/ if(capacity$1 < length)
       /*<<dynarray.ml:510:4>>*/ invalid_length(length, capacity$1);
     var
      values =
-        /*<<dynarray.ml:1375:31>>*/ length === capacity$0
+        /*<<dynarray.ml:1380:31>>*/ length === capacity$0
         ? arr
-        :  /*<<dynarray.ml:1380:6>>*/ prefix(arr, length);
-     /*<<dynarray.ml:1382:2>>*/ try{
+        :  /*<<dynarray.ml:1385:6>>*/ prefix(arr, length);
+     /*<<dynarray.ml:1387:2>>*/ try{
      var n =  /*<<dynarray.ml:299:6>>*/ values.length - 1;
      a:
      {
        /*<<dynarray.ml:300:6>>*/ if(0 !== n){
-       var _v_ =  /*<<dynarray.ml:300:33>>*/ Stdlib_Obj[16];
+       var _v_ =  /*<<dynarray.ml:300:33>>*/ Stdlib_Obj[17];
        if
         ( /*<<dynarray.ml:300:23>>*/ caml_obj_tag
           ( /*<<dynarray.ml:300:33>>*/ caml_check_bound(values, 0)[1])
@@ -33615,11 +33670,11 @@
      var
       i$1 = exn[2],
       values$0 =
-         /*<<dynarray.ml:1384:70>>*/  /*<<dynarray.ml:1384:38>>*/ missing_element
+         /*<<dynarray.ml:1389:70>>*/  /*<<dynarray.ml:1389:38>>*/ missing_element
          (i$1, length);
     }
-     /*<<dynarray.ml:1386:2>>*/ return values$0;
-    /*<<dynarray.ml:1386:31>>*/ }
+     /*<<dynarray.ml:1391:2>>*/ return values$0;
+    /*<<dynarray.ml:1391:31>>*/ }
     /*<<dynarray.ml:410:33>>*/ runtime.caml_register_global
     ([0,
       create,
@@ -33634,6 +33689,7 @@
       copy,
       add_last,
       append_array,
+      append_iarray,
       append_list,
       append,
       append_seq,
@@ -34522,7 +34578,7 @@
      var
       decode =
          /*<<format.ml:984:19>>*/ Stdlib_String[73].call(null, s, current$0),
-      advance =  /*<<format.ml:985:20>>*/ Stdlib_Uchar[21].call(null, decode),
+      advance =  /*<<format.ml:985:20>>*/ Stdlib_Uchar[25].call(null, decode),
       current$1 =  /*<<format.ml:986:6>>*/ current$0 + advance | 0,
       count$0 = count + 1 | 0;
      count = count$0;
@@ -35249,7 +35305,7 @@
    function pp_print_dynarray(opt, pp_v, ppf, v){
     var pp_sep =  /*<<format.ml:1338:22>>*/ opt ? opt[1] : pp_print_cut;
      /*<<format.ml:1339:2>>*/ return pp_print_iter
-            ([0, pp_sep], Stdlib_Dynarray[23], pp_v, ppf, v) /*<<format.ml:1339:48>>*/ ;
+            ([0, pp_sep], Stdlib_Dynarray[24], pp_v, ppf, v) /*<<format.ml:1339:48>>*/ ;
    }
    function pp_print_seq(opt, pp_v, ppf, seq){
     var pp_sep =  /*<<format.ml:1342:17>>*/ opt ? opt[1] : pp_print_cut;
@@ -36309,7 +36365,7 @@
 
 //# unitInfo: Provides: Stdlib__Pqueue
 //# unitInfo: Requires: Stdlib, Stdlib__Dynarray
-//# shape: Stdlib__Pqueue:[F(1)*->[N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N],F(1)*->[N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N],F(1)*->[N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N],F(1)*->[N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N]]
+//# shape: Stdlib__Pqueue:[F(1)*->[N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N],F(1)*->[N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N],F(1)*->[N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N],F(1)*->[N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N]]
 (function
   (globalThis){
    "use strict";
@@ -36330,7 +36386,7 @@
      create = Stdlib_Dynarray[1],
      length = Stdlib_Dynarray[6],
      is_empty = Stdlib_Dynarray[7],
-     clear = Stdlib_Dynarray[22];
+     clear = Stdlib_Dynarray[23];
     function left_child(i){
       /*<<pqueue.ml:49:23>>*/ return (2 * i | 0) + 1 | 0;
      /*<<pqueue.ml:49:32>>*/ }
@@ -36406,7 +36462,7 @@
     function pop_min(h){
      var n =  /*<<pqueue.ml:112:14>>*/ Stdlib_Dynarray[6].call(null, h);
       /*<<pqueue.ml:113:6>>*/ if(0 === n)  /*<<pqueue.ml:113:20>>*/ return 0;
-     var x =  /*<<pqueue.ml:114:14>>*/ Stdlib_Dynarray[19].call(null, h);
+     var x =  /*<<pqueue.ml:114:14>>*/ Stdlib_Dynarray[20].call(null, h);
       /*<<pqueue.ml:115:6>>*/ if(1 === n)
        /*<<pqueue.ml:115:20>>*/ return [0, x];
      var r =  /*<<pqueue.ml:116:16>>*/ Stdlib_Dynarray[4].call(null, h, 0);
@@ -36419,7 +36475,7 @@
       _b_ =  /*<<pqueue.ml:123:6>>*/ 0 < n ? 1 : 0;
      if(_b_){
       var
-       x =  /*<<pqueue.ml:124:16>>*/ Stdlib_Dynarray[19].call(null, h),
+       x =  /*<<pqueue.ml:124:16>>*/ Stdlib_Dynarray[20].call(null, h),
        _b_ =  /*<<pqueue.ml:125:8>>*/ 1 < n ? 1 : 0;
       if(_b_)
         /*<<pqueue.ml:125:22>>*/ return sift_down(h, n - 1 | 0, 0, x) /*<<pqueue.ml:126:7>>*/ ;
@@ -36448,23 +36504,27 @@
      /*<<pqueue.ml:140:7>>*/ }
     function of_array(a){
       /*<<pqueue.ml:143:6>>*/ return  /*<<pqueue.ml:143:25>>*/ heapify
-             ( /*<<pqueue.ml:143:6>>*/ Stdlib_Dynarray[45].call(null, a)) /*<<pqueue.ml:143:36>>*/ ;
+             ( /*<<pqueue.ml:143:6>>*/ Stdlib_Dynarray[46].call(null, a)) /*<<pqueue.ml:143:36>>*/ ;
+    }
+    function of_iarray(a){
+      /*<<pqueue.ml:146:6>>*/ return  /*<<pqueue.ml:146:26>>*/ heapify
+             ( /*<<pqueue.ml:146:6>>*/ Stdlib_Dynarray[48].call(null, a)) /*<<pqueue.ml:146:37>>*/ ;
     }
     function of_list(l){
-      /*<<pqueue.ml:146:6>>*/ return  /*<<pqueue.ml:146:24>>*/ heapify
-             ( /*<<pqueue.ml:146:6>>*/ Stdlib_Dynarray[49].call(null, l)) /*<<pqueue.ml:146:35>>*/ ;
+      /*<<pqueue.ml:149:6>>*/ return  /*<<pqueue.ml:149:24>>*/ heapify
+             ( /*<<pqueue.ml:149:6>>*/ Stdlib_Dynarray[50].call(null, l)) /*<<pqueue.ml:149:35>>*/ ;
     }
     function of_iter(iter, x){
      var
-      a =  /*<<pqueue.ml:149:14>>*/ Stdlib_Dynarray[1].call(null, 0),
-      _a_ =  /*<<pqueue.ml:150:11>>*/ Stdlib_Dynarray[11];
-      /*<<pqueue.ml:150:6>>*/ caml_call2
-      (iter, function(_b_){ /*<<pqueue.ml:150:11>>*/ return _a_(a, _b_);}, x);
-      /*<<pqueue.ml:150:34>>*/ return heapify(a) /*<<pqueue.ml:151:15>>*/ ;
+      a =  /*<<pqueue.ml:152:14>>*/ Stdlib_Dynarray[1].call(null, 0),
+      _a_ =  /*<<pqueue.ml:153:11>>*/ Stdlib_Dynarray[11];
+      /*<<pqueue.ml:153:6>>*/ caml_call2
+      (iter, function(_b_){ /*<<pqueue.ml:153:11>>*/ return _a_(a, _b_);}, x);
+      /*<<pqueue.ml:153:34>>*/ return heapify(a) /*<<pqueue.ml:154:15>>*/ ;
     }
     var
-     iter_unordered =  /*<<?>>*/ Stdlib_Dynarray[23],
-     fold_unordered = Stdlib_Dynarray[29];
+     iter_unordered =  /*<<?>>*/ Stdlib_Dynarray[24],
+     fold_unordered = Stdlib_Dynarray[30];
     return [0,
             create,
             length,
@@ -36485,6 +36545,7 @@
             copy,
             ,
             of_array,
+            of_iarray,
             of_list,
             of_iter,
             iter_unordered,
@@ -36492,7 +36553,7 @@
    }
    function MakeMaxPoly(E){
     function compare(x, y){
-      /*<<pqueue.ml:210:24>>*/ return caml_call2(E[1], y, x) /*<<pqueue.ml:210:37>>*/ ;
+      /*<<pqueue.ml:215:24>>*/ return caml_call2(E[1], y, x) /*<<pqueue.ml:215:37>>*/ ;
     }
     var
      include =  /*<<?>>*/ MakeMinPoly([0, compare]),
@@ -36508,10 +36569,11 @@
      remove_min = include[16],
      copy = include[17],
      of_array = include[19],
-     of_list = include[20],
-     of_iter = include[21],
-     iter_unordered = include[22],
-     fold_unordered = include[23];
+     of_iarray = include[20],
+     of_list = include[21],
+     of_iter = include[22],
+     iter_unordered = include[23],
+     fold_unordered = include[24];
     return [0,
             create,
             length,
@@ -36525,6 +36587,7 @@
             clear,
             copy,
             of_array,
+            of_iarray,
             of_list,
             of_iter,
             iter_unordered,
@@ -36549,10 +36612,11 @@
          remove_min = include[16],
          copy = include[17],
          of_array = include[19],
-         of_list = include[20],
-         of_iter = include[21],
-         iter_unordered = include[22],
-         fold_unordered = include[23];
+         of_iarray = include[20],
+         of_list = include[21],
+         of_iter = include[22],
+         iter_unordered = include[23],
+         fold_unordered = include[24];
         return [0,
                 create,
                 length,
@@ -36566,6 +36630,7 @@
                 clear,
                 copy,
                 of_array,
+                of_iarray,
                 of_list,
                 of_iter,
                 iter_unordered,
@@ -36573,7 +36638,7 @@
        },
        function(E){
         function compare(x, y){
-          /*<<pqueue.ml:281:49>>*/ return caml_call2(E[1], y, x) /*<<pqueue.ml:281:62>>*/ ;
+          /*<<pqueue.ml:288:49>>*/ return caml_call2(E[1], y, x) /*<<pqueue.ml:288:62>>*/ ;
         }
         var
          include =  /*<<?>>*/ MakeMinPoly([0, compare]),
@@ -36589,10 +36654,11 @@
          remove_min = include[16],
          copy = include[17],
          of_array = include[19],
-         of_list = include[20],
-         of_iter = include[21],
-         iter_unordered = include[22],
-         fold_unordered = include[23];
+         of_iarray = include[20],
+         of_list = include[21],
+         of_iter = include[22],
+         iter_unordered = include[23],
+         fold_unordered = include[24];
         return [0,
                 create,
                 length,
@@ -36606,6 +36672,7 @@
                 clear,
                 copy,
                 of_array,
+                of_iarray,
                 of_list,
                 of_iter,
                 iter_unordered,
@@ -36629,7 +36696,8 @@
                 _a_[20],
                 _a_[21],
                 _a_[22],
-                _a_[23]];
+                _a_[23],
+                _a_[24]];
        },
        MakeMaxPoly];
    runtime.caml_register_global(Stdlib_Pqueue, "Stdlib__Pqueue");
@@ -37160,24 +37228,24 @@
             stats_alive];
    }
    function create(param){
-     /*<<ephemeron.ml:394:30>>*/ return Stdlib_Obj[23][1].call(null, 1) /*<<ephemeron.ml:394:45>>*/ ;
+     /*<<ephemeron.ml:394:30>>*/ return Stdlib_Obj[24][1].call(null, 1) /*<<ephemeron.ml:394:45>>*/ ;
    }
    function get_key(t){
-    var x =  /*<<ephemeron.ml:396:50>>*/ Stdlib_Obj[23][3].call(null, t, 0);
+    var x =  /*<<ephemeron.ml:396:50>>*/ Stdlib_Obj[24][3].call(null, t, 0);
      /*<<ephemeron.ml:388:51>>*/ return x;
     /*<<ephemeron.ml:396:70>>*/ }
    function set_key(t, k){
-     /*<<ephemeron.ml:397:44>>*/ return Stdlib_Obj[23][5].call(null, t, 0, k) /*<<ephemeron.ml:397:75>>*/ ;
+     /*<<ephemeron.ml:397:44>>*/ return Stdlib_Obj[24][5].call(null, t, 0, k) /*<<ephemeron.ml:397:75>>*/ ;
    }
    function check_key(t){
-     /*<<ephemeron.ml:398:39>>*/ return Stdlib_Obj[23][7].call(null, t, 0) /*<<ephemeron.ml:398:59>>*/ ;
+     /*<<ephemeron.ml:398:39>>*/ return Stdlib_Obj[24][7].call(null, t, 0) /*<<ephemeron.ml:398:59>>*/ ;
    }
    function get_data(t){
-    var x =  /*<<ephemeron.ml:400:51>>*/ Stdlib_Obj[23][9].call(null, t);
+    var x =  /*<<ephemeron.ml:400:51>>*/ Stdlib_Obj[24][9].call(null, t);
      /*<<ephemeron.ml:388:51>>*/ return x;
     /*<<ephemeron.ml:400:70>>*/ }
    function set_data(t, d){
-     /*<<ephemeron.ml:401:45>>*/ return Stdlib_Obj[23][11].call(null, t, d) /*<<ephemeron.ml:401:75>>*/ ;
+     /*<<ephemeron.ml:401:45>>*/ return Stdlib_Obj[24][11].call(null, t, d) /*<<ephemeron.ml:401:75>>*/ ;
    }
    function make(key, data){
     var eph =  /*<<ephemeron.ml:405:14>>*/ create(0);
@@ -37210,7 +37278,7 @@
       /*<<ephemeron.ml:432:15>>*/ return caml_call2(H[1], k, k$0) ? 0 : 1 /*<<ephemeron.ml:432:76>>*/ ;
     }
     function set_key_data(c, k, d){
-      /*<<ephemeron.ml:402:40>>*/ Stdlib_Obj[23][12].call(null, c);
+      /*<<ephemeron.ml:402:40>>*/ Stdlib_Obj[24][12].call(null, c);
       /*<<ephemeron.ml:436:8>>*/ set_key(c, k);
       /*<<ephemeron.ml:436:19>>*/ return set_data(c, d) /*<<ephemeron.ml:437:20>>*/ ;
     }
@@ -37330,28 +37398,28 @@
     return 0;
     /*<<ephemeron.ml:482:25>>*/ }
    function create$0(param){
-     /*<<ephemeron.ml:491:35>>*/ return Stdlib_Obj[23][1].call(null, 2) /*<<ephemeron.ml:491:50>>*/ ;
+     /*<<ephemeron.ml:491:35>>*/ return Stdlib_Obj[24][1].call(null, 2) /*<<ephemeron.ml:491:50>>*/ ;
    }
    function get_key1(t){
-    var x =  /*<<ephemeron.ml:493:57>>*/ Stdlib_Obj[23][3].call(null, t, 0);
+    var x =  /*<<ephemeron.ml:493:57>>*/ Stdlib_Obj[24][3].call(null, t, 0);
      /*<<ephemeron.ml:388:51>>*/ return x;
     /*<<ephemeron.ml:493:77>>*/ }
    function set_key1(t, k){
-     /*<<ephemeron.ml:495:4>>*/ return Stdlib_Obj[23][5].call(null, t, 0, k) /*<<ephemeron.ml:495:35>>*/ ;
+     /*<<ephemeron.ml:495:4>>*/ return Stdlib_Obj[24][5].call(null, t, 0, k) /*<<ephemeron.ml:495:35>>*/ ;
    }
    function get_key2(t){
-    var x =  /*<<ephemeron.ml:498:57>>*/ Stdlib_Obj[23][3].call(null, t, 1);
+    var x =  /*<<ephemeron.ml:498:57>>*/ Stdlib_Obj[24][3].call(null, t, 1);
      /*<<ephemeron.ml:388:51>>*/ return x;
     /*<<ephemeron.ml:498:77>>*/ }
    function set_key2(t, k){
-     /*<<ephemeron.ml:500:4>>*/ return Stdlib_Obj[23][5].call(null, t, 1, k) /*<<ephemeron.ml:500:35>>*/ ;
+     /*<<ephemeron.ml:500:4>>*/ return Stdlib_Obj[24][5].call(null, t, 1, k) /*<<ephemeron.ml:500:35>>*/ ;
    }
    function get_data$0(t){
-    var x =  /*<<ephemeron.ml:503:56>>*/ Stdlib_Obj[23][9].call(null, t);
+    var x =  /*<<ephemeron.ml:503:56>>*/ Stdlib_Obj[24][9].call(null, t);
      /*<<ephemeron.ml:388:51>>*/ return x;
     /*<<ephemeron.ml:503:75>>*/ }
    function set_data$0(t, d){
-     /*<<ephemeron.ml:505:4>>*/ return Stdlib_Obj[23][11].call(null, t, d) /*<<ephemeron.ml:505:34>>*/ ;
+     /*<<ephemeron.ml:505:4>>*/ return Stdlib_Obj[24][11].call(null, t, d) /*<<ephemeron.ml:505:34>>*/ ;
    }
    function make$1(key1, key2, data){
     var eph =  /*<<ephemeron.ml:509:14>>*/ create$0(0);
@@ -37412,16 +37480,16 @@
      /*<<ephemeron.ml:545:60>>*/ }
     function set_key_data(c, param, d){
      var k2 =  /*<<ephemeron.ml:547:23>>*/ param[2], k1 = param[1];
-      /*<<ephemeron.ml:506:45>>*/ Stdlib_Obj[23][12].call(null, c);
+      /*<<ephemeron.ml:506:45>>*/ Stdlib_Obj[24][12].call(null, c);
       /*<<ephemeron.ml:549:8>>*/ set_key1(c, k1);
       /*<<ephemeron.ml:549:23>>*/ set_key2(c, k2);
       /*<<ephemeron.ml:549:36>>*/ return set_data$0(c, d) /*<<ephemeron.ml:550:20>>*/ ;
     }
     function check_key(c){
      var
-      _j_ =  /*<<ephemeron.ml:496:45>>*/ Stdlib_Obj[23][7].call(null, c, 0);
+      _j_ =  /*<<ephemeron.ml:496:45>>*/ Stdlib_Obj[24][7].call(null, c, 0);
       /*<<ephemeron.ml:551:36>>*/ return _j_
-             ?  /*<<ephemeron.ml:501:45>>*/ Stdlib_Obj[23][7].call(null, c, 1)
+             ?  /*<<ephemeron.ml:501:45>>*/ Stdlib_Obj[24][7].call(null, c, 1)
              : _j_ /*<<ephemeron.ml:551:52>>*/ ;
     }
      /*<<?>>*/ return MakeSeeded
@@ -37550,24 +37618,24 @@
     return 0;
     /*<<ephemeron.ml:602:25>>*/ }
    function create$1(n){
-     /*<<ephemeron.ml:611:29>>*/ return Stdlib_Obj[23][1].call(null, n) /*<<ephemeron.ml:611:44>>*/ ;
+     /*<<ephemeron.ml:611:29>>*/ return Stdlib_Obj[24][1].call(null, n) /*<<ephemeron.ml:611:44>>*/ ;
    }
    function length$1(k){
-     /*<<ephemeron.ml:612:35>>*/ return Stdlib_Obj[23][2].call(null, k) /*<<ephemeron.ml:612:50>>*/ ;
+     /*<<ephemeron.ml:612:35>>*/ return Stdlib_Obj[24][2].call(null, k) /*<<ephemeron.ml:612:50>>*/ ;
    }
    function get_key$0(t, n){
-    var x =  /*<<ephemeron.ml:614:58>>*/ Stdlib_Obj[23][3].call(null, t, n);
+    var x =  /*<<ephemeron.ml:614:58>>*/ Stdlib_Obj[24][3].call(null, t, n);
      /*<<ephemeron.ml:388:51>>*/ return x;
     /*<<ephemeron.ml:614:78>>*/ }
    function set_key$0(t, n, k){
-     /*<<ephemeron.ml:616:4>>*/ return Stdlib_Obj[23][5].call(null, t, n, k) /*<<ephemeron.ml:616:35>>*/ ;
+     /*<<ephemeron.ml:616:4>>*/ return Stdlib_Obj[24][5].call(null, t, n, k) /*<<ephemeron.ml:616:35>>*/ ;
    }
    function get_data$1(t){
-    var x =  /*<<ephemeron.ml:619:51>>*/ Stdlib_Obj[23][9].call(null, t);
+    var x =  /*<<ephemeron.ml:619:51>>*/ Stdlib_Obj[24][9].call(null, t);
      /*<<ephemeron.ml:388:51>>*/ return x;
     /*<<ephemeron.ml:619:70>>*/ }
    function set_data$1(t, d){
-     /*<<ephemeron.ml:620:45>>*/ return Stdlib_Obj[23][11].call(null, t, d) /*<<ephemeron.ml:620:75>>*/ ;
+     /*<<ephemeron.ml:620:45>>*/ return Stdlib_Obj[24][11].call(null, t, d) /*<<ephemeron.ml:620:75>>*/ ;
    }
    function make$3(keys, data){
     var
@@ -37679,7 +37747,7 @@
      }
      /*<<ephemeron.ml:675:33>>*/ }
     function set_key_data(c, k, d){
-      /*<<ephemeron.ml:621:40>>*/ Stdlib_Obj[23][12].call(null, c);
+      /*<<ephemeron.ml:621:40>>*/ Stdlib_Obj[24][12].call(null, c);
      var _d_ =  /*<<ephemeron.ml:678:20>>*/ k.length - 2 | 0;
      if(_d_ >= 0){
       var i = 0;
@@ -37702,7 +37770,7 @@
       if(_d_)
        ;
       else{
-        /*<<ephemeron.ml:617:47>>*/ _d_ = Stdlib_Obj[23][7].call(null, c, i);
+        /*<<ephemeron.ml:617:47>>*/ _d_ = Stdlib_Obj[24][7].call(null, c, i);
         /*<<ephemeron.ml:685:33>>*/ if(_d_){
         var i$0 = i - 1 | 0;
         i = i$0;
@@ -38112,169 +38180,176 @@
        dirname];
    function is_dir_sep$0(s, i){
     var
-     c =  /*<<filename.ml:123:31>>*/ caml_string_get(s, i),
-     _l_ =  /*<<filename.ml:123:40>>*/ 47 === c ? 1 : 0;
-    if(_l_) ; else{_l_ = 92 === c ? 1 : 0; _l_ ||= 58 === c ? 1 : 0;}
+     c =  /*<<filename.ml:124:12>>*/ caml_string_get(s, i),
+     _l_ =  /*<<filename.ml:125:4>>*/ 47 === c ? 1 : 0;
+    if(_l_)
+     ;
+    else{
+     _l_ = 92 === c ? 1 : 0;
+     if(_l_)
+      ;
+     else{_l_ = 58 === c ? 1 : 0; _l_ = _l_ ? 1 === i ? 1 : 0 : _l_;}
+    }
     return _l_;
-    /*<<filename.ml:123:70>>*/ }
+    /*<<filename.ml:125:43>>*/ }
    function is_relative$0(n){
     var
-     _l_ =  /*<<filename.ml:125:4>>*/ caml_ml_string_length(n) < 1 ? 1 : 0,
+     _l_ =  /*<<filename.ml:127:4>>*/ caml_ml_string_length(n) < 1 ? 1 : 0,
      _l_ =
        _l_
-       || (47 !==  /*<<filename.ml:125:28>>*/ caml_string_get(n, 0) ? 1 : 0);
-     /*<<filename.ml:125:4>>*/ if(_l_){
+       || (47 !==  /*<<filename.ml:127:28>>*/ caml_string_get(n, 0) ? 1 : 0);
+     /*<<filename.ml:127:4>>*/ if(_l_){
      _l_ = caml_ml_string_length(n) < 1 ? 1 : 0;
-     _l_ ||= 92 !==  /*<<filename.ml:126:31>>*/ caml_string_get(n, 0) ? 1 : 0;
-      /*<<filename.ml:125:4>>*/ if(_l_){
+     _l_ ||= 92 !==  /*<<filename.ml:128:31>>*/ caml_string_get(n, 0) ? 1 : 0;
+      /*<<filename.ml:127:4>>*/ if(_l_){
       _l_ = caml_ml_string_length(n) < 2 ? 1 : 0;
-      _l_ ||= 58 !==  /*<<filename.ml:127:31>>*/ caml_string_get(n, 1) ? 1 : 0;
+      _l_ ||= 58 !==  /*<<filename.ml:129:31>>*/ caml_string_get(n, 1) ? 1 : 0;
      }
     }
-     /*<<filename.ml:125:4>>*/ return _l_;
-    /*<<filename.ml:127:44>>*/ }
+     /*<<filename.ml:127:4>>*/ return _l_;
+    /*<<filename.ml:129:44>>*/ }
    function is_implicit$0(n){
-    var _l_ =  /*<<filename.ml:129:4>>*/ is_relative$0(n);
-     /*<<filename.ml:129:17>>*/ if(_l_){
-      /*<<filename.ml:130:11>>*/ _l_ =
+    var _l_ =  /*<<filename.ml:131:4>>*/ is_relative$0(n);
+     /*<<filename.ml:131:17>>*/ if(_l_){
+      /*<<filename.ml:132:11>>*/ _l_ =
       1 - Stdlib_String[13].call(null, cst$4, n);
-      /*<<filename.ml:130:46>>*/ if(_l_){
-       /*<<filename.ml:131:11>>*/ _l_ =
+      /*<<filename.ml:132:46>>*/ if(_l_){
+       /*<<filename.ml:133:11>>*/ _l_ =
        1 - Stdlib_String[13].call(null, ".\\", n);
-       /*<<filename.ml:131:47>>*/ if(_l_){
-        /*<<filename.ml:132:11>>*/ _l_ =
+       /*<<filename.ml:133:47>>*/ if(_l_){
+        /*<<filename.ml:134:11>>*/ _l_ =
         1 - Stdlib_String[13].call(null, cst$5, n);
-        /*<<filename.ml:132:47>>*/ _l_ =
+        /*<<filename.ml:134:47>>*/ _l_ =
         _l_
          ? 1
           -
-            /*<<filename.ml:133:11>>*/ Stdlib_String[13].call(null, "..\\", n)
+            /*<<filename.ml:135:11>>*/ Stdlib_String[13].call(null, "..\\", n)
          : _l_;
       }
      }
     }
-     /*<<filename.ml:129:17>>*/ return _l_;
-    /*<<filename.ml:133:48>>*/ }
+     /*<<filename.ml:131:17>>*/ return _l_;
+    /*<<filename.ml:135:48>>*/ }
    function check_suffix$0(filename, suffix){
     var
-     len_s =  /*<<filename.ml:135:4>>*/ caml_ml_string_length(suffix),
+     len_s =  /*<<filename.ml:137:4>>*/ caml_ml_string_length(suffix),
      len_f = caml_ml_string_length(filename);
-     /*<<filename.ml:136:4>>*/ if(len_s > len_f)
-      /*<<filename.ml:140:6>>*/ return 0;
+     /*<<filename.ml:138:4>>*/ if(len_s > len_f)
+      /*<<filename.ml:142:6>>*/ return 0;
     var
      r =
-        /*<<filename.ml:137:14>>*/ Stdlib_String[19].call
+        /*<<filename.ml:139:14>>*/ Stdlib_String[19].call
         (null, filename, len_f - len_s | 0, len_s),
-     _l_ =  /*<<filename.ml:138:33>>*/ Stdlib_String[48].call(null, suffix);
-     /*<<filename.ml:138:6>>*/ return Stdlib_String[48].call(null, r) === _l_
+     _l_ =  /*<<filename.ml:140:33>>*/ Stdlib_String[48].call(null, suffix);
+     /*<<filename.ml:140:6>>*/ return Stdlib_String[48].call(null, r) === _l_
             ? 1
-            : 0 /*<<filename.ml:138:62>>*/ ;
-    /*<<filename.ml:140:11>>*/ }
+            : 0 /*<<filename.ml:140:62>>*/ ;
+    /*<<filename.ml:142:11>>*/ }
    var
     temp_dir_name$0 =
-       /*<<filename.ml:143:22>>*/ runtime.caml_sys_temp_dir_name(0);
+       /*<<filename.ml:145:22>>*/ runtime.caml_sys_temp_dir_name(0);
    function quote$0(s){
     var
-     l =  /*<<filename.ml:146:4>>*/ caml_ml_string_length(s),
-     b =  /*<<filename.ml:147:12>>*/ Stdlib_Buffer[1].call(null, l + 20 | 0);
-     /*<<filename.ml:148:4>>*/ Stdlib_Buffer[12].call(null, b, 34);
+     l =  /*<<filename.ml:148:4>>*/ caml_ml_string_length(s),
+     b =  /*<<filename.ml:149:12>>*/ Stdlib_Buffer[1].call(null, l + 20 | 0);
+     /*<<filename.ml:150:4>>*/ Stdlib_Buffer[12].call(null, b, 34);
     function loop$0(counter, i$1){
-     var i =  /*<<filename.ml:150:6>>*/ i$1;
+     var i =  /*<<filename.ml:152:6>>*/ i$1;
      for(;;){
       if(i === l)
-        /*<<filename.ml:150:20>>*/ return Stdlib_Buffer[12].call(null, b, 34) /*<<filename.ml:154:48>>*/ ;
-      var c =  /*<<filename.ml:151:12>>*/ caml_string_get(s, i);
-       /*<<filename.ml:151:17>>*/ if(34 === c){
-       var _l_ =  /*<<filename.ml:152:16>>*/ 0;
+        /*<<filename.ml:152:20>>*/ return Stdlib_Buffer[12].call(null, b, 34) /*<<filename.ml:156:48>>*/ ;
+      var c =  /*<<filename.ml:153:12>>*/ caml_string_get(s, i);
+       /*<<filename.ml:153:17>>*/ if(34 === c){
+       var _l_ =  /*<<filename.ml:154:16>>*/ 0;
        return counter < 50
                ? loop_bs(counter + 1 | 0, _l_, i)
-               : caml_trampoline_return(loop_bs, [0, _l_, i]) /*<<filename.ml:154:48>>*/ ;
+               : caml_trampoline_return(loop_bs, [0, _l_, i]) /*<<filename.ml:156:48>>*/ ;
       }
-       /*<<filename.ml:151:17>>*/ if(92 === c){
-        /*<<filename.ml:153:16>>*/ _l_ = 0;
+       /*<<filename.ml:153:17>>*/ if(92 === c){
+        /*<<filename.ml:155:16>>*/ _l_ = 0;
        return counter < 50
                ? loop_bs(counter + 1 | 0, _l_, i)
-               : caml_trampoline_return(loop_bs, [0, _l_, i]) /*<<filename.ml:154:48>>*/ ;
+               : caml_trampoline_return(loop_bs, [0, _l_, i]) /*<<filename.ml:156:48>>*/ ;
       }
-       /*<<filename.ml:154:16>>*/ Stdlib_Buffer[12].call(null, b, c);
-      var i$0 =  /*<<filename.ml:154:35>>*/ i + 1 | 0;
+       /*<<filename.ml:156:16>>*/ Stdlib_Buffer[12].call(null, b, c);
+      var i$0 =  /*<<filename.ml:156:35>>*/ i + 1 | 0;
       i = i$0;
      }
-     /*<<filename.ml:154:48>>*/ }
+     /*<<filename.ml:156:48>>*/ }
     function loop(i){
-      /*<<filename.ml:150:6>>*/ return  /*<<?>>*/ caml_trampoline
-             ( /*<<filename.ml:150:6>>*/ loop$0(0, i)) /*<<filename.ml:154:48>>*/ ;
+      /*<<filename.ml:152:6>>*/ return  /*<<?>>*/ caml_trampoline
+             ( /*<<filename.ml:152:6>>*/ loop$0(0, i)) /*<<filename.ml:156:48>>*/ ;
     }
     function loop_bs(counter, n$1, i$1){
-     var n =  /*<<filename.ml:156:6>>*/ n$1, i = i$1;
+     var n =  /*<<filename.ml:158:6>>*/ n$1, i = i$1;
      for(;;){
       if(i === l){
-        /*<<filename.ml:157:8>>*/ Stdlib_Buffer[12].call(null, b, 34);
-        /*<<filename.ml:157:30>>*/ return add_bs(n) /*<<filename.ml:164:9>>*/ ;
+        /*<<filename.ml:159:8>>*/ Stdlib_Buffer[12].call(null, b, 34);
+        /*<<filename.ml:159:30>>*/ return add_bs(n) /*<<filename.ml:166:9>>*/ ;
       }
-      var _l_ =  /*<<filename.ml:160:14>>*/ caml_string_get(s, i);
-       /*<<filename.ml:160:19>>*/ if(34 === _l_){
-        /*<<filename.ml:161:18>>*/ add_bs((2 * n | 0) + 1 | 0);
-        /*<<filename.ml:161:34>>*/ Stdlib_Buffer[12].call(null, b, 34);
-        /*<<filename.ml:161:56>>*/ _l_ = i + 1 | 0;
+      var _l_ =  /*<<filename.ml:162:14>>*/ caml_string_get(s, i);
+       /*<<filename.ml:162:19>>*/ if(34 === _l_){
+        /*<<filename.ml:163:18>>*/ add_bs((2 * n | 0) + 1 | 0);
+        /*<<filename.ml:163:34>>*/ Stdlib_Buffer[12].call(null, b, 34);
+        /*<<filename.ml:163:56>>*/ _l_ = i + 1 | 0;
        return counter < 50
                ? loop$0(counter + 1 | 0, _l_)
-               : caml_trampoline_return(loop$0, [0, _l_]) /*<<filename.ml:164:9>>*/ ;
+               : caml_trampoline_return(loop$0, [0, _l_]) /*<<filename.ml:166:9>>*/ ;
       }
-       /*<<filename.ml:160:19>>*/ if(92 !== _l_){
-        /*<<filename.ml:163:18>>*/ add_bs(n);
-        /*<<filename.ml:163:26>>*/ return counter < 50
+       /*<<filename.ml:162:19>>*/ if(92 !== _l_){
+        /*<<filename.ml:165:18>>*/ add_bs(n);
+        /*<<filename.ml:165:26>>*/ return counter < 50
                ? loop$0(counter + 1 | 0, i)
-               : caml_trampoline_return(loop$0, [0, i]) /*<<filename.ml:164:9>>*/ ;
+               : caml_trampoline_return(loop$0, [0, i]) /*<<filename.ml:166:9>>*/ ;
       }
-      var i$0 =  /*<<filename.ml:162:18>>*/ i + 1 | 0, n$0 = n + 1 | 0;
+      var i$0 =  /*<<filename.ml:164:18>>*/ i + 1 | 0, n$0 = n + 1 | 0;
       n = n$0;
       i = i$0;
      }
-     /*<<filename.ml:164:9>>*/ }
+     /*<<filename.ml:166:9>>*/ }
     function add_bs(n){
-      /*<<filename.ml:165:19>>*/ if(n >= 1){
+      /*<<filename.ml:167:19>>*/ if(n >= 1){
       var j = 1;
       for(;;){
-        /*<<filename.ml:165:38>>*/ Stdlib_Buffer[12].call(null, b, 92);
-       var _l_ =  /*<<filename.ml:165:60>>*/ j + 1 | 0;
+        /*<<filename.ml:167:38>>*/ Stdlib_Buffer[12].call(null, b, 92);
+       var _l_ =  /*<<filename.ml:167:60>>*/ j + 1 | 0;
        if(n === j) break;
        j = _l_;
       }
      }
-     /*<<filename.ml:165:66>>*/ }
-     /*<<filename.ml:167:4>>*/ loop(0);
-     /*<<filename.ml:167:10>>*/ return Stdlib_Buffer[2].call(null, b) /*<<filename.ml:168:21>>*/ ;
+     /*<<filename.ml:167:66>>*/ }
+     /*<<filename.ml:169:4>>*/ loop(0);
+     /*<<filename.ml:169:10>>*/ return Stdlib_Buffer[2].call(null, b) /*<<filename.ml:170:21>>*/ ;
    }
    var cst$0 =  /*<<?>>*/ '"', _c_ = [0, cst$0, 0];
    function quote_cmd_filename(f){
     var
      f$0 =
-        /*<<filename.ml:204:9>>*/ Stdlib_String[18].call(null, f, 47)
-        ?  /*<<filename.ml:205:8>>*/ Stdlib_String
+        /*<<filename.ml:206:9>>*/ Stdlib_String[18].call(null, f, 47)
+        ?  /*<<filename.ml:207:8>>*/ Stdlib_String
            [39].call
           (null,
            function(c){
-             /*<<filename.ml:205:19>>*/ return 47 === c ? 92 : c /*<<filename.ml:205:50>>*/ ;
+             /*<<filename.ml:207:19>>*/ return 47 === c ? 92 : c /*<<filename.ml:207:50>>*/ ;
            },
            f)
         : f;
-     /*<<filename.ml:208:7>>*/ if
+     /*<<filename.ml:210:7>>*/ if
      (!
       Stdlib_String[44].call
        (null,
         function(param){
-          /*<<filename.ml:208:21>>*/ if(34 !== param && 37 !== param)
-           /*<<filename.ml:208:57>>*/ return 0;
-          /*<<filename.ml:208:45>>*/ return 1;
-         /*<<filename.ml:208:63>>*/ },
+          /*<<filename.ml:210:21>>*/ if(34 !== param && 37 !== param)
+           /*<<filename.ml:210:57>>*/ return 0;
+          /*<<filename.ml:210:45>>*/ return 1;
+         /*<<filename.ml:210:63>>*/ },
         f$0))
-      /*<<filename.ml:210:12>>*/ return Stdlib_String[44].call
+      /*<<filename.ml:212:12>>*/ return Stdlib_String[44].call
               (null,
                function(param){
                 a:
                 {
-                  /*<<filename.ml:210:26>>*/ if(42 <= param){
+                  /*<<filename.ml:212:26>>*/ if(42 <= param){
                   if(94 !== param) break a;
                  }
                  else{
@@ -38288,68 +38363,68 @@
                      break a;
                   }
                  }
-                  /*<<filename.ml:211:53>>*/ return 1;
+                  /*<<filename.ml:213:53>>*/ return 1;
                 }
-                 /*<<filename.ml:212:21>>*/ return 0;
-                /*<<filename.ml:212:27>>*/ },
+                 /*<<filename.ml:214:21>>*/ return 0;
+                /*<<filename.ml:214:27>>*/ },
                f$0)
-             ?  /*<<filename.ml:213:6>>*/ Stdlib_String
+             ?  /*<<filename.ml:215:6>>*/ Stdlib_String
                 [8].call
                (null, cst, [0, cst$0, [0, f$0, _c_]])
-             : f$0 /*<<filename.ml:215:7>>*/ ;
+             : f$0 /*<<filename.ml:217:7>>*/ ;
     var
      _l_ =
-        /*<<filename.ml:209:15>>*/ Stdlib[28].call
+        /*<<filename.ml:211:15>>*/ Stdlib[28].call
         (null, "Filename.quote_command: bad file name ", f$0);
-     /*<<filename.ml:209:61>>*/ return Stdlib[2].call(null, _l_) /*<<filename.ml:215:7>>*/ ;
+     /*<<filename.ml:211:61>>*/ return Stdlib[2].call(null, _l_) /*<<filename.ml:217:7>>*/ ;
    }
    var _d_ =  /*<<?>>*/ [0, cst$0, 0];
    function quote_command$0(cmd, stdin, stdout, stderr, args){
-     /*<<filename.ml:220:4>>*/ if(stderr){
+     /*<<filename.ml:222:4>>*/ if(stderr){
      var f = stderr[1];
-      /*<<filename.ml:228:43>>*/ if(caml_equal(stderr, stdout))
-      var _j_ =  /*<<filename.ml:228:58>>*/ cst_2_1;
+      /*<<filename.ml:230:43>>*/ if(caml_equal(stderr, stdout))
+      var _j_ =  /*<<filename.ml:230:58>>*/ cst_2_1;
      else{
-       /*<<filename.ml:230:53>>*/ _j_ = quote_cmd_filename(f);
-       /*<<filename.ml:230:73>>*/ _j_ =
-        /*<<filename.ml:230:45>>*/ Stdlib[28].call(null, cst_2, _j_);
+       /*<<filename.ml:232:53>>*/ _j_ = quote_cmd_filename(f);
+       /*<<filename.ml:232:73>>*/ _j_ =
+        /*<<filename.ml:232:45>>*/ Stdlib[28].call(null, cst_2, _j_);
      }
     }
     else
-      /*<<filename.ml:220:4>>*/ _j_ = cst;
+      /*<<filename.ml:222:4>>*/ _j_ = cst;
     _j_ = [0, _j_, _d_];
     if(stdout)
      var
       f$0 = stdout[1],
-      _k_ =  /*<<filename.ml:226:55>>*/ quote_cmd_filename(f$0),
+      _k_ =  /*<<filename.ml:228:55>>*/ quote_cmd_filename(f$0),
       _k_ =
-         /*<<filename.ml:226:75>>*/  /*<<filename.ml:226:48>>*/ Stdlib[28].call
+         /*<<filename.ml:228:75>>*/  /*<<filename.ml:228:48>>*/ Stdlib[28].call
          (null, cst$1, _k_);
     else
-      /*<<filename.ml:220:4>>*/ _k_ = cst;
+      /*<<filename.ml:222:4>>*/ _k_ = cst;
     _j_ = [0, _k_, _j_];
     if(stdin)
      var
       f$1 = stdin[1],
-      _k_ =  /*<<filename.ml:225:55>>*/ quote_cmd_filename(f$1),
+      _k_ =  /*<<filename.ml:227:55>>*/ quote_cmd_filename(f$1),
       _k_ =
-         /*<<filename.ml:225:75>>*/  /*<<filename.ml:225:48>>*/ Stdlib[28].call
+         /*<<filename.ml:227:75>>*/  /*<<filename.ml:227:48>>*/ Stdlib[28].call
          (null, cst$2, _k_);
     else
-      /*<<filename.ml:220:4>>*/ _k_ = cst;
+      /*<<filename.ml:222:4>>*/ _k_ = cst;
     var
      _l_ =
-        /*<<filename.ml:224:35>>*/ Stdlib_List[21].call(null, quote$0, args),
-     s =  /*<<filename.ml:224:16>>*/ Stdlib_String[8].call(null, cst$3, _l_),
+        /*<<filename.ml:226:35>>*/ Stdlib_List[21].call(null, quote$0, args),
+     s =  /*<<filename.ml:226:16>>*/ Stdlib_String[8].call(null, cst$3, _l_),
      b =
-        /*<<filename.ml:190:4>>*/  /*<<filename.ml:190:12>>*/ Stdlib_Buffer[1].call
-        (null,  /*<<filename.ml:190:4>>*/ caml_ml_string_length(s) + 20 | 0);
-     /*<<filename.ml:191:4>>*/ Stdlib_String[51].call
+        /*<<filename.ml:192:4>>*/  /*<<filename.ml:192:12>>*/ Stdlib_Buffer[1].call
+        (null,  /*<<filename.ml:192:4>>*/ caml_ml_string_length(s) + 20 | 0);
+     /*<<filename.ml:193:4>>*/ Stdlib_String[51].call
      (null,
       function(c){
        a:
        {
-         /*<<filename.ml:193:8>>*/ if(62 <= c){
+         /*<<filename.ml:195:8>>*/ if(62 <= c){
          var _l_ = c - 63 | 0;
          if(60 < _l_ >>> 0){
           if(62 <= _l_) break a;
@@ -38365,78 +38440,78 @@
           switch(c - 33 | 0){case 2:case 3:case 6: break a;
           }
          }
-         /*<<filename.ml:195:12>>*/ Stdlib_Buffer[12].call(null, b, 94);
-         /*<<filename.ml:195:33>>*/ return Stdlib_Buffer[12].call(null, b, c) /*<<filename.ml:197:31>>*/ ;
+         /*<<filename.ml:197:12>>*/ Stdlib_Buffer[12].call(null, b, 94);
+         /*<<filename.ml:197:33>>*/ return Stdlib_Buffer[12].call(null, b, c) /*<<filename.ml:199:31>>*/ ;
        }
-        /*<<filename.ml:197:12>>*/ return Stdlib_Buffer[12].call(null, b, c) /*<<filename.ml:197:31>>*/ ;
+        /*<<filename.ml:199:12>>*/ return Stdlib_Buffer[12].call(null, b, c) /*<<filename.ml:199:31>>*/ ;
       },
       s);
-     /*<<filename.ml:198:7>>*/ _j_ =
+     /*<<filename.ml:200:7>>*/ _j_ =
      [0, cst$3, [0, Stdlib_Buffer[2].call(null, b), [0, _k_, _j_]]];
-     /*<<filename.ml:222:6>>*/ _j_ =
+     /*<<filename.ml:224:6>>*/ _j_ =
      [0, cst$0, [0, quote_cmd_filename(cmd), _j_]];
-     /*<<filename.ml:222:28>>*/ return Stdlib_String[8].call(null, cst, _j_) /*<<filename.ml:232:5>>*/ ;
+     /*<<filename.ml:224:28>>*/ return Stdlib_String[8].call(null, cst, _j_) /*<<filename.ml:234:5>>*/ ;
    }
    function drive_and_path(s){
-    var _j_ =  /*<<filename.ml:238:4>>*/ 2 <= caml_ml_string_length(s);
+    var _j_ =  /*<<filename.ml:240:4>>*/ 2 <= caml_ml_string_length(s);
     if(_j_){
-      /*<<filename.ml:238:38>>*/ _j_ = caml_string_get(s, 0);
+      /*<<filename.ml:240:38>>*/ _j_ = caml_string_get(s, 0);
      a:
      {
       b:
       {
-        /*<<filename.ml:234:20>>*/ if(91 <= _j_){
+        /*<<filename.ml:236:20>>*/ if(91 <= _j_){
         if(25 < _j_ - 97 >>> 0) break b;
        }
        else if(65 > _j_) break b;
-        /*<<filename.ml:235:35>>*/ _j_ = 1;
+        /*<<filename.ml:237:35>>*/ _j_ = 1;
        break a;
       }
-       /*<<filename.ml:236:13>>*/ _j_ = 0;
+       /*<<filename.ml:238:13>>*/ _j_ = 0;
      }
-      /*<<filename.ml:238:43>>*/ _j_ =
-      _j_ ? 58 ===  /*<<filename.ml:238:47>>*/ caml_string_get(s, 1) : _j_;
+      /*<<filename.ml:240:43>>*/ _j_ =
+      _j_ ? 58 ===  /*<<filename.ml:240:47>>*/ caml_string_get(s, 1) : _j_;
     }
-     /*<<filename.ml:240:18>>*/ if(! _j_)
-      /*<<filename.ml:242:9>>*/ return [0, cst, s];
-     /*<<filename.ml:241:9>>*/ _j_ =
-      /*<<filename.ml:241:28>>*/ Stdlib_String[19].call
+     /*<<filename.ml:242:18>>*/ if(! _j_)
+      /*<<filename.ml:244:9>>*/ return [0, cst, s];
+     /*<<filename.ml:243:9>>*/ _j_ =
+      /*<<filename.ml:243:28>>*/ Stdlib_String[19].call
       (null,
        s,
        2,
-        /*<<filename.ml:241:9>>*/ caml_ml_string_length(s) - 2 | 0);
-     /*<<filename.ml:241:10>>*/ return [0,
+        /*<<filename.ml:243:9>>*/ caml_ml_string_length(s) - 2 | 0);
+     /*<<filename.ml:243:10>>*/ return [0,
             Stdlib_String[19].call(null, s, 0, 2),
-            _j_] /*<<filename.ml:241:26>>*/ ;
-    /*<<filename.ml:242:16>>*/ }
+            _j_] /*<<filename.ml:243:26>>*/ ;
+    /*<<filename.ml:244:16>>*/ }
    var current_dir_name$0 =  /*<<?>>*/ _a_;
    function dirname$0(s){
     var
-     match =  /*<<filename.ml:244:24>>*/ drive_and_path(s),
-     path =  /*<<filename.ml:244:40>>*/ match[2],
+     match =  /*<<filename.ml:246:24>>*/ drive_and_path(s),
+     path =  /*<<filename.ml:246:40>>*/ match[2],
      drive = match[1],
      dir =
-        /*<<filename.ml:245:14>>*/ generic_dirname
+        /*<<filename.ml:247:14>>*/ generic_dirname
         (is_dir_sep$0, current_dir_name$0, path);
-     /*<<filename.ml:246:4>>*/ return Stdlib[28].call(null, drive, dir) /*<<filename.ml:246:15>>*/ ;
+     /*<<filename.ml:248:4>>*/ return Stdlib[28].call(null, drive, dir) /*<<filename.ml:248:15>>*/ ;
    }
    function basename$0(s){
-    var path =  /*<<filename.ml:248:25>>*/ drive_and_path(s)[2];
-     /*<<filename.ml:249:4>>*/ return generic_basename
-            (is_dir_sep$0, current_dir_name$0, path) /*<<filename.ml:249:53>>*/ ;
+    var path =  /*<<filename.ml:250:25>>*/ drive_and_path(s)[2];
+     /*<<filename.ml:251:4>>*/ return generic_basename
+            (is_dir_sep$0, current_dir_name$0, path) /*<<filename.ml:251:53>>*/ ;
    }
    var current_dir_name$1 =  /*<<?>>*/ _a_;
    function basename$1(_j_){
-     /*<<filename.ml:264:17>>*/ return generic_basename
+     /*<<filename.ml:266:17>>*/ return generic_basename
             (is_dir_sep$0, current_dir_name$1, _j_);
    }
    function dirname$1(_j_){
-     /*<<filename.ml:265:16>>*/ return generic_dirname
+     /*<<filename.ml:267:16>>*/ return generic_dirname
             (is_dir_sep$0, current_dir_name$1, _j_);
    }
    var
     Cygwin =
-       /*<<filename.ml:265:59>>*/ [0,
+       /*<<filename.ml:267:59>>*/ [0,
        cst_dev_null,
        current_dir_name$1,
        cst$6,
@@ -38485,177 +38560,177 @@
     basename$2 = Sysdeps[12],
     dirname$2 = Sysdeps[13];
    function concat(dirname, filename){
-    var l =  /*<<filename.ml:277:2>>*/ caml_ml_string_length(dirname);
-     /*<<filename.ml:278:2>>*/ if
+    var l =  /*<<filename.ml:279:2>>*/ caml_ml_string_length(dirname);
+     /*<<filename.ml:280:2>>*/ if
      (0 !== l
-      && !  /*<<filename.ml:278:14>>*/ is_dir_sep$1(dirname, l - 1 | 0)){
+      && !  /*<<filename.ml:280:14>>*/ is_dir_sep$1(dirname, l - 1 | 0)){
      var
       _j_ =
-         /*<<filename.ml:280:17>>*/ Stdlib[28].call(null, dir_sep, filename);
-      /*<<filename.ml:280:35>>*/ return Stdlib[28].call(null, dirname, _j_);
+         /*<<filename.ml:282:17>>*/ Stdlib[28].call(null, dir_sep, filename);
+      /*<<filename.ml:282:35>>*/ return Stdlib[28].call(null, dirname, _j_);
     }
-     /*<<filename.ml:279:7>>*/ return Stdlib[28].call(null, dirname, filename) /*<<filename.ml:280:35>>*/ ;
+     /*<<filename.ml:281:7>>*/ return Stdlib[28].call(null, dirname, filename) /*<<filename.ml:282:35>>*/ ;
    }
    function chop_suffix(name, suff){
-     /*<<filename.ml:283:5>>*/ return check_suffix$1(name, suff)
-            ?  /*<<filename.ml:284:7>>*/ Stdlib_String
+     /*<<filename.ml:285:5>>*/ return check_suffix$1(name, suff)
+            ?  /*<<filename.ml:286:7>>*/ Stdlib_String
                [19].call
               (null,
                name,
                0,
                caml_ml_string_length(name) - caml_ml_string_length(suff) | 0)
-            :  /*<<filename.ml:285:7>>*/ Stdlib
+            :  /*<<filename.ml:287:7>>*/ Stdlib
                [1].call
-              (null, "Filename.chop_suffix") /*<<filename.ml:285:41>>*/ ;
+              (null, "Filename.chop_suffix") /*<<filename.ml:287:41>>*/ ;
    }
    function chop_suffix_opt(suffix, name){
-     /*<<filename.ml:288:5>>*/ return check_suffix$1(name, suffix)
+     /*<<filename.ml:290:5>>*/ return check_suffix$1(name, suffix)
             ? [0,
-               /*<<filename.ml:289:12>>*/ Stdlib_String[19].call
+               /*<<filename.ml:291:12>>*/ Stdlib_String[19].call
                (null,
                 name,
                 0,
-                 /*<<filename.ml:289:7>>*/ caml_ml_string_length(name)
+                 /*<<filename.ml:291:7>>*/ caml_ml_string_length(name)
                 - caml_ml_string_length(suffix)
                 | 0)]
-            : 0 /*<<filename.ml:290:11>>*/ ;
+            : 0 /*<<filename.ml:292:11>>*/ ;
    }
    function extension_len(name){
     var
-     i$3 =  /*<<filename.ml:303:2>>*/ caml_ml_string_length(name) - 1 | 0,
+     i$3 =  /*<<filename.ml:305:2>>*/ caml_ml_string_length(name) - 1 | 0,
      i0 = i$3;
     for(;;){
-      /*<<filename.ml:299:4>>*/ if
-      (0 <= i0 && !  /*<<filename.ml:299:16>>*/ is_dir_sep$1(name, i0)){
-       /*<<filename.ml:300:12>>*/ if(46 === caml_string_get(name, i0)) break;
-      var i$2 =  /*<<filename.ml:301:9>>*/ i0 - 1 | 0;
+      /*<<filename.ml:301:4>>*/ if
+      (0 <= i0 && !  /*<<filename.ml:301:16>>*/ is_dir_sep$1(name, i0)){
+       /*<<filename.ml:302:12>>*/ if(46 === caml_string_get(name, i0)) break;
+      var i$2 =  /*<<filename.ml:303:9>>*/ i0 - 1 | 0;
       i0 = i$2;
       continue;
      }
-      /*<<filename.ml:299:39>>*/ return 0;
+      /*<<filename.ml:301:39>>*/ return 0;
     }
-    var i$1 =  /*<<filename.ml:300:32>>*/ i0 - 1 | 0, i = i$1;
+    var i$1 =  /*<<filename.ml:302:32>>*/ i0 - 1 | 0, i = i$1;
     for(;;){
-      /*<<filename.ml:294:4>>*/ if
-      (0 <= i && !  /*<<filename.ml:294:16>>*/ is_dir_sep$1(name, i)){
-       /*<<filename.ml:295:12>>*/ if(46 !== caml_string_get(name, i))
-        /*<<filename.ml:296:9>>*/ return caml_ml_string_length(name) - i0 | 0;
-      var i$0 =  /*<<filename.ml:295:32>>*/ i - 1 | 0;
+      /*<<filename.ml:296:4>>*/ if
+      (0 <= i && !  /*<<filename.ml:296:16>>*/ is_dir_sep$1(name, i)){
+       /*<<filename.ml:297:12>>*/ if(46 !== caml_string_get(name, i))
+        /*<<filename.ml:298:9>>*/ return caml_ml_string_length(name) - i0 | 0;
+      var i$0 =  /*<<filename.ml:297:32>>*/ i - 1 | 0;
       i = i$0;
       continue;
      }
-      /*<<filename.ml:294:39>>*/ return 0;
+      /*<<filename.ml:296:39>>*/ return 0;
     }
-    /*<<filename.ml:303:37>>*/ }
+    /*<<filename.ml:305:37>>*/ }
    function extension(name){
-    var l =  /*<<filename.ml:306:10>>*/ extension_len(name);
-     /*<<filename.ml:307:2>>*/ return 0 === l
+    var l =  /*<<filename.ml:308:10>>*/ extension_len(name);
+     /*<<filename.ml:309:2>>*/ return 0 === l
             ? cst
-            :  /*<<filename.ml:307:24>>*/ Stdlib_String
+            :  /*<<filename.ml:309:24>>*/ Stdlib_String
                [19].call
-              (null, name, caml_ml_string_length(name) - l | 0, l) /*<<filename.ml:307:66>>*/ ;
+              (null, name, caml_ml_string_length(name) - l | 0, l) /*<<filename.ml:309:66>>*/ ;
    }
    function chop_extension(name){
-    var l =  /*<<filename.ml:310:10>>*/ extension_len(name);
-     /*<<filename.ml:311:2>>*/ return 0 === l
-            ?  /*<<filename.ml:311:16>>*/ Stdlib
+    var l =  /*<<filename.ml:312:10>>*/ extension_len(name);
+     /*<<filename.ml:313:2>>*/ return 0 === l
+            ?  /*<<filename.ml:313:16>>*/ Stdlib
                [1].call
               (null, "Filename.chop_extension")
-            :  /*<<filename.ml:312:7>>*/ Stdlib_String
+            :  /*<<filename.ml:314:7>>*/ Stdlib_String
                [19].call
-              (null, name, 0, caml_ml_string_length(name) - l | 0) /*<<filename.ml:312:49>>*/ ;
+              (null, name, 0, caml_ml_string_length(name) - l | 0) /*<<filename.ml:314:49>>*/ ;
    }
    function remove_extension(name){
-    var l =  /*<<filename.ml:315:10>>*/ extension_len(name);
-     /*<<filename.ml:316:2>>*/ return 0 === l
+    var l =  /*<<filename.ml:317:10>>*/ extension_len(name);
+     /*<<filename.ml:318:2>>*/ return 0 === l
             ? name
-            :  /*<<filename.ml:316:26>>*/ Stdlib_String
+            :  /*<<filename.ml:318:26>>*/ Stdlib_String
                [19].call
-              (null, name, 0, caml_ml_string_length(name) - l | 0) /*<<filename.ml:316:68>>*/ ;
+              (null, name, 0, caml_ml_string_length(name) - l | 0) /*<<filename.ml:318:68>>*/ ;
    }
    var
     prng_key =
-       /*<<filename.ml:322:2>>*/ Stdlib_Domain[12][1].call
+       /*<<filename.ml:324:2>>*/ Stdlib_Domain[12][1].call
        (null, 0, Stdlib_Random[19][2]),
     _e_ =  /*<<?>>*/ [0, [2, 0, [4, 6, [0, 2, 6], 0, [2, 0, 0]]], "%s%06x%s"];
    function temp_file_name(temp_dir, prefix, suffix){
     var
      random_state =
-        /*<<filename.ml:325:21>>*/ Stdlib_Domain[12][2].call(null, prng_key),
+        /*<<filename.ml:327:21>>*/ Stdlib_Domain[12][2].call(null, prng_key),
      rnd =
-        /*<<filename.ml:326:12>>*/ Stdlib_Random[19][4].call
+        /*<<filename.ml:328:12>>*/ Stdlib_Random[19][4].call
         (null, random_state)
        & 16777215;
-     /*<<filename.ml:327:18>>*/ return  /*<<filename.ml:327:63>>*/ concat
+     /*<<filename.ml:329:18>>*/ return  /*<<filename.ml:329:63>>*/ concat
             (temp_dir,
-              /*<<filename.ml:327:18>>*/ caml_call3
-              (Stdlib_Printf[4].call(null, _e_), prefix, rnd, suffix)) /*<<filename.ml:327:63>>*/ ;
+              /*<<filename.ml:329:18>>*/ caml_call3
+              (Stdlib_Printf[4].call(null, _e_), prefix, rnd, suffix)) /*<<filename.ml:329:63>>*/ ;
    }
    var
     current_temp_dir_name =
-       /*<<filename.ml:330:2>>*/ Stdlib_Domain[12][1].call
+       /*<<filename.ml:332:2>>*/ Stdlib_Domain[12][1].call
        (null,
         [0, Stdlib_Fun[1]],
         function(param){
-          /*<<filename.ml:330:58>>*/ return temp_dir_name$1;
-         /*<<filename.ml:330:71>>*/ });
+          /*<<filename.ml:332:58>>*/ return temp_dir_name$1;
+         /*<<filename.ml:332:71>>*/ });
    function set_temp_dir_name(s){
-     /*<<filename.ml:332:26>>*/ return Stdlib_Domain[12][3].call
-            (null, current_temp_dir_name, s) /*<<filename.ml:332:64>>*/ ;
+     /*<<filename.ml:334:26>>*/ return Stdlib_Domain[12][3].call
+            (null, current_temp_dir_name, s) /*<<filename.ml:334:64>>*/ ;
    }
    function get_temp_dir_name(param){
-     /*<<filename.ml:333:27>>*/ return Stdlib_Domain[12][2].call
-            (null, current_temp_dir_name) /*<<filename.ml:333:63>>*/ ;
+     /*<<filename.ml:335:27>>*/ return Stdlib_Domain[12][2].call
+            (null, current_temp_dir_name) /*<<filename.ml:335:63>>*/ ;
    }
    var _f_ =  /*<<?>>*/ [0, 1, [0, 3, [0, 5, 0]]];
    function temp_file(opt, prefix, suffix){
     var
      temp_dir =
-        /*<<filename.ml:335:14>>*/ opt
+        /*<<filename.ml:337:14>>*/ opt
         ? opt[1]
-        :  /*<<filename.ml:335:27>>*/ Stdlib_Domain
+        :  /*<<filename.ml:337:27>>*/ Stdlib_Domain
             [12]
            [2].call
           (null, current_temp_dir_name),
-     counter =  /*<<filename.ml:343:5>>*/ 0;
+     counter =  /*<<filename.ml:345:5>>*/ 0;
     for(;;){
      var
       name =
-         /*<<filename.ml:337:15>>*/ temp_file_name(temp_dir, prefix, suffix);
-      /*<<filename.ml:338:4>>*/ try{
-       /*<<filename.ml:339:16>>*/  /*<<filename.ml:339:6>>*/ runtime.caml_sys_close
-       ( /*<<filename.ml:339:16>>*/ runtime.caml_sys_open(name, _f_, 384));
+         /*<<filename.ml:339:15>>*/ temp_file_name(temp_dir, prefix, suffix);
+      /*<<filename.ml:340:4>>*/ try{
+       /*<<filename.ml:341:16>>*/  /*<<filename.ml:341:6>>*/ runtime.caml_sys_close
+       ( /*<<filename.ml:341:16>>*/ runtime.caml_sys_open(name, _f_, 384));
       return name;
      }
      catch(e$0){
       var e =  /*<<?>>*/ caml_wrap_exception(e$0);
       if(e[1] !== Stdlib[11]) throw caml_maybe_attach_backtrace(e, 0);
-       /*<<filename.ml:342:6>>*/ if(20 <= counter)
-        /*<<filename.ml:342:28>>*/ throw caml_maybe_attach_backtrace(e, 0);
-      var counter$0 =  /*<<filename.ml:342:41>>*/ counter + 1 | 0;
+       /*<<filename.ml:344:6>>*/ if(20 <= counter)
+        /*<<filename.ml:344:28>>*/ throw caml_maybe_attach_backtrace(e, 0);
+      var counter$0 =  /*<<filename.ml:344:41>>*/ counter + 1 | 0;
       counter = counter$0;
      }
     }
-    /*<<filename.ml:343:15>>*/ }
+    /*<<filename.ml:345:15>>*/ }
    var _g_ =  /*<<?>>*/ [0, 7, 0];
    function open_temp_file(_j_, _i_, _h_, prefix, suffix){
     var
-     mode =  /*<<filename.ml:345:19>>*/ _j_ ? _j_[1] : _g_,
+     mode =  /*<<filename.ml:347:19>>*/ _j_ ? _j_[1] : _g_,
      perms = _i_ ? _i_[1] : 384,
      temp_dir =
        _h_
         ? _h_[1]
-        :  /*<<filename.ml:346:17>>*/ Stdlib_Domain
+        :  /*<<filename.ml:348:17>>*/ Stdlib_Domain
             [12]
            [2].call
           (null, current_temp_dir_name),
-     counter =  /*<<filename.ml:355:5>>*/ 0;
+     counter =  /*<<filename.ml:357:5>>*/ 0;
     for(;;){
      var
       name =
-         /*<<filename.ml:349:15>>*/ temp_file_name(temp_dir, prefix, suffix);
-      /*<<filename.ml:350:4>>*/ try{
-       /*<<filename.ml:352:7>>*/ _h_ =
+         /*<<filename.ml:351:15>>*/ temp_file_name(temp_dir, prefix, suffix);
+      /*<<filename.ml:352:4>>*/ try{
+       /*<<filename.ml:354:7>>*/ _h_ =
        [0,
         name,
         Stdlib[62].call(null, [0, 1, [0, 3, [0, 5, mode]]], perms, name)];
@@ -38664,43 +38739,43 @@
      catch(e$0){
       var e =  /*<<?>>*/ caml_wrap_exception(e$0);
       if(e[1] !== Stdlib[11]) throw caml_maybe_attach_backtrace(e, 0);
-       /*<<filename.ml:354:6>>*/ if(20 <= counter)
-        /*<<filename.ml:354:28>>*/ throw caml_maybe_attach_backtrace(e, 0);
-      var counter$0 =  /*<<filename.ml:354:41>>*/ counter + 1 | 0;
+       /*<<filename.ml:356:6>>*/ if(20 <= counter)
+        /*<<filename.ml:356:28>>*/ throw caml_maybe_attach_backtrace(e, 0);
+      var counter$0 =  /*<<filename.ml:356:41>>*/ counter + 1 | 0;
       counter = counter$0;
      }
     }
-    /*<<filename.ml:355:15>>*/ }
+    /*<<filename.ml:357:15>>*/ }
    function temp_dir(_g_, opt, prefix, suffix){
     var
      temp_dir =
-        /*<<filename.ml:357:13>>*/ _g_
+        /*<<filename.ml:359:13>>*/ _g_
         ? _g_[1]
-        :  /*<<filename.ml:357:26>>*/ Stdlib_Domain
+        :  /*<<filename.ml:359:26>>*/ Stdlib_Domain
             [12]
            [2].call
           (null, current_temp_dir_name),
-     perms =  /*<<filename.ml:357:13>>*/ opt ? opt[1] : 448,
-     counter =  /*<<filename.ml:366:5>>*/ 0;
+     perms =  /*<<filename.ml:359:13>>*/ opt ? opt[1] : 448,
+     counter =  /*<<filename.ml:368:5>>*/ 0;
     for(;;){
      var
       name =
-         /*<<filename.ml:360:15>>*/ temp_file_name(temp_dir, prefix, suffix);
-      /*<<filename.ml:361:4>>*/ try{
-       /*<<filename.ml:362:6>>*/ runtime.caml_sys_mkdir(name, perms);
+         /*<<filename.ml:362:15>>*/ temp_file_name(temp_dir, prefix, suffix);
+      /*<<filename.ml:363:4>>*/ try{
+       /*<<filename.ml:364:6>>*/ runtime.caml_sys_mkdir(name, perms);
       return name;
      }
      catch(e$0){
       var e =  /*<<?>>*/ caml_wrap_exception(e$0);
       if(e[1] !== Stdlib[11]) throw caml_maybe_attach_backtrace(e, 0);
-       /*<<filename.ml:365:6>>*/ if(20 <= counter)
-        /*<<filename.ml:365:28>>*/ throw caml_maybe_attach_backtrace(e, 0);
-      var counter$0 =  /*<<filename.ml:365:41>>*/ counter + 1 | 0;
+       /*<<filename.ml:367:6>>*/ if(20 <= counter)
+        /*<<filename.ml:367:28>>*/ throw caml_maybe_attach_backtrace(e, 0);
+      var counter$0 =  /*<<filename.ml:367:41>>*/ counter + 1 | 0;
       counter = counter$0;
      }
     }
-    /*<<filename.ml:366:15>>*/ }
-    /*<<filename.ml:330:72>>*/ runtime.caml_register_global
+    /*<<filename.ml:368:15>>*/ }
+    /*<<filename.ml:332:72>>*/ runtime.caml_register_global
     ([0,
       current_dir_name$2,
       parent_dir_name,


### PR DESCRIPTION
Fixes the `5.6+trunk / Ubuntu` CI failure on master.

OCaml trunk added `Obj.hash_variant` (shifting the `Stdlib_Obj` field indices used throughout the generated code) and moved lines in several stdlib modules (`sys.ml.in`, `result.ml`, `filename.ml`, `obj.ml`, …), so the debug locations and generated code in the snapshot drifted.

Re-promoted with a freshly built `ocaml-variants.5.6.0+trunk` switch; `dune build @compiler/tests-full/runtest` passes with it.

Test-only change, no changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)