### PR TITLE
Preserve leading BOMs when converting OCaml strings to JavaScript strings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -82,7 +82,8 @@
 * Tyxml: when the same attribute (e.g. multiple `a_class`) is given several
   times, keep the first one and ignore the rest, matching browser semantics,
   instead of letting the last one silently overwrite the others (#968)
-
+* Preserve leading BOMs when converting OCaml strings to JavaScript strings
+  (#2414)
 # 6.4.1 (2026-06-30) - Lille
 
 ## Bug fixes

--- a/compiler/tests-jsoo/test_text_codec_fallback.ml
+++ b/compiler/tests-jsoo/test_text_codec_fallback.ml
@@ -222,3 +222,10 @@ let%expect_test ("decoder: lead with bad continuation, mixed runs" [@when not qu
     ASCII after truncated 3-byte [e4 b8 41] -> [U+FFFD U+0041]
     valid then truncated [c3 a9 e4 b8] -> [U+00E9 U+FFFD]
     |}]
+
+let%expect_test "OCaml-to-JavaScript conversion preserves a leading BOM" =
+  let input = Bytes.of_string "\000\xbb\xbftext" in
+  Bytes.set input 0 '\xef';
+  let converted = Js.string (Bytes.unsafe_to_string input) in
+  print_endline (codepoints_of_jsstring converted);
+  [%expect {| U+FEFF U+0074 U+0065 U+0078 U+0074 |}]

--- a/runtime/js/mlBytes.js
+++ b/runtime/js/mlBytes.js
@@ -482,7 +482,7 @@ var jsoo_text_decoder_fallback = {
 //Requires: jsoo_text_decoder_fallback
 var jsoo_text_decoder =
   typeof TextDecoder !== "undefined"
-    ? new TextDecoder()
+    ? new TextDecoder("utf-8", { ignoreBOM: true })
     : jsoo_text_decoder_fallback;
 
 //Provides: caml_bytes_of_utf16_jsstring


### PR DESCRIPTION
Use ignoreBOM:true so TextDecoder does not strip a leading BOM.

(TextDecoder part of oxcaml/oxcaml@112978855461a6a6865940a659e5f7b71d2c027c)