### PR TITLE
Compiler: fix ASI over-insertion after `async`/`using` identifiers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,12 @@
   asynchronous toplevel originally contributed in the unmerged #435 (#66, #833)
 
 ## Bug fixes
+* Compiler: fix automatic semicolon insertion after `async` and `using` used
+  as plain identifiers: a line break was treated as a statement boundary
+  (e.g. `x = async\n+ 1` became `x = async; + 1`), and some inputs failed to
+  parse (e.g. `var async\n= 1`). A semicolon is now only inserted before the
+  restricted continuations (`function`, an arrow parameter, a class element
+  name, a `using` binding) (#2422)
 * Toplevel: keep the `/static/cmis` directory on the load path across
   `Toploop.initialize_toplevel_env`, so libraries whose cmis are loaded at
   runtime stay resolvable; previously the directory was registered only while

--- a/compiler/lib/parse_js.ml
+++ b/compiler/lib/parse_js.ml
@@ -417,6 +417,56 @@ let dummy_loc = Loc.create Lexer.dummy_pos Lexer.dummy_pos
 
 let dummy_ident = Js_token.T_IDENTIFIER (Utf8_string.of_string_exn "<DUMMY>", "<DUMMY>")
 
+(* Tokens that can be parsed as a plain identifier (see [identifier] in
+   the grammar), as produced by the lexer. [yield] and [await] are included
+   since they are only turned into keywords by [normalize_token], later. *)
+let is_identifier_like = function
+  | Js_token.T_IDENTIFIER _
+  | T_ACCESSOR
+  | T_AS
+  | T_ASYNC
+  | T_FROM
+  | T_GET
+  | T_META
+  | T_OF
+  | T_SET
+  | T_TARGET
+  | T_DEFER
+  | T_USING
+  | T_YIELD
+  | T_AWAIT -> true
+  | _ -> false
+
+(* [async] and [using] are contextual keywords. Unlike [return] or
+   [throw], only a few of their continuations are restricted by
+   [no LineTerminator here]; any other token simply means that they are
+   used as plain identifiers, and no semicolon must be inserted:
+
+   - [async [no LineTerminator here] function ...]
+   - [async [no LineTerminator here] AsyncArrowBindingIdentifier =>]
+   - [async [no LineTerminator here] ClassElementName (...)] (methods)
+   - [using [no LineTerminator here] BindingList]
+
+   [prev] is the contextual keyword just offered to the parser; [tok] is
+   the next token. We distinguish the expression context from class
+   bodies by checking whether [prev] could be followed by [.], which is
+   only the case when it is being parsed as an expression. *)
+let restricted_after_contextual_keyword t prev tok =
+  let expression_context = acceptable t Js_token.T_PERIOD in
+  match prev, tok with
+  | Js_token.T_ASYNC, _ when expression_context -> (
+      match tok with
+      | Js_token.T_FUNCTION -> true
+      | _ -> is_identifier_like tok)
+  | T_ASYNC, _ -> (
+      (* class element: [async] is a field name unless directly followed
+         by a method name; [async (...) {}] is a method named [async]. *)
+      match tok with
+      | Js_token.T_LPAREN | T_ASSIGN | T_SEMICOLON | T_RCURLY -> false
+      | _ -> true)
+  | T_USING, _ -> expression_context && is_identifier_like tok
+  | _ -> false
+
 let rec offer_one t (lexbuf : Lexer.t) =
   let tok, loc = Lexer.token lexbuf in
   match tok with
@@ -456,16 +506,18 @@ let rec offer_one t (lexbuf : Lexer.t) =
               , _
               , _ )
           , ((T_SEMICOLON | T_VIRTUAL_SEMICOLON) as tok) ) -> tok, loc
-        | ( Some
-              ( (T_RETURN | T_CONTINUE | T_BREAK | T_THROW | T_YIELD | T_ASYNC | T_USING)
-              , _
-              , _ )
-          , _ )
+        | Some ((T_RETURN | T_CONTINUE | T_BREAK | T_THROW | T_YIELD), _, _), _
           when nl_separated h loc && acceptable t T_VIRTUAL_SEMICOLON ->
             (* restricted token can also appear as regular identifier such
                as in [x.return]. In such case, feeding a virtual semicolon
                could trigger a parser error. Here, we first checkpoint
                that a virtual semicolon is acceptable. *)
+            Lexer.rollback lexbuf;
+            semicolon, dummy_loc
+        | Some (((T_ASYNC | T_USING) as prev), _, _), _
+          when restricted_after_contextual_keyword t prev tok
+               && nl_separated h loc
+               && acceptable t T_VIRTUAL_SEMICOLON ->
             Lexer.rollback lexbuf;
             semicolon, dummy_loc
         | _, ((T_DIV | T_DIV_ASSIGN) as tok) ->

--- a/compiler/tests-compiler/js_parser_printer.ml
+++ b/compiler/tests-compiler/js_parser_printer.ml
@@ -1387,3 +1387,45 @@ let%expect_test "in operator in conditional then-branch needs no parentheses" =
     x=/*<<fake:1:11>>*/c?z="a"in
     b:d;;);
     |}]
