### PR TITLE
Keep `static` on the same line as the class element it modifies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -55,6 +55,11 @@
   for the static evaluator and for `Sys.getenv` lookups at runtime (#2415)
 
 ## Bug fixes
+* Compiler: keep `static` on the same line as the class element it modifies.
+  In compact mode the separator was a newline, and Safari 17 reads `static`
+  alone on a line as a field name rather than a modifier, so every static
+  class field became an instance field; `Int64.of_string` then threw on
+  `MlInt64.UNSIGNED_MAX` (#2420)
 * Compiler/Wasm: sourcemaps were silently disabled on Windows: the detection
   of Binaryen's sourcemap support used Unix redirection syntax, so it always
   concluded that sourcemaps were unsupported (#2418)

--- a/compiler/lib/js_output.ml
+++ b/compiler/lib/js_output.ml
@@ -2125,7 +2125,7 @@ struct
             if static
             then (
               PP.string f "static";
-              PP.space f);
+              PP.non_breaking_space f);
             method_ f class_element_name n m;
             PP.end_group f
         | CEField (decorators, static, n, i) ->
@@ -2134,7 +2134,7 @@ struct
             if static
             then (
               PP.string f "static";
-              PP.space f);
+              PP.non_breaking_space f);
             class_element_name f n;
             (match i with
             | None -> ()
@@ -2152,7 +2152,7 @@ struct
             if static
             then (
               PP.string f "static";
-              PP.space f);
+              PP.non_breaking_space f);
             PP.string f "accessor";
             PP.space f;
             class_element_name f n;
@@ -2169,7 +2169,7 @@ struct
         | CEStaticBLock l ->
             PP.start_group f 0;
             PP.string f "static";
-            PP.space f;
+            PP.non_breaking_space f;
             block f l;
             PP.end_group f);
         if not last then PP.break f);

--- a/compiler/lib/js_output.ml
+++ b/compiler/lib/js_output.ml
@@ -2095,6 +2095,14 @@ struct
             PP.space f);
         PP.end_group f
 
+  and static_keyword f static =
+    if static
+    then (
+      PP.string f "static";
+      (* [static] is not a restricted token, but JavaScriptCore up to Safari 17
+         reads a line break after it as a field named [static] *)
+      PP.non_breaking_space f)
+
   and class_declaration f i x =
     PP.start_group f 0;
     decorator_list f x.decorators;
@@ -2122,21 +2130,13 @@ struct
         | CEMethod (decorators, static, n, m) ->
             PP.start_group f 0;
             decorator_list f decorators;
-            if static
-            then (
-              PP.string f "static";
-              (* [static] is not a restricted token, but JavaScriptCore up to Safari 17
-                 reads a line break after it as a field named [static] *)
-              PP.non_breaking_space f);
+            static_keyword f static;
             method_ f class_element_name n m;
             PP.end_group f
         | CEField (decorators, static, n, i) ->
             PP.start_group f 0;
             decorator_list f decorators;
-            if static
-            then (
-              PP.string f "static";
-              PP.non_breaking_space f);
+            static_keyword f static;
             class_element_name f n;
             (match i with
             | None -> ()
@@ -2151,10 +2151,7 @@ struct
         | CEAccessor (decorators, static, n, i) ->
             PP.start_group f 0;
             decorator_list f decorators;
-            if static
-            then (
-              PP.string f "static";
-              PP.non_breaking_space f);
+            static_keyword f static;
             PP.string f "accessor";
             PP.space f;
             class_element_name f n;
@@ -2171,7 +2168,7 @@ struct
         | CEStaticBLock l ->
             PP.start_group f 0;
             PP.string f "static";
-            PP.non_breaking_space f;
+            if not (PP.compact f) then PP.non_breaking_space f;
             block f l;
             PP.end_group f);
         if not last then PP.break f);

--- a/compiler/lib/js_output.ml
+++ b/compiler/lib/js_output.ml
@@ -2125,6 +2125,8 @@ struct
             if static
             then (
               PP.string f "static";
+              (* [static] is not a restricted token, but JavaScriptCore up to Safari 17
+                 reads a line break after it as a field named [static] *)
               PP.non_breaking_space f);
             method_ f class_element_name n m;
             PP.end_group f

--- a/compiler/tests-compiler/js_parser_printer.ml
+++ b/compiler/tests-compiler/js_parser_printer.ml
@@ -682,8 +682,7 @@ class x extends p {
        var s =  /*<<fake:8:12>>*/ super[d];
        var s =  /*<<fake:9:12>>*/ super.d;
        /*<<fake:6:4>>*/ }
-      static
-      bar(){
+      static bar(){
        var s =  /*<<fake:14:12>>*/ super[d];
        var s =  /*<<fake:15:12>>*/ super.d;
        /*<<fake:12:11>>*/ }


### PR DESCRIPTION
Fixes #2420.

One correction to the issue: I described this as a line that "can be wrapped". It is not occasional. In compact mode `PP.space` sets the pending separator to `"\n"` while `PP.non_breaking_space` sets it to `" "`, and a separator is always required between `static` and an identifier -- so every static class element is emitted with `static` alone on its line.

Safari 17 reads that as a field named `static` followed by a separate instance field, so `MlInt64.UNSIGNED_MAX` is undefined and `Int64.of_string` throws. Safari 18.5 parses it correctly, so this is a JavaScriptCore bug rather than a spec violation -- but `ECMASCRIPT.md` lists Safari 13.4+ as supported.

This adds `static` to the set of keywords `js_output.ml` already prints with `non_breaking_space` (`return`, `throw`, `async`, `using`, `await using`), in all four class-element cases.

One expectation moved: in pretty mode a static *method* was being split across two lines, so `js_parser_printer.ml` now reads `static bar(){`. The static field and static block cases in that same block already fitted on one line and are unchanged.

Checked with `let () = print_endline (Int64.to_string (Int64.of_string "0x7fffffffffffffff"))`: before, the generated JS has three `static`-then-newline fields; after, none, and the program prints the same value under node.

On `make tests` I get the same set of failures before and after this change, so it introduces none -- but I should say that my environment cannot run the whole suite (`graphics` wants xquartz here, so some packages are missing and a few cram tests cannot resolve `js_of_ocaml`). CI will be the real check. `make fmt` reports nothing.

First contribution here -- happy to close this if you would rather not guard against a browser bug that Apple has already fixed.
