### PR TITLE
Compiler/Wasm: fix sourcemap support detection on Windows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,6 +45,9 @@
   accept any element, not only images (#2404)
 
 ## Bug fixes
+* Compiler/Wasm: sourcemaps were silently disabled on Windows: the detection
+  of Binaryen's sourcemap support used Unix redirection syntax, so it always
+  concluded that sourcemaps were unsupported (#2418)
 * Compiler/Wasm runtime: fix toplevels built on Windows — the embedded cmi
   paths were built with `Filename.concat`, putting `\` separators in the
   unix-style virtual filesystem, and its lookups did not normalize the `\`

--- a/compiler/bin-wasm_of_ocaml/compile.ml
+++ b/compiler/bin-wasm_of_ocaml/compile.ml
@@ -161,7 +161,9 @@ let link_and_optimize
     (* Check that Binaryen supports the necessary sourcemaps options (requires
        version >= 118) *)
     match opt_sourcemap with
-    | Some _ when Sys.command "wasm-merge -osm foo 2> /dev/null" <> 0 -> None
+    | Some _
+      when Sys.command (Printf.sprintf "wasm-merge -osm foo 2> %s" Filename.null) <> 0 ->
+        None
     | Some _ | None -> opt_sourcemap
   in
   let enable_source_maps = Option.is_some opt_sourcemap_file in


### PR DESCRIPTION
The check that Binaryen is recent enough to support the necessary sourcemap options redirected stderr to /dev/null, which does not exist on Windows. The probe thus always failed there, silently disabling sourcemaps: the input sourcemaps were not passed to any of the Binaryen tools, so the final map contained no mappings. Use Filename.null, which expands to NUL on Windows.