+
+(* [async] and [using] are contextual keywords: they only introduce a
+   restricted production when followed by specific tokens ([function], [*],
+   arrow parameters, a class element name, a binding).  Used as plain
+   identifiers, a line break after them must not trigger ASI. *)
+let%expect_test "async/using identifiers followed by a line break" =
+  let test s = print ~debuginfo:false ~report:true ~compact:false s in
+  test {|
+var async = 1;
+var x = async
++ 1;
+|};
+  [%expect {| var async = 1; var x = async; + 1; |}];
+  test {|
+var async
+= 1;
+|};
+  [%expect {| cannot parse js (from l:3, c:0)@. |}];
+  test {|
+var async = { f() { return 1 } };
+var x = async
+.f();
+|};
+  [%expect {| cannot parse js (from l:4, c:0)@. |}];
+  test {|
+var async = (a) => a;
+var x = async
+(2);
+|};
+  [%expect {| var async = a=>a; var x = async; 2; |}];
+  test {|
+var using = 1;
+var x = using
++ 1;
+|};
+  [%expect {| var using = 1; var x = using; + 1; |}];
+  test {|
+var using = (a) => a;
+var x = using
+(2);
+|};
+  [%expect {| var using = a=>a; var x = using; 2; |}]

--- a/compiler/tests-compiler/js_parser_printer.ml
+++ b/compiler/tests-compiler/js_parser_printer.ml
@@ -1389,8 +1389,8 @@ let%expect_test "in operator in conditional then-branch needs no parentheses" =
     |}]
 
 (* [async] and [using] are contextual keywords: they only introduce a
-   restricted production when followed by specific tokens ([function], [*],
-   arrow parameters, a class element name, a binding).  Used as plain
+   restricted production when followed by specific tokens ([function], an
+   arrow parameter name, a class element name, a binding).  Used as plain
    identifiers, a line break after them must not trigger ASI. *)
 let%expect_test "async/using identifiers followed by a line break" =
   let test s = print ~debuginfo:false ~report:true ~compact:false s in
@@ -1399,33 +1399,83 @@ var async = 1;
 var x = async
 + 1;
 |};
-  [%expect {| var async = 1; var x = async; + 1; |}];
+  [%expect {| var async = 1; var x = async + 1; |}];
   test {|
 var async
 = 1;
 |};
-  [%expect {| cannot parse js (from l:3, c:0)@. |}];
+  [%expect {| var async = 1; |}];
   test {|
 var async = { f() { return 1 } };
 var x = async
 .f();
 |};
-  [%expect {| cannot parse js (from l:4, c:0)@. |}];
+  [%expect {| var async = {f(){return 1;}}; var x = async.f(); |}];
   test {|
 var async = (a) => a;
 var x = async
 (2);
 |};
-  [%expect {| var async = a=>a; var x = async; 2; |}];
+  [%expect {| var async = a=>a; var x = async(2); |}];
   test {|
 var using = 1;
 var x = using
 + 1;
 |};
-  [%expect {| var using = 1; var x = using; + 1; |}];
+  [%expect {| var using = 1; var x = using + 1; |}];
   test {|
 var using = (a) => a;
 var x = using
 (2);
 |};
-  [%expect {| var using = a=>a; var x = using; 2; |}]
+  [%expect {| var using = a=>a; var x = using(2); |}];
+  (* [*] is only restricted in method definitions *)
+  test {|
+var async = 1;
+var x = async
+* 2;
+|};
+  [%expect {| var async = 1; var x = async * 2; |}];
+  test {|
+var async = 1;
+async
+: 1;
+|};
+  [%expect {| var async = 1; async: 1; |}];
+  (* Restricted continuations: a semicolon must still be inserted. *)
+  test {|
+var x = async
+function f() {}
+|};
+  [%expect {| var x = async; function f(){} |}];
+  test {|
+var x = async
+y => 1;
+|};
+  [%expect {| var x = async; y=>1; |}];
+  test {|
+var using = 1;
+using
+x = 2;
+|};
+  [%expect {| var using = 1; using; x = 2; |}];
+  (* In a class body, [async] on its own line is a field name, unless
+     directly followed by [(], [=] or [;]. *)
+  test
+    {|
+class A {
+  async
+  foo() {}
+  async
+  * gen() {}
+  async
+  [x]() {}
+  async
+  (x) {}
+  async
+  = 1;
+  async
+}
+|};
+  [%expect
+    {| class A{async;foo(){}async;* gen(){}async;[x](){}async(x){}async = 1;async;} |}]


### PR DESCRIPTION
`async` and `using` were handled like `return`/`throw` in the restricted-production ASI rule: any line break after them inserted a semicolon whenever one was acceptable. Only a few continuations are actually restricted by `[no LineTerminator here]`:

- `async` `function ...`
- `async` `AsyncArrowBindingIdentifier =>`
- `async` `ClassElementName (...)` in class bodies
- `using` `BindingList`

So when these words are used as plain identifiers, `x = async\n+ 1` was split into `x = async; + 1`, `async\n(2)` into two statements, and `var async\n= 1` or `async\n.f()` failed to parse.

The parser now only inserts the semicolon before those restricted continuations; any other token means the keyword is used as an identifier. Expression context vs class body is told apart by checking whether `.` would be acceptable after the keyword.

The first commit adds the tests with the buggy output; the second fixes the parser and updates the expectations. Every expected output was cross-checked against V8 (node 25).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016FUpoKLLtA5bsSFoSLqCvX
