### PR TITLE
Compiler/Wasm: fix the ;;@ annotation emitted before each function

### DIFF
--- a/compiler/lib-wasm/wat_output.ml
+++ b/compiler/lib-wasm/wat_output.ml
@@ -666,7 +666,7 @@ let field ctx st f =
          mapping emitted at the very start of the function by [Wasm_output]. *)
       (match body with
         | Event Parse_info.{ src = Some src; col; line; _ } :: _ ->
-            [ Comment (Format.sprintf "@ %s:%d:%d" src line col) ]
+            [ Comment ("@ " ^ Format.sprintf "%s:%d:%d" src line col) ]
         | _ -> [])
       @ [ funct ctx st name exported_name typ signature param_names locals body ]
   | Global { name; exported_name; typ; init } ->


### PR DESCRIPTION
Format.sprintf interpreted "@ " as a break hint, so the @ was dropped and the annotation was printed as a plain comment.

But introduced in #2417. This only impact the debug output.