### PR TITLE
Fix typed array constructors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,11 @@
 * Compiler/Wasm: emit a sourcemap mapping at the very start of each function,
   since the Chrome profiler attributes the samples within a function to its
   start offset (#2417)
+* Lib (breaking): `Typed_array.float32Array_fromArray` and
+  `float64Array_fromArray` now take a `number_t js_array t` instead of a
+  `float js_array t`. The previous type was wrong for wasm_of_ocaml, where
+  OCaml floats are not JavaScript numbers; existing callers must build their
+  array from `Js.number_of_float` elements (#2416)
 
 ## Bug fixes
 * Compiler/Wasm: sourcemaps were silently disabled on Windows: the detection

--- a/lib/js_of_ocaml/typed_array.mli
+++ b/lib/js_of_ocaml/typed_array.mli
@@ -167,7 +167,7 @@ val uint32Array_inBuffer : (arrayBuffer t -> int -> int -> uint32Array t) constr
 
 val float32Array : (int -> float32Array t) constr
 
-val float32Array_fromArray : (float js_array t -> float32Array t) constr
+val float32Array_fromArray : (number_t js_array t -> float32Array t) constr
 
 val float32Array_fromTypedArray : (float32Array t -> float32Array t) constr
 
@@ -177,7 +177,7 @@ val float32Array_inBuffer : (arrayBuffer t -> int -> int -> float32Array t) cons
 
 val float64Array : (int -> float64Array t) constr
 
-val float64Array_fromArray : (float js_array t -> float64Array t) constr
+val float64Array_fromArray : (number_t js_array t -> float64Array t) constr
 
 val float64Array_fromTypedArray : (float64Array t -> float64Array t) constr
 

--- a/lib/tests/test_typed_array.ml
+++ b/lib/tests/test_typed_array.ml
@@ -147,6 +147,17 @@ let%expect_test "float64" =
   test Setup.Float64 [| Float.neg_infinity; -1.; 0.; 1.; Float.infinity |];
   [%expect {||}]
 
+let%expect_test "float arrays from JS arrays" =
+  let input = [| -1.; -1.; 3.; -1.; -1.; 3. |] in
+  let js_input = Js.array (Array.map Js.float input) in
+  let float32 = new%js float32Array_fromArray js_input in
+  let float64 = new%js float64Array_fromArray js_input in
+  if not (array_of_ta Setup.Float32 float32 = input)
+  then print_endline "float32Array_fromArray doesn't match its input";
+  if not (array_of_ta Setup.Float64 float64 = input)
+  then print_endline "float64Array_fromArray doesn't match its input";
+  [%expect {||}]
+
 let%expect_test "int8" =
   test Setup.Int8 [| -128; -1; 0; 1; 127 |];
   [%expect {||}]


### PR DESCRIPTION
They should take as argument a `number_t js_array t`, not a `float js_array t`.