### PR TITLE
Toplevel: fix the build with tyxml 5

### DIFF
--- a/toplevel/examples/common/colorize.fake.ml
+++ b/toplevel/examples/common/colorize.fake.ml
@@ -1,7 +1,7 @@
 open Js_of_ocaml
 open Js_of_ocaml_tyxml
 
-let text ~a_class:cl s = Tyxml_js.Html.(span ~a:[ a_class [ cl ] ] [ txt s ])
+let text ~a_class:cl str = Tyxml_js.Html.(span ~a:[ a_class [ cl ] ] [ txt str ])
 
 let ocaml = text
 
@@ -17,10 +17,10 @@ let highlight from_ to_ e =
         | `Last -> String.length x - 1
       in
       e##.innerHTML := Js.string "";
-      let span kind s =
-        if s <> ""
+      let span kind str =
+        if str <> ""
         then
-          let span = Tyxml_js.Html.(span ~a:[ a_class [ kind ] ] [ txt s ]) in
+          let span = Tyxml_js.Html.(span ~a:[ a_class [ kind ] ] [ txt str ]) in
           Dom.appendChild e (Tyxml_js.To_dom.of_element span)
       in
       span "normal" (String.sub x 0 from_);

--- a/toplevel/examples/common/colorize.higlo.ml
+++ b/toplevel/examples/common/colorize.higlo.ml
@@ -1,11 +1,11 @@
 open Js_of_ocaml
 open Js_of_ocaml_tyxml
 
-let text ~a_class:cl s = Tyxml_js.Html.(span ~a:[ a_class [ cl ] ] [ txt s ])
+let text ~a_class:cl str = Tyxml_js.Html.(span ~a:[ a_class [ cl ] ] [ txt str ])
 
 let ocaml ~a_class:cl s =
   let tks = Higlo.Lang.parse ~lang:"ocaml" s in
-  let span' cl (s, _) = Tyxml_js.Html.(span ~a:[ a_class [ cl ] ] [ txt s ]) in
+  let span' cl (str, _) = Tyxml_js.Html.(span ~a:[ a_class [ cl ] ] [ txt str ]) in
   let make_span = function
     | Higlo.Lang.Bcomment s -> span' "comment" s
     | Higlo.Lang.Constant s -> span' "constant" s


### PR DESCRIPTION
tyxml 5.0.0 (released 2026-09-04) adds the `s` (strikethrough) element to `Html`. The local opens `Tyxml_js.Html.( ... [ txt s ])` in the toplevel colorize helpers then resolve `s` to that element instead of the string argument, and the toplevel examples no longer type-check:

```
File "toplevel/examples/common/colorize.fake.ml", line 4, characters 73-74:
Error: This expression has type
         ([< Html_types.s_attrib ] as 'a,
          [< Html_types.s_content_fun ] as 'b, [> Html_types.s ] as 'c)
         star = ?a:'a attrib list -> 'b elt list -> 'c elt
       but an expression was expected of type string
```

This currently only shows up on the Windows CI job (https://github.com/ocsigen/js_of_ocaml/actions/runs/34122810478/job/102006091454): the Linux/macOS runners restore a cached switch that already has tyxml 4.6.0, while the Windows switch installed tyxml fresh and got 5.0.0. They will break the same way once their caches refresh.

Rename the arguments so nothing in scope of the local open can be captured. Both `colorize.fake.ml` and `colorize.higlo.ml` are affected; the other `Html.(` blocks in the tree don't reference an outer `s`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017HzwqAJvwsdpAvXNcFimxb
